### PR TITLE
Wait for the consumer to be terminated

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -83,18 +83,13 @@ public class IndexTask extends PipelineTask implements Monitorable{
         publisher.publish(Channel.NLP, new Message(INIT_MONITORING).add(VALUE, valueOf(totalToProcess)));
 
         consumer.shutdown();
-        boolean consumerTerminated = false;
         // documents could be currently processed
-        while (!consumerTerminated) {
-          try {
-              consumerTerminated = consumer.awaitTermination(30, MINUTES);
-            if (!consumerTerminated) {
+        try {
+            while (!consumer.awaitTermination(30, MINUTES)) {
                 logger.info("Consumer has not terminated yet.");
             }
-          } catch (InterruptedException iex) {
-              logger.info("Got InterruptedException while waiting for the consumer shutdown.");
-              consumerTerminated = true;
-          }
+        } catch (InterruptedException iex) {
+            logger.info("Got InterruptedException while waiting for the consumer shutdown.");
         }
         publisher.publish(Channel.NLP, new ShutdownMessage());
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -92,7 +92,8 @@ public class IndexTask extends PipelineTask implements Monitorable{
                 logger.info("Consumer has not terminated yet.");
             }
           } catch (InterruptedException iex) {
-              logger.info("Got InterruptedException while waiting for the consumer shutdown. ");
+              logger.info("Got InterruptedException while waiting for the consumer shutdown.");
+              consumerTerminated = true;
           }
         }
         publisher.publish(Channel.NLP, new ShutdownMessage());


### PR DESCRIPTION
A PR for https://github.com/ICIJ/datashare/issues/86. 
Not sure if this is what you had in mind, but happy to change it to something else.

This should reliably wait for termination and log if it's been interrupted in the process.

Alternatively this can be changed to simply `consumer.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);` which will have a similar effect of waiting forever.

I personally like this approach better because it provides a little more visibility into "actively" waiting for the shutdown.