### PR TITLE
Clean NlpApp shutdown in tests to avoid race conditions

### DIFF
--- a/datashare-api/src/test/java/org/icij/datashare/text/nlp/NlpAppTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/nlp/NlpAppTest.java
@@ -126,7 +126,7 @@ public class NlpAppTest {
             if (nlpProcessDelayMillis > 0) Thread.sleep(nlpProcessDelayMillis);
             return new Annotations("docid_mock", Pipeline.Type.CORENLP, Language.FRENCH);
         });
-        NlpApp nlpApp = new NlpApp(dataBus, indexer, pipeline, properties, latch::countDown,1, local());
+        NlpApp nlpApp = new NlpApp(dataBus, indexer, pipeline, properties, latch::countDown, 1, true, local());
         executor.execute(nlpApp);
         latch.await(2, SECONDS);
         return nlpApp;


### PR DESCRIPTION
I noticed that `NlpAppTest`s often fail on my local checkout.
After some debugging I traced it down to a race condition in `NlpApp`/`NplConsumer`:

NlpApp shutdown waits for the queue to be drained and then sends a shutdown to the pool of `NplConsumer`s.
`NlpApp.shutdown()` only waits for a single millisecond in tests and if the pool is not shutdown issues a `shutdownNow()` which terminates all processing.
When NplConsumer drained the queue, but hasn't processed it yet - those in-flight operations are lost.

The tests rely on a strict definition of all data having been processed for the assertions to work (on the processing rate and with validating which methods were called). If NplConsumer doesn't have the time to finish its job - those assertions are invalid.

I preserved the default behavior of a forceful shutdown, only adding the new clean shutdown behavior for the NlpApp initialized by tests.