### PR TITLE
Remove ExpectedSystemExit rule

### DIFF
--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -29,13 +29,6 @@
 
         <!-- tests dependencies -->
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -1,8 +1,6 @@
 package org.icij.datashare.cli;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 import java.io.IOException;
 
@@ -11,7 +9,6 @@ import static org.fest.assertions.MapAssert.entry;
 
 public class DatashareCliTest {
     private DatashareCli cli = new DatashareCli();
-    @Rule public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void test_web_opt() {


### PR DESCRIPTION
This rule is no used since 8b0e061740702453ad232d7f892b133054a32a4c.