### PR TITLE
feat(logging): make configurable the GELF version

### DIFF
--- a/datashare-app/src/main/resources/logback-prod.xml
+++ b/datashare-app/src/main/resources/logback-prod.xml
@@ -4,7 +4,7 @@
     <appender name="gelf" class="biz.paluch.logging.gelf.logback.GelfLogbackAppender">
         <host>${datashare.loghost}</host>
         <port>${datashare.logport:-5140}</port>
-        <version>1.0</version>
+        <version>${datashare.gelf_version:-1.0}</version>
         <facility>local7</facility>
         <additionalFields>application=datashare</additionalFields>
         <extractStackTrace>true</extractStackTrace>


### PR DESCRIPTION
We need to support any version of GELF in use by biz.paluch.logging.gelf,
To simplify this we default to 1.0 but make it configurable using
configuration.