### PR TITLE
fix: batch download loop poll error

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadLoop.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadLoop.java
@@ -48,10 +48,13 @@ public class BatchDownloadLoop {
 
                 HashMap<String, Object> taskProperties = new HashMap<>();
                 taskProperties.put("batchDownload", currentBatch);
-                MonitorableFutureTask<File> fileMonitorableFutureTask = new MonitorableFutureTask<>(
-                        factory.createDownloadRunner(currentBatch, manager::save), taskProperties);
-                fileMonitorableFutureTask.run();
-                manager.save(new TaskView<>(fileMonitorableFutureTask));
+
+                if (!NULL_BATCH_DOWNLOAD.equals(currentBatch) && currentBatch != null) {
+                    MonitorableFutureTask<File> fileMonitorableFutureTask = new MonitorableFutureTask<>(
+                            factory.createDownloadRunner(currentBatch, manager::save), taskProperties);
+                    fileMonitorableFutureTask.run();
+                    manager.save(new TaskView<>(fileMonitorableFutureTask));
+                }
             } catch (Exception ex) {
                 logger.error("error in loop", ex);
             }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadLoop.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadLoop.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.batch.BatchDownload;
 import org.icij.datashare.cli.DatashareCliOptions;
-import org.icij.datashare.user.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,9 +16,7 @@ import java.util.HashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Collections.singletonList;
-import static org.icij.datashare.tasks.BatchDownloadRunner.*;
-import static org.icij.datashare.text.Project.project;
+import static org.icij.datashare.tasks.BatchDownloadRunner.NULL_BATCH_DOWNLOAD;
 
 public class BatchDownloadLoop {
     private final Path DOWNLOAD_DIR = Paths.get(System.getProperty("user.dir")).resolve("app/tmp");
@@ -49,7 +46,7 @@ public class BatchDownloadLoop {
                 HashMap<String, Object> taskProperties = new HashMap<>();
                 taskProperties.put("batchDownload", currentBatch);
 
-                if (!NULL_BATCH_DOWNLOAD.equals(currentBatch) && currentBatch != null) {
+                if (currentBatch != null && !NULL_BATCH_DOWNLOAD.equals(currentBatch)) {
                     MonitorableFutureTask<File> fileMonitorableFutureTask = new MonitorableFutureTask<>(
                             factory.createDownloadRunner(currentBatch, manager::save), taskProperties);
                     fileMonitorableFutureTask.run();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -75,7 +75,6 @@ public class BatchDownloadRunner implements Callable<File>, Monitorable, UserTas
 
     @Override
     public File call() throws Exception {
-        if (NULL_BATCH_DOWNLOAD.equals(batchDownload)) return null;
         int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE).orElse("0"));
         int maxResultSize = parseInt(propertiesProvider.get(BATCH_DOWNLOAD_MAX_NB_FILES).orElse(valueOf(MAX_BATCH_RESULT_SIZE)));
         int scrollSize = min(parseInt(propertiesProvider.get(SCROLL_SIZE).orElse("1000")), MAX_SCROLL_SIZE);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadLoopTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadLoopTest.java
@@ -47,8 +47,8 @@ public class BatchDownloadLoopTest {
 
         app.run();
 
-        verify(batchRunner, times(2)).call();
-        verify(manager, times(2)).save(argCaptor.capture());
+        verify(batchRunner).call();
+        verify(manager).save(argCaptor.capture());
         verify(batchDownloadCleaner, times(2)).run();
         assertThat(argCaptor.getValue().getState()).isEqualTo(TaskView.State.DONE);
     }
@@ -86,7 +86,7 @@ public class BatchDownloadLoopTest {
 
         app.run();
 
-        verify(manager,times(2)).save(argCaptor.capture());
+        verify(manager).save(argCaptor.capture());
         assertThat(argCaptor.getValue().getState()).isEqualTo(TaskView.State.ERROR);
         assertThat(argCaptor.getValue().error.getClass()).isNotEqualTo(ElasticsearchStatusException.class);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerTest.java
@@ -67,15 +67,6 @@ public class BatchDownloadRunnerTest {
         new BatchDownloadRunner(indexer, new PropertiesProvider(), new BatchDownload(singletonList(project("test-datashare")), User.local(), "query"), updater).call();
     }
 
-    @Test
-    public void test_do_nothing_with_null_object() throws Exception {
-        Document[] documents = IntStream.range(0, 3).mapToObj(i -> createDoc("doc" + i).with(createFile(i)).build()).toArray(Document[]::new);
-        mockSearch.willThrow(new RuntimeException("ES should not be called"));
-        File zip = new BatchDownloadRunner(indexer, new PropertiesProvider(new HashMap<>()), BatchDownload.nullObject(), updater).call();
-
-        assertThat(zip).isNull();
-    }
-
     private Path createFile(int index) {
         File file;
         try {


### PR DESCRIPTION
Following [this commit](https://github.com/ICIJ/datashare/commit/6625d460b37ec84716138142ffc080421b5ee022) a bug has been introduced. 
After launching Datashare in Batch Download mode, this error message appears every minute : 
```
2023-01-12 16:18:31,419 [main] INFO  BatchDownloadLoop - Datashare running in batch mode. Waiting batch from ds:batchdownload.queue (class org.icij.datashare.extract.RedisBlockingQueue)
2023-01-12 16:19:31,531 [main] ERROR BatchDownloadLoop - error in loop
com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051)
        at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3974)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4935)
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4941)
        at com.google.inject.internal.util.StackTraceElements.forMember(StackTraceElements.java:70)
        at com.google.inject.internal.Errors.formatParameter(Errors.java:859)
        at com.google.inject.internal.Errors.checkForNull(Errors.java:655)
        at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:81)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:53)
        at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:61)
        at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:45)
        at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
        at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:110)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
        at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1019)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1085)
        at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1015)
        at com.google.inject.assistedinject.FactoryProvider2.invoke(FactoryProvider2.java:776)
        at com.sun.proxy.$Proxy17.createDownloadRunner(Unknown Source)
        at org.icij.datashare.tasks.BatchDownloadLoop.run(BatchDownloadLoop.java:52)
        at org.icij.datashare.BatchDownloadApp.start(BatchDownloadApp.java:16)
        at org.icij.datashare.Main.main(Main.java:22)
Caused by: java.lang.IllegalArgumentException: null
        at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
        at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
        at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
        at com.google.inject.internal.util.LineNumbers.<init>(LineNumbers.java:66)
        at com.google.inject.internal.util.StackTraceElements$1.load(StackTraceElements.java:46)
        at com.google.inject.internal.util.StackTraceElements$1.load(StackTraceElements.java:43)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
        ... 24 common frames omitted

``` 

While fixing the `BatchDownloadLoop` poison pill, we withdrew a condition that checks if the `batchdownload` is null after polling (we moved into the runner). Without this condition it tries to create a `BatchDownloadRunner`with Guice injector with a null value and throws the error above. 
To fix this, at first, I added `@Nullable`annotation in `BatchDownloadRunner`'s constructor to make this happen, and it worked for this part. After this the TaskManager tries to save the task that include the `null batchdownload`which fails again with a `NullPointerException` in the `TaskManager`. Instead of modifying `TaskManager` classes (which can lead to consequent changes), I prefered to put back the condition in `BatchDownloadLoop`.