### PR TITLE
Fix/batch instance graceful stop

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
@@ -4,10 +4,14 @@ import com.google.inject.Injector;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.BatchDownloadLoop;
 import org.icij.datashare.tasks.TaskFactory;
+import org.icij.datashare.tasks.TaskManager;
+import org.icij.datashare.text.indexing.Indexer;
+import org.redisson.api.RedissonClient;
 
 import java.util.Properties;
 
 import static com.google.inject.Guice.createInjector;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class BatchDownloadApp {
     public static void start(Properties properties) throws Exception {
@@ -15,5 +19,6 @@ public class BatchDownloadApp {
         BatchDownloadLoop batchDownloadLoop = injector.getInstance(TaskFactory.class).createBatchDownloadLoop();
         batchDownloadLoop.run();
         batchDownloadLoop.close();
+        injector.getInstance(RedissonClient.class).shutdown();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
@@ -19,6 +19,7 @@ public class BatchDownloadApp {
         BatchDownloadLoop batchDownloadLoop = injector.getInstance(TaskFactory.class).createBatchDownloadLoop();
         batchDownloadLoop.run();
         batchDownloadLoop.close();
+        injector.getInstance(Indexer.class).close();
         injector.getInstance(RedissonClient.class).shutdown();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/BatchSearchApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/BatchSearchApp.java
@@ -5,6 +5,7 @@ import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.BatchSearchLoop;
 import org.icij.datashare.tasks.TaskFactory;
 import org.icij.datashare.text.indexing.Indexer;
+import org.redisson.api.RedissonClient;
 
 import java.util.Properties;
 
@@ -17,6 +18,7 @@ public class BatchSearchApp {
         batchSearchLoop.requeueDatabaseBatches();
         batchSearchLoop.run();
         batchSearchLoop.close();
-        injector.getInstance(Indexer.class).close(); // to avoid being blocked
+        injector.getInstance(Indexer.class).close();// to avoid being blocked
+        injector.getInstance(RedissonClient.class).shutdown();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/extract/RedisBlockingQueue.java
+++ b/datashare-app/src/main/java/org/icij/datashare/extract/RedisBlockingQueue.java
@@ -3,18 +3,17 @@ package org.icij.datashare.extract;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.mode.CommonMode;
 import org.icij.extract.redis.RedissonClientFactory;
 import org.icij.task.Options;
 import org.redisson.Redisson;
 import org.redisson.RedissonBlockingQueue;
 import org.redisson.api.RedissonClient;
-import org.redisson.client.codec.StringCodec;
 import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.command.CommandSyncService;
 import org.redisson.liveobject.core.RedissonObjectBuilder;
 
 import java.io.Closeable;
-import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 public class RedisBlockingQueue<T> extends RedissonBlockingQueue<T> implements Closeable {
@@ -26,7 +25,7 @@ public class RedisBlockingQueue<T> extends RedissonBlockingQueue<T> implements C
     }
 
     public RedisBlockingQueue(PropertiesProvider propertiesProvider) {
-        this(propertiesProvider, "ds:batchsearch:queue");
+        this(propertiesProvider, CommonMode.DS_BATCHSEARCH_QUEUE_NAME);
     }
 
     public RedisBlockingQueue(RedissonClient redissonClient, String queueName) {

--- a/datashare-app/src/main/java/org/icij/datashare/mode/BatchMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/BatchMode.java
@@ -16,8 +16,7 @@ public class BatchMode extends CommonMode {
     protected void configure() {
         super.configure();
 
-        RBlockingQueue<BatchDownload> batchDownloadQueue = redissonClient.getBlockingQueue(DS_BATCHDOWNLOAD_QUEUE_NAME);
-        bind(TaskManager.class).toInstance(new TaskManagerRedis(redissonClient, DS_TASK_MANAGER_QUEUE_NAME, batchDownloadQueue));
+        bind(TaskManager.class).to(TaskManagerRedis.class).asEagerSingleton();
         configurePersistence();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/BatchMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/BatchMode.java
@@ -1,10 +1,9 @@
 package org.icij.datashare.mode;
 
+import org.icij.datashare.batch.BatchDownload;
 import org.icij.datashare.tasks.TaskManager;
 import org.icij.datashare.tasks.TaskManagerRedis;
-import org.icij.extract.redis.RedissonClientFactory;
-import org.icij.task.Options;
-import org.redisson.api.RedissonClient;
+import org.redisson.api.RBlockingQueue;
 
 import java.util.Properties;
 
@@ -16,7 +15,9 @@ public class BatchMode extends CommonMode {
     @Override
     protected void configure() {
         super.configure();
-        bind(TaskManager.class).to(TaskManagerRedis.class).asEagerSingleton();
+
+        RBlockingQueue<BatchDownload> batchDownloadQueue = redissonClient.getBlockingQueue(DS_BATCHDOWNLOAD_QUEUE_NAME);
+        bind(TaskManager.class).toInstance(new TaskManagerRedis(redissonClient, DS_TASK_MANAGER_QUEUE_NAME, batchDownloadQueue));
         configurePersistence();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -31,7 +31,6 @@ import org.icij.datashare.nlp.OptimaizeLanguageGuesser;
 import org.icij.datashare.tasks.DocumentCollectionFactory;
 import org.icij.datashare.tasks.MemoryDocumentCollectionFactory;
 import org.icij.datashare.tasks.TaskFactory;
-import org.icij.datashare.tasks.TaskManagerMemory;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.LanguageGuesser;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
@@ -59,6 +58,9 @@ import static org.icij.datashare.PluginService.PLUGINS_BASE_URL;
 import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration.createESClient;
 
 public class CommonMode extends AbstractModule {
+    public static final String DS_BATCHSEARCH_QUEUE_NAME = "ds:batchsearch:queue";
+    public static final String DS_BATCHDOWNLOAD_QUEUE_NAME = "ds:batchdownload:queue";
+    public static final String DS_TASK_MANAGER_QUEUE_NAME = "ds:task:manager";
     protected final PropertiesProvider propertiesProvider;
 
     protected CommonMode(Properties properties) {
@@ -96,9 +98,9 @@ public class CommonMode extends AbstractModule {
 
         String batchQueueType = propertiesProvider.get("batchQueueType").orElse("org.icij.datashare.extract.MemoryBlockingQueue");
         bind(new TypeLiteral<BlockingQueue<String>>(){}).toInstance(
-                getBlockingQueue(propertiesProvider, batchQueueType, "ds:batchsearch:queue"));
+                getBlockingQueue(propertiesProvider, batchQueueType, DS_BATCHSEARCH_QUEUE_NAME));
         bind(new TypeLiteral<BlockingQueue<BatchDownload>>(){}).toInstance(
-                getBlockingQueue(propertiesProvider, batchQueueType, "ds:batchdownload:queue"));
+                getBlockingQueue(propertiesProvider, batchQueueType, DS_BATCHDOWNLOAD_QUEUE_NAME));
 
         RestHighLevelClient esClient = createESClient(propertiesProvider);
         bind(RestHighLevelClient.class).toInstance(esClient);

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -63,12 +63,10 @@ public class CommonMode extends AbstractModule {
     public static final String DS_BATCHDOWNLOAD_QUEUE_NAME = "ds:batchdownload:queue";
     public static final String DS_TASK_MANAGER_QUEUE_NAME = "ds:task:manager";
     protected final PropertiesProvider propertiesProvider;
-    protected final RedissonClient redissonClient;
 
     protected CommonMode(Properties properties) {
         propertiesProvider = properties == null ? new PropertiesProvider() :
                 new PropertiesProvider(properties.getProperty(PropertiesProvider.SETTINGS_FILE_PARAMETER_KEY)).mergeWith(properties);
-        redissonClient = new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create();
     }
 
     CommonMode(final Map<String, String> map) {
@@ -98,6 +96,7 @@ public class CommonMode extends AbstractModule {
     @Override
     protected void configure() {
         bind(PropertiesProvider.class).toInstance(propertiesProvider);
+        RedissonClient redissonClient = new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create();
         bind(RedissonClient.class).toInstance(redissonClient);
 
         QueueType batchQueueType = QueueType.valueOf(propertiesProvider.get("batchQueueType").orElse(QueueType.MEMORY.name()));

--- a/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
@@ -6,6 +6,7 @@ import net.codestory.http.filters.PayloadSupplier;
 import net.codestory.http.payload.Payload;
 import net.codestory.http.routes.Routes;
 import net.codestory.http.security.SessionIdStore;
+import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.session.*;
 import org.icij.datashare.tasks.TaskManager;
 import org.icij.datashare.tasks.TaskManagerRedis;
@@ -34,7 +35,8 @@ public class ServerMode extends CommonMode {
             logger.warn("\"{}\" auth users provider class not found. Setting provider to {}", authUsersProviderClassName, authUsersProviderClass);
         }
         bind(UsersWritable.class).to(authUsersProviderClass);
-        if ("memory".equals(propertiesProvider.getProperties().get("sessionStoreType"))) {
+        QueueType sessionStoreType = QueueType.valueOf(propertiesProvider.get("sessionStoreType").orElse(QueueType.MEMORY.name()));
+        if (QueueType.MEMORY == sessionStoreType) {
             bind(SessionIdStore.class).toInstance(SessionIdStore.inMemory());
         } else {
             bind(SessionIdStore.class).to(RedisSessionIdStore.class);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
@@ -44,16 +44,16 @@ public class TaskManagerRedis implements TaskManager {
     private final BlockingQueue<BatchDownload> batchDownloadQueue;
 
     @Inject
-    public TaskManagerRedis(PropertiesProvider propertiesProvider, BlockingQueue<BatchDownload> batchDownloadQueue) {
-        this(propertiesProvider, CommonMode.DS_TASK_MANAGER_QUEUE_NAME, batchDownloadQueue);
-    }
-
     public TaskManagerRedis(RedissonClient redissonClient, String taskMapName, BlockingQueue<BatchDownload> batchDownloadQueue) {
         CommandSyncService commandSyncService = new CommandSyncService(((Redisson) redissonClient).getConnectionManager(), new RedissonObjectBuilder(redissonClient));
         this.tasks = new RedissonMap<>(new TaskViewCodec(), commandSyncService, taskMapName, redissonClient, null, null);
         this.batchDownloadQueue = batchDownloadQueue;
     }
 
+    public TaskManagerRedis(PropertiesProvider propertiesProvider, BlockingQueue<BatchDownload> batchDownloadQueue) {
+        this(propertiesProvider, CommonMode.DS_TASK_MANAGER_QUEUE_NAME, batchDownloadQueue);
+    }
+    
     TaskManagerRedis(PropertiesProvider propertiesProvider, String taskMapName, BlockingQueue<BatchDownload> batchDownloadQueue) {
         RedissonClient redissonClient = new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create();
         CommandSyncService commandSyncService = new CommandSyncService(((Redisson) redissonClient).getConnectionManager(), new RedissonObjectBuilder(redissonClient));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
@@ -11,6 +11,7 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.batch.BatchDownload;
+import org.icij.datashare.mode.CommonMode;
 import org.icij.extract.redis.RedissonClientFactory;
 import org.icij.task.Options;
 import org.redisson.Redisson;
@@ -44,7 +45,7 @@ public class TaskManagerRedis implements TaskManager {
 
     @Inject
     public TaskManagerRedis(PropertiesProvider propertiesProvider, BlockingQueue<BatchDownload> batchDownloadQueue) {
-        this(propertiesProvider, "ds:task:manager", batchDownloadQueue);
+        this(propertiesProvider, CommonMode.DS_TASK_MANAGER_QUEUE_NAME, batchDownloadQueue);
     }
 
     TaskManagerRedis(PropertiesProvider propertiesProvider, String taskMapName, BlockingQueue<BatchDownload> batchDownloadQueue) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
@@ -48,6 +48,12 @@ public class TaskManagerRedis implements TaskManager {
         this(propertiesProvider, CommonMode.DS_TASK_MANAGER_QUEUE_NAME, batchDownloadQueue);
     }
 
+    public TaskManagerRedis(RedissonClient redissonClient, String taskMapName, BlockingQueue<BatchDownload> batchDownloadQueue) {
+        CommandSyncService commandSyncService = new CommandSyncService(((Redisson) redissonClient).getConnectionManager(), new RedissonObjectBuilder(redissonClient));
+        this.tasks = new RedissonMap<>(new TaskViewCodec(), commandSyncService, taskMapName, redissonClient, null, null);
+        this.batchDownloadQueue = batchDownloadQueue;
+    }
+
     TaskManagerRedis(PropertiesProvider propertiesProvider, String taskMapName, BlockingQueue<BatchDownload> batchDownloadQueue) {
         RedissonClient redissonClient = new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create();
         CommandSyncService commandSyncService = new CommandSyncService(((Redisson) redissonClient).getConnectionManager(), new RedissonObjectBuilder(redissonClient));

--- a/datashare-app/src/test/java/org/icij/datashare/mode/BatchModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/BatchModeTest.java
@@ -2,7 +2,7 @@ package org.icij.datashare.mode;
 
 import com.google.inject.Injector;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.extract.RedisBlockingQueue;
+import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.tasks.BatchDownloadLoop;
 import org.icij.datashare.tasks.BatchSearchLoop;
 import org.icij.datashare.tasks.TaskFactory;
@@ -10,6 +10,7 @@ import org.icij.datashare.text.indexing.Indexer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.redisson.api.RedissonClient;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -24,7 +25,7 @@ public class BatchModeTest {
         Injector injector = createInjector(new BatchMode(PropertiesProvider.fromMap(new HashMap<>() {{
             put("dataDir", dataDir.getRoot().toString());
             put("mode", "BATCH_SEARCH");
-            put("batchQueueType", RedisBlockingQueue.class.getName());
+            put("batchQueueType", QueueType.REDIS.name());
         }})));
 
         BatchSearchLoop batchSearchLoop = injector.getInstance(TaskFactory.class).createBatchSearchLoop();
@@ -39,7 +40,7 @@ public class BatchModeTest {
         Injector injector = createInjector(new BatchMode(PropertiesProvider.fromMap(new HashMap<>() {{
             put("dataDir", dataDir.getRoot().toString());
             put("mode", "BATCH_DOWNLOAD");
-            put("batchQueueType", RedisBlockingQueue.class.getName());
+            put("batchQueueType", QueueType.MEMORY.name());
         }})));
 
         BatchDownloadLoop batchDownloadLoop = injector.getInstance(TaskFactory.class).createBatchDownloadLoop();

--- a/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.mode;
 import com.google.inject.Injector;
 import net.codestory.http.filters.Filter;
 import net.codestory.http.security.SessionIdStore;
+import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.session.*;
 import org.junit.Test;
 
@@ -53,7 +54,7 @@ public class ServerModeTest {
     @Test
     public void test_session_store_redis() {
         Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
-            put("sessionStoreType", "redis");
+            put("sessionStoreType", QueueType.REDIS.name());
         }}));
         assertThat(injector.getInstance(SessionIdStore.class)).isInstanceOf(RedisSessionIdStore.class);
     }
@@ -61,7 +62,7 @@ public class ServerModeTest {
     @Test
     public void test_session_store_memory() {
         Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
-            put("sessionStoreType", "memory");
+            put("sessionStoreType", QueueType.MEMORY.name());
         }}));
         assertThat(injector.getInstance(SessionIdStore.class)).isInstanceOf(net.codestory.http.security.SessionIdStore.inMemory().getClass());
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -221,8 +221,8 @@ public final class DatashareCliOptions {
         parser.acceptsAll(
                 singletonList("busType"),
                 "Backend data bus type. Values can be \"memory\" or \"redis\"")
-                .withRequiredArg()
-                .defaultsTo("redis");
+                .withRequiredArg().ofType( QueueType.class )
+                .defaultsTo(QueueType.REDIS);
     }
 
     static void redisAddress(OptionParser parser) {
@@ -237,8 +237,8 @@ public final class DatashareCliOptions {
             parser.acceptsAll(
                     singletonList("queueType"),
                     "Backend queues and sets type. Values can be \"memory\" or \"redis\"")
-                    .withRequiredArg()
-                    .defaultsTo("redis");
+                    .withRequiredArg().ofType(QueueType.class)
+                    .defaultsTo(QueueType.REDIS);
         }
 
     static void fileParserParallelism(OptionParser parser) {
@@ -450,9 +450,9 @@ public final class DatashareCliOptions {
 
     public static void batchSearchQueueType(OptionParser parser) {
         parser.acceptsAll(
-                singletonList("batchQueueType"), "Queue class for batch search queue")
-                        .withRequiredArg()
-                        .ofType(String.class);
+                singletonList("batchQueueType"), "")
+                .withRequiredArg().ofType( QueueType.class )
+                .defaultsTo(QueueType.REDIS);
     }
 
     public static void batchDownloadTimeToLive(OptionParser parser) {
@@ -506,6 +506,6 @@ public final class DatashareCliOptions {
         parser.acceptsAll(
                 singletonList("sessionStoreType"), "Type of session store (redis|memory)")
                 .withRequiredArg()
-                .ofType(String.class);
+                .ofType(QueueType.class);
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/QueueType.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/QueueType.java
@@ -1,0 +1,5 @@
+package org.icij.datashare.cli;
+
+public enum QueueType {
+    MEMORY, REDIS
+}


### PR DESCRIPTION
This PR aims to fix the instances that are unable to close. We make sure that we are closing all connections both in Batch Search and Batch Download modes.

**Important note**: In the next release, we have to modify installers and deployment scripts to use QueueTypes names `REDIS` and `MEMORY`instead of the current parameters