### PR TITLE
fix: display project list in detailed view

### DIFF
--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -69,6 +69,30 @@ public class JooqBatchSearchRepositoryTest {
     }
 
     @Test
+    public void test_get_batch_search_by_user_with_projects_without_queries() {
+        BatchSearch batchSearch = new BatchSearch(asList(project("prj1"), project("prj2")), "name1", "description1",
+                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),
+                3,true);
+
+        repository.save(batchSearch);
+        BatchSearch batchSearchFromGet = repository.get(User.local(), batchSearch.uuid, false);
+
+        assertThat(batchSearchFromGet.projects).isEqualTo(batchSearch.projects);
+    }
+
+    @Test
+    public void test_get_batch_search_by_user_with_projects_with_queries() {
+        BatchSearch batchSearch = new BatchSearch(asList(project("prj1"), project("prj2")), "name1", "description1",
+                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),
+                3,true);
+
+        repository.save(batchSearch);
+        BatchSearch batchSearchFromGet = repository.get(User.local(), batchSearch.uuid, true);
+
+        assertThat(batchSearchFromGet.projects).isEqualTo(batchSearch.projects);
+    }
+
+    @Test
     public void test_get_records_filter_by_project() {
         BatchSearch batchSearch1 = new BatchSearch(singletonList(project("prj1")), "name1", "description1",
                 asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);


### PR DESCRIPTION
Related to #993 

The batchSearch without queries: 
before fix: based on a single project
after fix: get the BS projects from the BS and merge projects into a comma separated string of projects

The batchSearch with queries: not changed because they are already merging the projects into a comma separated string of projects with the "mergeBatchSearches". Eg with 2 projects (p1,p2) and 2 queries (q1, q2), the merge will create 4 rows p1q1, p1q2,p2q1, p2q2 and then retrieve all the different project values from these rows.
