### PR TITLE
build: upgrade extension json and pom

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -13,36 +13,36 @@
       "id": "datashare-nlp-ixapipe",
       "name": "IXAPIPE Pipeline",
       "description": "Extension to extract NER entities with ixapipe",
-      "url": "https://github.com/ICIJ/datashare-extension-nlp-ixapipe/releases/download/8.0.1/datashare-nlp-ixapipe-8.0.1-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-nlp-ixapipe/releases/download/8.0.2/datashare-nlp-ixapipe-8.0.2-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-nlp-ixapipe",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "type": "NLP"
     },
     {
       "id": "datashare-nlp-mitie",
       "name": "NLP Mitie Pipeline",
       "description": "Extension to extract NER entities with Mitie",
-      "url": "https://github.com/ICIJ/datashare-extension-nlp-mitie/releases/download/8.0.1/datashare-nlp-mitie-8.0.1-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-nlp-mitie/releases/download/8.0.2/datashare-nlp-mitie-8.0.2-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-nlp-mitie",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "type": "NLP"
     },
     {
       "id": "datashare-nlp-opennlp",
       "name": "OPENNLP Pipeline",
       "description": "Extension to extract NER entities with OPENNLP",
-      "url": "https://github.com/ICIJ/datashare-extension-nlp-opennlp/releases/download/8.0.1/datashare-nlp-opennlp-8.0.1-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-nlp-opennlp/releases/download/8.0.2/datashare-nlp-opennlp-8.0.2-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-nlp-opennlp",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "type": "NLP"
     },
     {
       "id": "datashare-extension-dataconnect",
       "name": "Dataconnect",
       "description": "A Datashare extension to create Dataconnect, a bridge between Datashare and I-Hub.",
-      "url": "https://github.com/ICIJ/datashare-extension-dataconnect/releases/download/0.0.10/datashare-extension-dataconnect-0.0.10-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-dataconnect/releases/download/1.0.0/datashare-extension-dataconnect-1.0.0-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-dataconnect",
-      "version": "0.0.10",
+      "version": "1.0.0",
       "type": "WEB"
     }
   ]

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>8.7.0</datashare-api.version>
+        <datashare-api.version>8.7.2</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
This PR aims to integrate libraries which are now updated to openjdk 11

- [Datashare-api](https://github.com/ICIJ/datashare-api/commit/2f4d5a1bb8e0adf758d9a238d68e34cdb4d715ed)
- [Open NLP](https://github.com/ICIJ/datashare-extension-nlp-opennlp/commit/fb39e94717fbcb45c26b69906f14ab66333831d0) and [here](https://github.com/ICIJ/datashare-extension-nlp-opennlp/commit/d00d56bf29537bc95f8410307e5bf20b3afe3540)
- [Mitie](https://github.com/ICIJ/datashare-extension-nlp-mitie/commit/0ffc721914a330ae27400743958314d248da3881)
- [Ixapipe](https://github.com/ICIJ/datashare-extension-nlp-ixapipe/commit/aa6a23557b06b619415dbe6509518963e87fb7da)