### PR TITLE
Fix/redis memory confusion

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/session/RedisSessionIdStore.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/RedisSessionIdStore.java
@@ -15,7 +15,7 @@ public class RedisSessionIdStore implements SessionIdStore {
 
     @Inject
     public RedisSessionIdStore(PropertiesProvider propertiesProvider) {
-        this.redis = new JedisPool(propertiesProvider.get("messageBusAddress").orElse("redis://redis:6379"));
+        this.redis = new JedisPool(propertiesProvider.get("redisAddress").orElse("redis://redis:6379"));
         this.ttl = Integer.valueOf(ofNullable(propertiesProvider.getProperties().getProperty("sessionTtlSeconds")).orElse("1"));
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/session/UsersInRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/UsersInRedis.java
@@ -20,7 +20,7 @@ public class UsersInRedis implements UsersWritable {
 
     @Inject
     public UsersInRedis(PropertiesProvider propertiesProvider) {
-        redis = new JedisPool(propertiesProvider.get("messageBusAddress").orElse("redis://redis:6379"));
+        redis = new JedisPool(propertiesProvider.get("redisAddress").orElse("redis://redis:6379"));
         this.ttl = Integer.valueOf(ofNullable(propertiesProvider.getProperties().getProperty("sessionTtlSeconds")).orElse("1"));
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -504,7 +504,7 @@ public final class DatashareCliOptions {
 
     public static void sessionStoreType(OptionParser parser) {
         parser.acceptsAll(
-                singletonList("sessionStoreType"), "Type of session store (redis|memory)")
+                singletonList("sessionStoreType"), "Type of session store")
                 .withRequiredArg()
                 .ofType(QueueType.class);
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -220,7 +220,7 @@ public final class DatashareCliOptions {
     public static void busType(OptionParser parser) {
         parser.acceptsAll(
                 singletonList("busType"),
-                "Backend data bus type. Values can be \"memory\" or \"redis\"")
+                "Backend data bus type.")
                 .withRequiredArg().ofType( QueueType.class )
                 .defaultsTo(QueueType.MEMORY);
     }
@@ -236,7 +236,7 @@ public final class DatashareCliOptions {
     static void queueType(OptionParser parser) {
             parser.acceptsAll(
                     singletonList("queueType"),
-                    "Backend queues and sets type. Values can be \"memory\" or \"redis\"")
+                    "Backend queues and sets type.")
                     .withRequiredArg().ofType(QueueType.class)
                     .defaultsTo(QueueType.MEMORY);
         }
@@ -383,7 +383,7 @@ public final class DatashareCliOptions {
 
     static void queueName(OptionParser parser) {
         parser.acceptsAll(
-                singletonList("queueName"), "Redis queue name")
+                singletonList("queueName"), "Extract queue name")
                 .withRequiredArg()
                 .ofType(String.class)
                 .defaultsTo("extract:queue");
@@ -506,6 +506,6 @@ public final class DatashareCliOptions {
         parser.acceptsAll(
                 singletonList("sessionStoreType"), "Type of session store")
                 .withRequiredArg()
-                .ofType(QueueType.class);
+                .ofType(QueueType.class).defaultsTo(QueueType.MEMORY);
     }
 }


### PR DESCRIPTION
This PR is just updating the CLI documentation and adds a default value to the `sessionStore` to `MEMORY`.
