### PR TITLE
fix: avoid startTask for batchSearch #1005

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
@@ -1,25 +1,21 @@
 package org.icij.datashare;
 
-import com.google.inject.Injector;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.BatchDownloadLoop;
 import org.icij.datashare.tasks.TaskFactory;
-import org.icij.datashare.tasks.TaskManager;
 import org.icij.datashare.text.indexing.Indexer;
 import org.redisson.api.RedissonClient;
 
 import java.util.Properties;
 
-import static com.google.inject.Guice.createInjector;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class BatchDownloadApp {
     public static void start(Properties properties) throws Exception {
-        Injector injector = createInjector(CommonMode.create(properties));
-        BatchDownloadLoop batchDownloadLoop = injector.getInstance(TaskFactory.class).createBatchDownloadLoop();
+        CommonMode commonMode = CommonMode.create(properties);
+        BatchDownloadLoop batchDownloadLoop = commonMode.get(TaskFactory.class).createBatchDownloadLoop();
         batchDownloadLoop.run();
         batchDownloadLoop.close();
-        injector.getInstance(Indexer.class).close();
-        injector.getInstance(RedissonClient.class).shutdown();
+        commonMode.get(Indexer.class).close();
+        commonMode.get(RedissonClient.class).shutdown();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/BatchSearchApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/BatchSearchApp.java
@@ -1,6 +1,5 @@
 package org.icij.datashare;
 
-import com.google.inject.Injector;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.BatchSearchLoop;
 import org.icij.datashare.tasks.TaskFactory;
@@ -9,16 +8,15 @@ import org.redisson.api.RedissonClient;
 
 import java.util.Properties;
 
-import static com.google.inject.Guice.createInjector;
 
 public class BatchSearchApp {
     public static void start(Properties properties) throws Exception {
-        Injector injector = createInjector(CommonMode.create(properties));
-        BatchSearchLoop batchSearchLoop = injector.getInstance(TaskFactory.class).createBatchSearchLoop();
+        CommonMode mode = CommonMode.create(properties);
+        BatchSearchLoop batchSearchLoop = mode.get(TaskFactory.class).createBatchSearchLoop();
         batchSearchLoop.requeueDatabaseBatches();
         batchSearchLoop.run();
         batchSearchLoop.close();
-        injector.getInstance(Indexer.class).close();// to avoid being blocked
-        injector.getInstance(RedissonClient.class).shutdown();
+        mode.get(Indexer.class).close();// to avoid being blocked
+        mode.get(RedissonClient.class).shutdown();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/WebApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/WebApp.java
@@ -1,8 +1,13 @@
 package org.icij.datashare;
 
+import com.google.inject.Injector;
 import net.codestory.http.WebServer;
 import org.icij.datashare.cli.DatashareCli;
+import org.icij.datashare.cli.Mode;
 import org.icij.datashare.mode.CommonMode;
+import org.icij.datashare.tasks.BatchSearchLoop;
+import org.icij.datashare.tasks.TaskFactory;
+import org.icij.datashare.tasks.TaskManager;
 
 import java.awt.*;
 import java.io.IOException;
@@ -36,6 +41,11 @@ public class WebApp {
                 parseBoolean(properties.getProperty(OPEN_LINK))) {
             waitForServerToBeUp(parseInt(mode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT)));
             Desktop.getDesktop().browse(URI.create(new URI("http://localhost:")+mode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT)));
+        }
+        if (mode.getMode() == Mode.LOCAL || mode.getMode() == Mode.EMBEDDED) {
+            BatchSearchLoop batchSearchLoop = mode.get(TaskFactory.class).createBatchSearchLoop();
+            TaskManager taskManager = mode.get(TaskManager.class);
+            taskManager.startTask(batchSearchLoop::run);
         }
         webServerThread.join();
     }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CliMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CliMode.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.mode;
 
+import net.codestory.http.routes.Routes;
+
 import java.util.Properties;
 
 public class CliMode extends CommonMode {
@@ -12,5 +14,10 @@ public class CliMode extends CommonMode {
         super.configure();
 
         configurePersistence();
+    }
+
+    @Override
+    protected Routes addModeConfiguration(Routes routes) {
+        return null;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
@@ -2,6 +2,7 @@ package org.icij.datashare.mode;
 
 import net.codestory.http.routes.Routes;
 import org.icij.datashare.session.LocalUserFilter;
+import org.icij.datashare.tasks.BatchSearchLoop;
 import org.icij.datashare.web.*;
 
 import java.util.Map;
@@ -9,7 +10,7 @@ import java.util.Properties;
 
 public class LocalMode extends CommonMode {
     LocalMode(Properties properties) { super(properties);}
-    public LocalMode(Map<String, String> properties) { super(properties);}
+    LocalMode(Map<String, String> properties) { super(properties);}
 
     @Override
     protected void configure() {

--- a/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
@@ -16,9 +16,8 @@ import java.util.Map;
 import java.util.Properties;
 
 public class ServerMode extends CommonMode {
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    public ServerMode(Properties properties) { super(properties);}
-    public ServerMode(Map<String, String> properties) { super(properties);}
+    ServerMode(Properties properties) { super(properties);}
+    ServerMode(Map<String, String> properties) { super(properties);}
 
     @Override
     protected void configure() {

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -260,25 +260,6 @@ public class TaskResource {
     }
 
     /**
-     * Run batch searches
-     *
-     * @return 200 and the created task
-     *
-     * Example :
-     * $(curl -XPOST localhost:8080/api/task/batchSearch)
-     */
-    @Post("/batchSearch")
-    public TaskView<?> runBatchSearches(Context context) {
-        // TODO replace with call with batchId (in local mode there is only one batch run at a time)
-        BatchSearchLoop batchSearchLoop = taskFactory.createBatchSearchLoop();
-        batchSearchLoop.requeueDatabaseBatches();
-        batchSearchLoop.enqueuePoison();
-
-        return taskManager.startTask(batchSearchLoop::run);
-    }
-
-
-    /**
      * Cancels the task with the given name. It answers 200 with the cancellation status `true|false`
      *
      * @param taskId

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CliModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CliModeTest.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.mode;
 
-import com.google.inject.Injector;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.tasks.BatchDownloadLoop;
@@ -14,35 +13,34 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.util.HashMap;
 
-import static com.google.inject.Guice.createInjector;
 
 public class CliModeTest {
     @Rule public TemporaryFolder dataDir = new TemporaryFolder();
 
     @Test
     public void test_batch_search() throws IOException {
-        Injector injector = createInjector(new CliMode(PropertiesProvider.fromMap(new HashMap<>() {{
+        CommonMode mode = CommonMode.create(PropertiesProvider.fromMap(new HashMap<>() {{
             put("dataDir", dataDir.getRoot().toString());
             put("mode", "BATCH_SEARCH");
             put("batchQueueType", QueueType.REDIS.name());
-        }})));
+        }}));
 
-        BatchSearchLoop batchSearchLoop = injector.getInstance(TaskFactory.class).createBatchSearchLoop();
+        BatchSearchLoop batchSearchLoop = mode.get(TaskFactory.class).createBatchSearchLoop();
         batchSearchLoop.enqueuePoison();
         batchSearchLoop.run();
         batchSearchLoop.close();
-        injector.getInstance(Indexer.class).close();
+        mode.get(Indexer.class).close();
     }
 
     @Test
     public void test_batch_download() throws IOException {
-        Injector injector = createInjector(new CliMode(PropertiesProvider.fromMap(new HashMap<>() {{
+        CommonMode mode = CommonMode.create(PropertiesProvider.fromMap(new HashMap<>() {{
             put("dataDir", dataDir.getRoot().toString());
             put("mode", "BATCH_DOWNLOAD");
             put("batchQueueType", QueueType.MEMORY.name());
-        }})));
+        }}));
 
-        BatchDownloadLoop batchDownloadLoop = injector.getInstance(TaskFactory.class).createBatchDownloadLoop();
+        BatchDownloadLoop batchDownloadLoop = mode.get(TaskFactory.class).createBatchDownloadLoop();
         batchDownloadLoop.enqueuePoison();
         batchDownloadLoop.run();
         batchDownloadLoop.close();

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -1,70 +1,23 @@
 package org.icij.datashare.mode;
 
-import net.codestory.rest.FluentRestTest;
-import net.codestory.rest.RestAssert;
+import org.icij.datashare.cli.Mode;
 import org.icij.datashare.cli.QueueType;
-import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
 import java.util.HashMap;
 
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static java.util.Optional.ofNullable;
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.test.JarUtil.createJar;
 
-@RunWith(Parameterized.class)
-public class CommonModeTest extends AbstractProdWebServerTest {
-    private final String method;
-    @Rule public TemporaryFolder pluginFolder = new TemporaryFolder();
-    CommonMode mode;
-    @Parameterized.Parameters
-    public static Collection<Object[]> methods() {
-        return asList(new Object[][]{{"Get"}, {"Post"}, {"Patch"}, {"Put"}, {"Delete"}, {"Options"}});
-    }
-
-    @Test
-    public void test_one_extension() throws Throwable {
-        test_one_extension(method, "/foo").should().respond(200).contain("hello from foo extension");
-    }
-
-    RestAssert test_one_extension(String method, String prefix) throws Throwable {
-        String prefixString = prefix == null ? "\n":"@Prefix(\""+ prefix + "\")\n";
-        String source = format("package org.icij.datashare.mode;\n" +
-                "\n" +
-                "import net.codestory.http.annotations.%s;\n" +
-                "import net.codestory.http.annotations.Prefix;\n" +
-                "\n" + prefixString +
-                "public class FooResource {\n" +
-                "    @%s(\"url\")\n" +
-                "    public String url() {\n" +
-                "        return \"hello from foo extension with %s\";\n" +
-                "    }\n" +
-                "}", method, method, method);
-        createJar(pluginFolder.getRoot().toPath(), "extension", source);
-        configure(routes -> mode.addExtensionConfiguration(routes));
-
-        Method restAssertMethod = FluentRestTest.class.getMethod(method.toLowerCase(), String.class);
-        return (RestAssert) restAssertMethod.invoke(this, ofNullable(prefix).orElse("") + "/url");
-    }
-
+public class CommonModeTest {
     @Test
     public void test_has_redis_property() {
-        CommonMode modeWithRedis = new CommonMode(new HashMap<String, String>() {{
-            put("extensionsDir", pluginFolder.getRoot().toString());
+        CommonMode modeWithRedis = CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
             put("busType", QueueType.REDIS.name());
         }});
 
-        CommonMode modeWithoutRedis = new CommonMode(new HashMap<String, String>() {{
-            put("extensionsDir", pluginFolder.getRoot().toString());
+        CommonMode modeWithoutRedis = CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
             put("queueType", QueueType.MEMORY.name());
         }});
 
@@ -72,12 +25,4 @@ public class CommonModeTest extends AbstractProdWebServerTest {
         assertThat(modeWithoutRedis.hasRedisProperty()).isFalse();
     }
 
-    public CommonModeTest(String method) { this.method = method;}
-
-    @Before
-    public void setUp() {
-        mode = new CommonMode(new HashMap<String, String>() {{
-            put("extensionsDir", pluginFolder.getRoot().toString());
-        }});
-    }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeWebExtensionTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeWebExtensionTest.java
@@ -1,0 +1,69 @@
+package org.icij.datashare.mode;
+
+import net.codestory.rest.FluentRestTest;
+import net.codestory.rest.RestAssert;
+import org.icij.datashare.cli.Mode;
+import org.icij.datashare.cli.QueueType;
+import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Optional.ofNullable;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.test.JarUtil.createJar;
+
+@RunWith(Parameterized.class)
+public class CommonModeWebExtensionTest extends AbstractProdWebServerTest {
+    private final String method;
+    @Rule public TemporaryFolder pluginFolder = new TemporaryFolder();
+    CommonMode mode;
+    @Parameterized.Parameters
+    public static Collection<Object[]> methods() {
+        return asList(new Object[][]{{"Get"}, {"Post"}, {"Patch"}, {"Put"}, {"Delete"}, {"Options"}});
+    }
+
+    @Test
+    public void test_one_extension() throws Throwable {
+        test_one_extension(method, "/foo").should().respond(200).contain("hello from foo extension");
+    }
+
+    RestAssert test_one_extension(String method, String prefix) throws Throwable {
+        String prefixString = prefix == null ? "\n":"@Prefix(\""+ prefix + "\")\n";
+        String source = format("package org.icij.datashare.mode;\n" +
+                "\n" +
+                "import net.codestory.http.annotations.%s;\n" +
+                "import net.codestory.http.annotations.Prefix;\n" +
+                "\n" + prefixString +
+                "public class FooResource {\n" +
+                "    @%s(\"url\")\n" +
+                "    public String url() {\n" +
+                "        return \"hello from foo extension with %s\";\n" +
+                "    }\n" +
+                "}", method, method, method);
+        createJar(pluginFolder.getRoot().toPath(), "extension", source);
+        configure(routes -> mode.addExtensionConfiguration(routes));
+
+        Method restAssertMethod = FluentRestTest.class.getMethod(method.toLowerCase(), String.class);
+        return (RestAssert) restAssertMethod.invoke(this, ofNullable(prefix).orElse("") + "/url");
+    }
+
+    public CommonModeWebExtensionTest(String method) { this.method = method;}
+
+    @Before
+    public void setUp() {
+        mode = CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
+            put("extensionsDir", pluginFolder.getRoot().toString());
+        }});
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.mode;
 
-import com.google.inject.Injector;
 import net.codestory.http.filters.Filter;
 import net.codestory.http.security.SessionIdStore;
 import org.icij.datashare.cli.QueueType;
@@ -9,61 +8,68 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static com.google.inject.Guice.createInjector;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class ServerModeTest {
     @Test
     public void test_server_mode_default_auth_class() {
-        Injector injector = createInjector(new ServerMode(new HashMap<>()));
-        assertThat(injector.getInstance(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
     }
 
     @Test
     public void test_server_mode_auth_class() {
-        Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
             put("authFilter", "org.icij.datashare.session.BasicAuthAdaptorFilter");
-        }}));
-        assertThat(injector.getInstance(Filter.class)).isInstanceOf(BasicAuthAdaptorFilter.class);
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(BasicAuthAdaptorFilter.class);
     }
 
     @Test
     public void test_server_mode_bad_auth_class_uses_default() {
-        Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
             put("authFilter", "org.icij.UnknownClass");
-        }}));
-        assertThat(injector.getInstance(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
     }
 
     @Test
     public void test_server_mode_users_class() {
-        Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
             put("authUsersProvider", "org.icij.datashare.session.UsersInDb");
-        }}));
-        assertThat(injector.getInstance(UsersWritable.class)).isInstanceOf(UsersInDb.class);
+        }});
+        assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInDb.class);
     }
 
     @Test
     public void test_server_bad_users_class_uses_default() {
-        Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
             put("authUsersProvider", "org.icij.UnknownClass");
-        }}));
-        assertThat(injector.getInstance(UsersWritable.class)).isInstanceOf(UsersInRedis.class);
+        }});
+        assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInRedis.class);
     }
 
     @Test
     public void test_session_store_redis() {
-        Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
             put("sessionStoreType", QueueType.REDIS.name());
-        }}));
-        assertThat(injector.getInstance(SessionIdStore.class)).isInstanceOf(RedisSessionIdStore.class);
+        }});
+        assertThat(mode.get(SessionIdStore.class)).isInstanceOf(RedisSessionIdStore.class);
     }
 
     @Test
     public void test_session_store_memory() {
-        Injector injector = createInjector(new ServerMode(new HashMap<String, String>() {{
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
             put("sessionStoreType", QueueType.MEMORY.name());
-        }}));
-        assertThat(injector.getInstance(SessionIdStore.class)).isInstanceOf(net.codestory.http.security.SessionIdStore.inMemory().getClass());
+        }});
+        assertThat(mode.get(SessionIdStore.class)).isInstanceOf(net.codestory.http.security.SessionIdStore.inMemory().getClass());
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -44,9 +44,12 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
 
     @Before
     public void setUp() {
-        PipelineRegistry pipelineRegistry = new PipelineRegistry(new PropertiesProvider());
+        final PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
+            put("mode", "LOCAL");
+        }});
+        PipelineRegistry pipelineRegistry = new PipelineRegistry(propertiesProvider);
         pipelineRegistry.register(EmailPipeline.class);
-        configure(new CommonMode(new Properties()) {
+        configure(new CommonMode(propertiesProvider.getProperties()) {
                     @Override
                     protected void configure() {
                         bind(TaskFactory.class).toInstance(taskFactory);
@@ -111,14 +114,6 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
 
         response.should().respond(200).haveType("application/json");
         verify(taskFactory).createScanTask(local(), "extract:queue", Paths.get("/default/data/dir"), new PropertiesProvider(properties).getProperties());
-    }
-
-    @Test
-    public void test_run_batch_search() {
-        RestAssert response = post("/api/task/batchSearch", "{}");
-
-        response.should().respond(200).haveType("application/json");
-        verify(taskFactory).createBatchSearchLoop();
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
@@ -161,9 +162,11 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
     }
 
     private void setupAppWith(String... userLogins) {
-        final PropertiesProvider propertiesProvider = new PropertiesProvider();
+        final PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
+            put("mode", "LOCAL");
+        }});
         taskManager = new TaskManagerMemory(propertiesProvider);
-        configure(new CommonMode(new Properties()) {
+        configure(new CommonMode(propertiesProvider.getProperties()) {
             @Override
             protected void configure() {
                 bind(PropertiesProvider.class).toInstance(propertiesProvider);

--- a/datashare-app/src/test/java/org/icij/datashare/web/WebLocalAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/WebLocalAcceptanceTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.web;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.codestory.rest.Response;
+import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.mode.LocalMode;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
@@ -17,7 +18,8 @@ import static org.fest.assertions.Assertions.assertThat;
 public class WebLocalAcceptanceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() throws Exception {
-        configure(new LocalMode(new HashMap<String, String>() {{
+        configure(CommonMode.create(new HashMap<>() {{
+            put("mode", "LOCAL");
             put("dataDir", WebLocalAcceptanceTest.class.getResource("/data").getPath());
             put("extensionsDir", WebLocalAcceptanceTest.class.getResource("/extensions").getPath());
             put("pluginsDir", WebLocalAcceptanceTest.class.getResource("/plugins").getPath());
@@ -59,7 +61,7 @@ public class WebLocalAcceptanceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_extensions_plugins_without_directory() throws Exception {
-        configure(new LocalMode(new HashMap<>()).createWebConfiguration());
+        configure(CommonMode.create(new HashMap<>() {{ put("mode", "LOCAL");}}).createWebConfiguration());
         waitForDatashare();
         get("/api/extensions").should().haveType("application/json").contain("\"installed\":false");
         get("/api/plugins").should().haveType("application/json").contain("\"installed\":false");

--- a/datashare-app/src/test/java/org/icij/datashare/web/WebServerAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/WebServerAcceptanceTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.web;
 
 import org.icij.datashare.cli.DatashareCli;
+import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.mode.ServerMode;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
@@ -9,7 +10,7 @@ import org.junit.Test;
 public class WebServerAcceptanceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() throws Exception {
-        configure(new ServerMode(new DatashareCli().parseArguments(new String[]{"--cors=*"}).properties).createWebConfiguration());
+        configure(CommonMode.create(new DatashareCli().parseArguments(new String[]{"--cors=*", "--mode=SERVER"}).properties).createWebConfiguration());
         waitForDatashare();
     }
 


### PR DESCRIPTION
In addition to the fix, we reworked the mode implementation by removing the injector creator. Consequently the only way to create an app instance is to use the `CommonMode` creator and to pass the mode inside its properties.

