### PR TITLE
feat: BDCleaner deletes archives with underscores

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadCleaner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadCleaner.java
@@ -15,7 +15,7 @@ import static java.util.regex.Pattern.compile;
 
 public class BatchDownloadCleaner implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Pattern filePattern = compile(BatchDownload.ZIP_FORMAT.replace("%s", "[a-z0-9\\.:Z\\-\\[GMT\\]]+"));
+    private final Pattern filePattern = compile(BatchDownload.ZIP_FORMAT.replace("%s", "[a-z0-9\\.:|_Z\\-\\[GMT\\]]+"));
     private final Path downloadDir;
     private final int ttlHour;
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadCleanerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadCleanerTest.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.icij.datashare.batch.BatchDownload.createFilename;
-import static org.icij.datashare.text.Project.project;
 
 public class BatchDownloadCleanerTest {
     @Rule public DatashareTimeRule time = new DatashareTimeRule();
@@ -28,12 +27,15 @@ public class BatchDownloadCleanerTest {
     @Test
     public void test_remove_zip_file_with_correct_patterns() throws IOException {
         File file = downloadDir.newFile(createFilename(User.local()).toString());
+        File fileWithDoubleDots = downloadDir.newFile("archive_local_0000-00-00T00:00:00Z[GMT].zip");
+
         // we must advance the delay between time fixed by the time rule and file creation date ~60ms
         DatashareTime.getInstance().addMilliseconds(100);
 
         new BatchDownloadCleaner(downloadDir.getRoot().toPath(), 0).run();
 
         Assertions.assertThat(file).doesNotExist();
+        Assertions.assertThat(fileWithDoubleDots).doesNotExist();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>8.7.2</datashare-api.version>
+        <datashare-api.version>8.7.3</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
This PR aims to adapt changes done in datashare-api. `BatchDownloadCleaner` now deletes archives with underscore and the ones double dots (generated with previous versions).