### PR TITLE
chore: facilitate local development

### DIFF
--- a/datashare-db/pom.xml
+++ b/datashare-db/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.28.0</version>
+            <version>3.40.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>

--- a/datashare-db/scr/reset_datashare_db.sh
+++ b/datashare-db/scr/reset_datashare_db.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+export PGPASSWORD=test
 
 psql -h postgres -Utest test -c 'drop database datashare'
 psql -h postgres -Utest test -c 'create database datashare'

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -9,6 +9,7 @@ import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.user.User;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 
 import javax.sql.DataSource;

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -10,6 +10,7 @@ import org.icij.datashare.text.*;
 import org.icij.datashare.text.nlp.Pipeline;
 import org.icij.datashare.user.User;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
# PR description

This PR aims at making it easier to develop Datashare locally.
I've manage to build DS and run some test by applying the following modifications.

# Changes

## `datashare-db`

### Changed
- Bumped `sqlite-jdbc` to `3.40.1.0` in order to support MacOs Silicon
- Set test user password in `/scr/reset_datashare_db.sh` in order to avoid to type the password when `PGPASSWORD` is not set
- Import `import org.jooq.Record` unambiguously (compilation failed on my laptop due to ambiguity with `java.lang.Record`)

