### PR TITLE
Proposal to rename user history api methods

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
@@ -78,8 +78,8 @@ public class UserResource {
         String[] projectIds = projects == null || projects.isBlank() ? new String[] {}: projects.trim().split(",");
         try {
             WebResponse<UserEvent> userEventWebResponse = new WebResponse<>(
-                    repository.getUserEvents(user, eventType, from, size, sortBy, isDesc, projectIds),
-                    repository.getTotalUserEvents(user, eventType));
+                    repository.getUserHistory(user, eventType, from, size, sortBy, isDesc, projectIds),
+                    repository.getUserHistorySize(user, eventType));
             return new Payload(userEventWebResponse);
         } catch (IllegalArgumentException e){
             return Payload.badRequest();
@@ -100,9 +100,9 @@ public class UserResource {
      * $(curl -i -XPUT  -H "Content-Type: application/json"  localhost:8080/api/users/me/history -d '{"type": "SEARCH", "projectIds": ["apigen-datashare","local-datashare"], "name": "foo AND bar", "uri": "?q=foo%20AND%20bar&from=0&size=100&sort=relevance&index=luxleaks&field=all&stamp=cotgpe"}')
      */
     @Put("/me/history")
-    public Payload addToHistory(UserHistoryQuery query, Context context) {
-        repository.addToHistory(query.projects, new UserEvent((DatashareUser) context.currentUser(), query.type, query.name, query.uri));
-        return Payload.ok();
+    public Payload addToUserHistory(UserHistoryQuery query, Context context) {
+        repository.addToUserHistory(query.projects, new UserEvent((DatashareUser) context.currentUser(), query.type, query.name, query.uri));
+        return ok();
     }
 
     /**
@@ -147,7 +147,7 @@ public class UserResource {
      */
     @Delete("/me/history/event?id=:eventId")
     public Payload deleteUserEvent(String eventId, Context context) {
-        repository.deleteUserEvent((DatashareUser) context.currentUser(), Integer.parseInt(eventId));
+        repository.deleteUserHistoryEvent((DatashareUser) context.currentUser(), Integer.parseInt(eventId));
         return new Payload(204);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
@@ -43,47 +43,47 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&sort=modification_date&desc=true").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_default_sort_and_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_sort_field() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "name",true)).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "name",true)).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&sort=name").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_sort_and_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "uri",false)).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "uri",false)).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&sort=uri&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
 
     @Test
     public void test_get_user_history_with_invalid_sort(){
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modificationDate",true)).thenThrow(new IllegalArgumentException("Invalid sort attribute : modificationDate"));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modificationDate",true)).thenThrow(new IllegalArgumentException("Invalid sort attribute : modificationDate"));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
         get("/api/users/me/history?type=document&from=0&size=10&sort=modificationDate").should().respond(400);
     }
     @Test
     public void test_get_user_history_with_default_desc_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
         get("/api/users/me/history?type=document&from=0&size=10&desc=TOTO").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
@@ -92,8 +92,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history_with__false_desc_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date",false)).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",false)).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
         get("/api/users/me/history?type=document&from=0&size=10&desc=FALSE").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
@@ -102,8 +102,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history_without_project_filter() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&projects=").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
         get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
@@ -112,22 +112,22 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history_with_one_project_filter() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto")).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto")).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
         get("/api/users/me/history?type=document&from=0&size=10&projects=toto").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
 
     @Test
     public void test_get_user_history_with_two_projects_filter() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto","titi")).thenReturn(singletonList(userEvent));
-        when(repository.getTotalUserEvents(User.local(), DOCUMENT)).thenReturn(1);
+        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto","titi")).thenReturn(singletonList(userEvent));
+        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
         get("/api/users/me/history?type=document&from=0&size=10&projects=toto,titi").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
 
     @Test
     public void test_put_user_event_to_history() {
-        when(repository.addToHistory(eq(singletonList(project("prj"))),any(UserEvent.class))).thenReturn(true);
+        when(repository.addToUserHistory(eq(singletonList(project("prj"))),any(UserEvent.class))).thenReturn(true);
 
         put("/api/users/me/history", "{\"type\": \"SEARCH\", \"projectIds\": [\"prj\"], \"name\": \"foo AND bar\", \"uri\": \"search_uri\"}").should().respond(200);
     }
@@ -143,7 +143,7 @@ public class UserResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_delete_user_event_by_id() {
-        when(repository.deleteUserEvent(User.local(), 1)).thenReturn(true).thenReturn(false);
+        when(repository.deleteUserHistoryEvent(User.local(), 1)).thenReturn(true).thenReturn(false);
 
         delete("/api/users/me/history/event?id=7").should().respond(204);
         delete("/api/users/me/history/event?id=1").should().respond(204);

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -177,7 +177,7 @@ public class JooqRepository implements Repository {
     }
 
     @Override
-    public boolean addToHistory(List<Project> projects, UserEvent userEvent) {
+    public boolean addToUserHistory(List<Project> projects, UserEvent userEvent) {
         return using(connectionProvider, dialect).transactionResult(configuration -> {
             DSLContext inner = using(configuration);
             InsertValuesStep6<UserHistoryRecord, Timestamp, Timestamp, String, Short, String, String> insertHistory = inner.
@@ -202,7 +202,7 @@ public class JooqRepository implements Repository {
     }
 
     @Override
-    public List<UserEvent> getUserEvents(User user, UserEvent.Type type, int from, int size, String sort, boolean desc, String... projectIds) {
+    public List<UserEvent> getUserHistory(User user, UserEvent.Type type, int from, int size, String sort, boolean desc, String... projectIds) {
         Field<?> sortBy = USER_HISTORY.MODIFICATION_DATE;
         if(sort != null && !sort.trim().isEmpty()){
             sortBy =  USER_HISTORY.field(sort);
@@ -229,7 +229,7 @@ public class JooqRepository implements Repository {
     }
 
     @Override
-    public int getTotalUserEvents(User user, UserEvent.Type type) {
+    public int getUserHistorySize(User user, UserEvent.Type type) {
         SelectConditionStep<Record1<Integer>> query = using(connectionProvider, dialect).selectCount().from(USER_HISTORY).
                 where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id));
         return query.fetchOne(0, int.class);
@@ -251,7 +251,7 @@ public class JooqRepository implements Repository {
     }
 
     @Override
-    public boolean deleteUserEvent(User user, int eventId) {
+    public boolean deleteUserHistoryEvent(User user, int eventId) {
         return using(connectionProvider, dialect).transactionResult(configuration -> {
             DSLContext inner = using(configuration);
             inner.deleteFrom(USER_HISTORY_PROJECT).

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -333,7 +333,7 @@ public class JooqRepositoryTest {
 
     @Test
     public void test_get_empty_user_history() {
-        assertThat(repository.getUserEvents(User.local(), SEARCH, 0, 10, "modification_date", true)).isEmpty();
+        assertThat(repository.getUserHistory(User.local(), SEARCH, 0, 10, "modification_date", true)).isEmpty();
     }
 
     @Test
@@ -347,17 +347,17 @@ public class JooqRepositoryTest {
         UserEvent userEvent2 = new UserEvent(User.local(), DOCUMENT, "doc_name2", Paths.get("uri2_doc").toUri(), date2, date2);
         UserEvent userEvent3 = new UserEvent(User.local(), DOCUMENT, "doc_name3", Paths.get("doc_uri3").toUri(), date3, date3);
 
-        repository.addToHistory(project, userEvent3);
-        repository.addToHistory(project, userEvent);
-        repository.addToHistory(project, userEvent2);
+        repository.addToUserHistory(project, userEvent3);
+        repository.addToUserHistory(project, userEvent);
+        repository.addToUserHistory(project, userEvent2);
 
-        List<UserEvent> userEvents = repository.getUserEvents(User.local(), DOCUMENT, 0, 10,null ,true);
+        List<UserEvent> userEvents = repository.getUserHistory(User.local(), DOCUMENT, 0, 10,null ,true);
         assertThat(userEvents).hasSize(3);
         assertThat(userEvents.get(0).modificationDate.getTime()).isEqualTo(date3.getTime());
         assertThat(userEvents.get(1).modificationDate.getTime()).isEqualTo(date2.getTime());
         assertThat(userEvents.get(2).modificationDate.getTime()).isEqualTo(date1.getTime());
 
-        List<UserEvent> userEventsAsc = repository.getUserEvents(User.local(), DOCUMENT, 0, 10,null ,false);
+        List<UserEvent> userEventsAsc = repository.getUserHistory(User.local(), DOCUMENT, 0, 10,null ,false);
         assertThat(userEventsAsc.get(0).modificationDate.getTime()).isEqualTo(date1.getTime());
         assertThat(userEventsAsc.get(1).modificationDate.getTime()).isEqualTo(date2.getTime());
         assertThat(userEventsAsc.get(2).modificationDate.getTime()).isEqualTo(date3.getTime());
@@ -372,17 +372,17 @@ public class JooqRepositoryTest {
         UserEvent userEvent2 = new UserEvent(User.local(), DOCUMENT, "doc_name2", Paths.get("uri2_doc").toUri(), date1, date1);
         UserEvent userEvent3 = new UserEvent(User.local(), DOCUMENT, "doc_name3", Paths.get("doc_uri3").toUri(), date1, date1);
 
-        repository.addToHistory(project, userEvent3);
-        repository.addToHistory(project, userEvent);
-        repository.addToHistory(project, userEvent2);
+        repository.addToUserHistory(project, userEvent3);
+        repository.addToUserHistory(project, userEvent);
+        repository.addToUserHistory(project, userEvent2);
 
-        List<UserEvent> userEvents = repository.getUserEvents(User.local(), DOCUMENT, 0, 10, USER_HISTORY.URI.getName() ,true);
+        List<UserEvent> userEvents = repository.getUserHistory(User.local(), DOCUMENT, 0, 10, USER_HISTORY.URI.getName() ,true);
         assertThat(userEvents).hasSize(3);
         assertThat(userEvents.get(0).uri.getPath()).contains("uri2_doc");
         assertThat(userEvents.get(1).uri.getPath()).contains("doc_uri3");
         assertThat(userEvents.get(2).uri.getPath()).contains("doc_uri1");
 
-        List<UserEvent> userEventsAsc = repository.getUserEvents(User.local(), DOCUMENT, 0, 10,USER_HISTORY.URI.getName() ,false);
+        List<UserEvent> userEventsAsc = repository.getUserHistory(User.local(), DOCUMENT, 0, 10,USER_HISTORY.URI.getName() ,false);
         assertThat(userEventsAsc.get(0).uri.getPath()).contains("doc_uri1");
         assertThat(userEventsAsc.get(1).uri.getPath()).contains("doc_uri3");
         assertThat(userEventsAsc.get(2).uri.getPath()).contains("uri2_doc");
@@ -391,7 +391,7 @@ public class JooqRepositoryTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_sort_user_history_with_wrong_value(){
-        repository.getUserEvents(User.local(), SEARCH, 0, 10, "modificationDate", true);
+        repository.getUserHistory(User.local(), SEARCH, 0, 10, "modificationDate", true);
     }
 
     @Test
@@ -401,14 +401,14 @@ public class JooqRepositoryTest {
         List<Project> project2 = asList(project("project"),project("project2"));
         List<Project> project1 = singletonList(project("project1"));
 
-        repository.addToHistory(project, new UserEvent(User.local(), DOCUMENT, "doc_name1", Paths.get("doc_uri1").toUri(), date1, date1));
-        repository.addToHistory(project2, new UserEvent(User.local(), DOCUMENT, "doc_name2", Paths.get("uri2_doc").toUri(), date1, date1));
-        repository.addToHistory(project1, new UserEvent(User.local(), DOCUMENT, "doc_name3", Paths.get("doc_uri3").toUri(), date1, date1));
+        repository.addToUserHistory(project, new UserEvent(User.local(), DOCUMENT, "doc_name1", Paths.get("doc_uri1").toUri(), date1, date1));
+        repository.addToUserHistory(project2, new UserEvent(User.local(), DOCUMENT, "doc_name2", Paths.get("uri2_doc").toUri(), date1, date1));
+        repository.addToUserHistory(project1, new UserEvent(User.local(), DOCUMENT, "doc_name3", Paths.get("doc_uri3").toUri(), date1, date1));
 
-        assertThat(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date", true, "project")).hasSize(2);
-        assertThat(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date", true, "project3", "project2")).hasSize(1);
-        assertThat(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date", true, "")).hasSize(0);
-        assertThat(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date", true )).hasSize(3);
+        assertThat(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true, "project")).hasSize(2);
+        assertThat(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true, "project3", "project2")).hasSize(1);
+        assertThat(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true, "")).hasSize(0);
+        assertThat(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true )).hasSize(3);
     }
 
     @Test
@@ -422,15 +422,15 @@ public class JooqRepositoryTest {
         UserEvent userEvent2 = new UserEvent(user, DOCUMENT, "doc_name2", Paths.get("doc_uri2").toUri(), date2, date2);
         UserEvent userEvent3 = new UserEvent(user2, DOCUMENT, "doc_name1", Paths.get("doc_uri1").toUri());
 
-        assertThat(repository.addToHistory(asList(project("project1"),project("project2")), userEvent)).isTrue();
-        assertThat(repository.addToHistory(singletonList(project("project")), userEvent2)).isTrue();
-        assertThat(repository.addToHistory(singletonList(project("project")), userEvent3)).isTrue();
-        assertThat(repository.getUserEvents(user, DOCUMENT, 0, 10, "modification_date", true)).containsSequence(userEvent2,userEvent);
-        assertThat(repository.getTotalUserEvents(user, DOCUMENT)).isEqualTo(2);
-        assertThat(repository.getUserEvents(user, DOCUMENT, 0, 1, "modification_date", true)).containsExactly(userEvent2);
-        assertThat(repository.getUserEvents(user2, DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvent3);
-        assertThat(repository.getTotalUserEvents(user2, DOCUMENT)).isEqualTo(1);
-        assertThat(repository.getUserEvents(user, SEARCH, 0, 10, "modification_date", true)).isEmpty();
+        assertThat(repository.addToUserHistory(asList(project("project1"),project("project2")), userEvent)).isTrue();
+        assertThat(repository.addToUserHistory(singletonList(project("project")), userEvent2)).isTrue();
+        assertThat(repository.addToUserHistory(singletonList(project("project")), userEvent3)).isTrue();
+        assertThat(repository.getUserHistory(user, DOCUMENT, 0, 10, "modification_date", true)).containsSequence(userEvent2,userEvent);
+        assertThat(repository.getUserHistorySize(user, DOCUMENT)).isEqualTo(2);
+        assertThat(repository.getUserHistory(user, DOCUMENT, 0, 1, "modification_date", true)).containsExactly(userEvent2);
+        assertThat(repository.getUserHistory(user2, DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvent3);
+        assertThat(repository.getUserHistorySize(user2, DOCUMENT)).isEqualTo(1);
+        assertThat(repository.getUserHistory(user, SEARCH, 0, 10, "modification_date", true)).isEmpty();
     }
 
     @Test
@@ -440,36 +440,36 @@ public class JooqRepositoryTest {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", Paths.get("doc_uri").toUri(), date1, date1);
         UserEvent userEvent2 = new UserEvent(User.local(), DOCUMENT, "doc_name", Paths.get("doc_uri").toUri(), date2, date2);
 
-        assertThat(repository.addToHistory(singletonList(project("project")), userEvent)).isTrue();
-        assertThat(repository.addToHistory(singletonList(project("project")), userEvent2)).isTrue();
+        assertThat(repository.addToUserHistory(singletonList(project("project")), userEvent)).isTrue();
+        assertThat(repository.addToUserHistory(singletonList(project("project")), userEvent2)).isTrue();
 
-        assertThat(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvent);
+        assertThat(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvent);
     }
 
     @Test
     public void test_delete_user_event_by_type() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", Paths.get("doc_uri").toUri());
         UserEvent userEvent2 = new UserEvent(User.local(), SEARCH, "search_name", Paths.get("search_uri").toUri());
-        repository.addToHistory(singletonList(project("project")), userEvent);
-        repository.addToHistory(singletonList(project("project")), userEvent2);
+        repository.addToUserHistory(singletonList(project("project")), userEvent);
+        repository.addToUserHistory(singletonList(project("project")), userEvent2);
 
-        assertThat(repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvent);
+        assertThat(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvent);
         assertThat(repository.deleteUserHistory(User.local(), DOCUMENT)).isTrue();
         assertThat(repository.deleteUserHistory(User.local(), DOCUMENT)).isFalse();
-        assertThat(repository.getTotalUserEvents(User.local(),DOCUMENT)).isEqualTo(0);
-        assertThat(repository.getUserEvents(User.local(),SEARCH, 0, 10, "modification_date", true)).containsExactly(userEvent2);
+        assertThat(repository.getUserHistorySize(User.local(),DOCUMENT)).isEqualTo(0);
+        assertThat(repository.getUserHistory(User.local(),SEARCH, 0, 10, "modification_date", true)).containsExactly(userEvent2);
     }
 
     @Test
     public void test_delete_single_user_event_by_id() {
         Date date = new Date(new Date().getTime());
-        repository.addToHistory(singletonList(project("project")), new UserEvent(User.local(), DOCUMENT, "doc_name1", Paths.get("doc_uri1").toUri()));
-        repository.addToHistory(singletonList(project("project")), new UserEvent(User.local(), DOCUMENT, "doc_name2", Paths.get("doc_uri2").toUri()));
-        List<UserEvent> userEvents = repository.getUserEvents(User.local(), DOCUMENT, 0, 10, "modification_date", true);
+        repository.addToUserHistory(singletonList(project("project")), new UserEvent(User.local(), DOCUMENT, "doc_name1", Paths.get("doc_uri1").toUri()));
+        repository.addToUserHistory(singletonList(project("project")), new UserEvent(User.local(), DOCUMENT, "doc_name2", Paths.get("doc_uri2").toUri()));
+        List<UserEvent> userEvents = repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true);
 
-        assertThat(repository.deleteUserEvent(User.local(), userEvents.get(1).id)).isTrue();
-        assertThat(repository.deleteUserEvent(User.local(), userEvents.get(1).id)).isFalse();
-        assertThat(repository.getUserEvents(User.local(),DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvents.get(0));
+        assertThat(repository.deleteUserHistoryEvent(User.local(), userEvents.get(1).id)).isTrue();
+        assertThat(repository.deleteUserHistoryEvent(User.local(), userEvents.get(1).id)).isFalse();
+        assertThat(repository.getUserHistory(User.local(),DOCUMENT, 0, 10, "modification_date", true)).containsExactly(userEvents.get(0));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>8.8.0</datashare-api.version>
+        <datashare-api.version>9.0.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
Rename user history methods to prevent confusion coming from https://github.com/ICIJ/datashare-api/commit/ceb7930c75293f4cd682cca5a9756372d9beee46