### PR TITLE
Fix: sanitize parameters

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -98,20 +98,7 @@ public class DocumentResource {
         if (((DatashareUser)context.currentUser()).isGranted(project) &&
                 isAllowed(repository.getProject(project), context.request().clientAddress())) {
             try {
-                ExtractedText extractedText;
-                if(routing == null){
-                    if(targetLanguage!=null){
-                        extractedText = indexer.getExtractedText(project, id, offset, limit, targetLanguage);
-                    } else {
-                        extractedText = indexer.getExtractedText(project, id, offset, limit);
-                    }
-                }else{
-                    if(targetLanguage!=null) {
-                        extractedText = indexer.getExtractedText(project, id, routing, offset, limit, targetLanguage);
-                    } else {
-                        extractedText = indexer.getExtractedText(project, id, routing, offset, limit);
-                    }
-                }
+                ExtractedText extractedText = indexer.getExtractedText(project, id, routing, offset, limit, targetLanguage);
                 return new Payload(extractedText).withCode(200);
             }
             catch (StringIndexOutOfBoundsException e){

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.web;
 
-import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
 import org.icij.datashare.session.LocalUserFilter;
@@ -265,10 +264,9 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
         when(repository.getProject("local-datashare")).thenReturn(null);
         get("/api/local-datashare/documents/src/docId?routing=root").should().respond(200);
     }
-
     @Test
     public void test_get_document_extracted_text() throws IOException {
-        when(indexer.getExtractedText("local-datashare", "docId", 5, 6)).thenReturn(new ExtractedText("content", 5, 6, 7));
+        when(indexer.getExtractedText("local-datashare", "docId", null,5, 6, null)).thenReturn(new ExtractedText("content", 5, 6, 7));
         get("/api/local-datashare/documents/content/docId?offset=5&limit=6").should().respond(200)
                 .should()
                 .haveType("application/json")
@@ -277,9 +275,28 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
                 .contain("\"limit\":6")
                 .contain("\"maxOffset\":7");
     }
+
+    @Test
+    public void test_get_document_extracted_text_with_routing() throws IOException {
+        when(indexer.getExtractedText("local-datashare", "docId", "routingId", 5, 6, null)).thenReturn(new ExtractedText("content", 5, 6, 7));
+        get("/api/local-datashare/documents/content/docId?offset=5&limit=6&routing=routingId").should().respond(200)
+                .should()
+                .haveType("application/json")
+                .contain("\"content\":\"content\"")
+                .contain("\"offset\":5")
+                .contain("\"limit\":6")
+                .contain("\"maxOffset\":7");
+    }
+
+    @Test
+    public void test_get_document_extracted_text_with_blank_target_language() throws IOException {
+        when(indexer.getExtractedText("local-datashare", "docId",null, 5, 6, "")).thenReturn(new ExtractedText("content", 5, 6, 7));
+        get("/api/local-datashare/documents/content/docId?offset=5&limit=6&targetLanguage").should().respond(200);
+    }
+
     @Test
     public void test_get_document_extracted_text_with_out_of_bound_args() throws IOException {
-        when(indexer.getExtractedText("local-datashare", "docId", 6, -2))
+        when(indexer.getExtractedText("local-datashare", "docId",null, 6, -2, null))
                 .thenThrow(
                         new StringIndexOutOfBoundsException("Range [6-4] is out of document range ([0-10])")
                 );
@@ -290,7 +307,7 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     }
     @Test
     public void test_get_document_extracted_text_not_found() throws IOException {
-        when(indexer.getExtractedText("local-datashare", "notFoundDoc", 6, -2))
+        when(indexer.getExtractedText("local-datashare", "notFoundDoc", null,6, -2,null))
                 .thenThrow(
                         new IllegalArgumentException("Document not found")
                 );
@@ -301,7 +318,7 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_document_translated_extracted_text() throws IOException {
-        when(indexer.getExtractedText("local-datashare", "docId", 5, 6,"french"))
+        when(indexer.getExtractedText("local-datashare", "docId", null, 5, 6,"french"))
                 .thenReturn(new ExtractedText("content", 5, 6, 7, "french"));
         get("/api/local-datashare/documents/content/docId?offset=5&limit=6&targetLanguage=french").should().respond(200)
                 .should()
@@ -314,7 +331,7 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     }
     @Test
     public void test_get_document_translated_extracted_text_with_unknown_target_language() throws IOException {
-        when(indexer.getExtractedText("local-datashare", "docId", 5, 6,"unknown"))
+        when(indexer.getExtractedText("local-datashare", "docId", null,5, 6,"unknown"))
                 .thenThrow(
                         new IllegalArgumentException("Translated content in 'unknown' not found")
                 );

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -48,6 +48,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -245,17 +246,11 @@ public class ElasticsearchIndexer implements Indexer {
                 ElasticsearchIndexer.getScriptStringFromFile("extractedText.painless.java"),params);
     }
 
-    public ExtractedText getExtractedText(String indexName, String id, final int offset, final int limit, final String targetLanguage) throws IOException{
-        return getExtractedText(indexName, id, id, offset, limit, targetLanguage);
-    }
+
     public ExtractedText getExtractedText(String indexName, String id, String routing, final int offset, final int limit, String targetLanguage) throws IOException {
-        return this.getExtractedContent(indexName, id, routing, offset, limit, targetLanguage);
-    }
-    public ExtractedText getExtractedText(String indexName, String id, final int offset, final int limit) throws IOException {
-        return getExtractedContent(indexName, id, id, offset, limit, null);
-    }
-    public ExtractedText getExtractedText(String indexName, String id, String routing, final int offset, final int limit) throws IOException {
-        return this.getExtractedContent(indexName, id, routing, offset, limit, null);
+        String nullRouting = Optional.ofNullable(routing).filter(Predicate.not(String::isBlank)).orElse(id);
+        String nullTargetLanguage = Optional.ofNullable(targetLanguage).filter(Predicate.not(String::isBlank)).orElse(null);
+        return this.getExtractedContent(indexName, id, nullRouting, offset, limit, nullTargetLanguage);
     }
 
     private ExtractedText getExtractedContent(String indexName, String id, String routing, final int offset, final int limit, String targetLanguage) throws IOException {

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
@@ -434,7 +434,7 @@ public class ElasticsearchIndexerTest {
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
 
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 0, 10);
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 0, 10, null);
         assertThat(actual.content).isEqualTo("content wi");
         assertThat(actual.content.length()).isEqualTo(10);
         assertThat(actual.maxOffset).isEqualTo(21);
@@ -445,7 +445,7 @@ public class ElasticsearchIndexerTest {
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
 
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 10, 10);
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 10, 10, null);
         assertThat(actual.content).isEqualTo("th john do");
         assertThat(actual.content.length()).isEqualTo(10);
     }
@@ -455,7 +455,7 @@ public class ElasticsearchIndexerTest {
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
 
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 20, 1);
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 20, 1, null);
         assertThat(actual.content).isEqualTo("e");
         assertThat(actual.content.length()).isEqualTo(1);
     }
@@ -465,7 +465,7 @@ public class ElasticsearchIndexerTest {
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
 
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 21, 0);
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 21, 0, null);
         assertThat(actual.content).isEqualTo("");
         assertThat(actual.content.length()).isEqualTo(0);
     }
@@ -474,21 +474,21 @@ public class ElasticsearchIndexerTest {
         Document doc = new org.icij.datashare.text.Document("id", project("prj"), Paths.get("doc.txt"), "content with john doe",
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
-        indexer.getExtractedText(TEST_INDEX, "id", -10, 1);
+        indexer.getExtractedText(TEST_INDEX, "id", null, -10, 1, null);
     }
     @Test(expected = IndexOutOfBoundsException.class)
     public void test_get_slice_of_document_content_with_negative_start() throws Exception {
         Document doc = new org.icij.datashare.text.Document("id", project("prj"), Paths.get("doc.txt"), "content with john doe",
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
-        indexer.getExtractedText(TEST_INDEX, "id", 1, -10);
+        indexer.getExtractedText(TEST_INDEX, "id", null, 1, -10, null);
     }
     @Test(expected = IndexOutOfBoundsException.class)
     public void test_get_slice_of_document_content_with_oversize() throws Exception {
         Document doc = new org.icij.datashare.text.Document("id", project("prj"), Paths.get("doc.txt"), "content with john doe",
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 0, 22);
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 0, 22, null);
     }
     @Test(expected = IndexOutOfBoundsException.class)
     public void test_get_slice_of_document_content_with_out_of_range_limit() throws Exception {
@@ -496,12 +496,12 @@ public class ElasticsearchIndexerTest {
                 Language.FRENCH, Charset.defaultCharset(), "application/pdf", new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
 
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 10, 18);
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 10, 18, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_get_slice_of_document_not_found() throws Exception {
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 10, 18);
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 10, 18, null);
     }
     @Test(expected = IllegalArgumentException.class)
     public void test_get_slice_of_translated_document_not_found() throws Exception {
@@ -517,7 +517,7 @@ public class ElasticsearchIndexerTest {
                 new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
 
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 10, 18, "unknown");
+        indexer.getExtractedText(TEST_INDEX, "id", null, 10, 18, "unknown");
     }
 
     @Test
@@ -534,7 +534,7 @@ public class ElasticsearchIndexerTest {
                 new HashMap<>(), INDEXED, new HashSet<>(), 34L);
         indexer.add(TEST_INDEX, doc);
 
-        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", 0, 7, "ENGLISH");
+        ExtractedText actual = indexer.getExtractedText(TEST_INDEX, "id", null, 0, 7, "ENGLISH");
         assertThat(actual.content).isEqualTo("content");
         assertThat(actual.content.length()).isEqualTo(7);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>9.0.1</datashare-api.version>
+        <datashare-api.version>9.0.2</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
Sanitize parameters:
Restriction on index format (alpha/num/hyphen/dash)
Restriction on indices format (comma separated)
Prevent empty or null routingId or targetLangage on extracted text