### PR TITLE
feat: set up ES path tokenizer delimiter on windows

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
@@ -26,12 +26,14 @@ import java.net.URLDecoder;
 
 import static com.google.common.io.ByteStreams.toByteArray;
 import static java.lang.String.format;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.apache.http.HttpHost.create;
 import static org.elasticsearch.common.xcontent.XContentType.JSON;
 
 public class ElasticsearchConfiguration {
     static final String MAPPING_RESOURCE_NAME = "datashare_index_mappings.json";
     static final String SETTINGS_RESOURCE_NAME = "datashare_index_settings.json";
+    static final String SETTINGS_RESOURCE_NAME_WINDOWS = "datashare_index_settings_windows.json";
     static final int INDEX_MAX_RESULT_WINDOW = 100000;
     static Logger LOGGER = LoggerFactory.getLogger(ElasticsearchConfiguration.class);
 
@@ -101,7 +103,11 @@ public class ElasticsearchConfiguration {
             if (!client.indices().exists(request, RequestOptions.DEFAULT)) {
                 LOGGER.info("index {} does not exist, creating one", indexName);
                 CreateIndexRequest createReq = new CreateIndexRequest(indexName);
-                createReq.settings(getResourceContent(SETTINGS_RESOURCE_NAME), JSON);
+                if (IS_OS_WINDOWS) {
+                    createReq.settings(getResourceContent(SETTINGS_RESOURCE_NAME_WINDOWS), JSON);
+                } else {
+                    createReq.settings(getResourceContent(SETTINGS_RESOURCE_NAME), JSON);
+                }
                 createReq.mapping(getResourceContent(MAPPING_RESOURCE_NAME), JSON);
                 client.indices().create(createReq, RequestOptions.DEFAULT);
                 return true;

--- a/datashare-index/src/main/resources/datashare_index_settings_windows.json
+++ b/datashare-index/src/main/resources/datashare_index_settings_windows.json
@@ -1,0 +1,40 @@
+{
+  "index.mapping.total_fields.limit": 100000,
+  "index.number_of_shards" : 1,
+  "index.query.default_field": [
+    "content",
+    "mentionNorm",
+    "content_translated",
+    "metadata.tika_metadata_author",
+    "metadata.tika_metadata_creator",
+    "metadata.tika_metadata_dc_creator",
+    "metadata.tika_metadata_dc_title",
+    "metadata.tika_metadata_message_from",
+    "metadata.tika_metadata_message_to",
+    "metadata.tika_metadata_meta_author",
+    "metadata.tika_metadata_subject",
+    "metadata.tika_metadata_title",
+    "name",
+    "path",
+    "tags"
+  ],
+  "analysis": {
+    "analyzer": {
+      "path_analyzer": {
+        "tokenizer": "path_tokenizer"
+      }
+    },
+    "tokenizer": {
+      "path_tokenizer": {
+        "type": "path_hierarchy",
+        "delimiter": "\\"
+      }
+    },
+    "normalizer": {
+      "keyword_lowercase": {
+        "type": "custom",
+        "filter": ["lowercase"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
On Windows, Elasticsearch doesn't manage paths properly. This PR aims to create an index with [settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-pathhierarchy-tokenizer.html#_example_configuration_9) specially made for Windows