### PR TITLE
Refactor: use documentBuilder and add full extracted text content and translated content to API

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -281,8 +281,10 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     }
     @Test
     public void test_get_document_content() throws IOException {
+
         HashMap<String, String> language = new HashMap<>() {{
-            put("fr", "mon-contenu");
+            put("target_language", "fr");
+            put("content", "mon-contenu");
         }};
         List<Map<String,String>> langs = new ArrayList<>();
         langs.add(language);
@@ -293,10 +295,10 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
                 .with(langs).build();
         when(repository.getDocument("docId")).thenReturn(doc);
         get("/api/local-datashare/documents/content/docId").should().respond(200)
-                .haveType("text/html;charset=UTF-8")
+                .haveType("application/json;charset=UTF-8")
                 .contain("my-content");
         get("/api/local-datashare/documents/content/docId?targetLanguage=fr").should().respond(200)
-                .haveType("text/html;charset=UTF-8")
+                .haveType("application/json;charset=UTF-8")
                 .contain("mon-contenu");
     }
 

--- a/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
@@ -2,6 +2,7 @@ package org.icij.datashare.db;
 
 import org.icij.datashare.Repository;
 import org.icij.datashare.text.Document;
+import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.LanguageGuesser;
 import org.icij.extract.document.TikaDocument;
@@ -10,14 +11,12 @@ import org.icij.spewer.Spewer;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 
 import static java.lang.Long.valueOf;
 import static java.util.Optional.ofNullable;
-import static org.apache.tika.metadata.HttpHeaders.CONTENT_ENCODING;
-import static org.apache.tika.metadata.HttpHeaders.CONTENT_LENGTH;
-import static org.apache.tika.metadata.HttpHeaders.CONTENT_TYPE;
+import static org.apache.tika.metadata.HttpHeaders.*;
 
 public class DatabaseSpewer extends Spewer {
     private final Project project;
@@ -41,9 +40,23 @@ public class DatabaseSpewer extends Spewer {
         String parentId = parent == null ? null: parent.getId();
         String rootId = root == null ? null: root.getId();
 
-        Document document = new Document(project, tikaDocument.getId(), tikaDocument.getPath(), content,
-                languageGuesser.guess(content), charset, contentType, getMetadata(tikaDocument), Document.Status.INDEXED, new HashSet<>(), new Date(),
-                parentId, rootId, (short) level, contentLength);
+        Document document = DocumentBuilder.createDoc().
+                with(project).
+                withId(tikaDocument.getId()).
+                with(tikaDocument.getPath()).
+                with(Document.Status.PARSED).
+                with(content).
+                with(languageGuesser.guess(content)).
+                with(charset).
+                ofMimeType(contentType).
+                with(getMetadata(tikaDocument)).
+                with(new ArrayList<>()).
+                extractedAt(new Date()).
+                withParentId(parentId).
+                withRootId(rootId).
+                withExtractionLevel((short) level).
+                withContentLength(contentLength).
+                build();
         repository.create(document);
     }
 }

--- a/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
@@ -5,6 +5,7 @@ import org.icij.datashare.text.Document;
 import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.LanguageGuesser;
+import org.icij.datashare.text.nlp.Pipeline;
 import org.icij.extract.document.TikaDocument;
 import org.icij.spewer.FieldNames;
 import org.icij.spewer.Spewer;
@@ -13,6 +14,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 
 import static java.lang.Long.valueOf;
 import static java.util.Optional.ofNullable;
@@ -56,6 +58,7 @@ public class DatabaseSpewer extends Spewer {
                 withRootId(rootId).
                 withExtractionLevel((short) level).
                 withContentLength(contentLength).
+                with(new Pipeline.Type[]{}).
                 build();
         repository.create(document);
     }

--- a/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 
 import static java.lang.Long.valueOf;
 import static java.util.Optional.ofNullable;

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -444,7 +444,7 @@ public class JooqRepository implements Repository {
     private NamedEntity createFrom(NamedEntityRecord record) {
         try {
             return NamedEntity.create(NamedEntity.Category.parse(record.getCategory()),
-                    record.getMention(), getLongList(record.getOffsets()),
+                    record.getMention(), MAPPER.readValue(record.getOffsets(), List.class),
                     record.getDocId(), record.getRootId(), Pipeline.Type.fromCode(record.getExtractor()),
                     Language.parse(record.getExtractorLanguage()));
         } catch (IOException e) {
@@ -456,7 +456,7 @@ public class JooqRepository implements Repository {
         DocumentRecord documentRecord = result.into(DOCUMENT);
         Map<String, Object> metadata;
         try {
-            metadata = getHashMapStringObject(documentRecord.getMetadata());
+            metadata = MAPPER.readValue(documentRecord.getMetadata(), HashMap.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -469,7 +469,7 @@ public class JooqRepository implements Repository {
                 .with(documentRecord.getContent())
                 .with(parse(documentRecord.getLanguage()))
                 .with(forName(documentRecord.getCharset()))
-                .with(documentRecord.getContentType())
+                .ofMimeType(documentRecord.getContentType())
                 .with(metadata)
                 .with(nerTags)
                 .with(fromCode(documentRecord.getStatus()))

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -456,6 +456,7 @@ public class JooqRepository implements Repository {
         DocumentRecord documentRecord = result.into(DOCUMENT);
         Map<String, Object> metadata;
         try {
+            // type check
             metadata = MAPPER.readValue(documentRecord.getMetadata(), HashMap.class);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/datashare-db/src/test/java/org/icij/datashare/db/BenchDocument.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/BenchDocument.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.db;
 
 import org.icij.datashare.text.Document;
+import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Language;
 import org.icij.datashare.text.NamedEntity;
 import org.icij.datashare.text.nlp.Pipeline;
@@ -30,12 +31,12 @@ public class BenchDocument {
         logger.info("writing {} documents with {} named entities", nbDocs, nbNes);
         long beginTime = System.currentTimeMillis();
         for (int docIdx = 0; docIdx < nbDocs; docIdx++) {
-            Document document = new Document(project("prj"), Paths.get("/foo/bar_" + docIdx + ".txt"),
-                    "This is a content with Gael Giraud " + docIdx,
-                    Language.FRENCH,
-                    Charset.defaultCharset(),
-                    "text/plain",
-                    new HashMap<String, Object>() {{
+            Document document = DocumentBuilder.createDoc(project("prj"), Paths.get("/foo/bar_" + docIdx + ".txt"))
+                    .with("This is a content with Gael Giraud " + docIdx)
+                    .with(Language.FRENCH)
+                    .with(Charset.defaultCharset())
+                    .ofMimeType("text/plain")
+                    .with(new HashMap<String, Object>() {{
                         put("key1", "value1");
                         put("key2", "value2");
                         put("key3", "value3");
@@ -46,8 +47,11 @@ public class BenchDocument {
                         put("key8", "value8");
                         put("key9", "value9");
                         put("key10", "value10");
-                    }},
-                    Document.Status.INDEXED, 345L);
+                    }})
+                    .with(Document.Status.INDEXED)
+                    .withContentLength(345L)
+                    .build();
+
             repository.create(document);
 
             List<NamedEntity> neList = new ArrayList<>();

--- a/datashare-db/src/test/java/org/icij/datashare/db/DatabaseSpewerTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/DatabaseSpewerTest.java
@@ -45,8 +45,8 @@ public class DatabaseSpewerTest {
         Files.write(file.toPath(), singletonList("chaîne en iso8859"), forName("ISO-8859-1"));
         TikaDocument tikaDocument = new Extractor().extract(file.toPath());
 
+        System.out.println("************ " + tikaDocument.getId());
         dbSpewer.write(tikaDocument);
-
         Document actual = dbSpewer.repository.getDocument(tikaDocument.getId());
         assertThat(actual.getContent()).isEqualTo("chaîne en iso8859");
         assertThat(actual.getContentEncoding()).isEqualTo(forName("iso8859-1"));

--- a/datashare-db/src/test/java/org/icij/datashare/db/DatabaseSpewerTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/DatabaseSpewerTest.java
@@ -45,7 +45,6 @@ public class DatabaseSpewerTest {
         Files.write(file.toPath(), singletonList("chaîne en iso8859"), forName("ISO-8859-1"));
         TikaDocument tikaDocument = new Extractor().extract(file.toPath());
 
-        System.out.println("************ " + tikaDocument.getId());
         dbSpewer.write(tikaDocument);
         Document actual = dbSpewer.repository.getDocument(tikaDocument.getId());
         assertThat(actual.getContent()).isEqualTo("chaîne en iso8859");

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -5,11 +5,7 @@ import org.icij.datashare.Note;
 import org.icij.datashare.Repository;
 import org.icij.datashare.UserEvent;
 import org.icij.datashare.test.DatashareTimeRule;
-import org.icij.datashare.text.Document;
-import org.icij.datashare.text.NamedEntity;
-import org.icij.datashare.text.Project;
-import org.icij.datashare.text.Tag;
-import org.icij.datashare.text.nlp.Pipeline;
+import org.icij.datashare.text.*;
 import org.icij.datashare.user.User;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,13 +51,20 @@ public class JooqRepositoryTest {
 
     @Test
     public void test_create_document() throws Exception {
-        Document document = new Document("id", project("prj"), Paths.get("/path/to/doc"), "content",
-                FRENCH, Charset.defaultCharset(),
-                "text/plain", new HashMap<String, Object>() {{
-            put("key 1", "value 1");
-            put("key 2", "value 2");
-        }},
-                Document.Status.INDEXED, Pipeline.set(CORENLP, OPENNLP), 432L);
+
+        Document document = DocumentBuilder.createDoc("id")
+                .with(project("prj"))
+                .with(Paths.get("/path/to/doc"))
+                .with("content")
+                .with(FRENCH).with(Charset.defaultCharset())
+                .with("text/plain")
+                .with(new HashMap<>() {{
+                    put("key 1", "value 1");
+                    put("key 2", "value 2");
+                }})
+                .with(Document.Status.INDEXED)
+                .with(CORENLP, OPENNLP)
+                .withContentLength(432L).build();
 
         repository.create(document);
 
@@ -75,14 +78,27 @@ public class JooqRepositoryTest {
 
     @Test
     public void test_get_untagged_documents() throws Exception {
-        Document coreAndOpenNlp = new Document("idCore", project("prj"), Paths.get("/path/to/coreAndOpenNlp"), "coreAndOpenNlp",
-                FRENCH, Charset.defaultCharset(),
-                "text/plain", new HashMap<>(),
-                Document.Status.INDEXED, Pipeline.set(CORENLP, OPENNLP), 432L);
-        Document ixaPipe = new Document("idIxa", project("prj"), Paths.get("/path/to/ixaPipe"), "ixaPipe",
-                FRENCH, Charset.defaultCharset(),
-                "text/plain", new HashMap<>(),
-                Document.Status.INDEXED, Pipeline.set(IXAPIPE), 234L);
+        Document coreAndOpenNlp = DocumentBuilder.createDoc("idCore")
+                .with(project("prj"))
+                .with(Paths.get("/path/to/coreAndOpenNlp"))
+                .with("coreAndOpenNlp")
+                .with(FRENCH).with(Charset.defaultCharset())
+                .with("text/plain")
+                .with(new HashMap<>())
+                .with(Document.Status.INDEXED)
+                .with(CORENLP, OPENNLP)
+                .withContentLength(432L).build();
+        Document ixaPipe = DocumentBuilder.createDoc("idIxa")
+                .with(project("prj"))
+                .with(Paths.get("/path/to/ixaPipe"))
+                .with("ixaPipe")
+                .with(FRENCH).with(Charset.defaultCharset())
+                .with("text/plain")
+                .with(new HashMap<>())
+                .with(Document.Status.INDEXED)
+                .with(IXAPIPE)
+                .withContentLength(234L).build();
+
         repository.create(coreAndOpenNlp);
         repository.create(ixaPipe);
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -259,7 +259,7 @@ public class ElasticsearchIndexer implements Indexer {
             throw new StringIndexOutOfBoundsException(format("offset or limit should not be negative (offset=%d, limit=%d)", offset, limit));
         }
         sourceBuilder.query(boolQuery().must(termsQuery("_id", id)));
-        Script script= this.getExtractedTextScript(offset, limit, targetLanguage);;
+        Script script= this.getExtractedTextScript(offset, limit, targetLanguage);
         sourceBuilder.scriptField("pagination", script);
         SearchRequest searchRequest = new SearchRequest(new String[] {indexName}, sourceBuilder);
         SearchResponse search = client.search(searchRequest.routing(routing), RequestOptions.DEFAULT);

--- a/datashare-index/src/main/resources/extractedText.painless.java
+++ b/datashare-index/src/main/resources/extractedText.painless.java
@@ -17,8 +17,8 @@ int end = params.offset+params.limit;
 try{
     if(params.targetLanguage != null) {
         String content = getTranslationContent(params._source,params.targetLanguage);
-        String contentResized = content.substring(params.offset, end);
         maxOffset = content.length();
+        String contentResized = content.substring(params.offset, end);
         return [
             "content": contentResized,
             "maxOffset":maxOffset,

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
@@ -51,7 +51,7 @@ public class DatashareExtractIntegrationTest {
         assertThat(doc.getLanguage()).isEqualTo(ENGLISH);
         assertThat(doc.getContentLength()).isEqualTo(45);
         assertThat(doc.getDirname()).contains(get("docs"));
-        assertThat(doc.getStatus()).isEqualTo(Document.Status.PARSED);
+        assertThat(doc.getStatus()).isEqualTo(Document.Status.INDEXED);
         assertThat(doc.getPath()).contains(get("doc.txt"));
         assertThat(doc.getContentEncoding()).isEqualTo(Charset.forName("iso-8859-1"));
         assertThat(doc.getContentType()).isEqualTo("text/plain");

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
@@ -51,6 +51,7 @@ public class DatashareExtractIntegrationTest {
         assertThat(doc.getLanguage()).isEqualTo(ENGLISH);
         assertThat(doc.getContentLength()).isEqualTo(45);
         assertThat(doc.getDirname()).contains(get("docs"));
+        assertThat(doc.getStatus()).isEqualTo(Document.Status.PARSED);
         assertThat(doc.getPath()).contains(get("doc.txt"));
         assertThat(doc.getContentEncoding()).isEqualTo(Charset.forName("iso-8859-1"));
         assertThat(doc.getContentType()).isEqualTo("text/plain");

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -34,7 +34,6 @@ import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,7 +45,9 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
-import static org.junit.Assert.*;
+import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
@@ -216,11 +217,14 @@ public class ElasticsearchSpewerTest {
         extractor.setDigester(new UpdatableDigester("project", Document.HASHER.toString()));
 
         final TikaDocument extractDocument = extractor.extract(get(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).getPath()));
-
-        Document document = new Document(Project.project("project"), get(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).getPath()),
-                "This is a document to be parsed by datashare.",
-                Language.FRENCH, Charset.defaultCharset(), "text/plain", convert(extractDocument.getMetadata()),
-                Document.Status.INDEXED, 45L);
+        Document document = createDoc(Project.project("project"),get(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).getPath()))
+                .with("This is a document to be parsed by datashare.")
+                .with(Language.FRENCH)
+                .ofMimeType("text/plain")
+                .with(convert(extractDocument.getMetadata()))
+                .with(Document.Status.INDEXED)
+                .withContentLength(45L)
+                .build();
 
         assertThat(document.getId()).isEqualTo(extractDocument.getId());
     }

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
@@ -4,6 +4,7 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.com.Publisher;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.Document;
+import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Language;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.document.TikaDocument;
@@ -34,9 +35,14 @@ public class SourceExtractorTest {
 
     @Test
     public void test_get_source_for_root_doc() throws IOException {
-        Document document = new Document(project("project"), get(getClass().getResource("/docs/embedded_doc.eml").getPath()), "it has been parsed",
-                    Language.FRENCH, Charset.defaultCharset(), "message/rfc822", new HashMap<>(),
-                    Document.Status.INDEXED, 45L);
+        Document document = DocumentBuilder.createDoc(project("project"),get(getClass().getResource("/docs/embedded_doc.eml").getPath()))
+                .with("it has been parsed")
+                .with(Language.FRENCH)
+                .with(Charset.defaultCharset())
+                .ofMimeType("message/rfc822")
+                .with(new HashMap<>())
+                .with(Document.Status.INDEXED)
+                .withContentLength(45L).build();
 
         InputStream source = new SourceExtractor().getSource(document);
         assertThat(source).isNotNull();
@@ -45,9 +51,14 @@ public class SourceExtractorTest {
 
     @Test
     public void test_get_source_for_doc_and_pdf_with_without_metadata() throws IOException {
-        Document document = new Document(project("project"), get(getClass().getResource("/docs/office_document.doc").getPath()), null,
-                Language.ENGLISH, Charset.defaultCharset(), "application/msword", new HashMap<>(),
-                Document.Status.INDEXED, 0L);
+        Document document = DocumentBuilder.createDoc(project("project"),get(getClass().getResource("/docs/office_document.doc").getPath()))
+                .with((String) null)
+                .with(Language.ENGLISH)
+                .with(Charset.defaultCharset())
+                .ofMimeType("application/msword")
+                .with(new HashMap<>())
+                .with(Document.Status.INDEXED)
+                .withContentLength(0L).build();
 
         InputStream inputStreamWithMetadata = new SourceExtractor(false).getSource(document);
         InputStream inputStreamWithoutMetadata = new SourceExtractor(true).getSource(document);

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>9.0.2</datashare-api.version>
+        <datashare-api.version>9.1.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>9.2.0-SNAPSHOT</datashare-api.version>
+        <datashare-api.version>10.0.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>9.1.0</datashare-api.version>
+        <datashare-api.version>9.2.0-SNAPSHOT</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
This PR results from an update of the datashare api  (https://github.com/ICIJ/datashare-api/pull/11) about document, document builder and extracted text and is a mix of two refactors :

1/ Retrieve complete content and translation:
- Add API endpoint for retrieving complete text and translation on the extract text endpoint (@09622722aa6955c61bf1b0d2be3e244a837d8231)

2/ Document builder:
- Use document builder instead of document constructor to avoid endless list of constructor
- Update tests and code accordingly

Not fixed: 
Warning concerning Type reference in JSON serializer (Mapper readvalue) has not been changed to avoid a bigger refactor. 


This PR has been made with @bthomas. All commits will be squashed and merged to have a proper history.
 