### PR TITLE
fix: add missing nested fields for content_translated

### DIFF
--- a/datashare-index/src/main/resources/datashare_index_settings.json
+++ b/datashare-index/src/main/resources/datashare_index_settings.json
@@ -4,7 +4,7 @@
   "index.query.default_field": [
     "content",
     "mentionNorm",
-    "content_translated",
+    "content_translated.content",
     "metadata.tika_metadata_author",
     "metadata.tika_metadata_creator",
     "metadata.tika_metadata_dc_creator",

--- a/datashare-index/src/main/resources/datashare_index_settings_windows.json
+++ b/datashare-index/src/main/resources/datashare_index_settings_windows.json
@@ -4,7 +4,7 @@
   "index.query.default_field": [
     "content",
     "mentionNorm",
-    "content_translated",
+    "content_translated.content",
     "metadata.tika_metadata_author",
     "metadata.tika_metadata_creator",
     "metadata.tika_metadata_dc_creator",


### PR DESCRIPTION
This PR use a different index settings to search into nested attributes of the content_translated field when doing a search without specifying the field.

Documentation about flattened field names: https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html