### PR TITLE
feat: JDK17 retro-compatibility

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -12,6 +12,7 @@ public class Main {
     public static void main(String[] args) throws Exception {
         DatashareCli cli = new DatashareCli().parseArguments(args);
         LOGGER.info("Running datashare " + (cli.isWebServer() ? "web server" : ""));
+        LOGGER.info("JVM version {}", System.getProperty("java.version"));
         LOGGER.info("JVM charset encoding {}", Charset.defaultCharset());
         LOGGER.debug("debug logs are activated");
 

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -41,6 +41,8 @@ mkdir -p \
 cd $datashare_home || exit
 
 ${java_bin} \
+    --add-opens java.base/java.lang=ALL-UNNAMED \
+    --add-opens java.base/java.util=ALL-UNNAMED \
     -DPROD_MODE=true \
     -Dfile.encoding=UTF-8 \
     -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \

--- a/launchBack.sh
+++ b/launchBack.sh
@@ -21,6 +21,7 @@ mkdir -p $DIR/dist
 # options to force debug logs -Dlogback.debug=true -Dlog4j.debug 
 
 $JAVA -agentlib:jdwp=transport=dt_socket,server=y,address=$JDWP_TRANSPORT_PORT,suspend=n \
+ --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED \
  -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \
  -Djavax.net.ssl.trustStorePassword=changeit \
  -Ddatashare.loghost=udp:localhost -Dlogback.configurationFile=logback.xml \


### PR DESCRIPTION
Adding : 

A log to display JVM version.

And 
```
--add-opens java.base/java.lang=ALL-UNNAMED 
--add-opens java.base/java.util=ALL-UNNAMED
```

to `launchBack.sh` and datashare script for retro-compatibility from jdk17/18/19.

Tested with:
* 11 (to be sure that the option `--add-opens` doesn't break JDK11)
* OpenJDK 17 (LTS)
* OpenJDK 19 (latest available for ubuntu 22.02)

I didn't find any drawback of doing this, any ideas?

Same update to come in datashare-installer for snap.