### PR TITLE
feat: adds folding analyzer for windows

### DIFF
--- a/datashare-index/src/main/resources/datashare_index_settings_windows.json
+++ b/datashare-index/src/main/resources/datashare_index_settings_windows.json
@@ -22,6 +22,10 @@
     "analyzer": {
       "path_analyzer": {
         "tokenizer": "path_tokenizer"
+      },
+      "folding": {
+        "tokenizer": "standard",
+        "filter":  [ "lowercase", "asciifolding" ]
       }
     },
     "tokenizer": {


### PR DESCRIPTION
Elasticsearch settings file for windows wasn't edited as it should have been like in [this PR](https://github.com/ICIJ/datashare-client/pull/266/files#diff-32d99d68fd35ab2ae034ec7df1a435249136758969f03719acc295ef78f63f5a), causing an error at launch on Datashare on Windows