### PR TITLE
chore: adds project name and routing id on extraction error

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -67,7 +67,7 @@ public class SourceExtractor {
                 return filterMetadata ? new ByteArrayInputStream(metadataCleaner.clean(new ByteArrayInputStream(source.content)).getContent())
                         : new ByteArrayInputStream(source.content);
             } catch (SAXException | TikaException | IOException e) {
-                throw new ExtractException("extract error for embedded document " + document.getId(), e);
+                throw new ExtractException(String.format("extract error for embedded document in project %s / id : %s / routing_id : %s", document.getProject().getName(), document.getId(), document.getRootDocument()), e);
             }
         }
     }


### PR DESCRIPTION
This PR aims to give more context for extraction error that can often happen due to processing big files. Additionally to the document id of the failed document, we have now the project name and the routing id