### PR TITLE
feat: project metadata

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -191,7 +191,16 @@ public abstract class CommonMode extends AbstractModule {
     }
 
     public Configuration createWebConfiguration() {
-        return routes -> addModeConfiguration(defaultRoutes(addCors(routes, propertiesProvider), propertiesProvider));
+        return routes -> {
+            addModeConfiguration(
+                    defaultRoutes(
+                                addCorsFilter(routes,
+                                        propertiesProvider
+                                ),
+                                propertiesProvider
+                    )
+            );
+        };
     }
 
     protected abstract Routes addModeConfiguration(final Routes routes);
@@ -242,7 +251,7 @@ public abstract class CommonMode extends AbstractModule {
         return propertiesProvider.getProperties().contains(QueueType.REDIS.name());
     }
 
-    private Routes addCors(Routes routes, PropertiesProvider provider) {
+    private Routes addCorsFilter(Routes routes, PropertiesProvider provider) {
         String cors = provider.get("cors").orElse("no-cors");
         if (!cors.equals("no-cors")) {
             routes.filter(new CorsFilter(cors));

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -61,6 +61,9 @@ public class ProjectResource {
     public Payload createProject(Context context) throws IOException {
         this.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         Project project =  context.extract(Project.class);
+        if (repository.getProject(project.name) != null) {
+            return new Payload("Project already exists").withCode(HttpStatus.CONFLICT);
+        }
         if (isEmpty(project.name)) {
             return new Payload("`name` field is required.").withCode(HttpStatus.BAD_REQUEST);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import static net.codestory.http.payload.Payload.ok;
 import static org.apache.tika.utils.StringUtils.isEmpty;
 import static org.icij.datashare.text.Project.isAllowed;
-import static org.icij.datashare.text.Project.project;
 
 @Singleton
 @Prefix("/api/project")
@@ -130,17 +129,20 @@ public class ProjectResource {
      * Gets the project information for the given project id.
      *
      * @param id
-     * @return 200 and the project from database if it exists else a transient one
-     *
+     * @return 200 and the project from database if it exists
+     * <p>
      * Example :
-     *
+     * <p>
      * $(curl -H 'Content-Type:application/json' localhost:8080/api/project/apigen-datashare
-     *)
+     * )
      */
     @Get("/:id")
-    public Project getProject(String id) {
+    public Payload getProject(String id) {
         Project project = repository.getProject(id);
-        return project == null ? project(id) : project;
+        if (project == null) {
+            return new Payload("Project not found").withCode(HttpStatus.NOT_FOUND);
+        }
+        return new Payload(project).withCode(HttpStatus.OK);
     }
 
     /**

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -62,7 +62,7 @@ public class ProjectResource {
         this.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         Project project =  context.extract(Project.class);
         if (repository.getProject(project.name) != null) {
-            return new Payload("Project already exists").withCode(HttpStatus.CONFLICT);
+            return new Payload("Project already exists.").withCode(HttpStatus.CONFLICT);
         }
         if (isEmpty(project.name)) {
             return new Payload("`name` field is required.").withCode(HttpStatus.BAD_REQUEST);

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -74,6 +74,12 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_cannot_get_unknown_project() {
+        when(repository.getProject("projectId")).thenReturn(null);
+        get("/api/project/projectId").should().respond(404);
+    }
+
+    @Test
     public void test_get_project_with_more_properties() {
         Project project = new Project(
                 "projectId",

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -2,6 +2,7 @@ package org.icij.datashare.web;
 
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
+import org.icij.datashare.cli.Mode;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.session.YesBasicAuthFilter;
 import org.icij.datashare.text.Project;
@@ -11,19 +12,131 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import java.nio.file.Path;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Properties;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ProjectResourceTest extends AbstractProdWebServerTest {
     @Mock Repository repository;
     @Mock Indexer indexer;
+    PropertiesProvider propertiesProvider;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        configure(routes -> {
+            propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
+                put("dataDir", "/vault");
+                put("mode", "LOCAL");
+            }});
+
+            ProjectResource projectResource = new ProjectResource(repository, indexer, propertiesProvider);
+            routes.filter(new LocalUserFilter(propertiesProvider)).add(projectResource);
+        });
+    }
 
     @Test
     public void test_get_project() {
-        when(repository.getProject("projectId")).thenReturn(new Project("projectId"));
-        get("/api/project/projectId").should().respond(200).contain("projectId");
+        Project project = new Project("projectId");
+        when(repository.getProject("projectId")).thenReturn(project);
+        get("/api/project/projectId").should().respond(200)
+                .contain("\"name\":\"projectId\"")
+                .contain("\"label\":\"projectId\"");
+    }
+
+    @Test
+    public void test_get_project_with_more_properties() {
+        Project project = new Project(
+                "projectId",
+                "Project ID",
+                Path.of("/vault/project"),
+                "https://icij.org",
+                "Data Team",
+                "ICIJ",
+                null,
+                "*",
+                new Date(),
+                new Date());
+        when(repository.getProject("projectId")).thenReturn(project);
+        get("/api/project/projectId").should().respond(200)
+                .contain("\"name\":\"projectId\"")
+                .contain("\"label\":\"Project ID\"")
+                .contain("\"sourceUrl\":\"https://icij.org\"")
+                .contain("\"maintainerName\":\"Data Team\"")
+                .contain("\"publisherName\":\"ICIJ\"")
+                .contain("\"label\":\"Project ID\"");
+    }
+
+    @Test
+    public void test_create_project_with_name_and_label() {
+        String body = "{ \"name\": \"foo-bar\", \"label\": \"Foo Bar\", \"sourcePath\": \"/vault/foo\" }";
+        when(repository.save((Project) any())).thenReturn(true);
+        post("/api/project/", body).should().respond(201)
+                .contain("\"name\":\"foo-bar\"")
+                .contain("\"label\":\"Foo Bar\"");
+    }
+
+    @Test
+    public void test_create_project() {
+        String body = "{ \"name\": \"foo\", \"label\": \"Foo v2\", \"sourcePath\": \"/vault/foo\", \"publisherName\":\"ICIJ\" }";
+        when(repository.save((Project) any())).thenReturn(true);
+        post("/api/project/", body).should().respond(201)
+                .contain("\"name\":\"foo\"")
+                .contain("\"label\":\"Foo v2\"")
+                .contain("\"publisherName\":\"ICIJ\"")
+                .contain("\"sourcePath\":\"file:///vault/foo\"");
+    }
+
+    @Test
+    public void test_cannot_create_project_without_source_path() {
+        String body = "{ \"name\": \"projectId\", \"label\": \"Project ID\", \"sourceUrl\": \"https://icij.org\", \"publisherName\":\"ICIJ\" }";
+        post("/api/project/", body).should().respond(400);
+    }
+
+    @Test
+    public void test_cannot_create_project_with_source_path_outside_data_dir() {
+        String body = "{ \"name\": \"foo\", \"label\": \"Foo Bar\", \"sourcePath\": \"/home/foo\" }";
+        post("/api/project/", body).should().respond(400);
+    }
+
+    @Test
+    public void test_can_create_project_with_source_path_using_data_dir() {
+        String body = "{ \"name\": \"foo\", \"label\": \"Foo Bar\", \"sourcePath\": \"/vault\" }";
+        when(repository.save((Project) any())).thenReturn(true);
+        post("/api/project/", body).should().respond(201);
+    }
+
+    @Test
+    public void test_cannot_create_project_without_name() {
+        String body = "{ \"label\": \"Foo Bar\", \"sourcePath\": \"/vault/foo\" }";
+        post("/api/project/", body).should().respond(400);
+    }
+
+    @Test
+    public void test_update_project() {
+        when(repository.getProject("foo")).thenReturn(new Project("foo"));
+        when(repository.save((Project) any())).thenReturn(true);
+        String body = "{ \"name\": \"foo\", \"label\": \"Foo v3\" }";
+        put("/api/project/foo", body).should().respond(200)
+                .contain("\"name\":\"foo\"")
+                .contain("\"label\":\"Foo v3\"");
+    }
+
+    @Test
+    public void test_cannot_update_project_in_server_mode() {
+        Properties props = new PropertiesProvider(Collections.singletonMap("mode", Mode.SERVER.name())).getProperties();
+        propertiesProvider.overrideWith(props);
+        when(repository.getProject("foo")).thenReturn(new Project("foo"));
+        when(repository.save((Project) any())).thenReturn(true);
+        String body = "{ \"name\": \"foo\" }";
+        put("/api/project/foo", body).should().respond(403);
     }
 
     @Test
@@ -60,17 +173,14 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_delete_project_with_unauthorized_user() {
-        configure(routes -> routes.add(new ProjectResource(repository, indexer)).
-                filter(new YesBasicAuthFilter(new PropertiesProvider())));
+        configure(routes -> {
+            PropertiesProvider propertiesProvider = new PropertiesProvider(Collections.singletonMap("mode", Mode.SERVER.name()));
+            routes.filter(new YesBasicAuthFilter(propertiesProvider))
+                    .add(new ProjectResource(repository, indexer, propertiesProvider));
+        });
+        when(repository.deleteAll("hacker-datashare")).thenReturn(true);
         when(repository.deleteAll("projectId")).thenReturn(true);
-        delete("/api/project/hacker-datashare").withPreemptiveAuthentication("hacker", "pass").should().respond(401);
+        delete("/api/project/hacker-datashare").withPreemptiveAuthentication("hacker", "pass").should().respond(403);
         delete("/api/project/projectId").should().respond(401);
-    }
-
-    @Before
-    public void setUp() {
-        initMocks(this);
-        configure(routes -> routes.add(new ProjectResource(repository, indexer)).
-                filter(new LocalUserFilter(new PropertiesProvider())));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -86,6 +86,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_create_project() {
         String body = "{ \"name\": \"foo\", \"label\": \"Foo v2\", \"sourcePath\": \"/vault/foo\", \"publisherName\":\"ICIJ\" }";
+        when(repository.getProject("foo")).thenReturn(null);
         when(repository.save((Project) any())).thenReturn(true);
         post("/api/project/", body).should().respond(201)
                 .contain("\"name\":\"foo\"")
@@ -93,16 +94,27 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
                 .contain("\"publisherName\":\"ICIJ\"")
                 .contain("\"sourcePath\":\"file:///vault/foo\"");
     }
+    @Test
+    public void test_cannot_create_project_twice() {
+        String body = "{ \"name\": \"foo\", \"sourcePath\": \"/vault/foo\" }";
+        when(repository.save((Project) any())).thenReturn(true);
+        when(repository.getProject("foo")).thenReturn(null);
+        post("/api/project/", body).should().respond(201);
+        when(repository.getProject("foo")).thenReturn(new Project("foo"));
+        post("/api/project/", body).should().respond(409);
+    }
 
     @Test
     public void test_cannot_create_project_without_source_path() {
         String body = "{ \"name\": \"projectId\", \"label\": \"Project ID\", \"sourceUrl\": \"https://icij.org\", \"publisherName\":\"ICIJ\" }";
+        when(repository.getProject("foo")).thenReturn(null);
         post("/api/project/", body).should().respond(400);
     }
 
     @Test
     public void test_cannot_create_project_with_source_path_outside_data_dir() {
         String body = "{ \"name\": \"foo\", \"label\": \"Foo Bar\", \"sourcePath\": \"/home/foo\" }";
+        when(repository.getProject("foo")).thenReturn(null);
         post("/api/project/", body).should().respond(400);
     }
 
@@ -116,6 +128,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_cannot_create_project_without_name() {
         String body = "{ \"label\": \"Foo Bar\", \"sourcePath\": \"/vault/foo\" }";
+        when(repository.getProject("foo")).thenReturn(null);
         post("/api/project/", body).should().respond(400);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>10.0.0</datashare-api.version>
+        <datashare-api.version>10.1.2</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
This PR add and modify several API endpoints to manage projects metadata.

## `GET` `/api/project/`

This endpoint now returns projects from the database. In SERVER mode, it's only the projects a user has access to. In LOCAL mode, that's all projects.

## `POST` `/api/project`

This endpoint allows users to create a project with all its metadata. This endpoint is only allowed in LOCAL mode. Creating a project will also create an index with the same name.

## `PUT` `/api/project/:id`

This endpoint allows users to update a project with all its metadata. This endpoint is only allowed in LOCAL mode. Any change made to the name or the sourcePath of the project will be ignored.

## `GET` `/api/project/:id`

Just like before, this endpoint allows users to get a project from the database. The only difference is that it doesn't return a "transient project" anymore when the project doesn't exist (it raise an exception instead).