### PR TITLE
feat: add a maxResults option to batch search queries endpoint

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -352,7 +352,11 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_queries_json() {
-        when(batchSearchRepository.getQueries(User.local(), "batchSearchId", 0, 0,null,null)).thenReturn(new HashMap<String, Integer>() {{put("q1", 1);put("q2", 2);}});
+        when(batchSearchRepository.getQueries(User.local(), "batchSearchId", 0, 0,null,null, -1)).
+                thenReturn(new HashMap<String, Integer>() {{
+                    put("q1", 1);
+                    put("q2", 2);
+                }});
         get("/api/batch/search/batchSearchId/queries").should().
                 respond(200).
                 haveType("application/json;charset=UTF-8").
@@ -361,11 +365,30 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_queries_csv() {
-        when(batchSearchRepository.getQueries(User.local(), "batchSearchId",0,0,null,null)).thenReturn(new HashMap<String, Integer>() {{ put("q1", 1);put("q2", 2);}});
+        when(batchSearchRepository.getQueries(User.local(), "batchSearchId",0,0,null,null, -1)).
+                thenReturn(new HashMap<String, Integer>() {{
+                    put("q1", 1);
+                    put("q2", 2);
+                }});
         get("/api/batch/search/batchSearchId/queries?format=csv").should().
                 respond(200).
                 haveType("text/csv;charset=UTF-8").
                 contain("q1\nq2");
+    }
+
+    @Test
+    public void test_get_queries_filtered_to_max_results() {
+        when(batchSearchRepository.getQueries(User.local(), "batchSearchId", 0, 0,null,null, 200)).
+                thenReturn(new HashMap<String, Integer>() {{
+                    put("q1", 100);
+                    put("q2", 200);
+                }});
+        get("/api/batch/search/batchSearchId/queries?maxResults=200").should().
+                respond(200).
+                haveType("application/json;charset=UTF-8").
+                contain("\"q1\":100").
+                contain("\"q2\":200").
+                not().contain("\"q3\":300");
     }
 
     @Test
@@ -381,7 +404,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_batch_search_queries_with_window_from_size() {
-        when(batchSearchRepository.getQueries(User.local(), "batchSearchId", 0, 2,null,null)).thenReturn(new HashMap<String, Integer>() {{put("q1", 1);put("q2", 2);}});
+        when(batchSearchRepository.getQueries(User.local(), "batchSearchId", 0, 2,null,null, -1)).thenReturn(new HashMap<String, Integer>() {{put("q1", 1);put("q2", 2);}});
         get("/api/batch/search/batchSearchId/queries?from=0&size=2").should().
                 respond(200).
                 haveType("application/json").
@@ -390,7 +413,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_batch_search_queries_with_window_from_size_with_filter_orderby() {
-        when(batchSearchRepository.getQueries(User.local(), "batchSearchId", 0, 2,"foo","bar")).thenReturn(new HashMap<String, Integer>() {{put("query", 1);}});
+        when(batchSearchRepository.getQueries(User.local(), "batchSearchId", 0, 2,"foo","bar", -1)).thenReturn(new HashMap<String, Integer>() {{put("query", 1);}});
         get("/api/batch/search/batchSearchId/queries?from=0&size=2&search=foo&orderBy=bar").should().
                 respond(200).
                 haveType("application/json").

--- a/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
@@ -40,7 +40,7 @@ public class DbSetupRule extends ExternalResource {
         dbSetup.launch();
     }
 
-    BatchSearchRepository createBatchSearchRepository() {
+    JooqBatchSearchRepository createBatchSearchRepository() {
         return new JooqBatchSearchRepository(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>10.2.0</datashare-api.version>
+        <datashare-api.version>10.3.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
This PR adds a `maxResults` to the `GET` `/search/:batchid/queries` endpoint.