### PR TITLE
chore: add neo4j extension

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -44,6 +44,15 @@
       "homepage": "https://github.com/ICIJ/datashare-extension-dataconnect",
       "version": "1.0.0",
       "type": "WEB"
+    },
+    {
+      "id": "datashare-extension-neo4j",
+      "name": "neo4j",
+      "description": "A Datashare extension to perform graph analysis using neo4j",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.1.0/datashare-extension-neo4j-0.1.0-jar-with-dependencies.jar",
+      "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
+      "version": "0.1.0",
+      "type": "WEB"
     }
   ]
 }

--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -49,9 +49,9 @@
       "id": "datashare-extension-neo4j",
       "name": "neo4j",
       "description": "A Datashare extension to perform graph analysis using neo4j",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.1.0/datashare-extension-neo4j-0.1.0-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.1.1/datashare-extension-neo4j-0.1.1-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "type": "WEB"
     }
   ]

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -9,7 +9,18 @@ import org.icij.datashare.json.JsonUtils;
 import org.icij.datashare.text.*;
 import org.icij.datashare.text.nlp.Pipeline;
 import org.icij.datashare.user.User;
-import org.jooq.*;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.InsertValuesStep2;
+import org.jooq.InsertValuesStep3;
+import org.jooq.InsertValuesStep5;
+import org.jooq.InsertValuesStep6;
+import org.jooq.InsertValuesStep9;
+import org.jooq.Record;
+import org.jooq.Record1;
+import org.jooq.SQLDialect;
+import org.jooq.SelectConditionStep;
+import org.jooq.SortField;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.slf4j.LoggerFactory;
@@ -128,7 +139,8 @@ public class JooqRepository implements Repository {
     // this could be removed later
     @Override
     public int star(Project project, User user, List<String> documentIds) {
-        InsertValuesStep3<DocumentUserStarRecord, String, String, String> query = using(connectionProvider, dialect).
+        InsertValuesStep3<DocumentUserStarRecord, String, String, String>
+            query = using(connectionProvider, dialect).
                 insertInto(DOCUMENT_USER_STAR, DOCUMENT_USER_STAR.DOC_ID, DOCUMENT_USER_STAR.USER_ID, DOCUMENT_USER_STAR.PRJ_ID);
         documentIds.forEach(t -> query.values(t, user.id, project.getId()));
         return query.onConflictDoNothing().execute();
@@ -180,7 +192,8 @@ public class JooqRepository implements Repository {
     public boolean addToUserHistory(List<Project> projects, UserEvent userEvent) {
         return using(connectionProvider, dialect).transactionResult(configuration -> {
             DSLContext inner = using(configuration);
-            InsertValuesStep6<UserHistoryRecord, Timestamp, Timestamp, String, Short, String, String> insertHistory = inner.
+            InsertValuesStep6<UserHistoryRecord, Timestamp, Timestamp, String, Short, String, String>
+                insertHistory = inner.
                     insertInto(USER_HISTORY, USER_HISTORY.CREATION_DATE, USER_HISTORY.MODIFICATION_DATE,
                             USER_HISTORY.USER_ID, USER_HISTORY.TYPE, USER_HISTORY.NAME, USER_HISTORY.URI);
             insertHistory.values(new Timestamp(userEvent.creationDate.getTime()), new Timestamp(userEvent.modificationDate.getTime()),
@@ -224,7 +237,8 @@ public class JooqRepository implements Repository {
 
     @Override
     public int getUserHistorySize(User user, UserEvent.Type type, String... projectIds) {
-        SelectConditionStep<Record1<Integer>> query = using(connectionProvider, dialect).selectCount().from(USER_HISTORY).
+        SelectConditionStep<Record1<Integer>>
+            query = using(connectionProvider, dialect).selectCount().from(USER_HISTORY).
                 where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id));
         if(projectIds.length>0){
             query.and(USER_HISTORY.ID.in(select(USER_HISTORY_PROJECT.USER_HISTORY_ID).from(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.in(projectIds))));

--- a/launchBack.sh
+++ b/launchBack.sh
@@ -11,9 +11,15 @@ else
   JAVA=${JAVA_HOME}/bin/java
 fi
 
+if [[ $(uname) == "Darwin" ]]; then
+  DOCKER_PS=docker ps
+else
+  DOCKER_PS=sudo docker ps
+fi
+
 export DS_DOCKER_PREVIEW_HOST="http://localhost:5000"
-export DS_DOCKER_BACK_HOST="http://localhost:$(sudo docker ps|grep 8080|sed 's/.*0.0.0.0:\([0-9]\{4\}\)->8080.*/\1/g')"
-export DS_DOCKER_FRONT_HOST="http://localhost:$(sudo docker ps|grep 9090|sed 's/.*0.0.0.0:\([0-9]\{4\}\)->9090.*/\1/g')"
+export DS_DOCKER_BACK_HOST="http://localhost:$($DOCKER_PS|grep 8080|sed 's/.*0.0.0.0:\([0-9]\{4\}\)->8080.*/\1/g')"
+export DS_DOCKER_FRONT_HOST="http://localhost:$($DOCKER_PS|grep 9090|sed 's/.*0.0.0.0:\([0-9]\{4\}\)->9090.*/\1/g')"
 export DS_DOCKER_USER_ADMIN="icij"
 
 mkdir -p $DIR/dist

--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
         <bouncycastle.version>1.66</bouncycastle.version>
         <httpcomponents.version>4.5.2</httpcomponents.version>
         <joptsimple.version>6.0-alpha-3</joptsimple.version>
-        <slf4j.version>1.7.25</slf4j.version>
-        <logback.version>1.2.9</logback.version>
+        <slf4j.version>2.0.7</slf4j.version>
+        <logback.version>1.4.8</logback.version>
         <log4jtoslf4j.version>2.17.2</log4jtoslf4j.version>
         <log4-over-slf4j.version>2.17.2</log4-over-slf4j.version>
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
# PR description

This PR adds the support for the  [datashare-extension-neo4j](https://github.com/ICIJ/datashare-extension-neo4j) inside Datashare. It also provide some fixes needed to build datashare on a mac M1.

# Change
## `pom.xml`
### Changed
- Bumped logs dependencies to be aligned with the neo4j extension versions (needed to forward Python logs to the Datashare logger via `syslog`)

## `datashare-app`
### Added
- Added to the [datashare-extension-neo4j](https://github.com/ICIJ/datashare-extension-neo4j) `0.1.1` tag to the `extension.json` repository

## `datashare-db`
### Changed
- Refacor `JooqRepository` imports to avoid ambiguous imports

## `launchback.sh`
### Changed
- Avoid using `docker sudo` when using a darwin machine