### PR TITLE
feat: add quotes arround password and more context info

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerEncryptedIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerEncryptedIntTest.java
@@ -45,7 +45,8 @@ public class BatchDownloadRunnerEncryptedIntTest {
         verify(mailSender).send(mailCaptor.capture());
         assertThat(mailCaptor.getValue().from).isEqualTo("engineering@icij.org");
         assertThat(mailCaptor.getValue().toRecipientList).containsExactly("foo@bar.com");
-        assertThat(mailCaptor.getValue().subject).isEqualTo("[datashare] " + batchDownload.filename.getFileName());
+        assertThat(mailCaptor.getValue().subject).isEqualTo("[Datashare] Your batch download is ready - " + batchDownload.filename.getFileName());
+        assertThat(mailCaptor.getValue().messageBody).contains("https://datashare-demo.icij.org/#/tasks/batch-download");
     }
 
     @NotNull
@@ -63,6 +64,7 @@ public class BatchDownloadRunnerEncryptedIntTest {
     private PropertiesProvider createProvider() {
         return new PropertiesProvider(new HashMap<String, String>() {{
             put("downloadFolder", fs.getRoot().toString());
+            put("rootHost", "https://datashare-demo.icij.org");
         }});
     }
 }


### PR DESCRIPTION
## PR description

This PR reformats the email sent when a BatchDownload zip is password protected.

## Changes

When Datashare is started with `rootUrl`, the email also contains a link:

![Screenshot 2023-07-03 at 16-49-33 MailDev](https://github.com/ICIJ/datashare/assets/471176/dc45d81e-cf63-4a00-bc16-d46458080316)

If not, this line is not used:

![Screenshot 2023-07-03 at 16-49-41 MailDev](https://github.com/ICIJ/datashare/assets/471176/3b665a97-9db4-4dc6-b9df-22d30c4a6950)
