### PR TITLE
feat: add batchsearch results filters

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -90,6 +90,7 @@ public class BatchSearchRunner implements Callable<Integer>, Monitorable, UserTa
                 Indexer.Searcher searcher = indexer.search(batchSearch.projects.stream().map(Project::getId).collect(toList()), Document.class).
                         with(query, batchSearch.fuzziness, batchSearch.phraseMatches).
                         withFieldValues("contentType", batchSearch.fileTypes.toArray(new String[]{})).
+                        withFieldValues("tags", batchSearch.tags.toArray(new String[]{})).
                         withPrefixQuery("dirname", batchSearch.paths.toArray(new String[]{})).
                         withoutSource("content").limit(scrollSize);
                 List<? extends Entity> docsToProcess = searcher.scroll().collect(toList());

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -260,6 +260,7 @@ public class BatchSearchResource {
         String description = fieldValue("description", parts);
         boolean published = "true".equalsIgnoreCase(fieldValue("published", parts)) ? TRUE: FALSE ;
         List<String> fileTypes = fieldValues("fileTypes", parts);
+        List<String> tags = fieldValues("tags", parts);
         List<String> paths = fieldValues("paths", parts);
         Optional<Part> fuzzinessPart = parts.stream().filter(p -> "fuzziness".equals(p.name())).findAny();
         int fuzziness = fuzzinessPart.isPresent() ? parseInt(fuzzinessPart.get().content()):0;
@@ -270,7 +271,7 @@ public class BatchSearchResource {
         if(queries.size() >= MAX_BATCH_SIZE)
             return new Payload(413);
         BatchSearch batchSearch = new BatchSearch(stream(comaSeparatedProjects.split(",")).map(Project::project).collect(Collectors.toList()), name, description, queries,
-                (User) context.currentUser(), published, fileTypes, paths, fuzziness,phraseMatches);
+                (User) context.currentUser(), published, fileTypes, tags, paths, fuzziness,phraseMatches);
         boolean isSaved = batchSearchRepository.save(batchSearch);
         if (isSaved) batchSearchQueue.put(batchSearch.uuid);
         return isSaved ? new Payload("application/json", batchSearch.uuid, 200) : badRequest();

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -9,10 +9,7 @@ import net.codestory.http.errors.NotFoundException;
 import net.codestory.http.errors.UnauthorizedException;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.batch.BatchSearch;
-import org.icij.datashare.batch.BatchSearchRecord;
-import org.icij.datashare.batch.BatchSearchRepository;
-import org.icij.datashare.batch.SearchResult;
+import org.icij.datashare.batch.*;
 import org.icij.datashare.db.JooqBatchSearchRepository;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.Project;
@@ -357,7 +354,7 @@ public class BatchSearchResource {
         BatchSearch batchSearch = batchSearchRepository.get((User) context.currentUser(), batchId);
         String url = propertiesProvider.get("rootHost").orElse(context.header("Host"));
 
-        getResultsOrThrowUnauthorized(batchId, (User) context.currentUser(), new BatchSearchRepository.WebQuery()).forEach(result -> builder.
+        getResultsOrThrowUnauthorized(batchId, (User) context.currentUser(), WebQueryBuilder.createWebQuery().queryAll().build()).forEach(result -> builder.
                 append("\"").append(result.query).append("\"").append(",").
                 append("\"").append(docUrl(url, batchSearch.projects, result.documentId, result.rootId)).append("\"").append(",").
                 append("\"").append(result.documentId).append("\"").append(",").

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
@@ -42,7 +42,7 @@ public class BatchSearchRunnerIntTest {
     public void test_search_with_file_types_ok() throws Exception {
         Document mydoc = createDoc("mydoc").build();
         indexer.add(TEST_INDEX, mydoc);
-        BatchSearch search = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(), false, singletonList("text/plain"), null, 0);
+        BatchSearch search = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(), false, singletonList("text/plain"), null, null, 0);
         new BatchSearchRunner(indexer, new PropertiesProvider(), search, resultConsumer).call();
         verify(resultConsumer).apply(search.uuid, "mydoc", singletonList(mydoc));
     }
@@ -51,7 +51,7 @@ public class BatchSearchRunnerIntTest {
     public void test_search_with_file_types_ko() throws Exception {
         Document mydoc = createDoc("mydoc").build();
         indexer.add(TEST_INDEX, mydoc);
-        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(), false, singletonList("application/pdf"), null, 0);
+        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(), false, singletonList("tag"), singletonList("application/pdf"), null, 0);
 
         new BatchSearchRunner(indexer, new PropertiesProvider(), searchKo, resultConsumer).call();
 
@@ -62,7 +62,7 @@ public class BatchSearchRunnerIntTest {
     public void test_search_with_paths_ok() throws Exception {
         Document mydoc = createDoc("mydoc").build();
         indexer.add(TEST_INDEX, mydoc);
-        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(),false, null,
+        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(),false, null, null,
                 singletonList("/path/to"), 0);
 
         new BatchSearchRunner(indexer, new PropertiesProvider(), searchOk, resultConsumer).call();
@@ -74,7 +74,7 @@ public class BatchSearchRunnerIntTest {
     public void test_search_with_paths_ko() throws Exception {
         Document mydoc = createDoc("mydoc").build();
         indexer.add(TEST_INDEX, mydoc);
-        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(),false, null,
+        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(),false, null, null,
                 singletonList("/foo/bar"), 0);
 
         new BatchSearchRunner(indexer, new PropertiesProvider(), searchKo, resultConsumer).call();
@@ -86,11 +86,11 @@ public class BatchSearchRunnerIntTest {
     public void test_search_with_fuzziness() throws Exception {
         Document mydoc = createDoc("mydoc").build();
         indexer.add(TEST_INDEX, mydoc);
-        BatchSearch searchKo1 = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("doc"), User.local(),false, null,
+        BatchSearch searchKo1 = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("doc"), User.local(),false, null, null,
                 null, 1);
-        BatchSearch searchKo2 = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("nodoc"), User.local(),false, null,
+        BatchSearch searchKo2 = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("nodoc"), User.local(),false, null, null,
                 null, 1);
-        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("hedoc"), User.local(),false, null,
+        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("hedoc"), User.local(),false, null, null,
                 null, 2);
 
         new BatchSearchRunner(indexer, new PropertiesProvider(), searchKo1, resultConsumer).call();
@@ -106,9 +106,9 @@ public class BatchSearchRunnerIntTest {
     public void test_search_with_phraseMatches() throws Exception {
         Document mydoc = createDoc("docId").with("mydoc to find").build();
         indexer.add(TEST_INDEX, mydoc);
-        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("to find mydoc"), User.local(),false, null,
+        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("to find mydoc"), User.local(),false, null, null,
                 null, true);
-        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc to find"), User.local(),false, null,
+        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc to find"), User.local(),false, null, null,
                 null,true);
 
         new BatchSearchRunner(indexer, new PropertiesProvider(), searchKo, resultConsumer).call();
@@ -123,9 +123,9 @@ public class BatchSearchRunnerIntTest {
         Document mydoc = createDoc("docId").with("anne's doc to find").build();
         indexer.add(TEST_INDEX, mydoc);
         indexer.add(TEST_INDEX, NamedEntity.create(NamedEntity.Category.PERSON, "anne", asList(12L), mydoc.getId(), mydoc.getRootDocument(), Pipeline.Type.CORENLP, Language.FRENCH));
-        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("anne doc"), User.local(),false, null,
+        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("anne doc"), User.local(),false, null, null,
                 null, true);
-        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("anne's doc"), User.local(),false, null,
+        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("anne's doc"), User.local(),false, null, null,
                 null,true);
 
         new BatchSearchRunner(indexer, new PropertiesProvider(), searchKo, resultConsumer).call();
@@ -141,7 +141,7 @@ public class BatchSearchRunnerIntTest {
         // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html
         Document mydoc = createDoc("docId").with("mydoc find").build();
         indexer.add(TEST_INDEX, mydoc);
-        BatchSearch search = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("find mydoc"), User.local(), false, null,
+        BatchSearch search = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("find mydoc"), User.local(), false, null, null,
                  null, 2,true);
 
         new BatchSearchRunner(indexer, new PropertiesProvider(), search, resultConsumer).call();

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -120,6 +120,8 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
                 .addField("published",String.valueOf(true))
                 .addField("fileTypes","application/pdf")
                 .addField("fileTypes","image/jpeg")
+                .addField("tags","tag_01")
+                .addField("tags","tag_02")
                 .addField("paths","/path/to/document")
                 .addField("paths","/other/path/")
                 .addField("fuzziness",String.valueOf(4))
@@ -130,6 +132,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
         verify(batchSearchRepository).save(argument.capture());
         assertThat(argument.getValue().published).isTrue();
         assertThat(argument.getValue().fileTypes).containsExactly("application/pdf", "image/jpeg");
+        assertThat(argument.getValue().tags).containsExactly("tag_01", "tag_02");
         assertThat(argument.getValue().paths).containsExactly("/path/to/document", "/other/path/");
         assertThat(argument.getValue().fuzziness).isEqualTo(4);
         assertThat(argument.getValue().phraseMatches).isTrue();
@@ -416,7 +419,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_batch_search_without_queries() {
         BatchSearch search = new BatchSearch("uuid", singletonList(project("prj")), "name", "desc", 2, new Date(), BatchSearchRecord.State.SUCCESS, User.local(),
-                                        3, true, singletonList("application/pdf"), asList("/path"), 0, false, null, null);
+                                        3, true, singletonList("application/pdf"), null, asList("/path"), 0, false, null, null);
         when(batchSearchRepository.get(User.local(), search.uuid, false)).thenReturn(search);
 
         get("/api/batch/search/uuid?withQueries=false").should().

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -264,7 +264,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
             }
         }
         if(webQuery.hasFilteredContentTypes()){
-            query.and(BATCH_SEARCH_RESULT.QUERY.in(webQuery.contentTypes));
+            query.and(BATCH_SEARCH_RESULT.CONTENT_TYPE.in(webQuery.contentTypes));
         }
         if (webQuery.isSorted()) {
             query.orderBy(field(webQuery.sort + " " + webQuery.order));

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -48,11 +48,12 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
         return DSL.using(dataSource, dialect).transactionResult(configuration -> {
             DSLContext inner = using(configuration);
             inner.insertInto(BATCH_SEARCH, BATCH_SEARCH.UUID, BATCH_SEARCH.NAME, BATCH_SEARCH.DESCRIPTION, BATCH_SEARCH.USER_ID,
-                    BATCH_SEARCH.BATCH_DATE, BATCH_SEARCH.STATE, BATCH_SEARCH.PUBLISHED, BATCH_SEARCH.FILE_TYPES,
+                    BATCH_SEARCH.BATCH_DATE, BATCH_SEARCH.STATE, BATCH_SEARCH.PUBLISHED, BATCH_SEARCH.FILE_TYPES, BATCH_SEARCH.TAGS,
                     BATCH_SEARCH.PATHS, BATCH_SEARCH.FUZZINESS, BATCH_SEARCH.PHRASE_MATCHES).
                     values(batchSearch.uuid, batchSearch.name, batchSearch.description, batchSearch.user.id,
                             new Timestamp(batchSearch.getDate().getTime()), batchSearch.state.name(), batchSearch.published?1:0,
-                            join(LIST_SEPARATOR, batchSearch.fileTypes),join(LIST_SEPARATOR, batchSearch.paths), batchSearch.fuzziness,batchSearch.phraseMatches?1:0).execute();
+                            join(LIST_SEPARATOR, batchSearch.fileTypes), join(LIST_SEPARATOR, batchSearch.tags),
+                            join(LIST_SEPARATOR, batchSearch.paths), batchSearch.fuzziness,batchSearch.phraseMatches?1:0).execute();
 
             InsertValuesStep4<BatchSearchQueryRecord, String, String, Integer, Integer> insertQuery = inner.insertInto(BATCH_SEARCH_QUERY, BATCH_SEARCH_QUERY.SEARCH_UUID, BATCH_SEARCH_QUERY.QUERY, BATCH_SEARCH_QUERY.QUERY_NUMBER, BATCH_SEARCH_QUERY.QUERY_RESULTS);
             List<String> queries = new ArrayList<>(batchSearch.queries.keySet());
@@ -295,12 +296,12 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                                         LinkedHashMap::new)),
                         batchSearches.get(0).getDate(),
                         batchSearches.get(0).state, batchSearches.get(0).user, batchSearches.get(0).nbResults, batchSearches.get(0).published,
-                        batchSearches.get(0).fileTypes, batchSearches.get(0).paths, batchSearches.get(0).fuzziness,
+                        batchSearches.get(0).fileTypes, batchSearches.get(0).tags, batchSearches.get(0).paths, batchSearches.get(0).fuzziness,
                         batchSearches.get(0).phraseMatches, batchSearches.get(0).errorMessage, batchSearches.get(0).errorQuery)).
                 sorted(comparing(BatchSearch::getDate).reversed()).collect(toList());
     }
 
-    private SelectJoinStep<Record18<String, String, String, String, Timestamp, String, Integer, String, String, Integer, Integer, Integer, String, String, String, String, Integer, Integer>>
+    private SelectJoinStep<Record19<String, String, String, String, Timestamp, String, Integer, String, String, String,Integer, Integer, Integer, String, String, String, String, Integer, Integer>>
     createBatchSearchWithQueriesSelectStatement(DSLContext create) {
         return create.select(
                 BATCH_SEARCH.UUID,
@@ -311,6 +312,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                 BATCH_SEARCH.STATE,
                 BATCH_SEARCH.PUBLISHED,
                 BATCH_SEARCH.FILE_TYPES,
+                BATCH_SEARCH.TAGS,
                 BATCH_SEARCH.PATHS,
                 BATCH_SEARCH.FUZZINESS,
                 BATCH_SEARCH.PHRASE_MATCHES,
@@ -325,7 +327,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                         .join(BATCH_SEARCH_PROJECT).on(BATCH_SEARCH.UUID.eq(BATCH_SEARCH_PROJECT.SEARCH_UUID)));
     }
 
-    private SelectJoinStep<Record16<String, String, String, String, Timestamp, String, Integer, String, String, Integer, Integer, Integer, String, String, String, Integer>>
+    private SelectJoinStep<Record17<String, String, String, String, Timestamp, String, Integer, String, String, String, Integer, Integer, Integer, String, String, String, Integer>>
     createBatchSearchWithoutQueriesSelectStatement(DSLContext create) {
         return create.select(
                         BATCH_SEARCH.UUID,
@@ -336,6 +338,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                         BATCH_SEARCH.STATE,
                         BATCH_SEARCH.PUBLISHED,
                         BATCH_SEARCH.FILE_TYPES,
+                        BATCH_SEARCH.TAGS,
                         BATCH_SEARCH.PATHS,
                         BATCH_SEARCH.FUZZINESS,
                         BATCH_SEARCH.PHRASE_MATCHES,
@@ -387,6 +390,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                 record.get(BATCH_SEARCH.BATCH_RESULTS),
                 record.get(BATCH_SEARCH.PUBLISHED) > 0,
                 getListFromStringOrNull(record.get(BATCH_SEARCH.FILE_TYPES)),
+                getListFromStringOrNull(record.get(BATCH_SEARCH.TAGS)),
                 getListFromStringOrNull(record.get(BATCH_SEARCH.PATHS)),
                 record.get(BATCH_SEARCH.FUZZINESS),
                 phraseMatches,
@@ -409,6 +413,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                 record.get(BATCH_SEARCH.BATCH_RESULTS),
                 record.get(BATCH_SEARCH.PUBLISHED) > 0,
                 getListFromStringOrNull(record.get(BATCH_SEARCH.FILE_TYPES)),
+                getListFromStringOrNull(record.get(BATCH_SEARCH.TAGS)),
                 getListFromStringOrNull(record.get(BATCH_SEARCH.PATHS)),
                 record.get(BATCH_SEARCH.FUZZINESS),
                 phraseMatches,

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -265,7 +265,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
             }
         }
         if(webQuery.hasFilteredContentTypes()){
-            query.and(BATCH_SEARCH_RESULT.CONTENT_TYPE.in(webQuery.contentTypes));
+            query.and(BATCH_SEARCH_RESULT.QUERY.in(webQuery.contentTypes));
         }
         if (webQuery.isSorted()) {
             query.orderBy(field(webQuery.sort + " " + webQuery.order));

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -265,7 +265,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
             }
         }
         if(webQuery.hasFilteredContentTypes()){
-            query.and(BATCH_SEARCH_RESULT.QUERY.in(webQuery.contentTypes));
+            query.and(BATCH_SEARCH_RESULT.CONTENT_TYPE.in(webQuery.contentTypes));
         }
         if (webQuery.isSorted()) {
             query.orderBy(field(webQuery.sort + " " + webQuery.order));

--- a/datashare-db/src/main/resources/liquibase/changelog/changes/032-batch-search-adds-tags-column.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/changes/032-batch-search-adds-tags-column.yml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: 60
+      author: mvanza
+      changes:
+        - addColumn:
+            tableName: batch_search
+            column:
+              name: tags
+              type: text

--- a/datashare-db/src/main/resources/liquibase/changelog/db.changelog.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/db.changelog.yml
@@ -95,3 +95,6 @@ databaseChangeLog:
   - include:
       file: changes/031-adds-description-to-project.yml
       relativeToChangelogFile: true
+  - include:
+      file: changes/032-batch-search-adds-tags-column.yml
+      relativeToChangelogFile: true

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -49,8 +49,8 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_save_and_get_batch_search() {
         BatchSearch batchSearch = new BatchSearch(asList(project("prj1"), project("prj2")), "name1", "description1",
-                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),
-                3,true);
+                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), singletonList("tag"),
+                asList("/path/to/docs", "/path/to/pdfs"), 3,true);
 
         repository.save(batchSearch);
 
@@ -59,6 +59,7 @@ public class JooqBatchSearchRepositoryTest {
         assertThat(batchSearchFromGet.name).isEqualTo(batchSearch.name);
         assertThat(batchSearchFromGet.published).isEqualTo(batchSearch.published);
         assertThat(batchSearchFromGet.fileTypes).isEqualTo(batchSearch.fileTypes);
+        assertThat(batchSearchFromGet.tags).isEqualTo(batchSearch.tags);
         assertThat(batchSearchFromGet.paths).isEqualTo(batchSearch.paths);
         assertThat(batchSearchFromGet.fuzziness).isEqualTo(batchSearch.fuzziness);
         assertThat(batchSearchFromGet.description).isEqualTo(batchSearch.description);
@@ -72,8 +73,8 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_by_user_with_projects_without_queries() {
         BatchSearch batchSearch = new BatchSearch(asList(project("prj1"), project("prj2")), "name1", "description1",
-                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),
-                3,true);
+                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), singletonList("tag"),
+                asList("/path/to/docs", "/path/to/pdfs"), 3,true);
 
         repository.save(batchSearch);
         BatchSearch batchSearchFromGet = repository.get(User.local(), batchSearch.uuid, false);
@@ -84,8 +85,8 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_by_user_with_projects_with_queries() {
         BatchSearch batchSearch = new BatchSearch(asList(project("prj1"), project("prj2")), "name1", "description1",
-                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),
-                3,true);
+                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), singletonList("tag"),
+                asList("/path/to/docs", "/path/to/pdfs"), 3,true);
 
         repository.save(batchSearch);
         BatchSearch batchSearchFromGet = repository.get(User.local(), batchSearch.uuid, true);
@@ -96,7 +97,8 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_records_filter_by_project() {
         BatchSearch batchSearch1 = new BatchSearch(singletonList(project("prj1")), "name1", "description1",
-                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), singletonList("tag"),
+                asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         BatchSearch batchSearch2 = new BatchSearch(singletonList(project("prj2")), "name2", "description2",
                 asSet("q3", "q4"), new Date(new Date().getTime() + 1000000000));
 
@@ -110,7 +112,8 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_total_filter_by_project() {
         BatchSearch batchSearch1 = new BatchSearch(asList(project("prj1"), project("prj2")), "name1", "description1",
-                        asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                        asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), singletonList("tag"), 
+                asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         BatchSearch batchSearch2 = new BatchSearch(singletonList(project("prj2")), "name2", "description2",
                 asSet("q3", "q4"), User.local(), true);
 
@@ -127,7 +130,7 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_records() {
         BatchSearch batchSearch = new BatchSearch(singletonList(project("prj")),"name","description",asSet("q1", "q2"), User.local(),
-                true,asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                true,asList("application/json", "image/jpeg"), singletonList("tag"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         repository.save(batchSearch);
 
         List<BatchSearchRecord> batchSearchRecords = repository.getRecords(User.local(), singletonList("prj"));
@@ -148,7 +151,7 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_records_with_multiple_project_intersection() {
         BatchSearch batchSearch = new BatchSearch(asList(project("prj1"), project("prj2")),"name","description",asSet("q1", "q2"), User.local(),
-                true,asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                true,asList("application/json", "image/jpeg"), singletonList("tag"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         repository.save(batchSearch);
 
         assertThat(repository.getRecords(User.local(), asList("prj1", "prj2"))).isNotEmpty();
@@ -160,11 +163,11 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_records_with_query_and_field() {
         BatchSearch batchSearch1 = new BatchSearch(singletonList(project("prj")),"foo","baz",asSet("q1", "q2"), User.local(),
-                false,asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                false,asList("application/json", "image/jpeg"), singletonList("tag"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         BatchSearch batchSearch2 = new BatchSearch(singletonList(project("anotherPrj")),"bar","baz",asSet("q3", "q2"), User.local(),
-                true,asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                true,asList("application/json", "image/jpeg"), null, asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         BatchSearch batchSearch3 = new BatchSearch(singletonList(project("otherPrj")),"bar","baz",asSet("q4", "q1"), User.local(),
-                true,asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                true,asList("application/json", "image/jpeg"), null, asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         long currentDateTime = new Date().getTime();
         BatchSearch batchSearch4 = new BatchSearch(asList(project("prj"),project("anotherPrj")),"qux","baz",asSet("q1", "q3"), new Date(currentDateTime + 50), State.SUCCESS, true);
         repository.save(batchSearch1);
@@ -195,7 +198,7 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_records_with_query() {
         IntStream.range(0, 5).mapToObj(i -> new BatchSearch(singletonList(project("prj1")), "name" + i, "description" + i, asSet("q1/" + i, "q2/" + i), User.local(),
-                true, asList("application/json", "image/jpeg"), asList("/path/to/docs", "/path/to/pdfs"), 3, true)).
+                true, asList("application/json", "image/jpeg"), singletonList("tag"), asList("/path/to/docs", "/path/to/pdfs"), 3, true)).
                 forEach(bs -> {
                             repository.save(bs);
                             DatashareTime.getInstance().addMilliseconds(1000);

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -387,39 +387,13 @@ public class JooqBatchSearchRepositoryTest {
         repository.save(batchSearch);
         repository.saveResults(batchSearch.uuid, "q1", asList(createDoc("doc1").build(), createDoc("doc2").build()));
         repository.saveResults(batchSearch.uuid, "q2", asList(createDoc("doc3").build(), createDoc("doc4").build()));
-        repository.saveResults(batchSearch.uuid, "q3", asList(createDoc("doc5").build(), createDoc("doc6").build()));
         List<SearchResult> results = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("q1")).build());
         assertThat(results).hasSize(2);
         assertThat(results).containsExactly(
                 resultFrom(createDoc("doc1").build(), 1, "q1"),
                 resultFrom(createDoc("doc2").build(), 2, "q1")
         );
-        List<SearchResult> resultExcludingQ1 = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("q1")).queriesExcluded(true).build());
-        assertThat(resultExcludingQ1).hasSize(4);
-        assertThat(resultExcludingQ1).containsExactly(
-                resultFrom(createDoc("doc3").build(), 1, "q2"),
-                resultFrom(createDoc("doc4").build(), 2, "q2"),
-                resultFrom(createDoc("doc5").build(), 1, "q3"),
-                resultFrom(createDoc("doc6").build(), 2, "q3")
-        );
-    }
-
-    @Test
-    public void test_get_results_filtered_by_content_type() {
-        BatchSearch batchSearch = new BatchSearch(singletonList(project("prj")), "name", "description", asSet("q1", "q2"), User.local());
-        repository.save(batchSearch);
-        repository.saveResults(batchSearch.uuid, "q1", asList(createDoc("doc1").ofMimeType("application/pdf").build(), createDoc("doc2").ofMimeType("content/type").build()));
-        repository.saveResults(batchSearch.uuid, "q2", asList(createDoc("doc3").ofMimeType("application/pdf").build(), createDoc("doc4").build()));
-        List<SearchResult> results = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withContentTypes(asList("application/pdf")).build());
-        assertThat(results).hasSize(2);
-        assertThat(results).containsExactly(
-                resultFrom(createDoc("doc1").ofMimeType("application/pdf").build(), 1, "q1"),
-                resultFrom(createDoc("doc3").ofMimeType("application/pdf").build(), 1, "q2")
-        );
-        //empty list means all and no content types
-        List<SearchResult> results2 = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withContentTypes(asList()).build());
-        assertThat(results2).hasSize(4);
-
+        assertThat(repository.getResults(User.local(), batchSearch.uuid,  WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("q2")).build())).hasSize(2);
     }
     @Test
     public void test_get_results_order() {

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -116,13 +116,12 @@ public class JooqBatchSearchRepositoryTest {
 
         repository.save(batchSearch1);
         repository.save(batchSearch2);
-
-        assertThat(repository.getTotal(User.local(), asList("prj1", "prj2"),new BatchSearchRepository.WebQuery())).isEqualTo(2);
-        assertThat(repository.getTotal(User.local(), asList("prj1", "prj2", "prj3"),new BatchSearchRepository.WebQuery())).isEqualTo(2);
-        assertThat(repository.getTotal(User.local(), singletonList("prj2"), new BatchSearchRepository.WebQuery())).isEqualTo(1);
-        assertThat(repository.getTotal(User.local(), asList("prj2", "prj3"),new BatchSearchRepository.WebQuery())).isEqualTo(1);
-        assertThat(repository.getTotal(User.local(), singletonList("prj3"), new BatchSearchRepository.WebQuery())).isEqualTo(0);
-        assertThat(repository.getTotal(User.local(), singletonList("prj1"), new BatchSearchRepository.WebQuery())).isEqualTo(0);
+        assertThat(repository.getTotal(User.local(), asList("prj1", "prj2"), WebQueryBuilder.createWebQuery().queryAll().build())).isEqualTo(2);
+        assertThat(repository.getTotal(User.local(), asList("prj1", "prj2", "prj3"), WebQueryBuilder.createWebQuery().queryAll().build())).isEqualTo(2);
+        assertThat(repository.getTotal(User.local(), singletonList("prj2"),  WebQueryBuilder.createWebQuery().queryAll().build())).isEqualTo(1);
+        assertThat(repository.getTotal(User.local(), asList("prj2", "prj3"), WebQueryBuilder.createWebQuery().queryAll().build())).isEqualTo(1);
+        assertThat(repository.getTotal(User.local(), singletonList("prj3"),  WebQueryBuilder.createWebQuery().queryAll().build())).isEqualTo(0);
+        assertThat(repository.getTotal(User.local(), singletonList("prj1"),  WebQueryBuilder.createWebQuery().queryAll().build())).isEqualTo(0);
     }
 
     @Test
@@ -173,24 +172,24 @@ public class JooqBatchSearchRepositoryTest {
         repository.save(batchSearch3);
         repository.save(batchSearch4);
 
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery("*","all"))).hasSize(4);
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery("foo","all"))).hasSize(1);
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery("oo","all"))).hasSize(1);
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery("baz","description"))).hasSize(4);
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery("baz","name"))).hasSize(0);
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery("","all")));
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery("*","all").build())).hasSize(4);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery("foo","all").build())).hasSize(1);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery("oo","all").build())).hasSize(1);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery("baz","description").build())).hasSize(4);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery("baz","name").build())).hasSize(0);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery("","all").build()));
 
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery(singletonList("anotherPrj"), null, null, null))).hasSize(1);
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery(asList("prj","anotherPrj"), null, null, null))).hasSize(3);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery().queryAll().withProjects(singletonList("anotherPrj")).build())).hasSize(1);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery().queryAll().withProjects(asList("prj","anotherPrj")).withState(asList(State.SUCCESS.toString(), State.QUEUED.toString())).build())).hasSize(3);
 
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery(null, asList(String.valueOf(currentDateTime + 10), String.valueOf(currentDateTime + 100)), null, null))).hasSize(1);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery().queryAll().withBatchDate(asList(String.valueOf(currentDateTime + 10), String.valueOf(currentDateTime + 100))).build())).hasSize(1);
 
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery(null, null, singletonList(State.SUCCESS.toString()), null))).hasSize(1);
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery(null, null, asList(State.SUCCESS.toString(), State.QUEUED.toString()), null))).hasSize(4);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery().queryAll().withState(singletonList(State.SUCCESS.toString())).build())).hasSize(1);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery().queryAll().withState(asList(State.SUCCESS.toString(), State.QUEUED.toString())).build())).hasSize(4);
 
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery(asList("otherPrj","prj"), null, null, "0"))).hasSize(1);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery().queryAll().withProjects(asList("otherPrj","prj")).withPublishState("0").build())).hasSize(1);
 
-        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), new BatchSearchRepository.WebQuery(asList("otherPrj","prj"), null, asList(State.SUCCESS.toString(), State.QUEUED.toString()), null))).hasSize(2);
+        assertThat(repository.getRecords(User.local(), asList("prj", "otherPrj", "anotherPrj"), WebQueryBuilder.createWebQuery().queryAll().withProjects(asList("otherPrj","prj")).withState(asList(State.SUCCESS.toString(), State.QUEUED.toString())).build())).hasSize(2);
     }
 
     @Test
@@ -203,12 +202,12 @@ public class JooqBatchSearchRepositoryTest {
                         }
                 );
 
-        List<BatchSearchRecord> from0To2 = repository.getRecords(User.local(), asList("prj1", "prj2"), new BatchSearchRepository.WebQuery(2, 0));
+        List<BatchSearchRecord> from0To2 = repository.getRecords(User.local(), asList("prj1", "prj2"), WebQueryBuilder.createWebQuery().queryAll().withRange(0,2).build());
         assertThat(from0To2).hasSize(2);
         assertThat(from0To2.get(0).name).isEqualTo("name4");
         assertThat(from0To2.get(1).name).isEqualTo("name3");
 
-        List<BatchSearchRecord> from0To2OrderByName = repository.getRecords(User.local(), asList("prj1", "prj2"), new BatchSearchRepository.WebQuery(1, 1, "name", "asc", "*", "all", null, null, null, null, null, true));
+        List<BatchSearchRecord> from0To2OrderByName = repository.getRecords(User.local(), asList("prj1", "prj2"),WebQueryBuilder.createWebQuery().queryAll().withRange(1,1).withSortOrder("name","asc").queryAll().queriesRetrieved(true).build());
         assertThat(from0To2OrderByName).hasSize(1);
         assertThat(from0To2OrderByName.get(0).name).isEqualTo("name1");
     }
@@ -341,11 +340,12 @@ public class JooqBatchSearchRepositoryTest {
         assertThat(repository.saveResults(batchSearch.uuid, "query", asList(
                 createDoc("doc1").build(), createDoc("doc2").build(), createDoc("doc3").build(), createDoc("doc4").build()))).isTrue();
 
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery(2, 0))).hasSize(2);
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery(2, 0))).containsExactly(
+        assertThat(repository.getResults(User.local(), batchSearch.uuid,WebQueryBuilder.createWebQuery().withRange(0,2).build())).hasSize(2);
+        assertThat(repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().withRange(0,2).build())).containsExactly(
                 resultFrom(createDoc("doc1").build(), 1, "query"), resultFrom(createDoc("doc2").build(), 2, "query"));
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery( 2, 2))).containsExactly(
+        assertThat(repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().withRange(2,2).build())).containsExactly(
                 resultFrom(createDoc("doc3").build(), 3, "query"), resultFrom(createDoc("doc4").build(), 4, "query"));
+
     }
 
     @Test
@@ -354,17 +354,30 @@ public class JooqBatchSearchRepositoryTest {
         repository.save(batchSearch);
         repository.saveResults(batchSearch.uuid, "q1", asList(createDoc("doc1").build(), createDoc("doc2").build()));
         repository.saveResults(batchSearch.uuid, "q2", asList(createDoc("doc3").build(), createDoc("doc4").build()));
-
-        List<SearchResult> results = repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery(singletonList("q1")));
+        List<SearchResult> results = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("q1")).build());
         assertThat(results).hasSize(2);
         assertThat(results).containsExactly(
                 resultFrom(createDoc("doc1").build(), 1, "q1"),
                 resultFrom(createDoc("doc2").build(), 2, "q1")
         );
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery(singletonList("q2")))).
+        assertThat(repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("q2")).build())).
                 hasSize(2);
     }
 
+    @Test
+    public void test_get_results_filtered_by_excluding_queries() {
+        BatchSearch batchSearch = new BatchSearch(singletonList(project("prj")), "name", "description", asSet("q1", "q2"), User.local());
+        repository.save(batchSearch);
+        repository.saveResults(batchSearch.uuid, "q1", asList(createDoc("doc1").build(), createDoc("doc2").build()));
+        repository.saveResults(batchSearch.uuid, "q2", asList(createDoc("doc3").build(), createDoc("doc4").build()));
+        List<SearchResult> results = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("q1")).build());
+        assertThat(results).hasSize(2);
+        assertThat(results).containsExactly(
+                resultFrom(createDoc("doc1").build(), 1, "q1"),
+                resultFrom(createDoc("doc2").build(), 2, "q1")
+        );
+        assertThat(repository.getResults(User.local(), batchSearch.uuid,  WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("q2")).build())).hasSize(2);
+    }
     @Test
     public void test_get_results_order() {
         BatchSearch batchSearch = new BatchSearch(singletonList(project("prj")), "name", "description", asSet("q1", "q2"), User.local());
@@ -372,28 +385,28 @@ public class JooqBatchSearchRepositoryTest {
         repository.saveResults(batchSearch.uuid, "q1", asList(createDoc("a").build(), createDoc("c").build()));
         repository.saveResults(batchSearch.uuid, "q2", asList(createDoc("b").build(), createDoc("d").build()));
 
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery(0, 0))).
+        assertThat(repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().build())).
                 containsExactly(
                         resultFrom(createDoc("a").build(), 1, "q1"),
                         resultFrom(createDoc("c").build(), 2, "q1"),
                         resultFrom(createDoc("b").build(), 1, "q2"),
                         resultFrom(createDoc("d").build(), 2, "q2")
                 );
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery("doc_path", "asc","*","all"))).
+        assertThat(repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withSortOrder("doc_path","asc").build())).
                 containsExactly(
                         resultFrom(createDoc("a").build(), 1, "q1"),
                         resultFrom(createDoc("b").build(), 1, "q2"),
                         resultFrom(createDoc("c").build(), 2, "q1"),
                         resultFrom(createDoc("d").build(), 2, "q2")
                 );
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery("doc_path", "desc","*","all"))).
+        assertThat(repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withSortOrder("doc_path","desc").build())).
                 containsExactly(
                         resultFrom(createDoc("d").build(), 2, "q2"),
                         resultFrom(createDoc("c").build(), 2, "q1"),
                         resultFrom(createDoc("b").build(), 1, "q2"),
                         resultFrom(createDoc("a").build(), 1, "q1")
                 );
-        assertThat(repository.getResults(User.local(), batchSearch.uuid, new BatchSearchRepository.WebQuery("doc_nb", "desc","*","all"))).
+        assertThat(repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withSortOrder("doc_nb","desc").build())).
                 containsExactly(
                         resultFrom(createDoc("d").build(), 2, "q2"),
                         resultFrom(createDoc("b").build(), 1, "q2"),
@@ -534,7 +547,7 @@ public class JooqBatchSearchRepositoryTest {
         repository.saveResults(batchSearch.uuid, "query", asList(
               createDoc("doc1").build(), createDoc("doc2").build(), createDoc("doc3").build(), createDoc("doc4").build()));
 
-        assertThat(repository.getResults(new User("other"), batchSearch.uuid, new BatchSearchRepository.WebQuery(2, 0))).hasSize(2);
+        assertThat(repository.getResults(new User("other"), batchSearch.uuid,WebQueryBuilder.createWebQuery().withRange(0,2).build())).hasSize(2);
     }
 
     @Test

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -217,11 +217,11 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_records_filtered_by_content_type(){
         BatchSearch batchSearch1 = new BatchSearch(singletonList(project("prj1")),"foo","baz",asSet("q1", "q2"), User.local(),
-                false,asList("application/json", "application/text"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                false,asList("application/json", "application/text"),null, asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         BatchSearch batchSearch2 = new BatchSearch(singletonList(project("prj1")),"bar","baz",asSet("q3", "q2"), User.local(),
-                true,asList("application/json"), asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                true,asList("application/json"), null,asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         BatchSearch batchSearch3 = new BatchSearch(asList(project("prj1")),"bar","baz",asSet("q3", "q2"), User.local(),
-                true,null, asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+                true,null, null,asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         repository.save(batchSearch1);
         repository.save(batchSearch2);
         repository.save(batchSearch3);

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>10.3.0</datashare-api.version>
+        <datashare-api.version>10.5.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
Before:
- [x] merge https://github.com/ICIJ/datashare-api/pull/15

Based on https://github.com/ICIJ/datashare/tree/feat/batch_search_tag_filter so
- [x]  merge the PR related to the batch_search_tag_filter  branch when available

Add batch search result filter on contentTypes and allow querie filter inversion with queriesExcluded attribute.

Refactor: use WebqueryBuilder instead of Webquery construtor