### PR TITLE
fix: unknown batch search wrong status

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -36,7 +36,6 @@ public class BatchSearchResource {
     private final BatchSearchRepository batchSearchRepository;
     private final BlockingQueue<String> batchSearchQueue;
     private final PropertiesProvider propertiesProvider;
-    private final PayloadFormatter payloadFormatter;
     private final int MAX_BATCH_SIZE = 60000;
 
     @Inject
@@ -44,7 +43,6 @@ public class BatchSearchResource {
         this.batchSearchRepository = batchSearchRepository;
         this.batchSearchQueue = batchSearchQueue;
         this.propertiesProvider = propertiesProvider;
-        this.payloadFormatter = new PayloadFormatter();
     }
 
     /**
@@ -107,7 +105,7 @@ public class BatchSearchResource {
     public Object getBatch(String batchId, Context context) {
         boolean withQueries = Boolean.parseBoolean(context.get("withQueries"));
         BatchSearch batchSearch = batchSearchRepository.get((User) context.currentUser(), batchId, withQueries);
-        return batchSearch == null ? payloadFormatter.error("Batch search not found.", HttpStatus.NOT_FOUND) : batchSearch;
+        return batchSearch == null ? PayloadFormatter.error("Batch search not found.", HttpStatus.NOT_FOUND) : batchSearch;
     }
 
     /**

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -206,6 +206,14 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_get_unknown_batch_search_returns_404() {
+        get("/api/batch/search/unknown-id").should()
+                .respond(404)
+                .haveType("application/json")
+                .contain("Batch search not found.");
+    }
+
+    @Test
     public void test_get_batch_searches_json() {
         when(batchSearchRepository.getRecords(User.local(), singletonList("local-datashare"))).thenReturn(asList(
                 new BatchSearch(singletonList(project("prj")), "name1", "description1", asSet("query 1", "query 2"), User.local()),

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -520,6 +520,18 @@ public class JooqBatchSearchRepositoryTest {
     }
 
     @Test
+    public void test_cannot_get_unknown_batch_search_without_queries() {
+        BatchSearch batchSearch = repository.get(User.local(), "unknown-id", false);
+        assertThat(batchSearch).isNull();
+    }
+
+    @Test
+    public void test_cannot_get_unknown_batch_search_with_queries() {
+        BatchSearch batchSearch = repository.get(User.local(), "unknown-id", true);
+        assertThat(batchSearch).isNull();
+    }
+
+    @Test
     public void test_delete_batch_searches() {
         BatchSearch batchSearch1 = new BatchSearch(singletonList(project("prj")), "name", "description1", asSet("q1", "q2"), User.local());
         repository.save(batchSearch1);


### PR DESCRIPTION
## PR description

This tackles the issue of unknown BS returning a 500 as described in https://github.com/ICIJ/datashare/issues/1093.

## Changes

The error handling is done at two level:

* In the `BatchSearchResources` to ensure the correct code and error message is shown
* In the `BatchSearchRepository` to ensure get a BS from the db is done with a safe accessor