### PR TITLE
fix: use of TLS/auth for mail sender see #1106

### DIFF
--- a/datashare-app/pom.xml
+++ b/datashare-app/pom.xml
@@ -123,9 +123,9 @@
         
         <!--test dependencies-->
         <dependency>
-            <groupId>org.subethamail</groupId>
+            <groupId>com.github.voodoodyne</groupId>
             <artifactId>subethasmtp</artifactId>
-            <version>3.1.7</version>
+            <version>e70b7dd3357f82a3e9c0da43290ef9e47ec982ad</version>
             <scope>test</scope>
         </dependency>
 

--- a/datashare-app/src/main/java/org/icij/datashare/com/mail/MailSender.java
+++ b/datashare-app/src/main/java/org/icij/datashare/com/mail/MailSender.java
@@ -1,17 +1,13 @@
 package org.icij.datashare.com.mail;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Properties;
-
-
 import com.sun.mail.smtp.SMTPMessage;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.mail.*;
-import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
+import java.net.URI;
+import java.util.Properties;
 
 import static java.util.Optional.ofNullable;
 import static javax.mail.Message.RecipientType.CC;
@@ -19,15 +15,17 @@ import static javax.mail.Message.RecipientType.TO;
 
 
 public class MailSender {
-    protected final Log logger = LogFactory.getLog(this.getClass());
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
     
     public final int port;
     public final String host;
     final String user;
     final String password;
+    final boolean tls;
+    final boolean debug;
 
     public MailSender(String host, int port) {
-        this(host, port, null, null);
+        this(host, port, null, null, false, false);
     }
 
     public MailSender(URI uri) {
@@ -35,32 +33,45 @@ public class MailSender {
             uri.getHost(),
             uri.getPort(),
             uri.getUserInfo() != null ? uri.getUserInfo().split(":")[0]: null,
-            uri.getUserInfo() != null ? uri.getUserInfo().split(":")[1]: null
+            uri.getUserInfo() != null ? uri.getUserInfo().split(":")[1]: null,
+            uri.getScheme().equals("smtps"),
+            ofNullable(uri.getQuery()).orElse("").contains("debug=true")
         );
     }
 
-    public MailSender(String host, int port, String user, String password) {
+    public MailSender(String host, int port, String user, String password, boolean tls, boolean debug) {
         this.host = host;
         this.port = port;
         this.user = user;
         this.password = password;
+        this.tls = tls;
+        this.debug = debug;
     }
 
     public void send(Mail donneesEmail) throws MailException {
         try {
             Message message = createMessage(donneesEmail);
-            Transport.send(message);
+            if (shouldAuth()) {
+                Transport.send(message, user, password);
+            } else {
+                Transport.send(message);
+            }
         } catch (NullPointerException e) {
             logger.error("If error is about MailcapFile, delete .mailcap in the user's home");
             throw new MailException(e);
         } catch (Throwable t) {
-            logger.fatal("Failed to send mail : hostmail=" + host + ", port=" + port + ", Exception=" + t.getMessage());
+            logger.error("Failed to send mail : hostmail=" + host + ", port=" + port,  t);
             throw new MailException(t);
         }
     }
 
-    private Message createMessage(Mail donneesEmail) throws MessagingException, AddressException {
-        Message message = new SMTPMessage(getMailSession(host, port, user, password));
+    private Message createMessage(Mail donneesEmail) throws MessagingException {
+        Session mailSession = getMailSession(this);
+        mailSession.setDebug(debug);
+        if (shouldAuth()) {
+            mailSession.getTransport().connect(host, user, password);
+        }
+        Message message = new SMTPMessage(mailSession);
         logger.info("MimeMessage: host = " + host + " - port = " + port);
 
         message.setHeader("X-Mailer", "msgsend");
@@ -82,16 +93,23 @@ public class MailSender {
         return message;
     }
 
-    private synchronized static Session getMailSession(String hostTransportMail, int portTransportMail, String user, String password) {
+    private synchronized static Session getMailSession(MailSender mailSender) {
         Properties properties = new Properties();
         properties.setProperty("mail.smtp.class", "com.sun.mail.smtp.SMTPTransport");
-        properties.setProperty("mail.smtp.port", String.valueOf(portTransportMail));
-        properties.setProperty("mail.smtp.host", hostTransportMail);
-        return user == null ? Session.getDefaultInstance(properties): Session.getInstance(properties, new Authenticator() {
+        properties.setProperty("mail.smtp.port", String.valueOf(mailSender.port));
+        properties.setProperty("mail.smtp.host", mailSender.host);
+        if (mailSender.shouldAuth()) {
+            properties.setProperty("mail.smtp.auth", "true");
+        }
+        properties.setProperty("mail.smtp.ssl.enable", String.valueOf(mailSender.tls));
+
+        return mailSender.shouldAuth() ? Session.getDefaultInstance(properties) : Session.getInstance(properties, new Authenticator() {
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {
-                return new PasswordAuthentication(user, password);
+                return new PasswordAuthentication(mailSender.user, mailSender.password);
             }
         });
     }
+
+    boolean shouldAuth() {return user != null;}
 }

--- a/datashare-app/src/main/java/org/icij/datashare/com/mail/MailSender.java
+++ b/datashare-app/src/main/java/org/icij/datashare/com/mail/MailSender.java
@@ -51,17 +51,21 @@ public class MailSender {
     public void send(Mail donneesEmail) throws MailException {
         try {
             Message message = createMessage(donneesEmail);
-            if (shouldAuth()) {
-                Transport.send(message, user, password);
-            } else {
-                Transport.send(message);
-            }
+            send(message);
         } catch (NullPointerException e) {
             logger.error("If error is about MailcapFile, delete .mailcap in the user's home");
             throw new MailException(e);
         } catch (Throwable t) {
             logger.error("Failed to send mail : hostmail=" + host + ", port=" + port,  t);
             throw new MailException(t);
+        }
+    }
+
+    private void send(Message message) throws MessagingException {
+        if (shouldAuth()) {
+            Transport.send(message, user, password);
+        } else {
+            Transport.send(message);
         }
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/com/mail/MailSender.java
+++ b/datashare-app/src/main/java/org/icij/datashare/com/mail/MailSender.java
@@ -102,9 +102,7 @@ public class MailSender {
         properties.setProperty("mail.smtp.class", "com.sun.mail.smtp.SMTPTransport");
         properties.setProperty("mail.smtp.port", String.valueOf(mailSender.port));
         properties.setProperty("mail.smtp.host", mailSender.host);
-        if (mailSender.shouldAuth()) {
-            properties.setProperty("mail.smtp.auth", "true");
-        }
+        properties.setProperty("mail.smtp.auth", String.valueOf(mailSender.shouldAuth()));
         properties.setProperty("mail.smtp.ssl.enable", String.valueOf(mailSender.tls));
 
         return mailSender.shouldAuth() ? Session.getDefaultInstance(properties) : Session.getInstance(properties, new Authenticator() {


### PR DESCRIPTION
Second PR to fix the use of mailsender with authenticated user.

It comes with  :
* fix for the logger that was not properly used
* a new parameter for TLS connection (on 465)
* a new debug parameter to see exactly why the mail sending is failing
* extracted a `shouldAuth()` méthod that centralize the criteria for knowing if we sould auth or not
 