### PR TITLE
chore: bump neo4j extension to 0.2.0

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -49,9 +49,9 @@
       "id": "datashare-extension-neo4j",
       "name": "neo4j",
       "description": "A Datashare extension to perform graph analysis using neo4j",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.1.1/datashare-extension-neo4j-0.1.1-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.2.0/datashare-extension-neo4j-0.2.0-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "type": "WEB"
     }
   ]


### PR DESCRIPTION
# Changes
Bump extension version to `0.2.0` (skipping `0.1.2`)
- https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.2.0
- https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.1.2
