### PR TITLE
feat: allow multi projects in local

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
@@ -1,8 +1,9 @@
 package org.icij.datashare.mode;
 
 import net.codestory.http.routes.Routes;
+import org.icij.datashare.db.JooqRepository;
+import org.icij.datashare.db.RepositoryFactoryImpl;
 import org.icij.datashare.session.LocalUserFilter;
-import org.icij.datashare.tasks.BatchSearchLoop;
 import org.icij.datashare.web.*;
 
 import java.util.Map;
@@ -12,12 +13,18 @@ public class LocalMode extends CommonMode {
     LocalMode(Properties properties) { super(properties);}
     LocalMode(Map<String, String> properties) { super(properties);}
 
+    protected LocalUserFilter getLocalUserFilter() {
+        RepositoryFactoryImpl repositoryFactory = new RepositoryFactoryImpl(propertiesProvider);
+        JooqRepository jooqRepository = (JooqRepository) repositoryFactory.createRepository();
+        return new LocalUserFilter(propertiesProvider, jooqRepository);
+    }
+
     @Override
     protected void configure() {
         super.configure();
         bind(IndexWaiterFilter.class).asEagerSingleton();
         bind(StatusResource.class).asEagerSingleton();
-
+        bind(LocalUserFilter.class).toInstance(getLocalUserFilter());
         configurePersistence();
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/session/DatashareUser.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/DatashareUser.java
@@ -21,12 +21,15 @@ public class DatashareUser extends User implements net.codestory.http.security.U
     @Override public String name() { return (String) details.get("name"); }
     @Override public String[] roles() { return isLocal() ? new String[] {LOCAL}: new String[0]; }
     public Object get(String key) { return details.get(key); }
-
     public static Users singleUser(String name) { return singleUser(User.localUser(name));}
     public static Users singleUser(final User user) {
         return new Users() {
-            @Override public net.codestory.http.security.User find(String s, String s1) { return s.equals(user.id) ? new DatashareUser(user) : null;}
-            @Override public net.codestory.http.security.User find(String s) { return s.equals(user.id) ? new DatashareUser(user) : null;}
+            @Override public net.codestory.http.security.User find(String s, String s1) {
+                return s.equals(user.id) ? new DatashareUser(user) : null;
+            }
+            @Override public net.codestory.http.security.User find(String s) {
+                return s.equals(user.id) ? new DatashareUser(user) : null;
+            }
         };
     }
     public static Users users(String... logins) {
@@ -36,8 +39,12 @@ public class DatashareUser extends User implements net.codestory.http.security.U
                     put(login, new DatashareUser(login));
                 }
             }};
-            @Override public net.codestory.http.security.User find(String s, String s1) { return users.get(s);}
-            @Override public net.codestory.http.security.User find(String s) { return users.get(s);}
+            @Override public net.codestory.http.security.User find(String s, String s1) {
+                return users.get(s);
+            }
+            @Override public net.codestory.http.security.User find(String s) {
+                return users.get(s);
+            }
         };
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -1,0 +1,58 @@
+package org.icij.datashare.utils;
+
+import net.codestory.http.Context;
+import net.codestory.http.Query;
+import net.codestory.http.errors.UnauthorizedException;
+import org.icij.datashare.session.DatashareUser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.join;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+public class IndexAccessVerifier {
+
+    public String checkIndices(String indices) {
+        if( indices == null) {
+            throw new IllegalArgumentException("indices is null");
+        }
+        Pattern pattern = Pattern.compile("^[-a-zA-Z0-9_]+(,[-a-zA-Z0-9_]+)*$");
+        Matcher matcher = pattern.matcher(indices);
+        if( !matcher.find()) {
+            throw new IllegalArgumentException("Bad format for indices : '" + indices+"'");
+        }
+        return indices;
+    }
+
+    public String checkPath(String path, Context context) {
+        String[] pathParts = path.split("/");
+        if(pathParts.length < 2){
+            throw new IllegalArgumentException(String.format("Invalid path: '%s'", path));
+        }
+        if ("_search".equals(pathParts[0]) && "scroll".equals(pathParts[1])) {
+            return getUrlString(context, path);
+        }
+        String[] indexes = this.checkIndices(pathParts[0]).split(",");
+        if (stream(indexes).allMatch(index -> ((DatashareUser)context.currentUser()).isGranted(index)) &&
+                ("GET".equalsIgnoreCase(context.method()) ||
+                        "_search".equals(pathParts[1]) ||
+                        "_count".equals(pathParts[1]) ||
+                        (pathParts.length >=3 && "_search".equals(pathParts[2])))) {
+            return getUrlString(context, path);
+        }
+        throw new UnauthorizedException();
+    }
+
+    static String getUrlString(Context context, String s) {
+        if (context.query().keyValues().size() > 0) {
+            s += "?" + getQueryAsString(context.query());
+        }
+        return s;
+    }
+
+    static String getQueryAsString(final Query query) {
+        return join("&", query.keyValues().entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(toList()));
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -14,7 +14,7 @@ import static java.util.stream.Collectors.toList;
 
 public class IndexAccessVerifier {
 
-    public String checkIndices(String indices) {
+    static public String checkIndices(String indices) {
         if( indices == null) {
             throw new IllegalArgumentException("indices is null");
         }
@@ -26,7 +26,7 @@ public class IndexAccessVerifier {
         return indices;
     }
 
-    public String checkPath(String path, Context context) {
+    static public String checkPath(String path, Context context) {
         String[] pathParts = path.split("/");
         if (pathParts.length < 2) {
             throw new IllegalArgumentException(String.format("Invalid path: '%s'", path));
@@ -34,19 +34,19 @@ public class IndexAccessVerifier {
         if (isSearchScrollPath(path)) {
             return getUrlString(context, path);
         }
-        String[] indexes = this.checkIndices(pathParts[0]).split(",");
+        String[] indexes = checkIndices(pathParts[0]).split(",");
         if (isAuthorizedRequest(context, pathParts, indexes)) {
             return getUrlString(context, path);
         }
         throw new UnauthorizedException();
     }
 
-    private boolean isSearchScrollPath(String path) {
+    static private boolean isSearchScrollPath(String path) {
         String[] pathParts = path.split("/");
         return "_search".equals(pathParts[0]) && "scroll".equals(pathParts[1]);
     }
 
-    private boolean isAuthorizedRequest(Context context, String[] pathParts, String[] indexes) {
+    static private boolean isAuthorizedRequest(Context context, String[] pathParts, String[] indexes) {
         DatashareUser currentUser = (DatashareUser) context.currentUser();
         boolean isMethodGet = "GET".equalsIgnoreCase(context.method());
         boolean isSearchPath = "_search".equals(pathParts[1]);

--- a/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
@@ -14,7 +14,7 @@ public class PayloadFormatter {
 
     public Payload error(String message, int status) {
         Map<String, String> responseBody = Collections.singletonMap("error", message);
-        return new Payload(responseBody).withCode(status);
+        return json(responseBody).withCode(status);
     }
 
     public Payload error(RuntimeException error, int status) {

--- a/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
@@ -8,7 +8,16 @@ import java.util.Map;
 public class PayloadFormatter {
 
     public Payload error(String message, int status) {
-        Map<String, String> body = Collections.singletonMap("error", message);
-        return new Payload(body).withCode(status);
+        Map<String, String> responseBody = Collections.singletonMap("error", message);
+        return new Payload(responseBody).withCode(status);
+    }
+
+    public Payload error(RuntimeException error, int status) {
+        String message = error.getMessage();
+        return error(message, status);
+    }
+
+    public Payload json(String responseBody) {
+        return new Payload("application/json", responseBody);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
@@ -26,6 +26,10 @@ public class PayloadFormatter {
         return new Payload("application/json", responseBody);
     }
 
+    public Payload json(Object content) {
+        return new Payload("application/json", content);
+    }
+
     public Payload allowMethods(String... methodOrMethods) {
         List<String> methods = Arrays.stream(methodOrMethods)
                 .flatMap(s -> Arrays.stream(s.split(",")))

--- a/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
@@ -12,25 +12,25 @@ import static net.codestory.http.payload.Payload.ok;
 
 public class PayloadFormatter {
 
-    public Payload error(String message, int status) {
+    static public Payload error(String message, int status) {
         Map<String, String> responseBody = Collections.singletonMap("error", message);
         return json(responseBody).withCode(status);
     }
 
-    public Payload error(RuntimeException error, int status) {
+    static public Payload error(RuntimeException error, int status) {
         String message = error.getMessage();
         return error(message, status);
     }
 
-    public Payload json(String responseBody) {
+    static public Payload json(String responseBody) {
         return new Payload("application/json", responseBody);
     }
 
-    public Payload json(Object content) {
+    static public Payload json(Object content) {
         return new Payload("application/json", content);
     }
 
-    public Payload allowMethods(String... methodOrMethods) {
+    static public Payload allowMethods(String... methodOrMethods) {
         List<String> methods = Arrays.stream(methodOrMethods)
                 .flatMap(s -> Arrays.stream(s.split(",")))
                 .map(String::trim)

--- a/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/PayloadFormatter.java
@@ -2,8 +2,13 @@ package org.icij.datashare.utils;
 
 import net.codestory.http.payload.Payload;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static net.codestory.http.payload.Payload.ok;
 
 public class PayloadFormatter {
 
@@ -19,5 +24,13 @@ public class PayloadFormatter {
 
     public Payload json(String responseBody) {
         return new Payload("application/json", responseBody);
+    }
+
+    public Payload allowMethods(String... methodOrMethods) {
+        List<String> methods = Arrays.stream(methodOrMethods)
+                .flatMap(s -> Arrays.stream(s.split(",")))
+                .map(String::trim)
+                .collect(Collectors.toList());
+        return ok().withAllowMethods(methods.toArray(new String[0]));
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -54,7 +54,7 @@ public class BatchSearchResource {
     @Get("/search")
     public List<BatchSearchRecord> getSearches(Context context) {
         DatashareUser user = (DatashareUser) context.currentUser();
-        return batchSearchRepository.getRecords(user, user.getProjects());
+        return batchSearchRepository.getRecords(user, user.getProjectNames());
     }
 
     /**
@@ -84,8 +84,8 @@ public class BatchSearchResource {
     @Post("/search")
     public WebResponse<BatchSearchRecord> getSearchesFiltered(BatchSearchRepository.WebQuery webQuery, Context context) {
         DatashareUser user = (DatashareUser) context.currentUser();
-        return new WebResponse<>(batchSearchRepository.getRecords(user, user.getProjects(), webQuery),
-                batchSearchRepository.getTotal(user, user.getProjects(), webQuery));
+        return new WebResponse<>(batchSearchRepository.getRecords(user, user.getProjectNames(), webQuery),
+                batchSearchRepository.getTotal(user, user.getProjectNames(), webQuery));
     }
 
     /**

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -61,7 +61,7 @@ public class IndexResource {
     public Payload createIndexPreflight(final String index) {
         try{
             this.checkIndices(index);
-            return ok().withAllowMethods("OPTIONS", "PUT");
+            return payloadFormatter.allowMethods("OPTIONS", "PUT");
         }catch (IllegalArgumentException e){
             return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
@@ -142,7 +142,7 @@ public class IndexResource {
     public Payload esOptions(final String index, final String path, Context context) throws IOException {
         try {
             this.checkIndices(index);
-            return ok().withAllowMethods(indexer.executeRaw("OPTIONS", path, null).split(","));
+            return payloadFormatter.allowMethods(indexer.executeRaw("OPTIONS", path, null));
         } catch (IllegalArgumentException e){
             return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -27,14 +27,10 @@ import static net.codestory.http.payload.Payload.ok;
 @Prefix("/api/index")
 public class IndexResource {
     private final Indexer indexer;
-    private final PayloadFormatter payloadFormatter;
-    private final IndexAccessVerifier indexAccessVerifier;
 
     @Inject
     public IndexResource(Indexer indexer) {
         this.indexer = indexer;
-        this.payloadFormatter = new PayloadFormatter();
-        this.indexAccessVerifier = new IndexAccessVerifier();
     }
 
     /**
@@ -48,9 +44,9 @@ public class IndexResource {
     @Put("/:index")
     public Payload createIndex(final String index) throws IOException {
         try{
-            return indexer.createIndex(indexAccessVerifier.checkIndices(index)) ? created() : ok();
+            return indexer.createIndex(IndexAccessVerifier.checkIndices(index)) ? created() : ok();
         }catch (IllegalArgumentException e){
-            return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
+            return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -63,10 +59,10 @@ public class IndexResource {
     @Options("/:index")
     public Payload createIndexPreflight(final String index) {
         try{
-            indexAccessVerifier.checkIndices(index);
-            return payloadFormatter.allowMethods("OPTIONS", "PUT");
+            IndexAccessVerifier.checkIndices(index);
+            return PayloadFormatter.allowMethods("OPTIONS", "PUT");
         }catch (IllegalArgumentException e){
-            return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
+            return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -81,7 +77,7 @@ public class IndexResource {
         try {
             return new Payload(indexer.executeRaw("HEAD", path, null));
         } catch (IllegalArgumentException e){
-            return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
+            return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -106,9 +102,9 @@ public class IndexResource {
     @Post("/search/:path:")
     public Payload esPost(final String path, Context context, final net.codestory.http.Request request) throws IOException {
         try {
-            return payloadFormatter.json(indexer.executeRaw("POST", indexAccessVerifier.checkPath(path, context), new String(request.contentAsBytes())));
+            return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.checkPath(path, context), new String(request.contentAsBytes())));
         } catch ( IllegalArgumentException e){
-            return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
+            return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -129,9 +125,9 @@ public class IndexResource {
     @Get("/search/:path:")
     public Payload esGet(final String path, Context context) throws IOException {
         try {
-            return payloadFormatter.json(indexer.executeRaw("GET", indexAccessVerifier.checkPath(path, context), ""));
+            return PayloadFormatter.json(indexer.executeRaw("GET", IndexAccessVerifier.checkPath(path, context), ""));
         } catch (IllegalArgumentException e){
-            return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
+            return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -144,10 +140,10 @@ public class IndexResource {
     @Options("/search/:path:")
     public Payload esOptions(final String index, final String path, Context context) throws IOException {
         try {
-            indexAccessVerifier.checkIndices(index);
-            return payloadFormatter.allowMethods(indexer.executeRaw("OPTIONS", path, null));
+            IndexAccessVerifier.checkIndices(index);
+            return PayloadFormatter.allowMethods(indexer.executeRaw("OPTIONS", path, null));
         } catch (IllegalArgumentException e){
-            return payloadFormatter.error(e, HttpStatus.BAD_REQUEST);
+            return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -32,7 +32,6 @@
         private final Indexer indexer;
         private final DataDirVerifier dataDirVerifier;
         private final ModeVerifier modeVerifier;
-        private final PayloadFormatter payloadFormatter;
 
 
         @Inject
@@ -41,7 +40,6 @@
             this.indexer = indexer;
             this.dataDirVerifier = new DataDirVerifier(propertiesProvider);;
             this.modeVerifier = new ModeVerifier(propertiesProvider);
-            this.payloadFormatter = new PayloadFormatter();
         }
 
         String[] getUserProjectIds(DatashareUser user) {
@@ -89,13 +87,13 @@
             Project project = context.extract(Project.class);
 
             if (projectExists(project)) {
-                return payloadFormatter.error("Project already exists.", HttpStatus.CONFLICT);
+                return PayloadFormatter.error("Project already exists.", HttpStatus.CONFLICT);
             } else if (isProjectNameEmpty(project)) {
-                return payloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
+                return PayloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
             } else if (isProjectSourcePathNull(project) || !dataDirVerifier.allowed(project.getSourcePath())) {
-                return payloadFormatter.error(String.format("`sourcePath` is required and must not be outside %s.", dataDirVerifier.value()), HttpStatus.BAD_REQUEST);
+                return PayloadFormatter.error(String.format("`sourcePath` is required and must not be outside %s.", dataDirVerifier.value()), HttpStatus.BAD_REQUEST);
             } else if (!repository.save(project) || !this.indexer.createIndex(project.getId())) {
-                return payloadFormatter.error("Unable to create the project", HttpStatus.INTERNAL_SERVER_ERROR);
+                return PayloadFormatter.error("Unable to create the project", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
             return new Payload(project).withCode(HttpStatus.CREATED);
@@ -106,10 +104,10 @@
             modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
             Project project = context.extract(Project.class);
             if (!projectExists(project) || !Objects.equals(project.getId(), id)) {
-                return payloadFormatter.error("Project not found", HttpStatus.NOT_FOUND);
+                return PayloadFormatter.error("Project not found", HttpStatus.NOT_FOUND);
             }
             if (!project.getId().equals(id) || !repository.save(project)) {
-                return payloadFormatter.error("Unable to save the project", HttpStatus.INTERNAL_SERVER_ERROR);
+                return PayloadFormatter.error("Unable to save the project", HttpStatus.INTERNAL_SERVER_ERROR);
             }
             return new Payload(project).withCode(HttpStatus.OK);
         }
@@ -129,7 +127,7 @@
         public Payload getProject(String id, Context context) {
             Project project = getUserProject((DatashareUser) context.currentUser(), id);
             if (project == null) {
-                return payloadFormatter.error("Project not found", HttpStatus.NOT_FOUND);
+                return PayloadFormatter.error("Project not found", HttpStatus.NOT_FOUND);
             }
             return new Payload(project).withCode(HttpStatus.OK);
         }
@@ -163,7 +161,7 @@
             Project project = repository.getProject(projectId);
 
             if (project != null && !isAllowed(project, context.request().clientAddress()))  {
-                return payloadFormatter.error("Download not allowed", HttpStatus.FORBIDDEN);
+                return PayloadFormatter.error("Download not allowed", HttpStatus.FORBIDDEN);
             }
 
             return ok();

--- a/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
@@ -12,6 +12,7 @@ import org.icij.datashare.text.Language;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -55,7 +56,7 @@ public class RootResource {
         } else {
             content = new String(Files.readAllBytes(index), Charset.defaultCharset());
         }
-        List<String> projects = context.currentUser() == null ? new LinkedList<String>() : ((DatashareUser)context.currentUser()).getProjects();
+        List<String> projects = context.currentUser() == null ? new LinkedList<String>() : ((DatashareUser)context.currentUser()).getProjectNames();
         return propertiesProvider.get(PLUGINS_DIR).isPresent() ?
                 new PluginService(propertiesProvider).addPlugins(content, projects):
                 content;
@@ -91,7 +92,10 @@ public class RootResource {
     public Properties getVersion() {
         try {
             Properties properties = new Properties();
-            properties.load(getClass().getResourceAsStream("/git.properties"));
+            InputStream gitProperties = getClass().getResourceAsStream("/git.properties");
+            if (gitProperties != null) {
+                properties.load(gitProperties);
+            }
             return properties;
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/datashare-app/src/test/java/org/icij/datashare/session/LocalUserFilterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/session/LocalUserFilterTest.java
@@ -5,8 +5,10 @@ import net.codestory.http.filters.PayloadSupplier;
 import net.codestory.http.payload.Payload;
 import net.codestory.http.security.User;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.Repository;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 
 import java.util.HashMap;
 
@@ -16,6 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class LocalUserFilterTest {
+    @Mock Repository repository;
     private Payload next = Payload.ok();
     private PayloadSupplier nextFilter = () -> next;
     private Context context = mock(Context.class);
@@ -23,9 +26,10 @@ public class LocalUserFilterTest {
 
     @Test
     public void test_matches() {
-        LocalUserFilter localUserFilter = new LocalUserFilter(new PropertiesProvider(new HashMap<String, String>() {{
+        PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
             put("protectedUrPrefix", "test");
-        }}));
+        }});
+        LocalUserFilter localUserFilter = new LocalUserFilter(propertiesProvider, repository);
 
         assertThat(localUserFilter.matches("foo", null)).isFalse();
         assertThat(localUserFilter.matches("/foo", null)).isFalse();
@@ -37,7 +41,7 @@ public class LocalUserFilterTest {
 
     @Test
     public void test_adds_local_user_to_context() throws Exception {
-        LocalUserFilter localUserFilter = new LocalUserFilter(new PropertiesProvider());
+        LocalUserFilter localUserFilter = new LocalUserFilter(new PropertiesProvider(), repository);
         Payload payload = localUserFilter.apply("url", context, nextFilter);
 
         assertThat(payload).isSameAs(next);
@@ -48,9 +52,10 @@ public class LocalUserFilterTest {
 
     @Test
     public void test_adds_custom_user_to_context() throws Exception {
-        LocalUserFilter localUserFilter = new LocalUserFilter(new PropertiesProvider(new HashMap<String, String>() {{
+        PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
             put("defaultUserName", "foo");
-        }}));
+        }});
+        LocalUserFilter localUserFilter = new LocalUserFilter(propertiesProvider, repository);
         Payload payload = localUserFilter.apply("url", context, nextFilter);
 
         assertThat(payload).isSameAs(next);
@@ -60,7 +65,7 @@ public class LocalUserFilterTest {
 
     @Test
     public void test_adds_cookie() throws Exception {
-        LocalUserFilter localUserFilter = new LocalUserFilter(new PropertiesProvider());
+        LocalUserFilter localUserFilter = new LocalUserFilter(new PropertiesProvider(), repository);
         Payload payload = localUserFilter.apply("url", context, nextFilter);
 
         assertThat(payload.cookies().size()).isEqualTo(1);

--- a/datashare-app/src/test/java/org/icij/datashare/session/YesCookieAuthFilterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/session/YesCookieAuthFilterTest.java
@@ -41,7 +41,7 @@ public class YesCookieAuthFilterTest {
          assertThat(payload).isSameAs(next);
          verify(context).setCurrentUser(user.capture());
          assertThat(user.getValue().login()).isNotEmpty();
-         assertThat(((DatashareUser)user.getValue()).getProjects()).containsExactly("demo");
+         assertThat(((DatashareUser)user.getValue()).getProjectNames()).containsExactly("demo");
          assertThat(user.getValue().isInRole("local")).isFalse();
      }
 

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -1,0 +1,42 @@
+package org.icij.datashare.utils;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class IndexAccessVerifierTest {
+
+    private IndexAccessVerifier indexAccessVerifier;
+
+    @Before
+    public void setUp() {
+        indexAccessVerifier = new IndexAccessVerifier();
+    }
+
+    @Test
+    public void test_check_single_index() {
+        assertThat(indexAccessVerifier.checkIndices("foo")).isEqualTo("foo");
+    }
+
+
+    @Test
+    public void test_check_invalid_single_index() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            indexAccessVerifier.checkIndices("foo?");
+        });
+    }
+
+    @Test
+    public void test_check_multiple_indices() {
+        assertThat(indexAccessVerifier.checkIndices("bar,foo")).isEqualTo("bar,foo");
+    }
+
+    @Test
+    public void test_check_invalid_multiple_indices() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            indexAccessVerifier.checkIndices("bar,foo!");
+        });
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -10,33 +10,28 @@ public class IndexAccessVerifierTest {
 
     private IndexAccessVerifier indexAccessVerifier;
 
-    @Before
-    public void setUp() {
-        indexAccessVerifier = new IndexAccessVerifier();
-    }
-
     @Test
     public void test_check_single_index() {
-        assertThat(indexAccessVerifier.checkIndices("foo")).isEqualTo("foo");
+        assertThat(IndexAccessVerifier.checkIndices("foo")).isEqualTo("foo");
     }
 
 
     @Test
     public void test_check_invalid_single_index() {
         assertThrows(IllegalArgumentException.class, () -> {
-            indexAccessVerifier.checkIndices("foo?");
+            IndexAccessVerifier.checkIndices("foo?");
         });
     }
 
     @Test
     public void test_check_multiple_indices() {
-        assertThat(indexAccessVerifier.checkIndices("bar,foo")).isEqualTo("bar,foo");
+        assertThat(IndexAccessVerifier.checkIndices("bar,foo")).isEqualTo("bar,foo");
     }
 
     @Test
     public void test_check_invalid_multiple_indices() {
         assertThrows(IllegalArgumentException.class, () -> {
-            indexAccessVerifier.checkIndices("bar,foo!");
+            IndexAccessVerifier.checkIndices("bar,foo!");
         });
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/utils/PayloadFormatterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/PayloadFormatterTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -24,5 +26,37 @@ public class PayloadFormatterTest {
 
         assertTrue(result.isError());
         assertEquals(result.rawContent(), expectedPayload.rawContent());
+    }
+
+    @Test
+    public void test_allow_single_method() {
+        PayloadFormatter payloadFormatter = new PayloadFormatter();
+        Payload payload = payloadFormatter.allowMethods("GET");
+
+        assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET"));
+    }
+
+    @Test
+    public void test_allow_multiple_methods() {
+        PayloadFormatter payloadFormatter = new PayloadFormatter();
+        Payload payload = payloadFormatter.allowMethods("GET", "POST");
+
+        assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET, POST"));
+    }
+
+    @Test
+    public void test_allow_multiple_comma_separated_methods() {
+        PayloadFormatter payloadFormatter = new PayloadFormatter();
+        Payload payload = payloadFormatter.allowMethods("GET,POST");
+
+        assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET, POST"));
+    }
+
+    @Test
+    public void test_allow_multiple_comma_separated_trimmed_methods() {
+        PayloadFormatter payloadFormatter = new PayloadFormatter();
+        Payload payload = payloadFormatter.allowMethods("GET,  POST", "PATCH");
+
+        assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET, POST, PATCH"));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/utils/PayloadFormatterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/PayloadFormatterTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.utils;
 import net.codestory.http.payload.Payload;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -58,5 +59,19 @@ public class PayloadFormatterTest {
         Payload payload = payloadFormatter.allowMethods("GET,  POST", "PATCH");
 
         assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET, POST, PATCH"));
+    }
+
+    @Test
+    public void test_create_json_payload_with_string() {
+        PayloadFormatter payloadFormatter = new PayloadFormatter();
+        Payload payload = payloadFormatter.json("Foo");
+        assertThat(payload.rawContentType()).isEqualTo("application/json");
+    }
+
+    @Test
+    public void test_create_json_payload_with_list_of_string() {
+        PayloadFormatter payloadFormatter = new PayloadFormatter();
+        Payload payload = payloadFormatter.json(new String[]{"Foo", "Bar"});
+        assertThat(payload.rawContentType()).isEqualTo("application/json");
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/utils/PayloadFormatterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/PayloadFormatterTest.java
@@ -16,14 +16,13 @@ public class PayloadFormatterTest {
 
     @Test
     public void test_error_should_create_payload_with_error_message_and_status() {
-        PayloadFormatter payloadFormatter = new PayloadFormatter();
         String message = "Error message";
         int status = 400;
 
         Map<String, String> expectedBody = Collections.singletonMap("error", message);
         Payload expectedPayload = new Payload(expectedBody).withCode(status);
 
-        Payload result = payloadFormatter.error(message, status);
+        Payload result = PayloadFormatter.error(message, status);
 
         assertTrue(result.isError());
         assertEquals(result.rawContent(), expectedPayload.rawContent());
@@ -31,47 +30,41 @@ public class PayloadFormatterTest {
 
     @Test
     public void test_allow_single_method() {
-        PayloadFormatter payloadFormatter = new PayloadFormatter();
-        Payload payload = payloadFormatter.allowMethods("GET");
+        Payload payload = PayloadFormatter.allowMethods("GET");
 
         assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET"));
     }
 
     @Test
     public void test_allow_multiple_methods() {
-        PayloadFormatter payloadFormatter = new PayloadFormatter();
-        Payload payload = payloadFormatter.allowMethods("GET", "POST");
+        Payload payload = PayloadFormatter.allowMethods("GET", "POST");
 
         assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET, POST"));
     }
 
     @Test
     public void test_allow_multiple_comma_separated_methods() {
-        PayloadFormatter payloadFormatter = new PayloadFormatter();
-        Payload payload = payloadFormatter.allowMethods("GET,POST");
+        Payload payload = PayloadFormatter.allowMethods("GET,POST");
 
         assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET, POST"));
     }
 
     @Test
     public void test_allow_multiple_comma_separated_trimmed_methods() {
-        PayloadFormatter payloadFormatter = new PayloadFormatter();
-        Payload payload = payloadFormatter.allowMethods("GET,  POST", "PATCH");
+        Payload payload = PayloadFormatter.allowMethods("GET,  POST", "PATCH");
 
         assertThat(payload.headers()).includes(entry("Access-Control-Allow-Methods", "GET, POST, PATCH"));
     }
 
     @Test
     public void test_create_json_payload_with_string() {
-        PayloadFormatter payloadFormatter = new PayloadFormatter();
-        Payload payload = payloadFormatter.json("Foo");
+        Payload payload = PayloadFormatter.json("Foo");
         assertThat(payload.rawContentType()).isEqualTo("application/json");
     }
 
     @Test
     public void test_create_json_payload_with_list_of_string() {
-        PayloadFormatter payloadFormatter = new PayloadFormatter();
-        Payload payload = payloadFormatter.json(new String[]{"Foo", "Bar"});
+        Payload payload = PayloadFormatter.json(new String[]{"Foo", "Bar"});
         assertThat(payload.rawContentType()).isEqualTo("application/json");
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ApiKeyResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ApiKeyResourceTest.java
@@ -2,6 +2,7 @@ package org.icij.datashare.web;
 
 
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.Repository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.tasks.DelApiKeyTask;
 import org.icij.datashare.tasks.GenApiKeyTask;
@@ -19,6 +20,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ApiKeyResourceTest extends AbstractProdWebServerTest {
     @Mock public TaskFactory taskFactory;
+    @Mock Repository repository;
 
     @Test
     public void test_generate_key() throws Exception {
@@ -60,6 +62,6 @@ public class ApiKeyResourceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() {
         initMocks(this);
-        configure(routes -> routes.add(new ApiKeyResource(taskFactory)).filter(new LocalUserFilter(new PropertiesProvider())));
+        configure(routes -> routes.add(new ApiKeyResource(taskFactory)).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ApiKeyResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ApiKeyResourceTest.java
@@ -2,7 +2,7 @@ package org.icij.datashare.web;
 
 
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.tasks.DelApiKeyTask;
 import org.icij.datashare.tasks.GenApiKeyTask;
@@ -20,7 +20,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ApiKeyResourceTest extends AbstractProdWebServerTest {
     @Mock public TaskFactory taskFactory;
-    @Mock Repository repository;
+    @Mock JooqRepository jooqRepository;
 
     @Test
     public void test_generate_key() throws Exception {
@@ -62,6 +62,6 @@ public class ApiKeyResourceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() {
         initMocks(this);
-        configure(routes -> routes.add(new ApiKeyResource(taskFactory)).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
+        configure(routes -> routes.add(new ApiKeyResource(taskFactory)).filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -2,11 +2,12 @@ package org.icij.datashare.web;
 
 import net.codestory.rest.Response;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.batch.BatchSearch;
 import org.icij.datashare.batch.BatchSearchRecord;
 import org.icij.datashare.batch.BatchSearchRepository;
 import org.icij.datashare.batch.SearchResult;
+import org.icij.datashare.batch.WebQueryBuilder;
 import org.icij.datashare.db.JooqBatchSearchRepository;
 import org.icij.datashare.function.Pair;
 import org.icij.datashare.session.LocalUserFilter;
@@ -40,7 +41,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     @Mock BatchSearchRepository batchSearchRepository;
-    @Mock Repository repository;
+    @Mock JooqRepository jooqRepository;
     BlockingQueue<String> batchSearchQueue = new ArrayBlockingQueue<>(5);
 
     @Test
@@ -334,7 +335,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
                 put("rootHost", "http://foo.com:12345");
             }});
             routes.add(new BatchSearchResource(batchSearchRepository, batchSearchQueue, propertiesProvider)).
-                    filter(new LocalUserFilter(propertiesProvider, repository));
+                    filter(new LocalUserFilter(propertiesProvider, jooqRepository));
         });
         when(batchSearchRepository.get(User.local(), "batchSearchId")).thenReturn(new BatchSearch(singletonList(project("prj")), "name", "desc", asSet("q"), User.local()));
         when(batchSearchRepository.getResults(User.local(), "batchSearchId",WebQueryBuilder.createWebQuery().queryAll().build())).thenReturn(singletonList(
@@ -474,7 +475,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     public void setUp() {
         initMocks(this);
         configure(routes -> routes.add(new BatchSearchResource(batchSearchRepository, batchSearchQueue, new PropertiesProvider())).
-                filter(new LocalUserFilter(new PropertiesProvider(), repository)));
+                filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
     }
 
     private static class MultipartContentBuilder {

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -2,7 +2,11 @@ package org.icij.datashare.web;
 
 import net.codestory.rest.Response;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.batch.*;
+import org.icij.datashare.Repository;
+import org.icij.datashare.batch.BatchSearch;
+import org.icij.datashare.batch.BatchSearchRecord;
+import org.icij.datashare.batch.BatchSearchRepository;
+import org.icij.datashare.batch.SearchResult;
 import org.icij.datashare.db.JooqBatchSearchRepository;
 import org.icij.datashare.function.Pair;
 import org.icij.datashare.session.LocalUserFilter;
@@ -36,6 +40,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     @Mock BatchSearchRepository batchSearchRepository;
+    @Mock Repository repository;
     BlockingQueue<String> batchSearchQueue = new ArrayBlockingQueue<>(5);
 
     @Test
@@ -329,7 +334,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
                 put("rootHost", "http://foo.com:12345");
             }});
             routes.add(new BatchSearchResource(batchSearchRepository, batchSearchQueue, propertiesProvider)).
-                    filter(new LocalUserFilter(propertiesProvider));
+                    filter(new LocalUserFilter(propertiesProvider, repository));
         });
         when(batchSearchRepository.get(User.local(), "batchSearchId")).thenReturn(new BatchSearch(singletonList(project("prj")), "name", "desc", asSet("q"), User.local()));
         when(batchSearchRepository.getResults(User.local(), "batchSearchId",WebQueryBuilder.createWebQuery().queryAll().build())).thenReturn(singletonList(
@@ -469,7 +474,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     public void setUp() {
         initMocks(this);
         configure(routes -> routes.add(new BatchSearchResource(batchSearchRepository, batchSearchQueue, new PropertiesProvider())).
-                filter(new LocalUserFilter(new PropertiesProvider())));
+                filter(new LocalUserFilter(new PropertiesProvider(), repository)));
     }
 
     private static class MultipartContentBuilder {

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -47,7 +47,10 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() {
         initMocks(this);
-        configure(routes -> routes.add(new DocumentResource(repository, indexer)).filter(new LocalUserFilter(new PropertiesProvider())));
+        configure(routes -> {
+            routes.add(new DocumentResource(repository, indexer))
+                    .filter(new LocalUserFilter(new PropertiesProvider(), repository));
+        });
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
@@ -2,7 +2,7 @@ package org.icij.datashare.web;
 
 import org.icij.datashare.ExtensionService;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
@@ -14,12 +14,15 @@ import org.mockito.Mock;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 
 import static java.net.URLEncoder.encode;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ExtensionResourceTest extends AbstractProdWebServerTest  {
-    @Mock Repository repository;
+    @Mock JooqRepository jooqRepository;
     @Rule public TemporaryFolder extensionFolder = new TemporaryFolder();
 
     @Test
@@ -83,9 +86,11 @@ public class ExtensionResourceTest extends AbstractProdWebServerTest  {
 
     @Before
     public void setUp() {
+        initMocks(this);
+        when(jooqRepository.getProjects()).thenReturn(new ArrayList<>());
         configure(routes -> routes.add(new ExtensionResource(new ExtensionService(extensionFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
                 "{\"id\":\"my-extension\",\"name\":\"My extension\",\"description\":\"Description of my extension\",\"version\":\"1.0.1\",\"type\":\"WEB\",\"url\": \"" + ClassLoader.getSystemResource(("my-extension-1.0.1.jar")) + "\"}," +
                 "{\"id\":\"my-other-extension\",\"name\":\"My other extension\",\"description\":\"Description of my other extension\",\"type\":\"WEB\",\"url\": \"https://dummy.url/foo.jar\"}" +
-                "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
+                "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
@@ -2,12 +2,14 @@ package org.icij.datashare.web;
 
 import org.icij.datashare.ExtensionService;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.Repository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -17,7 +19,7 @@ import static java.net.URLEncoder.encode;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class ExtensionResourceTest extends AbstractProdWebServerTest  {
-
+    @Mock Repository repository;
     @Rule public TemporaryFolder extensionFolder = new TemporaryFolder();
 
     @Test
@@ -84,6 +86,6 @@ public class ExtensionResourceTest extends AbstractProdWebServerTest  {
         configure(routes -> routes.add(new ExtensionResource(new ExtensionService(extensionFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
                 "{\"id\":\"my-extension\",\"name\":\"My extension\",\"description\":\"Description of my extension\",\"version\":\"1.0.1\",\"type\":\"WEB\",\"url\": \"" + ClassLoader.getSystemResource(("my-extension-1.0.1.jar")) + "\"}," +
                 "{\"id\":\"my-other-extension\",\"name\":\"My other extension\",\"description\":\"Description of my other extension\",\"type\":\"WEB\",\"url\": \"https://dummy.url/foo.jar\"}" +
-                "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider())));
+                "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -174,7 +174,6 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         put("/api/index/ cecile-datashare").withPreemptiveAuthentication("cecile", "pass").should().respond(400);
     }
 
-
     @Before
     public void setUp() {
         configure(routes ->

--- a/datashare-app/src/test/java/org/icij/datashare/web/NamedEntityResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/NamedEntityResourceTest.java
@@ -1,6 +1,9 @@
 package org.icij.datashare.web;
 
+import liquibase.pro.packaged.J;
 import net.codestory.http.filters.basic.BasicAuthFilter;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.text.NamedEntity;
@@ -24,6 +27,8 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class NamedEntityResourceTest extends AbstractProdWebServerTest {
     @Mock Indexer indexer;
+    @Mock JooqRepository jooqRepository;
+
     @Test
     public void test_get_standalone_named_entity_should_return_not_found() {
         get("/api/index/namedEntity/my_id").should().respond(404);
@@ -70,6 +75,8 @@ public class NamedEntityResourceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() {
         initMocks(this);
-        configure(routes -> routes.add(new NamedEntityResource(indexer)).filter(LocalUserFilter.class));
+        PropertiesProvider propertiesProvider = new PropertiesProvider();
+        LocalUserFilter localUserFilter = new LocalUserFilter(propertiesProvider, jooqRepository);
+        configure(routes -> routes.add(new NamedEntityResource(indexer)).filter(localUserFilter));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/NoteResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/NoteResourceTest.java
@@ -2,7 +2,7 @@ package org.icij.datashare.web;
 
 import org.icij.datashare.Note;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class NoteResourceTest extends AbstractProdWebServerTest {
-    @Mock Repository repository;
+    @Mock JooqRepository jooqRepository;
 
     @Test
     public void test_forbidden_for_path() {
@@ -26,7 +26,7 @@ public class NoteResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_notes_for_path() {
-        when(repository.getNotes(project("local-datashare"), "url")).thenReturn(singletonList(new Note(project("local-datashare"), Paths.get("/path/to/note"), "this is a note")));
+        when(jooqRepository.getNotes(project("local-datashare"), "url")).thenReturn(singletonList(new Note(project("local-datashare"), Paths.get("/path/to/note"), "this is a note")));
         get("/api/local-datashare/notes/url").should().respond(200).
                 contain("/path/to/note").
                 contain("this is a note");
@@ -39,7 +39,7 @@ public class NoteResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_notes_for_project() {
-        when(repository.getNotes(project("local-datashare"))).thenReturn(singletonList(new Note(project("local-datashare"), Paths.get("/path/to/note"), "this is a note")));
+        when(jooqRepository.getNotes(project("local-datashare"))).thenReturn(singletonList(new Note(project("local-datashare"), Paths.get("/path/to/note"), "this is a note")));
         get("/api/local-datashare/notes").should().respond(200).
                 contain("/path/to/note").
                 contain("this is a note");
@@ -48,7 +48,7 @@ public class NoteResourceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() {
         initMocks(this);
-        configure(routes -> routes.add(new NoteResource(repository)).
-                filter(new LocalUserFilter(new PropertiesProvider(), repository)));
+        configure(routes -> routes.add(new NoteResource(jooqRepository)).
+                filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/NoteResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/NoteResourceTest.java
@@ -49,6 +49,6 @@ public class NoteResourceTest extends AbstractProdWebServerTest {
     public void setUp() {
         initMocks(this);
         configure(routes -> routes.add(new NoteResource(repository)).
-                filter(new LocalUserFilter(new PropertiesProvider())));
+                filter(new LocalUserFilter(new PropertiesProvider(), repository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/PluginResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/PluginResourceTest.java
@@ -2,12 +2,14 @@ package org.icij.datashare.web;
 
 import org.icij.datashare.PluginService;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.Repository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
@@ -16,7 +18,9 @@ import static java.net.URLEncoder.encode;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class PluginResourceTest extends AbstractProdWebServerTest {
+    @Mock Repository repository;
     @Rule public TemporaryFolder pluginFolder = new TemporaryFolder();
+
     @Test
     public void test_list_plugins() {
         get("/api/plugins").should().respond(200).
@@ -71,6 +75,6 @@ public class PluginResourceTest extends AbstractProdWebServerTest {
         configure(routes -> routes.add(new PluginResource(new PluginService(pluginFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
         "{\"id\":\"my-plugin\",\"name\":\"My plugin\",\"description\":\"Description of my plugin\", \"url\": \"" + ClassLoader.getSystemResource("my-plugin.tgz")+ "\"}," +
         "{\"id\":\"my-other-plugin\",\"name\":\"My other plugin\",\"description\":\"Description of my other plugin  \", \"url\": \"https://dummy.url\"}" +
-        "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider())));
+        "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/PluginResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/PluginResourceTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.web;
 import org.icij.datashare.PluginService;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
@@ -13,12 +14,15 @@ import org.mockito.Mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 
 import static java.net.URLEncoder.encode;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class PluginResourceTest extends AbstractProdWebServerTest {
-    @Mock Repository repository;
+    @Mock JooqRepository jooqRepository;
     @Rule public TemporaryFolder pluginFolder = new TemporaryFolder();
 
     @Test
@@ -72,9 +76,15 @@ public class PluginResourceTest extends AbstractProdWebServerTest {
 
     @Before
     public void setUp() {
-        configure(routes -> routes.add(new PluginResource(new PluginService(pluginFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
-        "{\"id\":\"my-plugin\",\"name\":\"My plugin\",\"description\":\"Description of my plugin\", \"url\": \"" + ClassLoader.getSystemResource("my-plugin.tgz")+ "\"}," +
-        "{\"id\":\"my-other-plugin\",\"name\":\"My other plugin\",\"description\":\"Description of my other plugin  \", \"url\": \"https://dummy.url\"}" +
-        "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
+        initMocks(this);
+        when(jooqRepository.getProjects()).thenReturn(new ArrayList<>());
+        configure(routes -> {
+            routes
+                    .add(new PluginResource(new PluginService(pluginFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
+                            "{\"id\":\"my-plugin\",\"name\":\"My plugin\",\"description\":\"Description of my plugin\", \"url\": \"" + ClassLoader.getSystemResource("my-plugin.tgz") + "\"}," +
+                            "{\"id\":\"my-other-plugin\",\"name\":\"My other plugin\",\"description\":\"Description of my other plugin  \", \"url\": \"https://dummy.url\"}" +
+                            "]}").getBytes()))))
+                    .filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository));
+        });
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -41,7 +41,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
             }});
 
             ProjectResource projectResource = new ProjectResource(repository, indexer, propertiesProvider);
-            routes.filter(new LocalUserFilter(propertiesProvider)).add(projectResource);
+            routes.filter(new LocalUserFilter(propertiesProvider, repository)).add(projectResource);
         });
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
@@ -7,9 +7,11 @@ import net.codestory.http.misc.Env;
 import net.codestory.rest.FluentRestTest;
 import org.apache.commons.io.FileUtils;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.Repository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,6 +23,7 @@ import static java.nio.file.Files.copy;
 import static java.util.Arrays.asList;
 
 public class RootResourcePluginTest implements FluentRestTest {
+    @Mock Repository repository;
     @ClassRule public static TemporaryFolder appFolder = new TemporaryFolder();
     @Rule public TemporaryFolder folder = new TemporaryFolder();
     private static WebServer server;
@@ -44,7 +47,11 @@ public class RootResourcePluginTest implements FluentRestTest {
         propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
             put("pluginsDir", folder.getRoot().toString());
         }});
-        server.configure(routes -> routes.add(new RootResource(propertiesProvider)).bind("/plugins", folder.getRoot()).filter(new LocalUserFilter(new PropertiesProvider())));
+        server.configure(routes -> {
+            routes.add(new RootResource(propertiesProvider))
+                    .bind("/plugins", folder.getRoot())
+                    .filter(new LocalUserFilter(new PropertiesProvider(), repository));
+        });
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
@@ -7,7 +7,7 @@ import net.codestory.http.misc.Env;
 import net.codestory.rest.FluentRestTest;
 import org.apache.commons.io.FileUtils;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
@@ -17,13 +17,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import static java.nio.file.Files.copy;
 import static java.util.Arrays.asList;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class RootResourcePluginTest implements FluentRestTest {
-    @Mock Repository repository;
+    @Mock JooqRepository jooqRepository;
     @ClassRule public static TemporaryFolder appFolder = new TemporaryFolder();
     @Rule public TemporaryFolder folder = new TemporaryFolder();
     private static WebServer server;
@@ -44,13 +47,15 @@ public class RootResourcePluginTest implements FluentRestTest {
 
     @Before
     public void setUp() {
+        initMocks(this);
+        when(jooqRepository.getProjects()).thenReturn(new ArrayList<>());
         propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
             put("pluginsDir", folder.getRoot().toString());
         }});
         server.configure(routes -> {
             routes.add(new RootResource(propertiesProvider))
                     .bind("/plugins", folder.getRoot())
-                    .filter(new LocalUserFilter(new PropertiesProvider(), repository));
+                    .filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository));
         });
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
@@ -2,7 +2,7 @@ package org.icij.datashare.web;
 
 import net.codestory.http.filters.basic.BasicAuthFilter;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.UserEvent;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.user.User;
@@ -23,17 +23,17 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class UserResourceTest extends AbstractProdWebServerTest {
-    @Mock Repository repository;
+    @Mock JooqRepository jooqRepository;
 
     @Before
     public void setUp() {
         initMocks(this);
-        configure(routes -> routes.add(new UserResource(repository)).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
+        configure(routes -> routes.add(new UserResource(jooqRepository)).filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
     }
 
     @Test
     public void get_user_information_test() {
-        configure(routes -> routes.add(new UserResource(repository)).
+        configure(routes -> routes.add(new UserResource(jooqRepository)).
                         filter(new BasicAuthFilter("/", "icij", singleUser("pierre"))));
 
         get("/api/users/me").withPreemptiveAuthentication("pierre", "pass").
@@ -43,16 +43,16 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&sort=modification_date&desc=true").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_default_sort_and_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
         get("/api/users/me/history?type=document&from=0&size=10&sort=").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
@@ -61,31 +61,31 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history_with_sort_field() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "name",true)).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "name",true)).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&sort=name").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_sort_and_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "uri",false)).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "uri",false)).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&sort=uri&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
 
     @Test
     public void test_get_user_history_with_invalid_sort(){
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modificationDate",true)).thenThrow(new IllegalArgumentException("Invalid sort attribute : modificationDate"));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modificationDate",true)).thenThrow(new IllegalArgumentException("Invalid sort attribute : modificationDate"));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
         get("/api/users/me/history?type=document&from=0&size=10&sort=modificationDate").should().respond(400);
     }
     @Test
     public void test_get_user_history_with_default_desc_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
         get("/api/users/me/history?type=document&from=0&size=10&desc=TOTO").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
@@ -94,8 +94,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history_with__false_desc_order() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",false)).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",false)).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
         get("/api/users/me/history?type=document&from=0&size=10&desc=FALSE").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
@@ -104,8 +104,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history_without_project_filter() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
         get("/api/users/me/history?type=document&from=0&size=10&projects=").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
         get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
@@ -114,29 +114,29 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_user_history_with_one_project_filter() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto")).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT, "toto")).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto")).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT, "toto")).thenReturn(1);
         get("/api/users/me/history?type=document&from=0&size=10&projects=toto").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
 
     @Test
     public void test_get_user_history_with_two_projects_filter() {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
-        when(repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto","titi")).thenReturn(singletonList(userEvent));
-        when(repository.getUserHistorySize(User.local(), DOCUMENT, "toto","titi")).thenReturn(1);
+        when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto","titi")).thenReturn(singletonList(userEvent));
+        when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT, "toto","titi")).thenReturn(1);
         get("/api/users/me/history?type=document&from=0&size=10&projects=toto,titi").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
     }
 
     @Test
     public void test_put_user_event_to_history() {
-        when(repository.addToUserHistory(eq(singletonList(project("prj"))),any(UserEvent.class))).thenReturn(true);
+        when(jooqRepository.addToUserHistory(eq(singletonList(project("prj"))),any(UserEvent.class))).thenReturn(true);
 
         put("/api/users/me/history", "{\"type\": \"SEARCH\", \"projectIds\": [\"prj\"], \"name\": \"foo AND bar\", \"uri\": \"search_uri\"}").should().respond(200);
     }
 
     @Test
     public void test_delete_user_history_by_type() {
-        when(repository.deleteUserHistory(User.local(), DOCUMENT)).thenReturn(true).thenReturn(false);
+        when(jooqRepository.deleteUserHistory(User.local(), DOCUMENT)).thenReturn(true).thenReturn(false);
 
         delete("/api/users/me/history?type=search").should().respond(204);
         delete("/api/users/me/history?type=document").should().respond(204);
@@ -145,7 +145,7 @@ public class UserResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_delete_user_event_by_id() {
-        when(repository.deleteUserHistoryEvent(User.local(), 1)).thenReturn(true).thenReturn(false);
+        when(jooqRepository.deleteUserHistoryEvent(User.local(), 1)).thenReturn(true).thenReturn(false);
 
         delete("/api/users/me/history/event?id=7").should().respond(204);
         delete("/api/users/me/history/event?id=1").should().respond(204);

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
@@ -28,7 +28,7 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     @Before
     public void setUp() {
         initMocks(this);
-        configure(routes -> routes.add(new UserResource(repository)).filter(new LocalUserFilter(new PropertiesProvider())));
+        configure(routes -> routes.add(new UserResource(repository)).filter(new LocalUserFilter(new PropertiesProvider(), repository)));
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/WebLocalAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/WebLocalAcceptanceTest.java
@@ -3,27 +3,38 @@ package org.icij.datashare.web;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.codestory.rest.Response;
+import org.icij.datashare.Repository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.mode.CommonMode;
-import org.icij.datashare.mode.LocalMode;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import static java.lang.String.format;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class WebLocalAcceptanceTest extends AbstractProdWebServerTest {
+    @Mock Repository jooqRepository;
+
     @Before
     public void setUp() throws Exception {
-        configure(CommonMode.create(new HashMap<>() {{
+        initMocks(this);
+        when(jooqRepository.getProjects()).thenReturn(new ArrayList<>());
+        HashMap<String, String> properties = new HashMap<>() {{
             put("mode", "LOCAL");
             put("dataDir", WebLocalAcceptanceTest.class.getResource("/data").getPath());
             put("extensionsDir", WebLocalAcceptanceTest.class.getResource("/extensions").getPath());
             put("pluginsDir", WebLocalAcceptanceTest.class.getResource("/plugins").getPath());
-        }}).createWebConfiguration());
+        }};
+        configure(CommonMode.create(properties).createWebConfiguration());
         waitForDatashare();
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.*;
 
 import static java.util.Optional.ofNullable;
@@ -156,7 +157,10 @@ public class DatashareCli {
 
     public String getVersion() throws IOException {
         Properties versions = new Properties();
-        versions.load(getClass().getResourceAsStream("/git.properties"));
+        InputStream gitProperties = getClass().getResourceAsStream("/git.properties");
+        if (gitProperties != null) {
+            versions.load(gitProperties);
+        }
         return versions.getProperty("git.build.version");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>10.5.0</datashare-api.version>
+        <datashare-api.version>11.0.1</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
## PR description

This PR ensures that users are granted access to every projects in LOCAL mode.

## Changes 

* Upgrade to Datashare API 11.0.1 in order to use `user.setProjects` ;
* In LocalUserFilter, build a user with access to all projects ;
* Adapt all the test to mock `getProjects` from the `JooqRepository` ;
* Refactor `IndexResource` with `PayloadFormatter` utils class ;
* Add `IndexAccessVerifier` utils class.