### PR TITLE
feat: add pagination to filtered and paginated lists 

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -13,22 +13,13 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import net.codestory.http.Context;
 import net.codestory.http.Part;
-import net.codestory.http.annotations.Delete;
-import net.codestory.http.annotations.Get;
-import net.codestory.http.annotations.Options;
-import net.codestory.http.annotations.Patch;
-import net.codestory.http.annotations.Post;
-import net.codestory.http.annotations.Prefix;
+import net.codestory.http.annotations.*;
 import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.errors.NotFoundException;
 import net.codestory.http.errors.UnauthorizedException;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.batch.BatchSearch;
-import org.icij.datashare.batch.BatchSearchRecord;
-import org.icij.datashare.batch.BatchSearchRepository;
-import org.icij.datashare.batch.SearchResult;
-import org.icij.datashare.batch.WebQueryBuilder;
+import org.icij.datashare.batch.*;
 import org.icij.datashare.db.JooqBatchSearchRepository;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.Project;
@@ -36,24 +27,16 @@ import org.icij.datashare.user.User;
 import org.icij.datashare.utils.PayloadFormatter;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
-import static java.lang.Boolean.parseBoolean;
+import static java.lang.Boolean.*;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
-import static net.codestory.http.payload.Payload.badRequest;
-import static net.codestory.http.payload.Payload.notFound;
-import static net.codestory.http.payload.Payload.ok;
+import static net.codestory.http.payload.Payload.*;
 import static org.icij.datashare.CollectionUtils.asSet;
 
 @Singleton
@@ -88,7 +71,7 @@ public class BatchSearchResource {
     @Post("/search")
     public WebResponse<BatchSearchRecord> getSearchesFiltered(BatchSearchRepository.WebQuery webQuery, Context context) {
         DatashareUser user = (DatashareUser) context.currentUser();
-        return new WebResponse<>(batchSearchRepository.getRecords(user, user.getProjectNames(), webQuery),
+        return new WebResponse<>(batchSearchRepository.getRecords(user, user.getProjectNames(), webQuery), webQuery.from, webQuery.size,
                 batchSearchRepository.getTotal(user, user.getProjectNames(), webQuery));
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
@@ -84,6 +84,7 @@ public class UserResource {
         try {
             WebResponse<UserEvent> userEventWebResponse = new WebResponse<>(
                     repository.getUserHistory(user, eventType, from, size, sortBy, parseBooleanQueryArg(desc), parseProjectIdsQueryArg(projects)),
+                    from,size,
                     repository.getUserHistorySize(user, eventType, parseProjectIdsQueryArg(projects)));
             return new Payload(userEventWebResponse);
         } catch (IllegalArgumentException e){

--- a/datashare-app/src/main/java/org/icij/datashare/web/WebResponse.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/WebResponse.java
@@ -4,10 +4,24 @@ import java.util.List;
 
 class WebResponse<T> {
     private final List<T> items;
-    private final int total;
+    private final Pagination pagination;
 
-    public WebResponse(List<T> items, int total) {
+    public WebResponse(List<T> items, final int from, final int size, final int total) {
         this.items = items;
-        this.total = total;
+        this.pagination = new Pagination(items.size(), from, size, total);
+    }
+
+    static class Pagination {
+        final int count;
+        final int from;
+        final int size;
+        final int total;
+
+        public Pagination(int count, int from, int size, int total) {
+            this.count = count;
+            this.from = from;
+            this.size = size;
+            this.total = total;
+        }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/WebResponse.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/WebResponse.java
@@ -1,13 +1,14 @@
 package org.icij.datashare.web;
 
+import java.util.Collections;
 import java.util.List;
 
 class WebResponse<T> {
-    private final List<T> items;
-    private final Pagination pagination;
+    public final List<T> items;
+    public final Pagination pagination;
 
     public WebResponse(List<T> items, final int from, final int size, final int total) {
-        this.items = items;
+        this.items = Collections.unmodifiableList(items);
         this.pagination = new Pagination(items.size(), from, size, total);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -268,10 +268,13 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
                 new SearchResult("q2", "docId2", "rootId2", Paths.get("/path/to/doc2"), new Date(), "content/type", 123L, 2)
         ));
 
+        when(batchSearchRepository.getResultsTotal(eq(User.local()), eq("batchSearchId"), any())).thenReturn(2);
+
         post("/api/batch/search/result/batchSearchId", "{\"from\":0, \"size\":0, \"query\":\"*\", \"field\":\"all\"}").
                 should().respond(200).haveType("application/json").
                 contain("\"documentId\":\"docId1\"").
-                contain("\"documentId\":\"docId2\"");
+                contain("\"documentId\":\"docId2\"").
+                contain("\"pagination\":{\"count\":2,\"from\":0,\"size\":0,\"total\":2}");
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -2,13 +2,9 @@ package org.icij.datashare.web;
 
 import net.codestory.rest.Response;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.db.JooqRepository;
-import org.icij.datashare.batch.BatchSearch;
-import org.icij.datashare.batch.BatchSearchRecord;
-import org.icij.datashare.batch.BatchSearchRepository;
-import org.icij.datashare.batch.SearchResult;
-import org.icij.datashare.batch.WebQueryBuilder;
+import org.icij.datashare.batch.*;
 import org.icij.datashare.db.JooqBatchSearchRepository;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.function.Pair;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.user.User;
@@ -236,14 +232,14 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
         post("/api/batch/search", "{\"from\":0, \"size\":2, \"query\":\"*\", \"field\":\"all\"}").should().respond(200).haveType("application/json").
                 contain("\"name\":\"name0\"").
                 contain("\"name\":\"name1\"").
-                contain("\"total\":10").
+                contain("\"pagination\":{\"count\":2,\"from\":0,\"size\":2,\"total\":10}").
                 should().not().contain("name2");
 
         post("/api/batch/search", "{\"from\":4, \"size\":3, \"query\":\"*\", \"field\":\"all\"}").should().respond(200).haveType("application/json").
                 contain("\"name\":\"name5\"").
                 contain("\"name\":\"name6\"").
                 contain("\"name\":\"name7\"").
-                contain("\"total\":10").
+                contain("\"pagination\":{\"count\":3,\"from\":4,\"size\":3,\"total\":10}").
                 should().not().contain("name8").
                 should().not().contain("name4");
     }

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
@@ -2,8 +2,8 @@ package org.icij.datashare.web;
 
 import net.codestory.http.filters.basic.BasicAuthFilter;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.UserEvent;
+import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.user.User;
@@ -14,7 +14,6 @@ import org.mockito.Mock;
 
 import java.net.URI;
 
-import static com.google.inject.util.Types.listOf;
 import static java.util.Collections.singletonList;
 import static org.icij.datashare.UserEvent.Type.DOCUMENT;
 import static org.icij.datashare.session.DatashareUser.singleUser;
@@ -73,7 +72,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
-        get("/api/users/me/history?type=document&from=0&size=10&sort=modification_date&desc=true").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&sort=modification_date&desc=true").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_default_sort_and_order() {
@@ -81,9 +81,12 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
-        get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
-        get("/api/users/me/history?type=document&from=0&size=10&sort=").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
-        get("/api/users/me/history?type=document&from=0&size=10&desc=").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&sort=").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&desc=").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_sort_field() {
@@ -91,7 +94,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "name",true)).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
-        get("/api/users/me/history?type=document&from=0&size=10&sort=name").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&sort=name").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
     @Test
     public void test_get_user_history_with_sort_and_order() {
@@ -99,7 +103,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "uri",false)).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
-        get("/api/users/me/history?type=document&from=0&size=10&sort=uri&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&sort=uri&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
 
     @Test
@@ -114,9 +119,15 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
-        get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
-        get("/api/users/me/history?type=document&from=0&size=10&desc=TOTO").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
-        get("/api/users/me/history?type=document&from=0&size=10&desc=true").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"pagination\":{\"count\":1,\"from\":0,\"size\":10,\"total\":1}")
+                .respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&desc=TOTO").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"pagination\":{\"count\":1,\"from\":0,\"size\":10,\"total\":1}")
+                .respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&desc=true").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"pagination\":{\"count\":1,\"from\":0,\"size\":10,\"total\":1}")
+                .respond(200);
     }
     @Test
     public void test_get_user_history_with__false_desc_order() {
@@ -124,8 +135,10 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",false)).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
-        get("/api/users/me/history?type=document&from=0&size=10&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
-        get("/api/users/me/history?type=document&from=0&size=10&desc=FALSE").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&desc=false").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&desc=FALSE").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
 
     @Test
@@ -134,8 +147,10 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true)).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT)).thenReturn(1);
 
-        get("/api/users/me/history?type=document&from=0&size=10&projects=").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
-        get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&projects=").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
 
     @Test
@@ -143,7 +158,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto")).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT, "toto")).thenReturn(1);
-        get("/api/users/me/history?type=document&from=0&size=10&projects=toto").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&projects=toto").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
 
     @Test
@@ -151,7 +167,8 @@ public class UserResourceTest extends AbstractProdWebServerTest {
         UserEvent userEvent = new UserEvent(User.local(), DOCUMENT, "doc_name", URI.create("doc_uri"));
         when(jooqRepository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date",true, "toto","titi")).thenReturn(singletonList(userEvent));
         when(jooqRepository.getUserHistorySize(User.local(), DOCUMENT, "toto","titi")).thenReturn(1);
-        get("/api/users/me/history?type=document&from=0&size=10&projects=toto,titi").should().contain(userEvent.uri.toString()).contain(User.local().id).contain("\"total\":1").respond(200);
+        get("/api/users/me/history?type=document&from=0&size=10&projects=toto,titi").should().contain(userEvent.uri.toString()).contain(User.local().id)
+                .contain("\"total\":1").respond(200);
     }
 
     @Test

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -327,6 +327,20 @@ public class JooqBatchSearchRepositoryTest {
     }
 
     @Test
+    public void test_get_results_total() {
+        BatchSearch batchSearch = new BatchSearch(singletonList(project("prj")), "name", "description", asSet("my query", "my other query"), User.local());
+        repository.save(batchSearch);
+
+        assertThat(repository.saveResults(batchSearch.uuid, "my query", asList(createDoc("doc1").build(), createDoc("doc2").build()))).isTrue();
+        assertThat(repository.saveResults(batchSearch.uuid, "my query2", asList(createDoc("doc3").build(), createDoc("doc2").build()))).isTrue();
+        assertThat(repository.get(User.local(), batchSearch.uuid).nbResults).isEqualTo(4);
+        int resultsTotal = repository.getResultsTotal(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().withQuery("*").withRange(0, 1).build());
+        assertThat(resultsTotal).isEqualTo(4);
+
+       assertThat(repository.getResultsTotal(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withQueries(singletonList("my query2")).withRange(0, 1).build())).isEqualTo(2);
+    }
+
+    @Test
     public void test_save_results_multiple_times() {
         BatchSearch batchSearch = new BatchSearch(singletonList(project("prj")), "name", "description", asSet("my query", "my other query"), User.local());
         repository.save(batchSearch);

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>11.0.1</datashare-api.version>
+        <datashare-api.version>11.1.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
Before : 
- [x] merge https://github.com/ICIJ/datashare-api/pull/17 to datashare-api / master 
- [x] create new version of datashare-api version to 11.1.0 on datashare-api / master 
- [x] wait for  datashare-api 11.1.0 to be [published](https://central.sonatype.com/artifact/org.icij.datashare/datashare-api/11.1.0)
- [x] update datashare datashare-api version to 11.1.0 in pom.xml
- [x] update datashare client response format for: user history, batch search and batch search results 

What is in this PR:

- Use webresponse format for filtered/paginated list of results (user history, batch search, batch search results) in the BREAKING CHANGE format:
```js
{
items:[..5items..],
pagination:{count: 5,from:0,size:5, total: 12}
}
```
Consequences:
Datashare client components about user history, batch search and batch search results should comply with new API response. 

Missing but not mandatory: return all available content types in a batch search