### PR TITLE
feat: project indexing

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -126,7 +126,7 @@ class CliApp {
                 taskManager.startTask(taskFactory.createNlpTask(nullUser(), pipelineClass));
             }
             if (resume(properties)) {
-                taskManager.startTask(taskFactory.createResumeNlpTask(nullUser(), nlpPipelines));
+                taskManager.startTask(taskFactory.createResumeNlpTask(nullUser(), nlpPipelines, properties));
             }
         }
         taskManager.shutdownAndAwaitTermination(Integer.MAX_VALUE, SECONDS);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ResumeNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ResumeNlpTask.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -35,12 +36,12 @@ public class ResumeNlpTask implements Callable<Long>, UserTask {
 
     @Inject
     public ResumeNlpTask(final Publisher publisher, final Indexer indexer, final PropertiesProvider propertiesProvider,
-                         @Assisted final User user, @Assisted final Set<Pipeline.Type> nlpPipelines) {
+                         @Assisted final User user, @Assisted final Set<Pipeline.Type> nlpPipelines, @Assisted final Properties taskProperties) {
         this.publisher = publisher;
         this.indexer = indexer;
         this.nlpPipelines = nlpPipelines;
         this.user = user;
-        this.projectName = propertiesProvider.get("defaultProject").orElse("local-datashare");
+        this.projectName = propertiesProvider.overrideWith(taskProperties).get("defaultProject").orElse("local-datashare");
     }
 
     @Override

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 public interface TaskFactory {
-    ResumeNlpTask createResumeNlpTask(final User user, Set<Pipeline.Type> pipelines);
+    ResumeNlpTask createResumeNlpTask(final User user, Set<Pipeline.Type> pipelines, Properties taskProperties);
     NlpApp createNlpTask(User user, Pipeline pipeline, Properties properties, Runnable subscribedCb);
     NlpApp createNlpTask(User user, Pipeline pipeline);
     BatchSearchLoop createBatchSearchLoop();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ResumeNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ResumeNlpTaskTest.java
@@ -11,8 +11,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.*;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
@@ -33,10 +32,8 @@ public class ResumeNlpTaskTest {
             indexer.add(TEST_INDEX, createDoc("doc" + i).with(Pipeline.Type.CORENLP).build());
         }
         Publisher publisher = mock(Publisher.class);
-        ResumeNlpTask resumeNlpTask = new ResumeNlpTask(publisher, indexer,
-                new PropertiesProvider(new HashMap<String, String>() {{
-                    put("defaultProject", "test-datashare");
-                }}), new User("test"), new HashSet<Pipeline.Type>() {{add(Pipeline.Type.OPENNLP);}});
+        PropertiesProvider propertiesProvider = new PropertiesProvider(Map.of("defaultProject", "test-datashare"));
+        ResumeNlpTask resumeNlpTask = new ResumeNlpTask(publisher, indexer, propertiesProvider, new User("test"), Set.of(Pipeline.Type.OPENNLP), new Properties());
         resumeNlpTask.call();
         verify(publisher, times(22)).publish(any(), any());
     }

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -204,7 +204,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
 
         List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.name).collect(toList());
         assertThat(taskNames.size()).isEqualTo(2);
-        verify(taskFactory).createResumeNlpTask(local(), singleton(Pipeline.Type.EMAIL));
+        verify(taskFactory).createResumeNlpTask(eq(local()), eq(singleton(Pipeline.Type.EMAIL)), any());
 
         ArgumentCaptor<Pipeline> pipelineArgumentCaptor = ArgumentCaptor.forClass(Pipeline.class);
 
@@ -218,14 +218,12 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     public void test_findNames_with_options_should_merge_with_property_provider() {
         RestAssert response = post("/api/task/findNames/EMAIL", "{\"options\":{\"waitForNlpApp\": false, \"key\":\"val\",\"foo\":\"loo\"}}");
         response.should().haveType("application/json");
-
-        verify(taskFactory).createResumeNlpTask(local(), singleton(Pipeline.Type.EMAIL));
+        verify(taskFactory).createResumeNlpTask(eq(local()), eq(singleton(Pipeline.Type.EMAIL)), any());
 
         ArgumentCaptor<Pipeline> pipelineCaptor = ArgumentCaptor.forClass(Pipeline.class);
         ArgumentCaptor<Properties> propertiesCaptor = ArgumentCaptor.forClass(Properties.class);
         verify(taskFactory).createNlpTask(eq(local()), pipelineCaptor.capture(), propertiesCaptor.capture(), any());
-        assertThat(propertiesCaptor.getValue()).includes(entry("key", "val"), entry("foo", "loo"));
-
+            assertThat(propertiesCaptor.getValue()).includes(entry("key", "val"), entry("foo", "loo"));
         assertThat(pipelineCaptor.getValue().getType()).isEqualTo(Pipeline.Type.EMAIL);
     }
 
@@ -234,7 +232,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         RestAssert response = post("/api/task/findNames/EMAIL", "{\"options\":{\"resume\":\"false\", \"waitForNlpApp\": false}}");
         response.should().haveType("application/json");
 
-        verify(taskFactory, never()).createResumeNlpTask(null, singleton(Pipeline.Type.OPENNLP));
+        verify(taskFactory, never()).createResumeNlpTask(null, singleton(Pipeline.Type.OPENNLP), new Properties());
     }
 
     @Test
@@ -402,7 +400,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         when(taskFactory.createDeduplicateTask(any(), any())).thenReturn(mock(DeduplicateTask.class));
         when(taskFactory.createDownloadRunner(any(), any())).thenReturn(mock(BatchDownloadRunner.class));
         when(taskFactory.createScanIndexTask(any(), any())).thenReturn(mock(ScanIndexTask.class));
-        when(taskFactory.createResumeNlpTask(any(), eq(singleton(Pipeline.Type.EMAIL)))).thenReturn(mock(ResumeNlpTask.class));
+        when(taskFactory.createResumeNlpTask(any(), eq(singleton(Pipeline.Type.EMAIL)), any())).thenReturn(mock(ResumeNlpTask.class));
         when(taskFactory.createNlpTask(any(), any())).thenReturn(mock(NlpApp.class));
         when(taskFactory.createNlpTask(any(), any(), any(), any())).thenReturn(mock(NlpApp.class));
     }


### PR DESCRIPTION
## PR description

This PR ensure that user can tweak the `defaultProject`, `queueName` and `reportName` when starting a new scanning, indexing and named entities finding. This will contribute to solve https://github.com/ICIJ/datashare/issues/1134.

## Changes

* add a new constructor argument to `ResumeNlpTask` to receive runtime properties ;
* ensure request's body is used to populate properties on scanning/indexing endpoints ;
* add tests accordingly 