### PR TITLE
fix: extension installation when digit in extension name

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/Extension.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Extension.java
@@ -36,7 +36,7 @@ import static org.apache.commons.io.FilenameUtils.getExtension;
 public class Extension implements Deliverable {
     @JsonIgnore
     protected final Logger logger = LoggerFactory.getLogger(getClass());
-    static Pattern extensionFormat = Pattern.compile("([a-zA-Z\\-.]*)-([0-9.]*)(?<!-)([-\\w]*)?$"); //of form: id-1.2.3-suffix with negative lookbehind for suffix dash
+    static Pattern extensionFormat = Pattern.compile("([[^\\W_][\\-.]]*)-([0-9.]*)(?<!-)([-\\w]*)?$"); //of form: id-with-numb3r-1.2.3-suffix with negative lookbehind for suffix dash
     static Pattern endsWithExtension = Pattern.compile("(.*)(\\.[a-zA-Z]+$)");
     public static final String TMP_PREFIX = "tmp";
     public final String id;

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.AbstractMap.SimpleEntry;
 
+import static org.apache.commons.io.FilenameUtils.getBaseName;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class ExtensionTest {
@@ -99,12 +100,13 @@ public class ExtensionTest {
 
     @Test
     public void test_has_previous_version() throws Exception {
-        File[] files = new File[] {extensionsDir.newFile("extension-1.0.0.jar")};
-        assertThat(Extension.getPreviousVersionInstalled(files, "extension-0.1.0")).hasSize(1);
-        assertThat(Extension.getPreviousVersionInstalled(files, "extension-1.1.0")).hasSize(1);
-        assertThat(Extension.getPreviousVersionInstalled(files, "extension-1.1")).hasSize(1);
-        assertThat(Extension.getPreviousVersionInstalled(files, "extension")).hasSize(1);
+        File[] files = new File[] {extensionsDir.newFile("ext3nsion-1.0.0.jar")};
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-0.1.0")).hasSize(1);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1.0")).hasSize(1);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1")).hasSize(1);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion")).hasSize(1);
 
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext_3nsion-1.1")).isEmpty();
         assertThat(Extension.getPreviousVersionInstalled(files, "other-extension")).isEmpty();
         assertThat(Extension.getPreviousVersionInstalled(files, "extension-other-1.2.3")).isEmpty();
     }


### PR DESCRIPTION
# Changes

## `datashare-app`
### Fixed
- Fixed previous extension installation detection when extension name has digit