### PR TITLE
feat: delete all projects endpoint

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -93,6 +93,16 @@
             return project.getSourcePath() == null;
         }
 
+
+        @Operation(description = "Preflight option request")
+        @ApiResponse(responseCode = "200", description = "returns 200 with OPTIONS, POST, GET and DELETE")
+        @Options("/")
+        public Payload rootProjectOpt(String id) {return ok().withAllowMethods("OPTIONS", "POST", "GET", "DELETE");}
+
+        @Operation(description = "Get all user's projects",
+                requestBody = @RequestBody(content = @Content(mediaType = "application/json", contentSchema = @Schema(implementation = Project[].class)))
+        )
+        @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
         @Get("/")
         public List<Project> getProjects(Context context) {
             DatashareUser user = (DatashareUser) context.currentUser();
@@ -177,6 +187,7 @@
         @ApiResponse(responseCode = "200", description = "returns 200 with OPTIONS and DELETE")
         @Options("/:id")
         public Payload deleteProjectOpt(String id) {return ok().withAllowMethods("OPTIONS", "DELETE");}
+
 
         @Operation(description = "Deletes the project from database and elasticsearch index.",
                 parameters = {@Parameter(name = "id", description = "project id")}

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -191,4 +191,21 @@
             LoggerFactory.getLogger(getClass()).info("deleted project {} index (deleted={}) and db (deleted={})", id, indexDeleted, isDeleted);
             return new Payload(204);
         }
+
+
+        @Operation(description = "Deletes all user's projects from database and elasticsearch index.")
+        @ApiResponse(responseCode = "204", description = "if projects are deleted")
+        @Delete("/")
+        public Payload deleteProjects(Context context) {
+            DatashareUser user = (DatashareUser) context.currentUser();
+            getUserProjects(user).forEach(project -> {
+                try {
+                    deleteProject(project.name, context);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            return new Payload(204);
+        }
+
     }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -273,4 +273,14 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         delete("/api/project/hacker-datashare").withPreemptiveAuthentication("hacker", "pass").should().respond(403);
         delete("/api/project/projectId").should().respond(401);
     }
+
+    @Test
+    public void test_delete_all_projects() throws SQLException {
+        Project foo = new Project("foo");
+        Project bar = new Project("bar");
+        when(repository.getProjects(any())).thenReturn(asList(foo, bar));
+        when(repository.deleteAll("foo")).thenReturn(true).thenReturn(false);
+        when(repository.deleteAll("bar")).thenReturn(true).thenReturn(false);
+        delete("/api/project/").should().respond(204);
+    }
 }


### PR DESCRIPTION
## PR description

Add `DELETE` on the `/api/project/` endpoint so it can be used to delete all user's projects.

## Changes

* add `DELETE` endpoint on `/api/project/`
* add doc for `GET` endpoint on `/api/project/`
* add preflight endpoint on `/api/project/` (for `GET`, `POST`, `OPTION` and `DELETE`)