### PR TITLE
chore: bump neo4j extension to 0.2.2

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -49,9 +49,9 @@
       "id": "datashare-extension-neo4j",
       "name": "neo4j",
       "description": "A Datashare extension to perform graph analysis using neo4j",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.2.1/datashare-extension-neo4j-0.2.1-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.2.2/datashare-extension-neo4j-0.2.2-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "type": "WEB"
     }
   ]


### PR DESCRIPTION
https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.2.2