### PR TITLE
feat: limit download for embedded docs

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -125,17 +125,6 @@ public class BatchDownloadRunner implements Callable<File>, Monitorable, UserTas
         return batchDownload.filename.toFile();
     }
 
-    private boolean isRootDocumentSizeAllowed(Document document) {
-        // Root documents have no download limit
-        if (document.isRootDocument()) {
-            return true;
-        }
-        String maxSize = propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE).orElse("1G");
-        long maxSizeBytes = HumanReadableSize.parse(maxSize);
-        Document rootDocument = indexer.get(document.getProjectId(), document.getRootDocument());
-        return rootDocument.getContentLength() < maxSizeBytes;
-    }
-
     private Zipper createZipper(BatchDownload batchDownload, PropertiesProvider propertiesProvider, Function<URI, MailSender> mailSenderSupplier) throws URISyntaxException, IOException {
         if (batchDownload.encrypted) {
             String rootHost = propertiesProvider.get("rootHost").orElse(null);

--- a/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
@@ -1,0 +1,55 @@
+package org.icij.datashare.utils;
+
+import org.icij.datashare.HumanReadableSize;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.indexing.Indexer;
+
+import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE;
+
+/**
+ * This class is responsible for verifying properties and conditions of documents.
+ */
+public class DocumentVerifier {
+
+    private static final String DEFAULT_MAX_SIZE = "1G";
+
+    private final Indexer indexer;
+    private final PropertiesProvider propertiesProvider;
+
+    /**
+     * Constructs a new DocumentVerifier with the provided indexer and propertiesProvider.
+     *
+     * @param indexer The indexer used to fetch document details.
+     * @param propertiesProvider The provider used to fetch system properties.
+     */
+    public DocumentVerifier(Indexer indexer, PropertiesProvider propertiesProvider) {
+        this.indexer = indexer;
+        this.propertiesProvider = propertiesProvider;
+    }
+
+    /**
+     * Checks if the root document size is allowed based on the provided document's properties.
+     *
+     * @param document The document to verify.
+     * @return true if the root document size is allowed, false otherwise.
+     */
+    public boolean isRootDocumentSizeAllowed(Document document) {
+        if (document.isRootDocument()) {
+            return true;
+        }
+        long maxSizeBytes = getEmbeddedDocumentDownloadMaxSizeBytes();
+        Document rootDocument = indexer.get(document.getProjectId(), document.getRootDocument());
+        return rootDocument.getContentLength() < maxSizeBytes;
+    }
+
+    /**
+     * Retrieves the max size in bytes based on app properties.
+     *
+     * @return The max size in bytes.
+     */
+    private long getEmbeddedDocumentDownloadMaxSizeBytes() {
+        String maxSize = propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE).orElse(DEFAULT_MAX_SIZE);
+        return HumanReadableSize.parse(maxSize);
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -80,9 +80,11 @@ public class DocumentResource {
     public Payload getSourceFile(final String project, final String id,
                                  final String routing, final String filterMetadata, final Context context) throws IOException {
         boolean inline = context.request().query().getBoolean("inline");
-        if (((DatashareUser)context.currentUser()).isGranted(project) &&
-                isAllowed(repository.getProject(project), context.request().clientAddress())) {
-            return routing == null ? getPayload(indexer.get(project, id), project, inline, parseBoolean(filterMetadata)) : getPayload(indexer.get(project, id, routing),project, inline, parseBoolean(filterMetadata));
+        boolean isProjectGranted = ((DatashareUser) context.currentUser()).isGranted(project);
+        boolean isDownloadAllowed = isAllowed(repository.getProject(project), context.request().clientAddress());
+        if (isProjectGranted && isDownloadAllowed) {
+            Document document = routing == null ? indexer.get(project, id) : indexer.get(project, id, routing);
+            return getPayload(document, project, inline, parseBoolean(filterMetadata));
         }
         throw new ForbiddenException();
     }

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -52,7 +52,6 @@ import static java.lang.Boolean.parseBoolean;
 import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
 import static net.codestory.http.payload.Payload.ok;
-import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE;
 import static org.icij.datashare.text.Project.isAllowed;
 import static org.icij.datashare.text.Project.project;
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -31,7 +31,6 @@
 
     import java.io.IOException;
     import java.util.*;
-    import java.util.function.Predicate;
 
     import static net.codestory.http.errors.NotFoundException.notFoundIfNull;
     import static net.codestory.http.payload.Payload.ok;
@@ -46,7 +45,6 @@
         private final DataDirVerifier dataDirVerifier;
         private final ModeVerifier modeVerifier;
         private final DocumentCollectionFactory documentCollectionFactory;
-
         private final PropertiesProvider propertiesProvider;
 
 

--- a/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
@@ -1,0 +1,64 @@
+package org.icij.datashare.utils;
+
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.DocumentBuilder;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.Indexer;
+import org.junit.Test;
+import org.junit.Before;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DocumentVerifierTest {
+
+    @Mock private Indexer indexer;
+    @Mock private PropertiesProvider propertiesProvider;
+    private DocumentVerifier documentVerifier;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        documentVerifier = new DocumentVerifier(indexer, propertiesProvider);
+    }
+
+    @Test
+    public void testIsRootDocumentSizeAllowed_RootDocument() {
+        Document doc = DocumentBuilder.createDoc("foo").withContentLength(2L * 1024 * 1024 * 1024).build();
+        assertTrue(documentVerifier.isRootDocumentSizeAllowed(doc));
+    }
+
+    @Test
+    public void testIsRootDocumentSizeAllowed_SizeAllowed() {
+        Project project = new Project("local-datashare");
+        Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(1024).build();
+        Document doc = DocumentBuilder.createDoc("foo").with(project).withParentId("bar").withRootId("bar").build();
+
+        when(indexer.get(project.getId(), "bar")).thenReturn(rootDoc);
+        when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE)).thenReturn(Optional.of("200G"));
+
+        assertTrue(documentVerifier.isRootDocumentSizeAllowed(doc));
+    }
+
+    @Test
+    public void testIsRootDocumentSizeAllowed_SizeNotAllowed() {
+        Project project = new Project("local-datashare");
+        Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(1024).build();
+        Document doc = DocumentBuilder.createDoc("foo").with(project).withParentId("bar").withRootId("bar").build();
+
+        when(indexer.get(project.getId(), "bar")).thenReturn(rootDoc);
+        when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE)).thenReturn(Optional.of("200"));
+
+        assertFalse(documentVerifier.isRootDocumentSizeAllowed(doc));
+    }
+
+    private void indexFile(String index, Document document) {
+        when(indexer.get(index, document.getId())).thenReturn(document);
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
@@ -29,13 +29,13 @@ public class DocumentVerifierTest {
     }
 
     @Test
-    public void testIsRootDocumentSizeAllowed_RootDocument() {
+    public void test_is_root_document_size_allowed_true_for_root_document() {
         Document doc = DocumentBuilder.createDoc("foo").withContentLength(2L * 1024 * 1024 * 1024).build();
         assertTrue(documentVerifier.isRootDocumentSizeAllowed(doc));
     }
 
     @Test
-    public void testIsRootDocumentSizeAllowed_SizeAllowed() {
+    public void test_is_root_document_size_allowed_true_for_small_root_document() {
         Project project = new Project("local-datashare");
         Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(1024).build();
         Document doc = DocumentBuilder.createDoc("foo").with(project).withParentId("bar").withRootId("bar").build();
@@ -47,7 +47,7 @@ public class DocumentVerifierTest {
     }
 
     @Test
-    public void testIsRootDocumentSizeAllowed_SizeNotAllowed() {
+    public void test_is_root_document_size_allowed_false_for_big_root_document() {
         Project project = new Project("local-datashare");
         Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(1024).build();
         Document doc = DocumentBuilder.createDoc("foo").with(project).withParentId("bar").withRootId("bar").build();

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -74,6 +74,7 @@ public class DatashareCli {
         DatashareCliOptions.nlpParallelism(parser);
         DatashareCliOptions.followSymlinks(parser);
         DatashareCliOptions.enableBrowserOpenLink(parser);
+        DatashareCliOptions.embeddedDocumentDownloadMaxSize(parser);
         DatashareCliOptions.batchSearchMaxTime(parser);
         DatashareCliOptions.batchThrottle(parser);
         DatashareCliOptions.batchQueueType(parser);
@@ -84,18 +85,13 @@ public class DatashareCli {
         DatashareCliOptions.batchDownloadEncrypt(parser);
         DatashareCliOptions.batchDownloadDir(parser);
         DatashareCliOptions.smtpUrl(parser);
-
         DatashareCliOptions.maxContentLength(parser);
-
         DatashareCliOptions.clusterName(parser);
         DatashareCliOptions.createIndex(parser);
-
         DatashareCliOptions.defaultUser(parser);
         DatashareCliOptions.defaultProject(parser);
-
         DatashareCliOptions.esHost(parser);
         DatashareCliOptions.queueName(parser);
-
         DatashareCliOptions.cors(parser);
         DatashareCliOptions.queueType(parser);
         DatashareCliOptions.busType(parser);
@@ -103,7 +99,6 @@ public class DatashareCli {
         DatashareCliOptions.redisAddress(parser);
         DatashareCliOptions.dataSourceUrl(parser);
         DatashareCliOptions.rootHost(parser);
-
         DatashareCliOptions.genApiKey(parser);
         DatashareCliOptions.delApiKey(parser);
         DatashareCliOptions.getApiKey(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -30,7 +30,6 @@ public final class DatashareCliOptions {
     public static final String BATCH_DOWNLOAD_MAX_NB_FILES = "batchDownloadMaxNbFiles";
     public static final String BATCH_DOWNLOAD_MAX_SIZE = "batchDownloadMaxSize";
     public static final String BATCH_DOWNLOAD_DIR = "batchDownloadDir";
-
     static final String MESSAGE_BUS_OPT = "messageBusAddress";
     static final String ROOT_HOST = "rootHost";
     public static final String RESUME_OPT = "resume";
@@ -47,6 +46,8 @@ public final class DatashareCliOptions {
     public static final String PARALLELISM = "parallelism";
     public static final String OPEN_LINK = "browserOpenLink";
     public static final String NLP_PARALLELISM_OPT = "nlpParallelism";
+    public static final String EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE = "embeddedDocumentDownloadMaxSize";
+    public static final String DEFAULT_EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE = "1G";
     public static final String DEFAULT_USER_NAME = "defaultUserName";
     public static final String DEFAULT_BATCH_DOWNLOAD_DIR = Paths.get(System.getProperty("user.dir")).resolve("app/tmp").toString();
     public static final String DEFAULT_BATCH_DOWNLOAD_MAX_SIZE = "100M";
@@ -498,6 +499,15 @@ public final class DatashareCliOptions {
                 singletonList("smtpUrl"), "Smtp url to allow datashare to send emails (ex: smtp://localhost:25)")
                 .withRequiredArg()
                 .ofType(URI.class);
+    }
+
+    public static void embeddedDocumentDownloadMaxSize(OptionParser parser) {
+        parser.acceptsAll(
+                singletonList(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE), "Maximum download size of embedded documents. Human readable suffix K/M/G for KB/MB/GB (Default 1G)")
+                .withRequiredArg()
+                .withValuesConvertedBy(regex("[0-9]+[KMG]?"))
+                .defaultsTo(DEFAULT_EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE);
+
     }
 
     public static void batchDownloadMaxSize(OptionParser parser) {

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -17,7 +17,6 @@ public class DatashareCliTest {
     public void test_web_opt() {
         assertThat(cli.parseArguments(new String[] {"-o true"})).isNotNull();
         assertThat(cli.isWebServer()).isTrue();
-
         assertThat(cli.parseArguments(new String[] {"--mode=BATCH_SEARCH"})).isNotNull();
         assertThat(cli.isWebServer()).isFalse();
         assertThat(cli.parseArguments(new String[] {"--mode=CLI"})).isNotNull();
@@ -74,6 +73,20 @@ public class DatashareCliTest {
 
     @Test(expected = OptionException.class)
     public void test_max_batch_download_size_illegal_value() {
+        cli.asProperties(cli.createParser().parse("--embeddedDocumentDownloadMaxSize", "123A"), null);
+    }
+
+    @Test
+    public void test_embedded_document_download_max_size() {
+        cli.parseArguments(new String[] {"--embeddedDocumentDownloadMaxSize", "123"});
+        assertThat(cli.properties).includes(entry("embeddedDocumentDownloadMaxSize", "123"));
+
+        cli.parseArguments(new String[] {"--embeddedDocumentDownloadMaxSize", "123G"});
+        assertThat(cli.properties).includes(entry("embeddedDocumentDownloadMaxSize", "123G"));
+    }
+
+    @Test(expected = OptionException.class)
+    public void test_embedded_document_download_max_size_illegal_value() {
         cli.asProperties(cli.createParser().parse("--batchDownloadMaxSize", "123A"), null);
     }
 


### PR DESCRIPTION
## PR description

This add a new `--embeddedDocumentDownloadMaxSize` option which prevent from downloading embedded files when there root is too big. The default value for this option is `1G`. It works both from the API endpoint to download document and from the batch download runner (https://github.com/ICIJ/datashare/issues/1161).