### PR TITLE
fix: use title and subject for email/tweet #1173

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -160,14 +160,29 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         return jsonDocument;
     }
 
-    String getTitle(Metadata metadata) {
-        if (metadata.get(DublinCore.SUBJECT) != null && !metadata.get(DublinCore.SUBJECT).isEmpty()) {
-            return metadata.get(DublinCore.SUBJECT);
-        } else if (metadata.get(DublinCore.TITLE) != null && !metadata.get(DublinCore.TITLE).isEmpty()) {
-            return metadata.get(DublinCore.TITLE);
-        } else {
-            return metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
+    protected boolean isEmail(Metadata metadata) {
+        String contentType = ofNullable(metadata.get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN);
+        return contentType.startsWith("message/") || contentType.equals("application/vnd.ms-outlook");
+    }
+
+    protected boolean isTweet(Metadata metadata) {
+        return ofNullable(metadata.get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN).equals("application/json; twint");
+    }
+
+    protected String getTitle(Metadata metadata) {
+        if (isEmail(metadata)) {
+            if (metadata.get(DublinCore.SUBJECT) != null && !metadata.get(DublinCore.SUBJECT).isEmpty()) {
+                return metadata.get(DublinCore.SUBJECT);
+            } else if (metadata.get(DublinCore.TITLE) != null && !metadata.get(DublinCore.TITLE).isEmpty()) {
+                return metadata.get(DublinCore.TITLE);
+            }
         }
+        if (isTweet(metadata)) {
+            if (metadata.get(DublinCore.TITLE) != null && !metadata.get(DublinCore.TITLE).isEmpty()) {
+                return metadata.get(DublinCore.TITLE);
+            }
+        }
+        return metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
     }
 
     public ElasticsearchSpewer withRefresh(WriteRequest.RefreshPolicy refreshPolicy) {


### PR DESCRIPTION
**Goal**
This PR is related to [this issue](https://github.com/ICIJ/datashare/issues/1173) and complete this [previous PR](https://github.com/ICIJ/datashare/pull/1174). This PR aims to use `dc_title` and `dc_subject` only for emails and tweets.