### PR TITLE
feature: include email header type in EMAIL name entity metadata

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
+++ b/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
@@ -23,10 +23,10 @@ import static org.icij.datashare.text.nlp.Pipeline.Type.EMAIL;
 /**
  * this is a fake NLP pipeline. It just uses syntactic methods to find
  * emails in document contents.
- *
+ * <p>
  * it uses the regexp mentioned here :
  * https://stackoverflow.com/questions/201323/how-to-validate-an-email-address-using-a-regular-expression
- *
+ * <p>
  * It implements the same API as the NLP pipelines to integrate seamlessly to datashare.
  *
  * if the the document is an rfc822 email
@@ -35,6 +35,7 @@ import static org.icij.datashare.text.nlp.Pipeline.Type.EMAIL;
  *
  * These fields are supposed to contain email addresses that we want to
  * save as named entities.
+ *
  */
 public class EmailPipeline extends AbstractPipeline {
     private static final String DEFAULT_METADATA_FIELD_PREFIX = "tika_metadata_";

--- a/datashare-app/src/test/java/org/icij/datashare/nlp/EmailPipelineTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/nlp/EmailPipelineTest.java
@@ -11,11 +11,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.nlp.EmailPipeline.*;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
@@ -92,62 +91,85 @@ public class EmailPipelineTest {
 
     @Test
     public void test_adds_document_headers_parsing_for_email() {
-        Document doc = createDoc("docid").with("hello@world.com").ofMimeType("message/rfc822").with(new HashMap<String, Object>() {{
-            put(tikaMsgHeader("To"), "email1@domain.com");
-            put(tikaMsgHeader("Cc"), "email2@domain.com");
-        }}).build();
+        Document doc = createDoc("docid")
+            .with("hello@world.com")
+            .withRootId("root")
+            .with(FRENCH)
+            .ofMimeType("message/rfc822")
+            .with(new HashMap<>() {{
+                put(tikaMsgHeader("To"), "email1@domain.com");
+                put(tikaMsgHeader("Cc"), "email2@domain.com,email3@domain.com");
+            }}).build();
 
         List<NamedEntity> namedEntities = pipeline.process(doc);
 
+        Map<String, Object> metaFirst = Map.of("emailHeaderField", "tika_metadata_message_to");
+        NamedEntity fourth = NamedEntity.create(
+            EMAIL, "email1@domain.com", List.of(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH, metaFirst
+        );
+        Map<String, Object> metaSecond = Map.of("emailHeaderField", "tika_metadata_message_cc");
+        NamedEntity second = NamedEntity.create(
+            EMAIL, "email2@domain.com", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, metaSecond
+        );
+        NamedEntity third = NamedEntity.create(
+            EMAIL, "email3@domain.com", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, metaSecond
+        );
+
         assertThat(namedEntities).containsExactly(
-                        NamedEntity.create(EMAIL, "hello@world.com", asList(0L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "email2@domain.com", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "email1@domain.com", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH)
-                        );
+            NamedEntity.create(EMAIL, "hello@world.com", List.of(0L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
+            second,
+            third,
+            fourth
+        );
     }
 
     @Test
     public void test_filter_headers_that_contains_mail_addresses() {
-        Document doc = createDoc("docid").with("mail content").ofMimeType("message/rfc822").with(new HashMap<String, Object>() {{
-            put(tikaRawHeader("field"), "email@domain.com");
-            put(tikaRawHeader("Message-ID"), "id@domain.com");
-            put(tikaRawHeader("Return-Path"), "return@head.er");
-            put(tikaMsgHeader("To"), "to@head.er");
-            put(tikaMsgHeader("From"), "from@head.er");
-            put(tikaMsgHeader("Cc"), "cc@head.er");
-            put(tikaMsgHeader("Bcc"), "bcc@head.er");
-            put(tika("Dc-Title"), "subject@head.er");
-            put(tikaRawHeader("Reply-To"), "replyto@head.er");
-            put(tikaRawHeader("Followup-To"), "followup@head.er");
-            put(tikaRawHeader("Alternate-Recipient"), "alternate@head.er");
-            put(tikaRawHeader("For-Handling"), "forhandling@head.er");
-            put(tikaRawHeader("Resent-Reply-To"), "resent-replyto@head.er");
-            put(tikaRawHeader("Resent-Sender"), "resent-sender@head.er");
-            put(tikaRawHeader("Resent-From"), "resent-from@head.er");
-            put(tikaRawHeader("Resent-To"), "resent-to@head.er");
-            put(tikaRawHeader("Resent-cc"), "resent-cc@head.er");
-            put(tikaRawHeader("Resent-bcc"), "resent-bcc@head.er");
-        }}).build();
+        Document doc = createDoc("docid")
+            .with("mail content")
+            .ofMimeType("message/rfc822")
+            .with(FRENCH)
+            .withRootId("root")
+            .with(new HashMap<>() {{
+                put(tikaRawHeader("field"), "email@domain.com");
+                put(tikaRawHeader("Message-ID"), "id@domain.com");
+                put(tikaRawHeader("Return-Path"), "return@head.er");
+                put(tikaMsgHeader("To"), "to@head.er");
+                put(tikaMsgHeader("From"), "from@head.er");
+                put(tikaMsgHeader("Cc"), "cc@head.er");
+                put(tikaMsgHeader("Bcc"), "bcc@head.er");
+                put(tika("Dc-Title"), "subject@head.er");
+                put(tikaRawHeader("Reply-To"), "replyto@head.er");
+                put(tikaRawHeader("Followup-To"), "followup@head.er");
+                put(tikaRawHeader("Alternate-Recipient"), "alternate@head.er");
+                put(tikaRawHeader("For-Handling"), "forhandling@head.er");
+                put(tikaRawHeader("Resent-Reply-To"), "resent-replyto@head.er");
+                put(tikaRawHeader("Resent-Sender"), "resent-sender@head.er");
+                put(tikaRawHeader("Resent-From"), "resent-from@head.er");
+                put(tikaRawHeader("Resent-To"), "resent-to@head.er");
+                put(tikaRawHeader("Resent-cc"), "resent-cc@head.er");
+                put(tikaRawHeader("Resent-bcc"), "resent-bcc@head.er");
+            }}).build();
 
         List<NamedEntity> namedEntities = pipeline.process(doc);
 
         assertThat(namedEntities).containsExactly(
-                        NamedEntity.create(EMAIL, "replyto@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "alternate@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "resent-sender@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "cc@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "from@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "resent-cc@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "forhandling@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "resent-replyto@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "return@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "resent-to@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "followup@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "resent-bcc@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "subject@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "bcc@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "to@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH),
-                        NamedEntity.create(EMAIL, "resent-from@head.er", asList(-1L), "docid", "root", Pipeline.Type.EMAIL, FRENCH)
-                );
+                        NamedEntity.create(EMAIL, "replyto@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_reply_to")),
+                        NamedEntity.create(EMAIL, "alternate@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_alternate_recipient")),
+                        NamedEntity.create(EMAIL, "resent-sender@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_resent_sender")),
+                        NamedEntity.create(EMAIL, "cc@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_cc")),
+                        NamedEntity.create(EMAIL, "from@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_from")),
+                        NamedEntity.create(EMAIL, "resent-cc@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_resent_cc")),
+                        NamedEntity.create(EMAIL, "forhandling@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_for_handling")),
+                        NamedEntity.create(EMAIL, "resent-replyto@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_resent_reply_to")),
+                        NamedEntity.create(EMAIL, "return@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_return_path")),
+                        NamedEntity.create(EMAIL, "resent-to@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_resent_to")),
+                        NamedEntity.create(EMAIL, "followup@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_followup_to")),
+                        NamedEntity.create(EMAIL, "resent-bcc@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_resent_bcc")),
+                        NamedEntity.create(EMAIL, "subject@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_dc_title")),
+                        NamedEntity.create(EMAIL, "bcc@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_bcc")),
+                        NamedEntity.create(EMAIL, "to@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_to")),
+                        NamedEntity.create(EMAIL, "resent-from@head.er", List.of(-1L), "docid", "root", Type.EMAIL, FRENCH, Map.of("emailHeaderField", "tika_metadata_message_raw_header_resent_from"))
+        );
     }
 }

--- a/datashare-index/src/main/resources/datashare_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_index_mappings.json
@@ -7,6 +7,9 @@
     },
     "metadata" : {
       "properties": {
+        "emailHeaderField": {
+          "type": "keyword"
+        },
         "tika_metadata_resourcename": {
           "type": "text",
           "analyzer": "folding",

--- a/datashare-index/src/main/resources/datashare_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_index_mappings.json
@@ -8,7 +8,6 @@
     "metadata": {
       "properties": {
         "emailHeaderField": {
-          "type": "keyword",
           "enabled": false
         },
         "tika_metadata_resourcename": {

--- a/datashare-index/src/main/resources/datashare_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_index_mappings.json
@@ -5,10 +5,11 @@
       "index_options": "offsets",
       "analyzer": "folding"
     },
-    "metadata" : {
+    "metadata": {
       "properties": {
         "emailHeaderField": {
-          "type": "keyword"
+          "type": "keyword",
+          "enabled": false
         },
         "tika_metadata_resourcename": {
           "type": "text",

--- a/datashare-index/src/main/resources/datashare_index_settings.json
+++ b/datashare-index/src/main/resources/datashare_index_settings.json
@@ -5,6 +5,7 @@
     "content",
     "mentionNorm",
     "content_translated.content",
+    "metadata.emailHeaderField",
     "metadata.tika_metadata_author",
     "metadata.tika_metadata_creator",
     "metadata.tika_metadata_dc_creator",


### PR DESCRIPTION
# TODO

- [x] wait https://github.com/ICIJ/datashare-api/pull/20 to be merge and release
- [x] discuss the impact of the new field addition
- [x] update API with https://github.com/ICIJ/datashare-api/pull/22

# PR description

Updated the `EmailPipeline` to preserve email header metadata when parsing emails. 

If the header contains `email2@domain.com,email3@domain.com` as `CC`, the parser will create 2 named entities with `{"emailHeaderField": "tika_metadata_message_cc"}` metadata.

**Please carefully review the naming** of the metadata as field as it will be painful the change it later, I'm open to suggestions.

# Changes
## `datashare-app`
### Changed
- modified `EmailPipeline.process` to preserver email header field name and use it as `NamedEntity.metadata` under the `emailHeaderField` key

## `datashare-index`
### Changed
- included the `NamedEntity.metadata.emailHeaderField` in the indexed fields as a `keyword`
- included the `NamedEntity.metadata.emailHeaderField` in the `index.query.default_field` 


## `pom.xml`
## Changed
- bumped `datashare-api` to `11.3.2` to add support for `NamedEntity.metadata`