### PR TITLE
feature: support installation of plugins with extensions dependencies

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -34,8 +34,9 @@ class CliApp {
     private static final Logger logger = LoggerFactory.getLogger(CliApp.class);
 
     static void start(Properties properties) throws Exception {
-        process(new PluginService(new PropertiesProvider(properties)), properties);
-        process(new ExtensionService(new PropertiesProvider(properties)), properties);
+        ExtensionService extensionService = new ExtensionService(new PropertiesProvider(properties));
+        process(extensionService, properties);
+        process(new PluginService(new PropertiesProvider(properties), extensionService), properties);
         CommonMode commonMode = CommonMode.create(properties);
         runTaskRunner(commonMode, properties);
     }

--- a/datashare-app/src/main/java/org/icij/datashare/Plugin.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Plugin.java
@@ -34,7 +34,7 @@ public class Plugin extends Extension {
                   @JsonProperty("extensions") List<String> extensions
     ){
         super(id, name, version, description, url, homepage, Type.PLUGIN);
-        this.extensions = extensions == null ? List.of() : extensions;
+        this.extensions = ofNullable(extensions).orElse(List.of());
     }
 
     public Plugin(String id, String name, String version, String description, URL url, URL homepage){

--- a/datashare-app/src/main/java/org/icij/datashare/Plugin.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Plugin.java
@@ -22,6 +22,7 @@ import static org.apache.commons.io.FilenameUtils.getBaseName;
 
 public class Plugin extends Extension {
     private static final Pattern versionBeginsWithV = Pattern.compile("v[0-9.]*");
+    public final List<String> extensions;
 
     @JsonCreator
     public Plugin(@JsonProperty("id") String id,
@@ -29,12 +30,20 @@ public class Plugin extends Extension {
                   @JsonProperty("version") String version,
                   @JsonProperty("description") String description,
                   @JsonProperty("url") URL url,
-                  @JsonProperty("homepage") URL homepage){
+                  @JsonProperty("homepage") URL homepage,
+                  @JsonProperty("extensions") List<String> extensions
+    ){
         super(id, name, version, description, url, homepage, Type.PLUGIN);
+        this.extensions = extensions == null ? List.of() : extensions;
+    }
+
+    public Plugin(String id, String name, String version, String description, URL url, URL homepage){
+        this(id, name, version, description, url, homepage, null);
     }
 
     Plugin(URL url) {
         super(url,Type.PLUGIN);
+        this.extensions = List.of();
     }
 
     @Override

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
@@ -1,5 +1,7 @@
 package org.icij.datashare;
 
+import java.io.InputStream;
+import java.nio.file.Path;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -20,6 +22,11 @@ import static org.icij.datashare.PropertiesProvider.EXTENSIONS_DIR;
 public class ExtensionServiceTest {
     @Rule public TemporaryFolder extensionFolder = new TemporaryFolder();
     @Rule public TemporaryFolder otherFolder = new TemporaryFolder();
+
+    public static ExtensionService createExtensionService(Path extensionsDir,
+                                                          InputStream inputStream) {
+        return new ExtensionService(extensionsDir, inputStream);
+    }
 
     @Test
     public void test_get_list() {

--- a/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.web;
 
 import org.icij.datashare.ExtensionService;
+import org.icij.datashare.ExtensionServiceTest;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
@@ -88,7 +89,8 @@ public class ExtensionResourceTest extends AbstractProdWebServerTest  {
     public void setUp() {
         initMocks(this);
         when(jooqRepository.getProjects()).thenReturn(new ArrayList<>());
-        configure(routes -> routes.add(new ExtensionResource(new ExtensionService(extensionFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
+        configure(routes -> routes.add(new ExtensionResource(
+            ExtensionServiceTest.createExtensionService(extensionFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
                 "{\"id\":\"my-extension\",\"name\":\"My extension\",\"description\":\"Description of my extension\",\"version\":\"1.0.1\",\"type\":\"WEB\",\"url\": \"" + ClassLoader.getSystemResource(("my-extension-1.0.1.jar")) + "\"}," +
                 "{\"id\":\"my-other-extension\",\"name\":\"My other extension\",\"description\":\"Description of my other extension\",\"type\":\"WEB\",\"url\": \"https://dummy.url/foo.jar\"}" +
                 "]}").getBytes())))).filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));


### PR DESCRIPTION
# PR description

This PR adds the ability for `Plugin` to depend on a list of `Extension`.

The dependency was added on this direction because if a `Plugin` depends on an `Extension` the opposite it not always true and the extension might be usable standalone (even if a plugin can run on the top of it).

I also allowed a plugin to depend on several extensions (this is debatable but a bit more futureproof).


# Changes
## `datashare-app`
### Added
- added an optional `public final List<String> extensions`  to the `Plugin` class

### Changed
- added a `private final ExtensionService extensionService;` to the `PluginService` which nows check if the installed plugin depends on extensions and installs them thanks to its `extensionService` if needed

