### PR TITLE
build: use new name and bump Java version

### DIFF
--- a/datashare-dist/src/main/deb/control/control
+++ b/datashare-dist/src/main/deb/control/control
@@ -1,8 +1,10 @@
-Package: [[name]]
+Package: datashare
+Replaces: datashare-dist
 Version: [[version]]
 Section: misc
 Priority: low
 Architecture: all
 Description: [[description]]
-Maintainer: Bruno Thomas <bthomas@icij.org>
-Depends: default-jre | openjdk-8-jre, tesseract-ocr
+Maintainer: ICIJ <datashare@icij.org>
+Depends: default-jre | openjdk-11-jre | openjdk-17-jre | openjdk-18-jre, tesseract-ocr
+Recommends: tesseract-ocr-all


### PR DESCRIPTION
## PR description

This PR improves the deb package:

* to use `datashare` as package name (replacing `datashare-dist`)
* to use `ICIJ <datashare@icij.org>` in the maintainer field
* to depends on higher Java version