### PR TITLE
feat: hash duplicates with cli option digestAlgorithm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>12.0.0</datashare-api.version>
+        <datashare-api.version>12.1.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
this PR is made to generalize the `digestAlgorithm` cli option to Duplicate type hash generation.

Note that with duplicates, for now, the project is never encoded in the hash.