### PR TITLE
feat: add cli extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run: mvn -pl commons-test -am install
       - run: mvn -pl datashare-db liquibase:update
       - run: mvn test
-      - run: mvn -pl datashare-app -pl datashare-nlp-corenlp -am install -Dmaven.test.skip=true
+      - run: mvn -s .circleci/maven-release-settings.xml -pl datashare-app -pl datashare-nlp-corenlp -am install -Dmaven.test.skip=true
       - save_cache:
           paths:
             - ~/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
 
       - run:
           name: Configure GPG private key for signing project artifacts in OSS Sonatype
+          shell: /bin/bash
           command: |
             echo ${RELEASES_GPG_PRIV_BASE64} | base64 --decode | gpg --batch --no-tty --import --yes
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,11 @@ jobs:
             sudo apt-get install -y postgresql-client-11
             PGPASSWORD=test psql -h postgres -U dstest dstest -c "CREATE DATABASE datashare;"
 
+      - run:
+          name: Configure GPG private key for signing project artifacts in OSS Sonatype
+          command: |
+            echo ${RELEASES_GPG_PRIV_BASE64} | base64 --decode | gpg --batch --no-tty --import --yes
+
       - run: sudo apt-get install -y tesseract-ocr-eng
       - run: mvn validate
       - run: mvn -pl commons-test -am install

--- a/.circleci/maven-release-settings.xml
+++ b/.circleci/maven-release-settings.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.executable>gpg</gpg.executable>
+                <gpg.passphrase>${env.RELEASES_GPG_PASS}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.SERVER_OSSRH_USERNAME}</username>
+            <password>${env.SERVER_OSSRH_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ datashare-web/src/main/resources/secret.properties
 .project
 .settings
 .classpath
+datashare-cli/doc/

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -37,12 +37,13 @@ class CliApp {
     private static final Logger logger = LoggerFactory.getLogger(CliApp.class);
 
     static void start(Properties properties) throws Exception {
+        Thread.sleep(10000);
         ExtensionService extensionService = new ExtensionService(new PropertiesProvider(properties));
         process(extensionService, properties);
         process(new PluginService(new PropertiesProvider(properties), extensionService), properties);
         CommonMode commonMode = CommonMode.create(properties);
         List<CliExtension> extensions = CliExtensionService.getInstance().getExtensions();
-        if (extensions.size() == 1 && properties.get("ext") != extensions.get(0).identifier()) {
+        if (extensions.size() == 1 && extensions.get(0).identifier().equals(properties.get("ext"))) {
             extensions.get(0).run(properties);
             System.exit(0);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -1,7 +1,9 @@
 package org.icij.datashare;
 
+import org.icij.datashare.cli.CliExtensionService;
 import org.icij.datashare.cli.DatashareCli;
 import org.icij.datashare.cli.DatashareCliOptions;
+import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.extension.PipelineRegistry;
 import org.icij.datashare.extract.RedisUserDocumentQueue;
 import org.icij.datashare.mode.CommonMode;
@@ -17,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -38,6 +41,11 @@ class CliApp {
         process(extensionService, properties);
         process(new PluginService(new PropertiesProvider(properties), extensionService), properties);
         CommonMode commonMode = CommonMode.create(properties);
+        List<CliExtension> extensions = CliExtensionService.getInstance().getExtensions();
+        if (extensions.size() == 1 && properties.get("ext") != extensions.get(0).identifier()) {
+            extensions.get(0).run(properties);
+            System.exit(0);
+        }
         runTaskRunner(commonMode, properties);
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/ExtensionService.java
+++ b/datashare-app/src/main/java/org/icij/datashare/ExtensionService.java
@@ -33,7 +33,7 @@ public class ExtensionService extends DeliverableService<Extension> {
     @Override
     DeliverableRegistry<Extension> createRegistry(InputStream pluginJsonContent) {
         try {
-            return new ObjectMapper().readValue(pluginJsonContent, new TypeReference<DeliverableRegistry<Extension>>() {});
+            return new ObjectMapper().readValue(pluginJsonContent, new TypeReference<>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -40,6 +40,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.adobe.testing</groupId>
             <artifactId>s3mock</artifactId>
             <version>1.0.1</version>

--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -65,8 +65,65 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <!-- This is necessary for gpg to not try to use the pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-
     </build>
 </project>
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/CliExtensionService.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/CliExtensionService.java
@@ -1,0 +1,27 @@
+package org.icij.datashare.cli;
+
+import org.icij.datashare.cli.spi.CliExtension;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+public class CliExtensionService {
+    private static CliExtensionService service;
+    private final ServiceLoader<CliExtension> loader;
+
+    private CliExtensionService() {
+        loader = ServiceLoader.load(CliExtension.class);
+    }
+
+    public static synchronized CliExtensionService getInstance() {
+        if (service == null) {
+            service = new CliExtensionService();
+        }
+        return service;
+    }
+
+    public List<CliExtension> getExtensions() {
+        return loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList());
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -4,6 +4,7 @@ package org.icij.datashare.cli;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import org.icij.datashare.cli.spi.CliExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +24,10 @@ public class DatashareCli {
 
     public DatashareCli parseArguments(String[] args) {
         OptionParser parser = createParser();
+
+        for (CliExtension extension: CliExtensionService.getInstance().getExtensions()) {
+            extension.addOptions(parser);
+        }
 
         OptionSpec<Void> helpOpt = DatashareCliOptions.help(parser);
         OptionSpec<Void> versionOpt = DatashareCliOptions.version(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -24,6 +24,8 @@ public class DatashareCli {
 
     public DatashareCli parseArguments(String[] args) {
         OptionParser parser = createParser();
+        OptionSpec<Void> helpOpt = DatashareCliOptions.help(parser);
+        OptionSpec<Void> versionOpt = DatashareCliOptions.version(parser);
 
         List<CliExtension> extensions  = CliExtensionService.getInstance().getExtensions();
         OptionSpec<String> extOption = DatashareCliOptions.extOption(parser);
@@ -40,8 +42,8 @@ public class DatashareCli {
                     System.exit(3);
                 }
                 OptionParser extParser = createExtParser(extensions.get(0));
+                helpOpt = DatashareCliOptions.help(extParser);
                 OptionSet extOptions = extParser.parse(args);
-                OptionSpec<Void> helpOpt = DatashareCliOptions.help(extParser);
                 if (extOptions.has(helpOpt)) {
                     printHelp(extParser);
                     System.exit(0);
@@ -51,8 +53,6 @@ public class DatashareCli {
             }
         }
 
-        OptionSpec<Void> helpOpt = DatashareCliOptions.help(parser);
-        OptionSpec<Void> versionOpt = DatashareCliOptions.version(parser);
         try {
             OptionSet options = parser.parse(args);
             if (options.has(helpOpt)) {
@@ -79,6 +79,7 @@ public class DatashareCli {
     private static OptionParser createExtParser(CliExtension cliExtension) {
         OptionParser parser = new OptionParser();
         DatashareCliOptions.extOption(parser);
+        DatashareCliOptions.mode(parser);
         cliExtension.addOptions(parser);
         return parser;
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -565,4 +565,9 @@ public final class DatashareCliOptions {
                         singletonList(NO_DIGEST_PROJECT), "Disable the project name in document hash processing (only using binary contents).")
                         .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
     }
+
+    public static OptionSpec<String> extOption(OptionParser parser) {
+        return parser.acceptsAll(
+                singletonList("ext"), "Run CLI extension").withRequiredArg().ofType(String.class);
+    }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
@@ -1,0 +1,7 @@
+package org.icij.datashare.cli.spi;
+
+import joptsimple.OptionParser;
+
+public interface CliExtension {
+    void addOptions(OptionParser parser);
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
@@ -2,6 +2,11 @@ package org.icij.datashare.cli.spi;
 
 import joptsimple.OptionParser;
 
+import java.util.Properties;
+
 public interface CliExtension {
     void addOptions(OptionParser parser);
+    String identifier();
+
+    void run(Properties properties) throws Exception;
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
@@ -1,0 +1,16 @@
+package org.icij.datashare.cli;
+
+import joptsimple.OptionParser;
+import org.icij.datashare.cli.spi.CliExtension;
+
+import static java.util.Collections.singletonList;
+
+public class CliExtensionFoo implements CliExtension {
+    @Override
+    public void addOptions(OptionParser parser) {
+        parser.acceptsAll(
+                        singletonList("foo"), "Test foo")
+                .withRequiredArg()
+                .ofType(String.class);
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
@@ -3,6 +3,8 @@ package org.icij.datashare.cli;
 import joptsimple.OptionParser;
 import org.icij.datashare.cli.spi.CliExtension;
 
+import java.util.Properties;
+
 import static java.util.Collections.singletonList;
 
 public class CliExtensionFoo implements CliExtension {
@@ -12,5 +14,14 @@ public class CliExtensionFoo implements CliExtension {
                         singletonList("foo"), "Test foo")
                 .withRequiredArg()
                 .ofType(String.class);
+        parser.acceptsAll(singletonList("fooCommand"));
     }
+
+    @Override
+    public String identifier() {
+        return "foo";
+    }
+
+    @Override
+    public void run(Properties properties) {}
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionServiceTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionServiceTest.java
@@ -1,0 +1,13 @@
+package org.icij.datashare.cli;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class CliExtensionServiceTest {
+    @Test
+    public void test_load_extension() {
+        assertThat(CliExtensionService.getInstance().getExtensions()).hasSize(1);
+        assertThat(CliExtensionService.getInstance().getExtensions().get(0)).isInstanceOf(CliExtensionFoo.class);
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -1,17 +1,19 @@
 package org.icij.datashare.cli;
 
 import joptsimple.OptionException;
-import joptsimple.OptionSet;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
 
 public class DatashareCliTest {
     private DatashareCli cli = new DatashareCli();
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void test_web_opt() {
@@ -129,5 +131,18 @@ public class DatashareCliTest {
     public void test_foo_extension_loaded() {
         cli.parseArguments(new String[] {"--foo", "bar"});
         assertThat(cli.properties).includes(entry("foo", "bar"));
+    }
+
+    @Test
+    public void test_foo_extension_loaded_help() {
+        cli.parseArguments(new String[] {"--ext", "foo", "--fooCommand"});
+        assertThat(cli.properties).excludes(entry("defaultProject", "local-datashare"));
+    }
+
+    @Test
+    public void test_foo_extension_should_exit_with_3_for_unknown_extension_id() {
+        exit.expectSystemExitWithStatus(3);
+        cli.parseArguments(new String[] {"--ext", "bar"});
+        assertThat(cli.properties).excludes(entry("defaultProject", "local-datashare"));
     }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -124,4 +124,10 @@ public class DatashareCliTest {
         assertThat(cli.properties).includes(entry("digestProjectName", "foo"));
         assertThat(cli.properties).includes(entry("noDigestProject", "false"));
     }
+
+    @Test
+    public void test_foo_extension_loaded() {
+        cli.parseArguments(new String[] {"--foo", "bar"});
+        assertThat(cli.properties).includes(entry("foo", "bar"));
+    }
 }

--- a/datashare-cli/src/test/resources/META-INF/services/org.icij.datashare.cli.spi.CliExtension
+++ b/datashare-cli/src/test/resources/META-INF/services/org.icij.datashare.cli.spi.CliExtension
@@ -1,0 +1,3 @@
+# in your extension module you must add a src/main/resources/META-INF/services directory
+# with a org.icij.datashare.cli.spi.CliExtension text file and the implementation class(es) listed:
+org.icij.datashare.cli.CliExtensionFoo


### PR DESCRIPTION
The goal of this request is to add a simple command line interface extension mechanism. It works not on the same way as others extensions because others extensions needed an extension folder that is set... in the CLI. So there was a chicken-and-egg issue.

So we used instead the [Service Provider](https://docs.oracle.com/javase/tutorial/ext/basics/spi.html) way.

Extensions that intend to update the command line interface and properties should:

1. add the `datashare-cli-<version>.jar` in their dependencies (see the maven [jar page](https://central.sonatype.com/artifact/org.icij.datashare/datashare-cli))
2. implement the Service Provider Interface `CliExtension` (SPI)
3. add a `src/java/resources/META-INF/services/org.icij.datashare.cli.spi.CliExtension` text file with the list of `CliExtension` implementations

The SPI is defined like this: 

```java
package org.icij.datashare.cli.spi;

import joptsimple.OptionParser;

public interface CliExtension {
    void addOptions(OptionParser parser);
}
```

And so you can add options in the `addOptions` functions like : 

```java
parser.acceptsAll(singletonList("foo"), "Test foo").withRequiredArg().ofType(String.class);
```

Then you have to compile the extension jar. Check that you have the `/META-INF/services/org.icij.datashare.cli.spi.CliExtension` file in it. 

Finally, you must add the jar in the datashare classpath.