### PR TITLE
feat: use several digesters to found embedded doc

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -28,10 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -175,7 +172,7 @@ public class BatchDownloadRunner implements Callable<File>, Monitorable, UserTas
                 }
                 zipOutputStream.closeEntry();
                 return zippedSize;
-            } catch (ExtractException|ZipException|ContentNotFoundException zex) {
+            } catch (ExtractException | ZipException | FileNotFoundException | ContentNotFoundException zex) {
                 logger.warn("exception during extract/zip. skipping entry for doc " + doc.getId(), zex);
                 return 0;
             }

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -63,6 +63,8 @@ public class SourceExtractor {
         digesters.add(new CommonsDigester(20 * 1024 * 1024, algorithm.replace("-", "")));
         digesters.add(new UpdatableDigester(project.getId(), algorithm));
 
+        // Try each digester to find embedded doc and ensure we 
+        // used every available digesters to find it.
         for (DigestingParser.Digester digester : digesters) {
             Identifier identifier = new DigestIdentifier(hasher.toString(), Charset.defaultCharset());
             TikaDocument rootDocument = new DocumentFactory().withIdentifier(identifier).create(document.getPath());


### PR DESCRIPTION
When downloading an embedded document, Datashare tries to get it with several digesters instead of one.