### PR TITLE
feat: rename saved search 

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import static java.util.Collections.singletonList;
 import static org.icij.datashare.UserEvent.Type.DOCUMENT;
@@ -172,12 +173,16 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_put_user_event_to_history() {
-        when(jooqRepository.addToUserHistory(eq(singletonList(project("prj"))),any(UserEvent.class))).thenReturn(true);
-
-        put("/api/users/me/history", "{\"type\": \"SEARCH\", \"projectIds\": [\"prj\"], \"name\": \"foo AND bar\", \"uri\": \"search_uri\"}").should().respond(200);
+    public void test_put_user_new_event_to_history() throws URISyntaxException {
+        when(jooqRepository.addToUserHistory(eq(singletonList(project("prj"))), any(UserEvent.class))).thenReturn(true);
+        put("/api/users/me/history", "{\"type\": \"SEARCH\", \"name\": \"TOTOTOTO AND bar\", \"uri\": \"search_uri\"}").should().respond(200);
     }
-
+    @Test
+    public void test_put_user_existing_event_to_history() {
+        when(jooqRepository.renameSavedSearch(User.local(),12,"test")).thenReturn(true);
+        put("/api/users/me/history", "{\"type\": \"SEARCH\", \"name\": \"test\", \"eventId\":12}").should().respond(200);
+        put("/api/users/me/history", "{\"type\": \"SEARCH\", \"name\": \"test\", \"eventId\":14}").should().respond(400);
+    }
     @Test
     public void test_delete_user_history_by_type() {
         when(jooqRepository.deleteUserHistory(User.local(), DOCUMENT)).thenReturn(true).thenReturn(false);

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -574,6 +574,24 @@ public class JooqRepositoryTest {
     }
 
     @Test
+    public void test_rename_single_user_event_by_id() {
+        repository.addToUserHistory(singletonList(project("project")), new UserEvent(User.local(), SEARCH, "search1", Paths.get("search_uri").toUri()));
+        List<UserEvent> userSearchEvents = repository.getUserHistory(User.local(), SEARCH, 0, 10, "modification_date", true);
+        assertThat(userSearchEvents.get(0).name).isEqualTo("search1");
+        boolean renamed =  repository.renameSavedSearch(User.local(),userSearchEvents.get(0).id, "search_renamed");
+        assertThat(renamed).isTrue();
+        List<UserEvent> userSearchEvents2 = repository.getUserHistory(User.local(), SEARCH, 0, 10, "modification_date", true);
+        assertThat(userSearchEvents2.get(0).name).isEqualTo("search_renamed");
+
+        repository.addToUserHistory(singletonList(project("project")), new UserEvent(User.local(), DOCUMENT, "doc_name1", Paths.get("doc_uri1").toUri()));
+        List<UserEvent> userDocEvents = repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true);
+        assertThat(userDocEvents.get(0).name).isEqualTo("doc_name1");
+        boolean renamedDoc =  repository.renameSavedSearch(User.local(),userDocEvents.get(0).id, "search_renamed");
+        assertThat(renamedDoc).isFalse();
+        List<UserEvent> userDocEvents2 = repository.getUserHistory(User.local(), DOCUMENT, 0, 10, "modification_date", true);
+        assertThat(userDocEvents2.get(0).name).isEqualTo("doc_name1");
+    }
+    @Test
     public void test_db_status(){
         assertThat(repository.getHealth()).isTrue();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>12.1.0</datashare-api.version>
+        <datashare-api.version>12.2.0</datashare-api.version>
 
         <datashare-cli.version>${project.version}</datashare-cli.version>
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
This PR is link to #1203 
It aims to rename a saved search by transforming the API endpoint to add an event into an upsert if the eventId to update is passed in the request. 
