### PR TITLE
fix: CLI extension add log and updates launchBack script 

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -42,6 +42,7 @@ class CliApp {
         process(new PluginService(new PropertiesProvider(properties), extensionService), properties);
         CommonMode commonMode = CommonMode.create(properties);
         List<CliExtension> extensions = CliExtensionService.getInstance().getExtensions();
+        logger.info("found {} CLI extension(s)", extensions.size());
         if (extensions.size() == 1 && extensions.get(0).identifier().equals(properties.get("ext"))) {
             extensions.get(0).run(properties);
             System.exit(0);

--- a/launchBack.sh
+++ b/launchBack.sh
@@ -2,8 +2,14 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 VERSION=$(cat $DIR/pom.xml | grep '<version>[0-9.]\+' | sed 's/<version>\([0-9a-z.\-]\+\)<\/version>/\1/g' | tr -d '[:space:]')
-CLASSPATH=$DIR/datashare-dist/target/datashare-dist-${VERSION}-all.jar
+CLASSPATH=${CLASSPATH:-$DIR/datashare-dist/target/datashare-dist-${VERSION}-all.jar}
 JDWP_TRANSPORT_PORT=${JDWP_TRANSPORT_PORT:-8000}
+
+if [[ $@ == *"SERVER"* ]]; then
+  OAUTH_LOCAL_OPTIONS="--oauthAuthorizeUrl http://xemx:3001/oauth/authorize --oauthTokenUrl http://xemx:3001/oauth/token --oauthApiUrl http://xemx:3001/api/v1/me.json"
+else
+  OAUTH_LOCAL_OPTIONS=""
+fi
 
 if [ -z "$JAVA_HOME" ]; then
   JAVA=java
@@ -31,7 +37,4 @@ $JAVA -agentlib:jdwp=transport=dt_socket,server=y,address=$JDWP_TRANSPORT_PORT,s
  -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \
  -Djavax.net.ssl.trustStorePassword=changeit \
  -Ddatashare.loghost=udp:localhost -Dlogback.configurationFile=logback.xml \
- -Xmx4g -DPROD_MODE=true -cp "$DIR/dist/:${CLASSPATH}" org.icij.datashare.Main --cors '*' \
- --oauthAuthorizeUrl http://xemx:3001/oauth/authorize \
- --oauthTokenUrl http://xemx:3001/oauth/token \
- --oauthApiUrl http://xemx:3001/api/v1/me.json "$@"
+ -Xmx4g -DPROD_MODE=true -cp "$DIR/dist/:${CLASSPATH}" org.icij.datashare.Main $OAUTH_LOCAL_OPTIONS "$@"


### PR DESCRIPTION
see ICIJ/datashare-extension-neo4j#80

The goal of the PR is to update the launchBack.sh script and add a log to debug easily the CLI extension loading.

The `launchBack.sh` script can be called with a cli extension like this:

```
CLASSPATH=./datashare-dist/target/datashare-dist-13.2.6-docker/lib/datashare-dist-13.2.6-all.jar:../cli-ext/target/cli-ext-1.0-SNAPSHOT.jar ./launchBack.sh -m CLI --ext foo
```