### PR TITLE
feature:`datashare-cli` `CliExtension` with dependencies

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -1,9 +1,10 @@
 package org.icij.datashare;
 
+import com.google.inject.Guice;
+import org.icij.datashare.cli.Cli;
 import org.icij.datashare.cli.CliExtensionService;
 import org.icij.datashare.cli.DatashareCli;
 import org.icij.datashare.cli.DatashareCliOptions;
-import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.extension.PipelineRegistry;
 import org.icij.datashare.extract.RedisUserDocumentQueue;
 import org.icij.datashare.mode.CommonMode;
@@ -41,10 +42,11 @@ class CliApp {
         process(extensionService, properties);
         process(new PluginService(new PropertiesProvider(properties), extensionService), properties);
         CommonMode commonMode = CommonMode.create(properties);
-        List<CliExtension> extensions = CliExtensionService.getInstance().getExtensions();
+        CliExtensionService cliExtensionService = CliExtensionService.getInstance();
+        List<Cli.CliExtender> extensions = cliExtensionService.getExtensions();
         logger.info("found {} CLI extension(s)", extensions.size());
         if (extensions.size() == 1 && extensions.get(0).identifier().equals(properties.get("ext"))) {
-            extensions.get(0).run(properties);
+            cliExtensionService.getExtensionRunners(Guice.createInjector(commonMode)).get(0).run(properties);
             System.exit(0);
         }
         runTaskRunner(commonMode, properties);

--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -51,16 +51,6 @@
             <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.adobe.testing</groupId>
-            <artifactId>s3mock</artifactId>
-            <version>1.0.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.icij.extract</groupId>
-            <artifactId>extract-lib</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -27,6 +27,12 @@
             <version>${slf4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
         <!-- tests dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -50,6 +56,10 @@
             <artifactId>s3mock</artifactId>
             <version>1.0.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.icij.extract</groupId>
+            <artifactId>extract-lib</artifactId>
         </dependency>
     </dependencies>
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/Cli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/Cli.java
@@ -1,0 +1,17 @@
+package org.icij.datashare.cli;
+
+import java.util.Properties;
+import joptsimple.OptionParser;
+
+public class Cli {
+    public interface CliExtender {
+        String identifier();
+
+        void addOptions(OptionParser parser);
+
+    }
+
+    public interface CliRunner {
+        void run(Properties properties) throws Exception;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/CliExtensionService.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/CliExtensionService.java
@@ -1,17 +1,21 @@
 package org.icij.datashare.cli;
 
-import org.icij.datashare.cli.spi.CliExtension;
-
+import com.google.inject.Injector;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.icij.datashare.cli.spi.CliExtension;
+import org.icij.datashare.cli.spi.CliExtensionFactory;
 
 public class CliExtensionService {
     private static CliExtensionService service;
-    private final ServiceLoader<CliExtension> loader;
+    private final ServiceLoader<CliExtensionFactory> factoriesLoader;
+    private final ServiceLoader<CliExtension> extensionLoader;
 
     private CliExtensionService() {
-        loader = ServiceLoader.load(CliExtension.class);
+        extensionLoader = ServiceLoader.load(CliExtension.class);
+        factoriesLoader = ServiceLoader.load(CliExtensionFactory.class);
     }
 
     public static synchronized CliExtensionService getInstance() {
@@ -21,7 +25,17 @@ public class CliExtensionService {
         return service;
     }
 
-    public List<CliExtension> getExtensions() {
-        return loader.stream().map(ServiceLoader.Provider::get).collect(Collectors.toList());
+    public List<Cli.CliExtender> getExtensions() {
+        return Stream.concat(
+            extensionLoader.stream().map(ServiceLoader.Provider::get),
+            factoriesLoader.stream().map(ServiceLoader.Provider::get)
+        ).collect(Collectors.toList());
+    }
+
+    public List<Cli.CliRunner> getExtensionRunners(Injector injector) {
+        return Stream.concat(
+            extensionLoader.stream().map(ServiceLoader.Provider::get),
+            factoriesLoader.stream().map(p -> p.get().apply(injector))
+        ).collect(Collectors.toList());
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -4,7 +4,6 @@ package org.icij.datashare.cli;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
-import org.icij.datashare.cli.spi.CliExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +26,7 @@ public class DatashareCli {
         OptionSpec<Void> helpOpt = DatashareCliOptions.help(parser);
         OptionSpec<Void> versionOpt = DatashareCliOptions.version(parser);
 
-        List<CliExtension> extensions  = CliExtensionService.getInstance().getExtensions();
+        List<Cli.CliExtender> extensions = CliExtensionService.getInstance().getExtensions();
         OptionSpec<String> extOption = DatashareCliOptions.extOption(parser);
         if (extensions.size() > 1) {
             System.out.println("For now we only allow one CLI extension");
@@ -76,11 +75,11 @@ public class DatashareCli {
         return this;
     }
 
-    private static OptionParser createExtParser(CliExtension cliExtension) {
+    private static OptionParser createExtParser(Cli.CliExtender cliExtender) {
         OptionParser parser = new OptionParser();
         DatashareCliOptions.extOption(parser);
         DatashareCliOptions.mode(parser);
-        cliExtension.addOptions(parser);
+        cliExtender.addOptions(parser);
         return parser;
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
@@ -1,12 +1,6 @@
 package org.icij.datashare.cli.spi;
 
-import joptsimple.OptionParser;
+import org.icij.datashare.cli.Cli;
 
-import java.util.Properties;
-
-public interface CliExtension {
-    void addOptions(OptionParser parser);
-    String identifier();
-
-    void run(Properties properties) throws Exception;
+public interface CliExtension extends Cli.CliRunner, Cli.CliExtender {
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtensionFactory.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtensionFactory.java
@@ -1,0 +1,14 @@
+package org.icij.datashare.cli.spi;
+
+import com.google.inject.Injector;
+import java.util.function.Function;
+import org.icij.datashare.cli.Cli;
+
+public interface CliExtensionFactory extends Function<Injector, Cli.CliRunner>, Cli.CliExtender {
+    Class<? extends Cli.CliRunner> type();
+
+    @Override
+    default Cli.CliRunner apply(Injector injector) {
+        return injector.getInstance(this.type());
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
@@ -1,19 +1,32 @@
 package org.icij.datashare.cli;
 
-import joptsimple.OptionParser;
-import org.icij.datashare.cli.spi.CliExtension;
-
-import java.util.Properties;
 
 import static java.util.Collections.singletonList;
 
+import com.google.inject.Inject;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
+import joptsimple.OptionParser;
+import org.icij.datashare.cli.spi.CliExtension;
+
 public class CliExtensionFoo implements CliExtension {
+    protected final Properties fooProperties;
+
+    public CliExtensionFoo() {
+        this.fooProperties = null;
+    }
+
+    @Inject
+    public CliExtensionFoo(Properties fooProperties) {
+        this.fooProperties = fooProperties;
+    }
+
     @Override
     public void addOptions(OptionParser parser) {
-        parser.acceptsAll(
-                        singletonList("foo"), "Test foo")
-                .withRequiredArg()
-                .ofType(String.class);
+        parser.acceptsAll(singletonList("foo"), "Test foo")
+            .withRequiredArg()
+            .ofType(String.class);
         parser.acceptsAll(singletonList("fooCommand"));
     }
 
@@ -23,5 +36,13 @@ public class CliExtensionFoo implements CliExtension {
     }
 
     @Override
-    public void run(Properties properties) {}
+    public void run(Properties properties) throws Exception {
+        Stream<Map.Entry<Object, Object>> props = properties.entrySet().stream();
+        if (this.fooProperties != null) {
+            props = props.filter(e -> !this.fooProperties.containsKey(e.getKey()));
+        }
+        props.forEach(
+            e -> System.out.println("extra key: " + e.getKey() + " extra value: " + e.getValue()));
+    }
+
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFooFactory.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFooFactory.java
@@ -1,0 +1,11 @@
+package org.icij.datashare.cli;
+
+
+import org.icij.datashare.cli.spi.CliExtension;
+import org.icij.datashare.cli.spi.CliExtensionFactory;
+
+public class CliExtensionFooFactory extends CliExtensionFoo implements CliExtensionFactory {
+    public Class<? extends CliExtension> type() {
+        return CliExtensionFoo.class;
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionServiceTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionServiceTest.java
@@ -1,13 +1,63 @@
 package org.icij.datashare.cli;
 
-import org.junit.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import java.util.List;
+import java.util.Properties;
+import org.junit.Test;
+
 public class CliExtensionServiceTest {
+    interface InjectedDependency {
+         Properties getProperties();
+    }
+
+    public static class InjectedDependencyImpl implements InjectedDependency {
+        private final Properties properties;
+
+        @Inject
+        public InjectedDependencyImpl(Properties properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public Properties getProperties() {
+            return this.properties;
+        }
+    }
+
+    public static class TestModule extends AbstractModule {
+        @Override
+        public void configure() {
+            bind(Properties.class).toInstance(new Properties());
+            bind(InjectedDependency.class).to(InjectedDependencyImpl.class).asEagerSingleton();
+        }
+    }
+
     @Test
-    public void test_load_extension() {
-        assertThat(CliExtensionService.getInstance().getExtensions()).hasSize(1);
-        assertThat(CliExtensionService.getInstance().getExtensions().get(0)).isInstanceOf(CliExtensionFoo.class);
+    public void test_load_extensions() {
+        // Given
+        Injector injector = Guice.createInjector(new TestModule());
+        // When
+        List<Cli.CliExtender> factories = CliExtensionService.getInstance().getExtensions();
+        // Then
+        assertThat(factories).hasSize(1);
+        assertThat(factories.get(0)).isInstanceOf(CliExtensionFoo.class);
+    }
+
+    @Test
+    public void test_load_runners() {
+        // Given
+        Injector injector = Guice.createInjector(new TestModule());
+        // When
+        List<Cli.CliRunner> runners = CliExtensionService.getInstance().getExtensionRunners(injector);
+        // Then
+        assertThat(runners).hasSize(1);
+        Cli.CliRunner firstRunner = runners.get(0);
+        assertThat(firstRunner).isInstanceOf(CliExtensionFoo.class);
+        assertThat(((CliExtensionFoo)firstRunner).fooProperties).isNotNull();
     }
 }

--- a/datashare-cli/src/test/resources/META-INF/services/org.icij.datashare.cli.spi.CliExtension
+++ b/datashare-cli/src/test/resources/META-INF/services/org.icij.datashare.cli.spi.CliExtension
@@ -1,3 +1,0 @@
-# in your extension module you must add a src/main/resources/META-INF/services directory
-# with a org.icij.datashare.cli.spi.CliExtension text file and the implementation class(es) listed:
-org.icij.datashare.cli.CliExtensionFoo

--- a/datashare-cli/src/test/resources/META-INF/services/org.icij.datashare.cli.spi.CliExtensionFactory
+++ b/datashare-cli/src/test/resources/META-INF/services/org.icij.datashare.cli.spi.CliExtensionFactory
@@ -1,0 +1,3 @@
+# in your extension module you must add a src/main/resources/META-INF/services directory
+# with a org.icij.datashare.cli.spi.CliExtensionFactory text file and the implementation class(es) listed:
+org.icij.datashare.cli.CliExtensionFooFactory


### PR DESCRIPTION
# Descriptions

Completes the work done in #1207 to allow to extend Datashare CLI with `CliExtension` which have dependencies.

Previously the extension mechanism required the `CliExtension` to have a [zero-arg constructor](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) which was very limiting as most CLI extension will need to use dependency injection

This PR leverages a factory-like pattern to allow extending the CLI with extensions relying on dependency injection.

Since dependency injection is only needed if the extension **if the extension is actually run**, the PR decouples extended the CLI (by adding the `Cli.CliExtender` interface) and running the actual CLI given properties (`Cli.CliRunner` interface).

A `CliExtensionFactory` interface was introduce to enable developers to create extensions which needs dependency injection, this factory class mainly needs to return implemented extension class through the `type` method and inherit from this class in order to implement `identifier` and `addOptions`. 
```java
public class CliExtensionFooFactory extends CliExtensionFoo implements CliExtensionFactory {
    public Class<? extends CliExtension> type() {
        return CliExtensionFoo.class;
    }
}
```

This design is a bit heavy but the fundamental problem is that, `identifier` and `addOptions` methods should actually be `static`  since nothing in them depends on the instance. If they were, we could access them through the class return by `type()` (and we couldn't have to `extend` that exact same type).

However Java doesn't allow for [`abstract static` methods](https://stackoverflow.com/a/1595000) so no simple solution could be found.

