### PR TITLE
refactor: use JAVA api

### DIFF
--- a/commons-test/pom.xml
+++ b/commons-test/pom.xml
@@ -16,6 +16,10 @@
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
         </dependency>

--- a/commons-test/pom.xml
+++ b/commons-test/pom.xml
@@ -12,10 +12,6 @@
     <artifactId>commons-test</artifactId>
     <dependencies>
         <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>elasticsearch-rest-high-level-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
         </dependency>

--- a/commons-test/src/main/java/org/icij/datashare/test/ElasticsearchRule.java
+++ b/commons-test/src/main/java/org/icij/datashare/test/ElasticsearchRule.java
@@ -16,6 +16,7 @@ import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
+import org.icij.datashare.json.JsonObjectMapper;
 import org.junit.rules.ExternalResource;
 
 import java.io.IOException;
@@ -56,7 +57,7 @@ public class ElasticsearchRule extends ExternalResource {
                     return httpAsyncClientBuilder;
                 })
                 .build();
-        client = new ElasticsearchClient(new RestClientTransport(rest, new JacksonJsonpMapper()));
+        client = new ElasticsearchClient(new RestClientTransport(rest, new JacksonJsonpMapper(JsonObjectMapper.MAPPER)));
     }
 
     @Override

--- a/commons-test/src/main/java/org/icij/datashare/test/ElasticsearchRule.java
+++ b/commons-test/src/main/java/org/icij/datashare/test/ElasticsearchRule.java
@@ -8,8 +8,6 @@ import co.elastic.clients.elasticsearch.indices.ExistsRequest;
 import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
-import co.elastic.clients.util.ApiTypeHelper;
-import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.entity.ContentType;
@@ -22,7 +20,6 @@ import org.junit.rules.ExternalResource;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.Collections;
 import java.util.Objects;
 
 import static com.google.common.io.ByteStreams.toByteArray;

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.mode;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
@@ -11,7 +12,6 @@ import net.codestory.http.extensions.Extensions;
 import net.codestory.http.injection.GuiceAdapter;
 import net.codestory.http.misc.Env;
 import net.codestory.http.routes.Routes;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
 import org.icij.datashare.TesseractOCRParserWrapper;
@@ -127,8 +127,8 @@ public abstract class CommonMode extends AbstractModule {
             bind(TaskManager.class).to(TaskManagerMemory.class).asEagerSingleton();
         }
 
-        RestHighLevelClient esClient = createESClient(propertiesProvider);
-        bind(RestHighLevelClient.class).toInstance(esClient);
+        ElasticsearchClient esClient = createESClient(propertiesProvider);
+        bind(ElasticsearchClient.class).toInstance(esClient);
         bind(Indexer.class).to(ElasticsearchIndexer.class).asEagerSingleton();
 
         bind(TesseractOCRParserWrapper.class).toInstance(new TesseractOCRParserWrapper());

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexWaiterFilter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexWaiterFilter.java
@@ -7,8 +7,6 @@ import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.filters.Filter;
 import net.codestory.http.filters.PayloadSupplier;
 import net.codestory.http.payload.Payload;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexWaiterFilter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexWaiterFilter.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.web;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.google.inject.Singleton;
 import net.codestory.http.Context;
 import net.codestory.http.constants.HttpStatus;
@@ -27,12 +28,12 @@ public class IndexWaiterFilter implements Filter {
     private static final String WAIT_CONTENT = "<!DOCTYPE html>" +
             "<head><meta HTTP-EQUIV=\"refresh\" CONTENT=\"2\"><title>Datashare</title></head>" +
             "<body>waiting for Datashare to be up...</body>";
-    private final RestHighLevelClient client;
+    private final ElasticsearchClient client;
     private final AtomicBoolean indexOk = new AtomicBoolean(false);
     final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Inject
-    public IndexWaiterFilter(final RestHighLevelClient client) {
+    public IndexWaiterFilter(final ElasticsearchClient client) {
         this.client = client;
         waitForIndexAsync();
     }
@@ -49,7 +50,7 @@ public class IndexWaiterFilter implements Filter {
         executor.submit(() -> {
             for (int i = 0; i < TIMEOUT_SECONDS; i++) {
                 try {
-                    if (client.ping(RequestOptions.DEFAULT)) {
+                    if (client.ping().value()) {
                         this.indexOk.set(true);
                         LOGGER.info("Ping elasticsearch succeeded");
                         break;

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerEncryptedIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerEncryptedIntTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.batch.BatchDownload;
 import org.icij.datashare.com.mail.Mail;
@@ -19,7 +20,6 @@ import java.util.HashMap;
 import java.util.function.Function;
 
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 import static org.icij.datashare.text.Project.project;
@@ -31,7 +31,7 @@ public class BatchDownloadRunnerEncryptedIntTest {
     @ClassRule public static ElasticsearchRule es = new ElasticsearchRule();
     @Rule public TemporaryFolder fs = new TemporaryFolder();
     @Mock Function<TaskView<File>, Void> updateCallback;
-    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(IMMEDIATE);
+    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
 
     @Test
     public void test_zip_with_password_should_encrypt_file_and_send_mail() throws Exception {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerIntTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.batch.BatchDownload;
 import org.icij.datashare.test.DatashareTimeRule;
@@ -19,7 +20,6 @@ import java.util.function.Function;
 import java.util.zip.ZipFile;
 
 import static java.util.Arrays.asList;
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEXES;
@@ -34,7 +34,7 @@ public class BatchDownloadRunnerIntTest {
     @Rule public DatashareTimeRule timeRule = new DatashareTimeRule("2020-05-25T10:11:12Z");
     @Rule public TemporaryFolder fs = new TemporaryFolder();
     @Mock Function<TaskView<File>, Void> updateCallback;
-    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(IMMEDIATE);
+    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
 
     @Test
     public void test_empty_response() throws Exception {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexerHelper.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexerHelper.java
@@ -1,7 +1,8 @@
 package org.icij.datashare.tasks;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import org.apache.commons.io.FilenameUtils;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.icij.datashare.Entity;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.com.Publisher;
@@ -27,17 +28,16 @@ import java.nio.file.Path;
 import java.util.Arrays;
 
 import static java.nio.file.Paths.get;
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.icij.datashare.text.Language.ENGLISH;
 import static org.mockito.Mockito.mock;
 
 public class IndexerHelper {
-    private final RestHighLevelClient client;
+    private final ElasticsearchClient client;
     private final ElasticsearchIndexer indexer;
 
-    public IndexerHelper(RestHighLevelClient elasticsearch) {
+    public IndexerHelper(ElasticsearchClient elasticsearch) {
         this.client = elasticsearch;
-        this.indexer = new ElasticsearchIndexer(elasticsearch, new PropertiesProvider()).withRefresh(IMMEDIATE);
+        this.indexer = new ElasticsearchIndexer(elasticsearch, new PropertiesProvider()).withRefresh(Refresh.True);
     }
 
     File indexFile(String fileName, String content, TemporaryFolder fs) throws IOException {
@@ -62,7 +62,7 @@ public class IndexerHelper {
         extractor.setDigester(new UpdatableDigester(project, Entity.DEFAULT_DIGESTER.toString()));
         TikaDocument document = extractor.extract(path);
         ElasticsearchSpewer elasticsearchSpewer = new ElasticsearchSpewer(client, l -> ENGLISH,
-                new FieldNames(), mock(Publisher.class), new PropertiesProvider()).withRefresh(IMMEDIATE).withIndex("test-datashare");
+                new FieldNames(), mock(Publisher.class), new PropertiesProvider()).withRefresh(Refresh.True).withIndex("test-datashare");
         elasticsearchSpewer.write(document);
         return path.toFile();
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ResumeNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ResumeNlpTaskTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.com.Publisher;
 import org.icij.datashare.test.ElasticsearchRule;
@@ -11,9 +12,10 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
 import static org.mockito.Matchers.any;
@@ -22,7 +24,7 @@ import static org.mockito.Mockito.*;
 public class ResumeNlpTaskTest {
     @ClassRule
     public static ElasticsearchRule es = new ElasticsearchRule();
-    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(IMMEDIATE);
+    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
 
     @After public void tearDown() throws IOException { es.removeAll();}
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.DocumentBuilder;
@@ -16,7 +17,6 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.HashMap;
 
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
@@ -27,7 +27,7 @@ public class ScanIndexTaskTest {
     private PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
         put("defaultProject", TEST_INDEX);
     }});
-    private ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(IMMEDIATE);
+    private ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
     private MemoryDocumentCollectionFactory documentCollectionFactory = new MemoryDocumentCollectionFactory();
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.web;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
 import net.codestory.http.filters.basic.BasicAuthFilter;
 import net.codestory.http.security.Users;
 import org.icij.datashare.PropertiesProvider;
@@ -22,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEXES;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -30,7 +30,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class IndexResourceTest extends AbstractProdWebServerTest {
     @Mock JooqRepository jooqRepository;
     @ClassRule public static ElasticsearchRule esRule = new ElasticsearchRule(TEST_INDEXES);
-    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(esRule.client, new PropertiesProvider()).withRefresh(IMMEDIATE);
+    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(esRule.client, new PropertiesProvider()).withRefresh(Refresh.True);
     private final PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
         put("defaultUserName", "test");
     }});

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexWaiterFilterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexWaiterFilterTest.java
@@ -1,13 +1,12 @@
 package org.icij.datashare.web;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import net.codestory.http.Context;
 import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.filters.PayloadSupplier;
 import net.codestory.http.payload.Payload;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration;
-import org.icij.datashare.web.IndexWaiterFilter;
 import org.junit.After;
 import org.junit.Test;
 
@@ -19,10 +18,10 @@ public class IndexWaiterFilterTest {
     private Payload next = Payload.ok();
     private PayloadSupplier nextFilter = () -> next;
     private Context context = mock(Context.class);
-    private final RestHighLevelClient esClient = ElasticsearchConfiguration.createESClient(new PropertiesProvider());
+    private final ElasticsearchClient esClient = ElasticsearchConfiguration.createESClient(new PropertiesProvider());
 
     @After
-    public void tearDown() throws Exception { esClient.close();}
+    public void tearDown() throws Exception { esClient._transport().close();}
 
     @Test
     public void test_wait_for_index() throws Exception {

--- a/datashare-index/pom.xml
+++ b/datashare-index/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/datashare-index/pom.xml
+++ b/datashare-index/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>elasticsearch-rest-high-level-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
         </dependency>
@@ -82,6 +78,11 @@
                         <artifactId>log4j-api</artifactId>
                     </exclusion>
                 </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>parent-join-client</artifactId>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.json.JsonObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +90,7 @@ public class ElasticsearchConfiguration {
                     .setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder
                             .setConnectTimeout(5000)
                             .setSocketTimeout(60000))
-                    .setHttpClientConfigCallback(httpClientConfigCallback).build(), new JacksonJsonpMapper());
+                    .setHttpClientConfigCallback(httpClientConfigCallback).build(), new JacksonJsonpMapper(JsonObjectMapper.MAPPER));
             ElasticsearchClient client = new ElasticsearchClient(transport);
             String clusterName = propertiesProvider.get(CLUSTER_PROP).orElse(ES_CLUSTER_NAME);
             return client;

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -1,36 +1,24 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.*;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.*;
+import co.elastic.clients.elasticsearch.core.bulk.*;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.document.DocumentField;
-import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.reindex.BulkByScrollResponse;
-import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.client.RestClient;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.icij.datashare.Entity;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.json.JsonObjectMapper;
@@ -47,24 +35,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
+import static co.elastic.clients.elasticsearch.core.UpdateRequest.Builder;
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.icij.datashare.json.JsonObjectMapper.*;
 import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration.DEFAULT_SEARCH_SIZE;
 import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSearcher.searchHitStream;
+import static org.icij.datashare.utils.JsonUtils.mapObjectTomapJsonData;
 
 
 public class ElasticsearchIndexer implements Indexer {
-    public final RestHighLevelClient client;
+    public final ElasticsearchClient client;
     private final ElasticsearchConfiguration esCfg;
 
     static private final Map<String, String> memoizeScript = new HashMap<>();
@@ -74,7 +59,7 @@ public class ElasticsearchIndexer implements Indexer {
     }
 
     @Inject
-    public ElasticsearchIndexer(final RestHighLevelClient esClient, final PropertiesProvider propertiesProvider) {
+    public ElasticsearchIndexer(final ElasticsearchClient esClient, final PropertiesProvider propertiesProvider) {
         this.client = esClient;
         esCfg = new ElasticsearchConfiguration(propertiesProvider);
         LOGGER.info("indexer defined with {}", esCfg);
@@ -83,37 +68,43 @@ public class ElasticsearchIndexer implements Indexer {
     @Override
     public void close() throws IOException {
         LOGGER.info("Closing Elasticsearch connections");
-        client.close();
+        client._transport().close();
         LOGGER.info("Elasticsearch connections closed");
     }
 
     @Override
     public boolean bulkAdd(final String indexName, Pipeline.Type nerType, List<NamedEntity> namedEntities, Document parent) throws IOException {
-        BulkRequest bulkRequest = new BulkRequest();
+        BulkRequest.Builder bulkRequest = new BulkRequest.Builder();
 
         String routing = ofNullable(parent.getRootDocument()).orElse(parent.getId());
-        bulkRequest.add(new UpdateRequest(indexName, parent.getId()).doc(
-                jsonBuilder().startObject()
-                        .field("status", Document.Status.DONE)
-                        .endObject()).routing(routing));
-        bulkRequest.add(new UpdateRequest(indexName, parent.getId())
-                .script(new Script(ScriptType.INLINE, "painless",
-                        "if (!ctx._source.nerTags.contains(params.nerTag)) ctx._source.nerTags.add(params.nerTag);",
-                        new HashMap<String, Object>() {{
-                            put("nerTag", nerType.toString());
-                        }})).routing(routing));
+        HashMap<String, Object> status = new HashMap<>() {{
+            put("status", Document.Status.DONE);
+        }};
+        bulkRequest.operations(
+            BulkOperation.of(op -> op.update(up -> up.index(indexName)
+                    .id(parent.getId())
+                    .routing(routing)
+                    .action(a -> a.doc(status)))),
+            BulkOperation.of(op -> op.update(up -> up.index(indexName)
+                    .id(parent.getId())
+                    .routing(routing)
+                    .action(a -> a.script(scr -> scr.inline(iscr -> iscr.lang("painless")
+                            .source("if (!ctx._source.nerTags.contains(params.nerTag)) ctx._source.nerTags.add(params.nerTag);")
+                            .params("nerTag", JsonData.of(nerType.toString())))))))
+        );
 
         for (Entity child : namedEntities) {
-            bulkRequest.add(createIndexRequest(indexName, JsonObjectMapper.getType(child), child.getId(),
-                    getJson(child), parent.getId(), routing));
+            bulkRequest.operations(op -> op.index(createIndexRequest(indexName, JsonObjectMapper.getType(child), child.getId(),
+                    getJson(child), parent.getId(), routing)));
         }
-        bulkRequest.setRefreshPolicy(esCfg.refreshPolicy);
 
-        BulkResponse bulkResponse = client.bulk(bulkRequest, RequestOptions.DEFAULT);
-        if (bulkResponse.hasFailures()) {
-            for (BulkItemResponse resp : bulkResponse.getItems()) {
-                if (resp.isFailed()) {
-                    LOGGER.error("bulk add failed : {}", resp.getFailureMessage());
+        bulkRequest.refresh(esCfg.refreshPolicy);
+
+        BulkResponse bulkResponse = client.bulk(bulkRequest.build());
+        if (bulkResponse.errors()) {
+            for (BulkResponseItem resp : bulkResponse.items()) {
+                if (resp.error() != null) {
+                    LOGGER.error("bulk add failed : {}", resp.error().reason());
                 }
             }
             return false;
@@ -123,15 +114,19 @@ public class ElasticsearchIndexer implements Indexer {
 
     @Override
     public <T extends Entity> boolean bulkAdd(final String indexName, List<T> objs) throws IOException {
-        BulkRequest bulkRequest = new BulkRequest();
-        objs.stream().map(e -> createIndexRequest(indexName, getType(e), e.getId(), getJson(e), getParent(e), getRoot(e))).forEach(bulkRequest::add);
+        BulkRequest.Builder bulkRequest = new BulkRequest.Builder();
+        for (T obj : objs) {
+            bulkRequest.operations(op -> op.index(createIndexRequest(indexName, getType(obj), obj.getId(), getJson(obj), getParent(obj), getRoot(obj))));
+        }
         return executeBulk(bulkRequest);
     }
 
     @Override
     public <T extends Entity> boolean bulkUpdate(String indexName, List<T> entities) throws IOException {
-        BulkRequest bulkRequest = new BulkRequest();
-        entities.stream().map(e -> createUpdateRequest(indexName, getType(e), e.getId(), getJson(e), getParent(e), getRoot(e))).forEach(bulkRequest::add);
+        co.elastic.clients.elasticsearch.core.BulkRequest.Builder bulkRequest = new co.elastic.clients.elasticsearch.core.BulkRequest.Builder();
+        for (T e : entities) {
+            bulkRequest.operations(op -> op.update(createUpdateRequest(indexName, getType(e), e.getId(), getJson(e), getParent(e), getRoot(e))));
+        }
         return executeBulk(bulkRequest);
     }
 
@@ -139,16 +134,32 @@ public class ElasticsearchIndexer implements Indexer {
     public <T extends Entity> void add(final String indexName, T obj) throws IOException {
         String type = JsonObjectMapper.getType(obj);
         String id = obj.getId();
-        client.index(createIndexRequest(indexName, type, id, getJson(obj), getParent(obj), getRoot(obj)).
-                setRefreshPolicy(esCfg.refreshPolicy), RequestOptions.DEFAULT);
+        Map<String, Object> json = getJson(obj);
+        String parent = getParent(obj);
+        String root = getRoot(obj);
+        setJoinFields(json, type, parent);
+        IndexRequest.Builder req = new IndexRequest.Builder().index(indexName)
+                .id(id).refresh(esCfg.refreshPolicy).document(json);
+        if (parent != null) {
+            req.routing(root);
+        }
+        client.index(req.build());
     }
 
     @Override
     public <T extends Entity> void update(String indexName, T obj) throws IOException {
         String type = JsonObjectMapper.getType(obj);
         String id = obj.getId();
-        client.update(createUpdateRequest(indexName, type, id, getJson(obj), getParent(obj), getRoot(obj)).
-                setRefreshPolicy(esCfg.refreshPolicy), RequestOptions.DEFAULT);
+        Map<String, Object> json = getJson(obj);
+        String parent = getParent(obj);
+        String root = getRoot(obj);
+        setJoinFields(json, type, parent);
+        Builder req = new Builder().index(indexName)
+                .id(id).refresh(esCfg.refreshPolicy).doc(json);
+        if (parent != null) {
+            req.routing(root);
+        }
+        client.update(req.build(), Object.class);
     }
 
     @Override
@@ -157,7 +168,8 @@ public class ElasticsearchIndexer implements Indexer {
         if (rawJson != null && !rawJson.isEmpty()) {
             request.setJsonEntity(rawJson);
         }
-        Response response = client.getLowLevelClient().performRequest(request);
+        RestClient restClient = ((RestClientTransport) client._transport()).restClient();
+        Response response = restClient.performRequest(request);
         if ("OPTIONS".equals(method)) {
             return response.getHeader("Allow");
         }
@@ -165,20 +177,32 @@ public class ElasticsearchIndexer implements Indexer {
         return entity != null ? EntityUtils.toString(entity) : null;
     }
 
-    private IndexRequest createIndexRequest(String index, String type, String id, Map<String, Object> json, String parent, String root) {
-        IndexRequest req = new IndexRequest(index).id(id);
+    private IndexOperation createIndexRequest(String index, String type, String id, Map<String, Object> json, String parent, String root) {
+        IndexOperation.Builder req = new IndexOperation.Builder();
+        req.index(index).id(id);
 
         setJoinFields(json, type, parent);
-        req = req.source(json);
-        return (parent != null) ? req.routing(root) : req;
+        req.document(json);
+        if (parent != null) {
+            req.routing(root);
+            return req.build();
+        } else {
+            return req.build();
+        }
     }
 
-    private UpdateRequest createUpdateRequest(String index, String type, String id, Map<String, Object> json, String parent, String root) {
-        UpdateRequest req = new UpdateRequest(index, id);
+    private UpdateOperation createUpdateRequest(String index, String type, String id, Map<String, Object> json, String parent, String root) {
+        UpdateOperation.Builder req = new UpdateOperation.Builder();
+        req.index(index).id(id);
 
         setJoinFields(json, type, parent);
-        req = req.doc(json);
-        return (parent != null) ? req.routing(root) : req;
+        req.action(UpdateAction.of(a -> a.doc(json)));
+        if (parent != null) {
+            req.routing(root);
+            return req.build();
+        } else {
+            return req.build();
+        }
     }
 
     private void setJoinFields(Map<String, Object> json, String type, String parent) {
@@ -203,15 +227,14 @@ public class ElasticsearchIndexer implements Indexer {
     public <T extends Entity> T get(String indexName, String id, String root) {
         String type = null;
         try {
-            final GetRequest req = new GetRequest(indexName, id).routing(root);
-            final GetResponse resp = client.get(req, RequestOptions.DEFAULT);
-            if (resp.isExists()) {
-                Map<String, Object> sourceAsMap = resp.getSourceAsMap();
-                sourceAsMap.put("rootDocument", ofNullable(resp.getFields().get("_routing")).orElse(
-                        new DocumentField("_routing", Collections.singletonList(id))).getValues().get(0));
+            final GetRequest req = new GetRequest.Builder().index(indexName).id(id).routing(root).build();
+            GetResponse<ObjectNode> resp = client.get(req, ObjectNode.class);
+            if (resp.found()) {
+                Map<String, Object> sourceAsMap = MAPPER.readValue(MAPPER.writeValueAsString(resp.source()), Map.class);
+                sourceAsMap.put("rootDocument", ofNullable(resp.routing()).orElse(id));
                 type = (String) sourceAsMap.get(esCfg.docTypeField);
                 Class<T> tClass = (Class<T>) Class.forName("org.icij.datashare.text." + type);
-                return JsonObjectMapper.getObject(id, resp.getIndex(), sourceAsMap, tClass);
+                return JsonObjectMapper.getObject(id, resp.index(), sourceAsMap, tClass);
             }
         } catch (IOException e) {
             LOGGER.error("Failed to get entity " + id + " in index " + indexName, e);
@@ -234,7 +257,7 @@ public class ElasticsearchIndexer implements Indexer {
         }
         return script;
     }
-    private static Script getExtractedTextScript(final int offset, final int limit, final String targetLanguage) throws IOException {
+    private static InlineScript getExtractedTextScript(final int offset, final int limit, final String targetLanguage) throws IOException {
         Map<String,Object> params =  new HashMap<String, Object>() {{
             put("offset", offset);
             put("limit", limit);
@@ -242,10 +265,10 @@ public class ElasticsearchIndexer implements Indexer {
         if(targetLanguage != null){
             params.put("targetLanguage",targetLanguage);
         }
-        return new Script(ScriptType.INLINE, "painless",
-                ElasticsearchIndexer.getScriptStringFromFile("extractedText.painless.java"),params);
+        return new InlineScript.Builder().lang("painless")
+                .source(ElasticsearchIndexer.getScriptStringFromFile("extractedText.painless.java"))
+                .params(mapObjectTomapJsonData(params)).build();
     }
-
 
     public ExtractedText getExtractedText(String indexName, String id, String routing, final int offset, final int limit, String targetLanguage) throws IOException {
         String nullRouting = Optional.ofNullable(routing).filter(Predicate.not(String::isBlank)).orElse(id);
@@ -254,20 +277,19 @@ public class ElasticsearchIndexer implements Indexer {
     }
 
     private ExtractedText getExtractedContent(String indexName, String id, String routing, final int offset, final int limit, String targetLanguage) throws IOException {
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(DEFAULT_SEARCH_SIZE).timeout(new TimeValue(30, TimeUnit.MINUTES));
+        SearchRequest.Builder sourceBuilder = new SearchRequest.Builder().index(indexName).size(DEFAULT_SEARCH_SIZE).timeout("30m");
         if (offset < 0 || limit < 0) {
             throw new StringIndexOutOfBoundsException(format("offset or limit should not be negative (offset=%d, limit=%d)", offset, limit));
         }
-        sourceBuilder.query(boolQuery().must(termsQuery("_id", id)));
-        Script script= this.getExtractedTextScript(offset, limit, targetLanguage);
-        sourceBuilder.scriptField("pagination", script);
-        SearchRequest searchRequest = new SearchRequest(new String[] {indexName}, sourceBuilder);
-        SearchResponse search = client.search(searchRequest.routing(routing), RequestOptions.DEFAULT);
-        List<SearchHit> tHits = searchHitStream(() -> search.getHits().iterator()).collect(Collectors.toList());
+        sourceBuilder.query(Query.of(q -> q.bool(bq -> bq.must(qt -> qt.term(t -> t.field("_id").value(id))))));
+        InlineScript script = this.getExtractedTextScript(offset, limit, targetLanguage);
+        sourceBuilder.scriptFields("pagination", ScriptField.of(sf -> sf.script(scr -> scr.inline(script))));
+        SearchResponse<ObjectNode> search = client.search(sourceBuilder.routing(routing).build(), ObjectNode.class);
+        List<Hit<ObjectNode>> tHits = searchHitStream(() -> search.hits().hits().iterator()).collect(toList());
         if(tHits.isEmpty()){
             throw new IllegalArgumentException("Document not found");
         }
-        Map<String,Object> pagination = (Map<String, Object>) tHits.get(0).field("pagination").getValues().get(0);
+        Map<String,Object> pagination = (Map<String,Object>) tHits.get(0).fields().get("pagination").to(ArrayList.class).get(0);
         if(pagination.get("error") != null ){
             int code= ((Integer)pagination.get("code"));
             if (code == 400){
@@ -288,16 +310,18 @@ public class ElasticsearchIndexer implements Indexer {
        return extractedText;
     }
 
-    private static Script searchQueryOccurrencesScript(final String query, String targetLanguage) throws IOException {
+    private static InlineScript searchQueryOccurrencesScript(final String query, String targetLanguage) throws IOException {
         Map<String,Object> params = new HashMap<String, Object>() {{
             put("query", query);
         }};
-        Script script;
+
         if(targetLanguage != null){
             params.put("targetLanguage",targetLanguage);
         }
-        return new Script(ScriptType.INLINE, "painless",
-                ElasticsearchIndexer.getScriptStringFromFile("searchOccurrences.painless.java"),params);
+
+        return new InlineScript.Builder().lang("painless")
+                .source(ElasticsearchIndexer.getScriptStringFromFile("searchOccurrences.painless.java"))
+                .params(mapObjectTomapJsonData(params)).build();
     }
     @Override
     public SearchedText searchTextOccurrences(String indexName, String id, String query, String targetLanguage) throws IOException {
@@ -310,20 +334,19 @@ public class ElasticsearchIndexer implements Indexer {
 
     }
     private SearchedText searchContentOccurrences(String indexName, String id, String routing, final String query, String targetLanguage) throws IOException {
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(DEFAULT_SEARCH_SIZE).timeout(new TimeValue(30, TimeUnit.MINUTES));
+        SearchRequest.Builder sourceBuilder = new SearchRequest.Builder().index(indexName).size(DEFAULT_SEARCH_SIZE).timeout("30m");
         if (query.length() == 0) {
             throw new IllegalArgumentException();
         }
-        sourceBuilder.query(boolQuery().must(termsQuery("_id", id)));
-        Script script = searchQueryOccurrencesScript(query, targetLanguage);
-        sourceBuilder.scriptField("pagination", script);
-        SearchRequest searchRequest = new SearchRequest(new String[] {indexName}, sourceBuilder);
-        SearchResponse search = client.search(searchRequest.routing(routing), RequestOptions.DEFAULT);
-        List<SearchHit> tHits = searchHitStream(() -> search.getHits().iterator()).collect(Collectors.toList());
+        sourceBuilder.query(Query.of(q -> q.bool(bq -> bq.must(qt -> qt.term(t -> t.field("_id").value(id))))));
+        InlineScript script = searchQueryOccurrencesScript(query, targetLanguage);
+        sourceBuilder.scriptFields("pagination", ScriptField.of(sf -> sf.script(scr -> scr.inline(script))));
+        SearchResponse<ObjectNode> search = client.search(sourceBuilder.routing(routing).build(), ObjectNode.class);
+        List<Hit<ObjectNode>> tHits = searchHitStream(() -> search.hits().hits().iterator()).collect(toList());
         if(tHits.isEmpty()){
             throw new IllegalArgumentException("Document not found");
         }
-        Map<String,Object> pagination = (Map<String, Object>) tHits.get(0).field("pagination").getValues().get(0);
+        Map<String,Object> pagination = (Map<String,Object>) tHits.get(0).fields().get("pagination").to(ArrayList.class).get(0);
         if(pagination.get("error") != null ){
             int code= ((Integer)pagination.get("code"));
             if (code == 400){
@@ -334,7 +357,7 @@ public class ElasticsearchIndexer implements Indexer {
             }
         }
         SearchedText searchedText;
-        List<Integer> l =(ArrayList<Integer>) pagination.get("offsets");
+        List<Integer> l = (ArrayList<Integer>) pagination.get("offsets");
         int[] offsets = l.stream().mapToInt(i-> i).toArray();
         if (targetLanguage != null){
             searchedText = new SearchedText(
@@ -361,12 +384,12 @@ public class ElasticsearchIndexer implements Indexer {
         return tagUntag(prj, documentId, rootDocument, createUntagScript(tags));
     }
 
-    private boolean tagUntag(Project prj, String documentId, String rootDocument, Script untagScript) throws IOException {
-        UpdateRequest update = new UpdateRequest(prj.getId(), documentId).routing(rootDocument);
-        update.script(untagScript);
-        update.setRefreshPolicy(esCfg.refreshPolicy);
-        UpdateResponse updateResponse = client.update(update, RequestOptions.DEFAULT);
-        return updateResponse.status() == RestStatus.OK && updateResponse.getResult() == DocWriteResponse.Result.UPDATED;
+    private boolean tagUntag(Project prj, String documentId, String rootDocument, InlineScript untagScript) throws IOException {
+        Builder updateRequest = new Builder().index(prj.getId()).id(documentId).routing(rootDocument);
+        updateRequest.script(co.elastic.clients.elasticsearch._types.Script.of(scr -> scr.inline(untagScript)));
+        updateRequest.refresh(esCfg.refreshPolicy);
+        UpdateResponse<ObjectNode> updateResponse = client.update(updateRequest.build(), ObjectNode.class);
+        return updateResponse.result() == Result.Updated;
     }
 
     @Override
@@ -379,19 +402,20 @@ public class ElasticsearchIndexer implements Indexer {
         return groupTagUntag(prj, documentIds, createUntagScript(tags));
     }
 
-    private boolean groupTagUntag(Project prj, List<String> documentIds, Script untagScript) throws IOException {
-        UpdateByQueryRequest updateByQuery = new UpdateByQueryRequest(prj.getId());
-        updateByQuery.setQuery(termsQuery("_id", documentIds.toArray(new String[0])));
-        updateByQuery.setConflicts("proceed");
-        updateByQuery.setScript(untagScript);
-        updateByQuery.setRefresh(esCfg.refreshPolicy.getValue().equals("true"));
-        BulkByScrollResponse updateResponse = client.updateByQuery(updateByQuery, RequestOptions.DEFAULT);
-        return updateResponse.getBulkFailures().size() == 0 && updateResponse.getUpdated() > 0;
+    private boolean groupTagUntag(Project prj, List<String> documentIds, InlineScript untagScript) throws IOException {
+        UpdateByQueryRequest.Builder updateByQuery = new UpdateByQueryRequest.Builder().index(prj.getId());
+        updateByQuery.query(q -> q.terms(qt -> qt.field("_id")
+                                                 .terms(tq -> tq.value(stream(documentIds.toArray(new String[0])).map(FieldValue::of).collect(toList())))));
+        updateByQuery.conflicts(Conflicts.Proceed);
+        updateByQuery.script(scr -> scr.inline(untagScript));
+        updateByQuery.refresh(esCfg.refreshPolicy.equals(Refresh.True));
+        UpdateByQueryResponse updateResponse = client.updateByQuery(updateByQuery.build());
+        return updateResponse.failures().size() == 0 && updateResponse.updated().intValue() > 0;
     }
 
-    private Script createTagScript(Tag[] tags) {
-        return new Script(ScriptType.INLINE, "painless",
-                "int updates = 0;" +
+    private InlineScript createTagScript(Tag[] tags) {
+        return new InlineScript.Builder().lang("painless")
+                .source(                "int updates = 0;" +
                         "if (ctx._source.tags == null) ctx._source.tags = [];" +
                         "for (int i = 0; i < params.tags.length; i++) {" +
                         "  if (!ctx._source.tags.contains(params.tags[i])) {" +
@@ -399,25 +423,25 @@ public class ElasticsearchIndexer implements Indexer {
                         "   updates++;" +
                         "  }" +
                         "}" +
-                        "if (updates == 0) ctx.op = 'noop';",
-                new HashMap<String, Object>() {{
+                        "if (updates == 0) ctx.op = 'noop';")
+                .params(mapObjectTomapJsonData(new HashMap<String, Object>() {{
                     put("tags", stream(tags).map(t -> t.label).collect(toList()));
-                }});
+                }})).build();
     }
 
-    private Script createUntagScript(Tag[] tags) {
-        return new Script(ScriptType.INLINE, "painless",
-                "int updates = 0;" +
+    private InlineScript createUntagScript(Tag[] tags) {
+        return new InlineScript.Builder().lang("painless")
+                .source("int updates = 0;" +
                         "for (int i = 0; i < params.tags.length; i++) {" +
                         "  if (ctx._source.tags.contains(params.tags[i])) {" +
                         "    ctx._source.tags.remove(ctx._source.tags.indexOf(params.tags[i]));" +
                         "    updates++;" +
                         "  }" +
                         "}" +
-                        "if (updates == 0) ctx.op = 'noop';",
-                new HashMap<String, Object>() {{
+                        "if (updates == 0) ctx.op = 'noop';")
+                .params(mapObjectTomapJsonData(new HashMap<String, Object>() {{
                     put("tags", stream(tags).map(t -> t.label).collect(toList()));
-                }});
+                }})).build();
     }
 
     @Override
@@ -434,27 +458,28 @@ public class ElasticsearchIndexer implements Indexer {
     public boolean deleteAll(String indexName) throws IOException {
         Request post = new Request("POST", indexName + "/_delete_by_query?refresh");
         post.setEntity(new NStringEntity("{\"query\":{\"match_all\": {}}}", ContentType.APPLICATION_JSON));
-        Response response = client.getLowLevelClient().performRequest(post);
+        RestClient restClient = ((RestClientTransport) client._transport()).restClient();
+        Response response = restClient.performRequest(post);
         return response.getStatusLine().getStatusCode() == RestStatus.OK.getStatus();
     }
 
-    public ElasticsearchIndexer withRefresh(WriteRequest.RefreshPolicy refresh) {
+    public ElasticsearchIndexer withRefresh(Refresh refresh) {
         esCfg.withRefresh(refresh);
         return this;
     }
 
-    private boolean executeBulk(BulkRequest bulkRequest) throws IOException {
-        bulkRequest.setRefreshPolicy(esCfg.refreshPolicy);
-        BulkResponse bulkResponse = client.bulk(bulkRequest, RequestOptions.DEFAULT);
-        if (bulkResponse.hasFailures()) {
-            for (BulkItemResponse resp : bulkResponse.getItems()) {
-                if (resp.isFailed()) {
-                    LOGGER.error("bulk request failed : {}", resp.getFailureMessage());
-                }
-            }
-            return false;
-        }
-        return true;
+    private boolean executeBulk(co.elastic.clients.elasticsearch.core.BulkRequest.Builder bulkRequest) throws IOException {
+      bulkRequest.refresh(esCfg.refreshPolicy);
+      BulkResponse bulkResponse = client.bulk(bulkRequest.build());
+      if (bulkResponse.errors()) {
+          for (BulkResponseItem resp : bulkResponse.items()) {
+              if (resp.error() != null) {
+                  LOGGER.error("bulk request failed : {}", resp.error().reason());
+              }
+          }
+          return false;
+      }
+      return true;
     }
 
     @Override
@@ -468,6 +493,6 @@ public class ElasticsearchIndexer implements Indexer {
     }
 
     public boolean ping() throws IOException {
-        return client.ping(RequestOptions.DEFAULT);
+        return client.ping().value();
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -123,7 +123,7 @@ public class ElasticsearchIndexer implements Indexer {
 
     @Override
     public <T extends Entity> boolean bulkUpdate(String indexName, List<T> entities) throws IOException {
-        co.elastic.clients.elasticsearch.core.BulkRequest.Builder bulkRequest = new co.elastic.clients.elasticsearch.core.BulkRequest.Builder();
+        BulkRequest.Builder bulkRequest = new BulkRequest.Builder();
         for (T e : entities) {
             bulkRequest.operations(op -> op.update(createUpdateRequest(indexName, getType(e), e.getId(), getJson(e), getParent(e), getRoot(e))));
         }
@@ -468,7 +468,7 @@ public class ElasticsearchIndexer implements Indexer {
         return this;
     }
 
-    private boolean executeBulk(co.elastic.clients.elasticsearch.core.BulkRequest.Builder bulkRequest) throws IOException {
+    private boolean executeBulk(BulkRequest.Builder bulkRequest) throws IOException {
       bulkRequest.refresh(esCfg.refreshPolicy);
       BulkResponse bulkResponse = client.bulk(bulkRequest.build());
       if (bulkResponse.errors()) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSearcher.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSearcher.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static co.elastic.clients.elasticsearch.core.SearchRequest.*;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration.DEFAULT_SEARCH_SIZE;
@@ -34,7 +35,7 @@ class ElasticsearchSearcher implements Indexer.Searcher {
     private final ElasticsearchClient client;
     private final List<String> indexesNames;
     private final Class<? extends Entity> cls;
-    private co.elastic.clients.elasticsearch.core.SearchRequest.Builder sourceBuilder;
+    private Builder sourceBuilder;
     private String scrollId;
     private long totalHits;
 
@@ -42,7 +43,7 @@ class ElasticsearchSearcher implements Indexer.Searcher {
         this.client = client;
         this.indexesNames = indexesNames;
         this.cls = cls;
-        sourceBuilder = new co.elastic.clients.elasticsearch.core.SearchRequest.Builder().size(DEFAULT_SEARCH_SIZE).timeout("30m");
+        sourceBuilder = new Builder().size(DEFAULT_SEARCH_SIZE).timeout("30m");
         this.boolQuery = new BoolQuery.Builder().must(must -> must.match(m -> m.field("type").query(JsonObjectMapper.getType(cls))));
     }
 
@@ -89,7 +90,7 @@ class ElasticsearchSearcher implements Indexer.Searcher {
         }
         if (scrollId == null) {
             SearchRequest searchRequest = sourceBuilder.scroll(KEEP_ALIVE).build();
-            this.sourceBuilder = new SearchRequest.Builder().size(DEFAULT_SEARCH_SIZE).timeout("30m")
+            this.sourceBuilder = new Builder().size(DEFAULT_SEARCH_SIZE).timeout("30m")
                     .index(searchRequest.index()).slice(searchRequest.slice()).source(searchRequest.source()).size(searchRequest.size());
             SearchResponse<ObjectNode> search = client.search(searchRequest, ObjectNode.class);
             scrollId = search.scrollId();

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import static co.elastic.clients.elasticsearch.core.ExistsRequest.*;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.file.Paths.get;
 import static java.util.Optional.ofNullable;
@@ -113,7 +114,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
     }
 
     private boolean isDuplicate(String docId) throws IOException {
-        co.elastic.clients.elasticsearch.core.ExistsRequest.Builder getRequest = new co.elastic.clients.elasticsearch.core.ExistsRequest.Builder().index(indexName).id(docId);
+        Builder getRequest = new Builder().index(indexName).id(docId);
         getRequest.source(SourceConfigParam.of(scp -> scp.fetch(false)));
         getRequest.storedFields("_none_");
         return client.exists(getRequest.build()).value();

--- a/datashare-index/src/main/java/org/icij/datashare/utils/JsonUtils.java
+++ b/datashare-index/src/main/java/org/icij/datashare/utils/JsonUtils.java
@@ -1,0 +1,13 @@
+package org.icij.datashare.utils;
+
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Map;
+
+public class JsonUtils {
+    public static Map nodeToMap(ObjectNode node) {
+        return new ObjectMapper().convertValue(node, Map.class);
+    }
+}

--- a/datashare-index/src/main/java/org/icij/datashare/utils/JsonUtils.java
+++ b/datashare-index/src/main/java/org/icij/datashare/utils/JsonUtils.java
@@ -1,13 +1,20 @@
 package org.icij.datashare.utils;
 
-import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.json.JsonData;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class JsonUtils {
-    public static Map nodeToMap(ObjectNode node) {
-        return new ObjectMapper().convertValue(node, Map.class);
+    public static Map<String, Object> nodeToMap(ObjectNode node) {
+        return new ObjectMapper().convertValue(node, new TypeReference<Map<String, Object>>(){});
+    }
+    public static Map<String, JsonData> mapObjectTomapJsonData(Map<String,Object> map) {
+        HashMap<String, JsonData> retMap = new HashMap<String, JsonData>();
+        map.entrySet().forEach(entry -> retMap.put(entry.getKey(), JsonData.of(entry.getValue())));
+        return retMap;
     }
 }

--- a/datashare-index/src/main/resources/datashare_index_settings.json
+++ b/datashare-index/src/main/resources/datashare_index_settings.json
@@ -22,16 +22,23 @@
   "analysis": {
     "analyzer": {
       "path_analyzer": {
+        "type":"custom",
         "tokenizer": "path_tokenizer"
       },
       "folding": {
+        "type":"custom",
         "tokenizer": "standard",
         "filter":  [ "lowercase", "asciifolding" ]
       }
     },
     "tokenizer": {
       "path_tokenizer": {
-        "type": "path_hierarchy"
+        "type": "path_hierarchy",
+        "delimiter": "/",
+        "replacement": "/",
+        "buffer_size": 1024,
+        "reverse": false,
+        "skip": 0
       }
     },
     "normalizer": {

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.Entity;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.com.Publisher;
@@ -20,7 +21,6 @@ import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 
 import static java.nio.file.Paths.get;
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 import static org.icij.datashare.text.Language.ENGLISH;
@@ -32,7 +32,7 @@ public class DatashareExtractIntegrationTest {
     public static ElasticsearchRule es = new ElasticsearchRule();
 
 	private ElasticsearchSpewer spewer = new ElasticsearchSpewer(es.client, l -> ENGLISH,
-            new FieldNames(), mock(Publisher.class), new PropertiesProvider()).withRefresh(IMMEDIATE).withIndex("test-datashare");
+            new FieldNames(), mock(Publisher.class), new PropertiesProvider()).withRefresh(Refresh.True).withIndex("test-datashare");
 	private ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider());
 
     public DatashareExtractIntegrationTest() throws IOException {}

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfigurationTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfigurationTest.java
@@ -1,8 +1,13 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.GetRequest;
+import co.elastic.clients.elasticsearch.core.GetResponse;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.test.ElasticsearchRule;
@@ -22,7 +27,8 @@ public class ElasticsearchConfigurationTest {
     public void test_create_client_creates_mapping() throws Exception {
         ElasticsearchConfiguration.createESClient(new PropertiesProvider());
 
-        Response response = es.client.getLowLevelClient().performRequest(new Request("GET", TEST_INDEX));
+        RestClient restClient = ((RestClientTransport) es.client._transport()).restClient();
+        Response response = restClient.performRequest(new Request("GET", TEST_INDEX));
 
         assertThat(EntityUtils.toString(response.getEntity())).contains("mapping");
     }
@@ -31,18 +37,20 @@ public class ElasticsearchConfigurationTest {
     public void test_create_client_creates_settings() throws Exception {
         ElasticsearchConfiguration.createESClient(new PropertiesProvider());
 
-        Response response = es.client.getLowLevelClient().performRequest(new Request("GET", TEST_INDEX));
+        RestClient restClient = ((RestClientTransport) es.client._transport()).restClient();
+        Response response = restClient.performRequest(new Request("GET", TEST_INDEX));
 
         assertThat(EntityUtils.toString(response.getEntity())).contains("settings");
     }
 
     @Test
     public void test_create_client_with_user_pass() throws Exception {
-        RestHighLevelClient esClient = ElasticsearchConfiguration.createESClient(new PropertiesProvider(new HashMap<String, String>() {{
+        ElasticsearchClient esClient = ElasticsearchConfiguration.createESClient(new PropertiesProvider(new HashMap<String, String>() {{
             put("elasticsearchAddress", "http://user:pass@elasticsearch:9200");
         }}));
 
-        Response response = esClient.getLowLevelClient().performRequest(new Request("GET", TEST_INDEX));
+        RestClient restClient = ((RestClientTransport) esClient._transport()).restClient();
+        Response response = restClient.performRequest(new Request("GET", TEST_INDEX));
 
         assertThat(EntityUtils.toString(response.getEntity())).contains("settings");
     }

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfigurationTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfigurationTest.java
@@ -1,14 +1,11 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch.core.GetRequest;
-import co.elastic.clients.elasticsearch.core.GetResponse;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.junit.ClassRule;

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
@@ -3,11 +3,7 @@ package org.icij.datashare.text.indexing.elasticsearch;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import org.apache.http.ConnectionClosedException;
-import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.icij.datashare.Entity;
@@ -20,10 +16,8 @@ import org.icij.datashare.text.NamedEntity;
 import org.icij.datashare.text.indexing.ExtractedText;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.SearchedText;
-import org.icij.datashare.text.nlp.Pipeline;
 import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -51,9 +45,12 @@ import static org.icij.datashare.text.NamedEntity.Category.PERSON;
 import static org.icij.datashare.text.NamedEntity.create;
 import static org.icij.datashare.text.Project.project;
 import static org.icij.datashare.text.Tag.tag;
-import static org.icij.datashare.text.nlp.Pipeline.Type.*;
+import static org.icij.datashare.text.nlp.Pipeline.Type.CORENLP;
+import static org.icij.datashare.text.nlp.Pipeline.Type.IXAPIPE;
+import static org.icij.datashare.text.nlp.Pipeline.Type.OPENNLP;
 import static org.junit.Assert.assertArrayEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class ElasticsearchIndexerTest {
     @ClassRule

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
@@ -356,10 +356,17 @@ public class ElasticsearchIndexerTest {
         assertThat(searcher.scroll().count()).isEqualTo(5);
         assertThat(searcher.scroll().count()).isEqualTo(2);
         assertThat(searcher.scroll().count()).isEqualTo(0);
+        searcher.clearScroll();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void test_searcher_scroll_is_not_usable_after_clear() throws IOException {
+        Indexer.Searcher searcher = indexer.search(singletonList(TEST_INDEX), Document.class).limit(5);
+        assertThat(searcher.scroll().count()).isEqualTo(0);
 
         searcher.clearScroll();
-        assertThat(searcher.scroll().count()).isEqualTo(5);
-        searcher.clearScroll();
+
+        searcher.scroll();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -1,7 +1,6 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
 import co.elastic.clients.elasticsearch._types.Refresh;
-import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
@@ -410,7 +409,7 @@ public class ElasticsearchSpewerTest {
     public void after() {
         try {
             DeleteByQueryRequest.Builder deleteByQueryRequest = new DeleteByQueryRequest.Builder().index("test-datashare");
-            deleteByQueryRequest.query(Query.of(q -> q.matchAll(MatchAllQuery.of(maq -> maq))));
+            deleteByQueryRequest.query(Query.of(q -> q.matchAll(ma -> ma)));
             es.client.deleteByQuery(deleteByQueryRequest.build()).deleted();
         } catch (IOException e) {
             e.printStackTrace();

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -8,7 +8,6 @@ import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.GetResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.tika.metadata.DublinCore;
 import org.apache.tika.metadata.Metadata;
@@ -50,6 +49,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.icij.datashare.utils.JsonUtils.nodeToMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -78,7 +78,7 @@ public class ElasticsearchSpewerTest {
         assertThat(documentFields.id()).isEqualTo(document.getId());
         assertEquals(new HashMap<String, String>() {{
             put("name", "Document");
-        }}, new ObjectMapper().convertValue(documentFields.source(), Map.class).get("join"));
+        }}, nodeToMap(documentFields.source()).get("join"));
         ArgumentCaptor<Message> argument = ArgumentCaptor.forClass(Message.class);
         verify(publisher).publish(eq(Channel.NLP), argument.capture());
         assertThat(argument.getValue().content).includes(entry(Field.DOC_ID, document.getId()));
@@ -95,7 +95,7 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(
+        assertThat(nodeToMap(documentFields.source())).includes(
                 entry("language", "CHINESE")
         );
     }
@@ -111,7 +111,7 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(
+        assertThat(nodeToMap(documentFields.source())).includes(
                 entry("language", "JAPANESE")
         );
     }
@@ -127,7 +127,7 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(
+        assertThat(nodeToMap(documentFields.source())).includes(
                 entry("language", "MALTESE")
         );
     }
@@ -151,7 +151,7 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(
+        assertThat(nodeToMap(documentFields.source())).includes(
                 entry("language", "ENGLISH")
         );
     }
@@ -165,7 +165,7 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(
+        assertThat(nodeToMap(documentFields.source())).includes(
                 entry("contentEncoding", "ISO-8859-1"),
                 entry("contentType", "text/plain"),
                 entry("nerTags", new ArrayList<>()),
@@ -187,7 +187,7 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("contentLength", 7862117376L));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("contentLength", 7862117376L));
     }
 
     @Test
@@ -199,8 +199,8 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("title", "T-File.txt"));
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("titleNorm", "t-file.txt"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("title", "T-File.txt"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("titleNorm", "t-file.txt"));
     }
 
     @Test
@@ -213,8 +213,8 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("title", "Tweet-File.json"));
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("titleNorm", "tweet-file.json"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("title", "Tweet-File.json"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("titleNorm", "tweet-file.json"));
     }
 
     @Test
@@ -228,8 +228,8 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("title", "This is a tweet."));
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("titleNorm", "this is a tweet."));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("title", "This is a tweet."));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("titleNorm", "this is a tweet."));
     }
 
     @Test
@@ -242,8 +242,8 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("title", "Email-File.txt"));
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("titleNorm", "email-file.txt"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("title", "Email-File.txt"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("titleNorm", "email-file.txt"));
     }
 
     @Test
@@ -257,8 +257,8 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("title", "This is an email."));
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("titleNorm", "this is an email."));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("title", "This is an email."));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("titleNorm", "this is an email."));
     }
 
     @Test
@@ -273,8 +273,8 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("title", "This is a more detailed email."));
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("titleNorm", "this is a more detailed email."));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("title", "This is a more detailed email."));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("titleNorm", "this is a more detailed email."));
     }
 
     @Test
@@ -287,9 +287,9 @@ public class ElasticsearchSpewerTest {
         spewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class).containsKey("metadata")).isTrue();
+        assertThat(nodeToMap(documentFields.source()).containsKey("metadata")).isTrue();
         @SuppressWarnings("unchecked")
-        HashMap<String, Object> metadata = (HashMap<String, Object>) new ObjectMapper().convertValue(documentFields.source(), Map.class).get("metadata");
+        HashMap<String, Object> metadata = (HashMap<String, Object>) nodeToMap(documentFields.source()).get("metadata");
         // Those values should be here
         assertThat(metadata).includes(entry("tika_metadata_resourcename", "doc.txt"));
         assertThat(metadata).includes(entry("tika_metadata_foo", "bar"));
@@ -360,9 +360,9 @@ public class ElasticsearchSpewerTest {
         GetResponse<ObjectNode> actualDocument = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
         GetResponse<ObjectNode> actualDocument2 = es.client.get(doc -> doc.index(TEST_INDEX).id(Hasher.SHA_256.hash(document2.getPath())), ObjectNode.class);
         assertThat(actualDocument.found()).isTrue();
-        assertThat(new ObjectMapper().convertValue(actualDocument.source(), Map.class)).includes(entry("type", "Document"));
+        assertThat(nodeToMap(actualDocument.source())).includes(entry("type", "Document"));
         assertThat(actualDocument2.found()).isTrue();
-        assertThat(new ObjectMapper().convertValue(actualDocument2.source(), Map.class)).includes(entry("type", "Duplicate"));
+        assertThat(nodeToMap(actualDocument2.source())).includes(entry("type", "Duplicate"));
         assertThat(actualDocument2.id().length()).isEqualTo(Hasher.SHA_256.digestLength);
     }
 
@@ -379,7 +379,7 @@ public class ElasticsearchSpewerTest {
         limitedContentSpewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("content", "this content should"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("content", "this content should"));
     }
 
     @Test
@@ -395,7 +395,7 @@ public class ElasticsearchSpewerTest {
         limitedContentSpewer.write(document);
 
         GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(TEST_INDEX).id(document.getId()), ObjectNode.class);
-        assertThat(new ObjectMapper().convertValue(documentFields.source(), Map.class)).includes(entry("content", "this content is ok"));
+        assertThat(nodeToMap(documentFields.source())).includes(entry("content", "this content is ok"));
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/EsEmbeddedServerIntTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/EsEmbeddedServerIntTest.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
-import org.elasticsearch.client.indices.GetIndexRequest;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
@@ -8,7 +7,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 
 import static org.apache.http.HttpHost.create;
-import static org.elasticsearch.client.RequestOptions.DEFAULT;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 
@@ -19,7 +17,7 @@ public class EsEmbeddedServerIntTest {
 
     @Test
     public void test_embedded_server_has_a_test_index() throws Exception {
-        assertThat(es.client.indices().exists(new GetIndexRequest(TEST_INDEX), DEFAULT)).isTrue();
+         assertThat(es.client.indices().exists(e -> e.index(TEST_INDEX)).value()).isTrue();
     }
 
     @BeforeClass

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.com.Publisher;
 import org.icij.datashare.test.ElasticsearchRule;
@@ -9,7 +10,6 @@ import org.icij.datashare.text.Language;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.document.TikaDocument;
 import org.icij.extract.extractor.Extractor;
-import org.icij.extract.extractor.UpdatableDigester;
 import org.icij.spewer.FieldNames;
 import org.icij.task.Options;
 import org.junit.ClassRule;
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 
 import static java.nio.file.Paths.get;
-import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 import static org.icij.datashare.text.Project.project;
@@ -80,7 +79,7 @@ public class SourceExtractorTest {
         Path path = get(getClass().getResource("/docs/embedded_doc.eml").getPath());
         final TikaDocument document = extractor.extract(path);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(es.client,
-                l -> Language.ENGLISH, new FieldNames(), Mockito.mock(Publisher.class), new PropertiesProvider()).withRefresh(IMMEDIATE).withIndex(TEST_INDEX);
+                l -> Language.ENGLISH, new FieldNames(), Mockito.mock(Publisher.class), new PropertiesProvider()).withRefresh(Refresh.True).withIndex(TEST_INDEX);
         spewer.write(document);
 
         Document attachedPdf = new ElasticsearchIndexer(es.client, new PropertiesProvider()).
@@ -106,7 +105,7 @@ public class SourceExtractorTest {
         Path path = get(getClass().getResource("/docs/embedded_doc.eml").getPath());
         final TikaDocument document = extractor.extract(path);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(es.client,
-                l -> Language.ENGLISH, new FieldNames(), Mockito.mock(Publisher.class), new PropertiesProvider()).withRefresh(IMMEDIATE).withIndex(TEST_INDEX);
+                l -> Language.ENGLISH, new FieldNames(), Mockito.mock(Publisher.class), new PropertiesProvider()).withRefresh(Refresh.True).withIndex(TEST_INDEX);
         spewer.write(document);
 
         Document attachedPdf = new ElasticsearchIndexer(es.client, new PropertiesProvider()).

--- a/datashare-index/src/test/java/org/icij/datashare/utils/JsonUtilsTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/utils/JsonUtilsTest.java
@@ -1,0 +1,24 @@
+package org.icij.datashare.utils;
+
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.fest.assertions.MapAssert;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
+public class JsonUtilsTest {
+
+    @Test
+    public void test_should_return_source_as_map() {
+        ObjectNode node = JsonNodeFactory.instance.objectNode()
+                .put("field1", "value1")
+                .put("field2", "value2");
+        assertThat(JsonUtils.nodeToMap(node)).includes(
+              entry("field1", "value1"),
+              entry("field2", "value2")
+        );
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -239,26 +239,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>elasticsearch-rest-high-level-client</artifactId>
-                <version>${elasticsearch.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpclient</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpcore</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpcore-nio</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>co.elastic.clients</groupId>
                 <artifactId>elasticsearch-java</artifactId>
                 <version>${elasticsearch.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,12 @@
             </dependency>
 
             <dependency>
+                <groupId>co.elastic.clients</groupId>
+                <artifactId>elasticsearch-java</artifactId>
+                <version>${elasticsearch.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpclient.version}</version>


### PR DESCRIPTION
This PR aims to replace [current HLRC](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.10/java-rest-high-getting-started.html) by [Java API](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/7.17/_getting_started.html)