### PR TITLE
chore: allow extending env `CLASSPATH` in docker image

### DIFF
--- a/datashare-dist/src/main/docker/entrypoint.sh
+++ b/datashare-dist/src/main/docker/entrypoint.sh
@@ -7,7 +7,7 @@ if [ "$1" = 'sh' ];
 then
     exec "$@"
 else
-    CLASSPATH=$(find /home/datashare/lib/ -name '*.jar' | xargs | sed 's/ /:/g')
+    CLASSPATH=$(find /home/datashare/lib/ -name '*.jar' | xargs | sed 's/ /:/g')${CLASSPATH:+:$CLASSPATH}
     # shellcheck disable=SC2086
     # https://github.com/koalaman/shellcheck/wiki/Sc2086
     exec java ${DS_JAVA_OPTS} -DPROD_MODE=true -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader -cp "/home/datashare/dist/:${CLASSPATH}" ${MAIN_CLASS} "$@"


### PR DESCRIPTION
# Context

When using CLI extensions (#1207), it will be necessary to start `datashare` with an extended classpath pointing to the CLI extension jars. This PR allows to extend the docker image `CLASSPATH` rather than (re)-setting it in the `datashare`'s docker entrypoint.

# Changes
## `datashare-dist`
### Changed
- extend the image environment `CLASSPATH` with datashare's class path when calling docker entry point