### PR TITLE
feature: support dependency injection in CliExtension

### DIFF
--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -27,6 +27,12 @@
             <version>${slf4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
         <!-- tests dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/CliExtensionService.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/CliExtensionService.java
@@ -1,10 +1,9 @@
 package org.icij.datashare.cli;
 
-import org.icij.datashare.cli.spi.CliExtension;
-
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
+import org.icij.datashare.cli.spi.CliExtension;
 
 public class CliExtensionService {
     private static CliExtensionService service;

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/spi/CliExtension.java
@@ -1,11 +1,16 @@
 package org.icij.datashare.cli.spi;
 
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import java.util.Properties;
+import java.util.function.Function;
 import joptsimple.OptionParser;
 
-import java.util.Properties;
-
 public interface CliExtension {
+    void init(Function<Module[], Injector> injectorCreator);
+
     void addOptions(OptionParser parser);
+
     String identifier();
 
     void run(Properties properties) throws Exception;

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionFoo.java
@@ -1,19 +1,31 @@
 package org.icij.datashare.cli;
 
-import joptsimple.OptionParser;
-import org.icij.datashare.cli.spi.CliExtension;
-
-import java.util.Properties;
 
 import static java.util.Collections.singletonList;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import java.util.Properties;
+import java.util.function.Function;
+import joptsimple.OptionParser;
+import org.icij.datashare.cli.spi.CliExtension;
+
 public class CliExtensionFoo implements CliExtension {
+    protected FooService service;
+
+    @Override
+    public void init(Function<Module[], Injector> injectorCreator)  {
+        Injector injector = injectorCreator.apply(new Module[] {new TestModule()});
+        service = injector.getInstance(FooService.class);
+    }
+
+
     @Override
     public void addOptions(OptionParser parser) {
-        parser.acceptsAll(
-                        singletonList("foo"), "Test foo")
-                .withRequiredArg()
-                .ofType(String.class);
+        parser.acceptsAll(singletonList("foo"), "Test foo")
+            .withRequiredArg()
+            .ofType(String.class);
         parser.acceptsAll(singletonList("fooCommand"));
     }
 
@@ -23,5 +35,14 @@ public class CliExtensionFoo implements CliExtension {
     }
 
     @Override
-    public void run(Properties properties) {}
+    public void run(Properties properties) throws Exception {
+        this.service.foo(properties);
+    }
+
+    static class TestModule extends AbstractModule {
+        @Override
+        public void configure() {
+            bind(FooService.class).to(FooService.FooServiceImpl.class).asEagerSingleton();
+        }
+    }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionServiceTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/CliExtensionServiceTest.java
@@ -1,13 +1,31 @@
 package org.icij.datashare.cli;
 
-import org.junit.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
 
+import com.google.inject.Guice;
+import java.util.List;
+import java.util.Properties;
+import org.icij.datashare.cli.spi.CliExtension;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
 public class CliExtensionServiceTest {
+    @Rule
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
     @Test
-    public void test_load_extension() {
-        assertThat(CliExtensionService.getInstance().getExtensions()).hasSize(1);
-        assertThat(CliExtensionService.getInstance().getExtensions().get(0)).isInstanceOf(CliExtensionFoo.class);
+    public void test_load_and_init_extension() throws Exception {
+        List<CliExtension> extensions = CliExtensionService.getInstance().getExtensions();
+
+        assertThat(extensions).hasSize(1);
+        CliExtension extension = extensions.get(0);
+        assertThat(extension).isInstanceOf(CliExtensionFoo.class);
+
+        extension.init(Guice::createInjector);
+        Properties props = new Properties();
+        props.setProperty("foo", "bar");
+        extension.run(props);
+        assertThat(systemOutRule.getLog()).contains("foo=bar");
     }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/FooService.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/FooService.java
@@ -1,0 +1,15 @@
+package org.icij.datashare.cli;
+
+import java.util.Properties;
+import org.slf4j.LoggerFactory;
+
+public interface FooService {
+    void foo(Properties properties);
+
+    class FooServiceImpl implements FooService {
+        @Override
+        public void foo(Properties properties) {
+            LoggerFactory.getLogger(getClass()).info("{}", properties);
+        }
+    }
+}


### PR DESCRIPTION
# Descriptions

Completes the work done in #1207 to allow to extend Datashare CLI with `CliExtension` which have dependencies.

Previously the extension mechanism required the `CliExtension` to have a [zero-arg constructor](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) which was very limiting as most CLI extension will need to use dependency injection

This PR leverages a factory-like pattern to allow extending the CLI with extensions relying on dependency injection.

Replaces and closes #1231