### PR TITLE
refactor: build improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             wget --no-check-certificate --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
             sudo apt-get update
             sudo apt-get install -y postgresql-client-11
-            PGPASSWORD=test psql -h postgres -U dstest dstest -c "CREATE DATABASE datashare;"
+            PGPASSWORD=test psql -h postgres -U dstest dstest -c "CREATE DATABASE datashare_liquibase;"
 
       - run:
           name: Configure GPG private key for signing project artifacts in OSS Sonatype

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       - run:
           name: Generate db doc
           environment:
-            PGDB: datashare
+            PGDB: datashare_liquibase
             PGUSER: dstest
             PGPASSWORD: test
           command: |

--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -108,19 +108,18 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <groupId>org.apache.maven.plugins</groupId>
-                <version>3.2.1</version>
+                <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>make-shade</id>
+                        <id>make-assembly</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/datashare-db/pom.xml
+++ b/datashare-db/pom.xml
@@ -172,6 +172,11 @@
                 </executions>
             </plugin>
             <plugin>
+                <!--
+                    shade is necessary here to avoid java.sql.SQLException: No suitable driver
+                    https://stackoverflow.com/questions/12297376/no-suitable-driver-found-when-including-the-needed-drivers-with-maven-assembly-p
+                    because information about drivers are stored in /META-INF thus can be overriden between drivers (sqlite, postgresql)
+                -->
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/datashare-db/pom.xml
+++ b/datashare-db/pom.xml
@@ -130,7 +130,7 @@
                 <configuration>
                     <changeLogFile>src/main/resources/liquibase/changelog/db.changelog.yml</changeLogFile>
                     <driver>org.postgresql.Driver</driver>
-                    <url>jdbc:postgresql://postgres/datashare</url>
+                    <url>jdbc:postgresql://postgres/datashare_liquibase</url>
                     <username>dstest</username>
                     <password>test</password>
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
@@ -163,7 +163,7 @@
                             </generator>
                             <jdbc>
                                 <driver>org.postgresql.Driver</driver>
-                                <url>jdbc:postgresql://postgres/datashare</url>
+                                <url>jdbc:postgresql://postgres/datashare_liquibase</url>
                                 <user>dstest</user>
                                 <password>test</password>
                             </jdbc>

--- a/datashare-db/scr/reset_datashare_db.sh
+++ b/datashare-db/scr/reset_datashare_db.sh
@@ -2,8 +2,9 @@
 export PGPASSWORD=admin
 
 psql -h postgres -Uadmin admin -c 'drop database datashare'
+psql -h postgres -Uadmin admin -c 'drop database datashare_liquibase'
 psql -h postgres -Uadmin admin -c 'drop database dstest'
-psql -h postgres -Uadmin admin -c 'drop user dstest'
+psql -h postgres -Uadmin admin -c 'REVOKE ALL ON schema public FROM dstest;drop user dstest;'
 
 psql -h postgres -Uadmin admin -c 'create database datashare'
 psql -h postgres -Uadmin admin -c "create user dstest with password 'test'"
@@ -13,3 +14,7 @@ psql -h postgres -Uadmin admin -c "grant all on database datashare to dstest"
 psql -h postgres -Uadmin admin -c 'create database dstest'
 psql -h postgres -Uadmin dstest -c 'grant all on schema public to dstest'
 psql -h postgres -Uadmin admin -c "grant all on database dstest to dstest"
+
+psql -h postgres -Uadmin admin -c 'create database datashare_liquibase'
+psql -h postgres -Uadmin datashare_liquibase -c 'grant all on schema public to dstest'
+psql -h postgres -Uadmin admin -c "grant all on database datashare_liquibase to dstest"


### PR DESCRIPTION
This PR replace shade plugin when it is not needed.

And it uses another database for code generation than datashare to avoid conflicting issues when testing locally and building.
