### PR TITLE
fix: extension cli to support main datashare CLI options

### DIFF
--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -41,10 +41,9 @@ public class DatashareCli {
                     System.out.println("Unknown extension: " + extId);
                     System.exit(3);
                 }
-                OptionParser extParser = createExtParser(extensions.get(0));
-                helpOpt = DatashareCliOptions.help(extParser);
-                OptionSet extOptions = extParser.parse(args);
+                OptionSet extOptions = parser.parse(args);
                 if (extOptions.has(helpOpt)) {
+                    OptionParser extParser = createExtParser(extensions.get(0));
                     printHelp(extParser);
                     System.exit(0);
                 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -135,8 +135,8 @@ public class DatashareCliTest {
 
     @Test
     public void test_foo_extension_loaded_help() {
-        cli.parseArguments(new String[] {"--ext", "foo", "--fooCommand"});
-        assertThat(cli.properties).excludes(entry("defaultProject", "local-datashare"));
+        cli.parseArguments(new String[] {"-s", "someSettingsPath", "--ext", "foo", "--fooCommand"});
+        assertThat(cli.properties).includes(entry("settings", "someSettingsPath"));
     }
 
     @Test


### PR DESCRIPTION
# PR description
In the previous implementation the `DatashareCli` was not including the main DS CLI options in the extended CLI  preventing to call the extension as following:
```bash
datashare -m CLI -s mySetting.properties --extensionsDir ./extensionPath  --ext neo4j --full-import -p myProject
```

The parsing of all configuration arguments of the CLI would have to be re-implemented in each extension. This change the extension mechanism to leave configuration arguments in the extended CLI, while not printing them when the help is called.

# Changes

## `src`
### Fixed
- refactored `DatashareCli.parseArguments` to include DS configuration arguments while not printing then when the extension help is called