### PR TITLE
fix: release datashare-cli 13.5.0

### DIFF
--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>datashare-cli</artifactId>
     <packaging>jar</packaging>
     <groupId>org.icij.datashare</groupId>
-    <version>13.4.0</version>
+    <version>13.5.0</version>
 
     <name>ICIJ Datashare CLI</name>
     <url>https://github.com/ICIJ/datashare</url>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <datashare-api.version>12.4.0</datashare-api.version>
-        <datashare-cli.version>13.4.0</datashare-cli.version>
+        <datashare-cli.version>13.5.0</datashare-cli.version>
 
         <datashare-mitie.version>${project.version}</datashare-mitie.version>
         <datashare-elasticsearch.version>${project.version}</datashare-elasticsearch.version>


### PR DESCRIPTION
release new version of datashare-cli 

That should be made in the main pom.xml for the project version and in the datashare-cli module.