### PR TITLE
feat: some minor oauth improvements

### DIFF
--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -153,6 +153,8 @@ public class DatashareCli {
         DatashareCliOptions.oauthTokenUrl(parser);
         DatashareCliOptions.authFilter(parser);
         DatashareCliOptions.oauthCallbackPath(parser);
+        DatashareCliOptions.oauthScope(parser);
+        DatashareCliOptions.oauthDefaultProject(parser);
         DatashareCliOptions.digestMethod(parser);
         DatashareCliOptions.digestProjectName(parser);
         DatashareCliOptions.noDigestProject(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -467,6 +467,18 @@ public final class DatashareCliOptions {
                 .withRequiredArg()
                 .ofType(String.class);
     }
+    static void oauthDefaultProject(OptionParser parser) {
+        parser.acceptsAll(
+                singletonList("oauthDefaultProject"), "Default project to use for Oauth2 users")
+                .withRequiredArg()
+                .ofType(String.class);
+    }
+    static void oauthScope(OptionParser parser) {
+        parser.acceptsAll(
+                singletonList("oauthScope"), "Set scope in oauth2 callback url, needed for OIDC providers")
+                .withRequiredArg()
+                .ofType(String.class);
+    }
 
     public static void batchQueueType(OptionParser parser) {
         parser.acceptsAll(


### PR DESCRIPTION
Here are some small improvements that we needed to get Datashare working with Okta and OIDC.

1. Support for `X-Forwarded-Proto` 
You already have support for `X-Forwarded-For` so this was needed for us to get the protocol correct for the oauth callback.

2. Support for scope in the callback url
To use OIDC we need scope in the callback url, added a cli option for this.

3. Support for sending oauth users to a specific project
We would like to send all okta users to the same project, and also the OIDC mappings in Okta didn't support adding arrays of string/list pairs, so we couldn't set `groups_by_applications` on the Okta side.