### PR TITLE
Refactor: reduce active connections

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
@@ -14,18 +14,12 @@ public class LocalMode extends CommonMode {
     LocalMode(Properties properties) { super(properties);}
     LocalMode(Map<String, String> properties) { super(properties);}
 
-    protected LocalUserFilter getLocalUserFilter() {
-        RepositoryFactoryImpl repositoryFactory = new RepositoryFactoryImpl(propertiesProvider);
-        JooqRepository jooqRepository = (JooqRepository) repositoryFactory.createRepository();
-        return new LocalUserFilter(propertiesProvider, jooqRepository);
-    }
-
     @Override
     protected void configure() {
         super.configure();
         bind(IndexWaiterFilter.class).asEagerSingleton();
         bind(StatusResource.class).asEagerSingleton();
-        bind(LocalUserFilter.class).toInstance(getLocalUserFilter());
+        bind(LocalUserFilter.class).asEagerSingleton();
         configurePersistence();
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/session/LocalUserFilter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/LocalUserFilter.java
@@ -8,21 +8,21 @@ import net.codestory.http.payload.Payload;
 import net.codestory.http.security.SessionIdStore;
 import net.codestory.http.security.User;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.db.JooqRepository;
+import org.icij.datashare.Repository;
 
 import static org.icij.datashare.session.DatashareUser.*;
 
 public class LocalUserFilter extends CookieAuthFilter {
     private final String userName;
-    private final JooqRepository jooqRepository;
+    private final Repository repository;
 
     @Inject
-    public LocalUserFilter(final PropertiesProvider propertiesProvider, final JooqRepository jooqRepository) {
+    public LocalUserFilter(final PropertiesProvider propertiesProvider, final Repository repository) {
         super(propertiesProvider.get("protectedUrPrefix").orElse("/"),
                 singleUser(propertiesProvider.get("defaultUserName").orElse("local")),
                 SessionIdStore.inMemory());
         this.userName = propertiesProvider.get("defaultUserName").orElse("local");
-        this.jooqRepository = jooqRepository;
+        this.repository = repository;
     }
 
     @Override
@@ -43,7 +43,7 @@ public class LocalUserFilter extends CookieAuthFilter {
     protected User getUserWithEveryProjects () {
         // We must cast back to DatashareUser to be able to use the `setProjects` method
         DatashareUser datashareUser = (DatashareUser) users.find(userName);
-        datashareUser.setProjects(jooqRepository.getProjects());
+        datashareUser.setProjects(repository.getProjects());
         return datashareUser;
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -294,9 +294,9 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
 
         List<SearchResult> searchResultsContentType = asList(searchResult1, searchResult2);
         List<SearchResult> searchResultsAllContentType = asList(searchResult1, searchResult2,searchResult3);
-        when(batchSearchRepository.getResults(User.local(), "batchSearchId", WebQueryBuilder.createWebQuery().queryAll().withContentTypes(asList("content/type")).build()))
+        when(batchSearchRepository.getResults(User.local(), "batchSearchId", WebQueryBuilder.createWebQuery().queryAll().withContentTypes(List.of("content/type")).build()))
                 .thenReturn(searchResultsContentType);
-        when(batchSearchRepository.getResults(User.local(), "batchSearchId", WebQueryBuilder.createWebQuery().queryAll().withContentTypes(asList()).build()))
+        when(batchSearchRepository.getResults(User.local(), "batchSearchId", WebQueryBuilder.createWebQuery().queryAll().withContentTypes(List.of()).build()))
                 .thenReturn(searchResultsAllContentType);
         post("/api/batch/search/result/batchSearchId", "{\"from\":0, \"size\":0, \"query\":\"*\", \"field\":\"all\",\"contentTypes\":[\"content/type\"]}").
                 should().respond(200).haveType("application/json").
@@ -423,7 +423,7 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_batch_search_without_queries() {
         BatchSearch search = new BatchSearch("uuid", singletonList(project("prj")), "name", "desc", 2, new Date(), BatchSearchRecord.State.SUCCESS, User.local(),
-                                        3, true, singletonList("application/pdf"), null, asList("/path"), 0, false, null, null);
+                                        3, true, singletonList("application/pdf"), null, List.of("/path"), 0, false, null, null);
         when(batchSearchRepository.get(User.local(), search.uuid, false)).thenReturn(search);
 
         get("/api/batch/search/uuid?withQueries=false").should().

--- a/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/DatabaseSpewer.java
@@ -15,7 +15,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Date;
 
-import static java.lang.Long.valueOf;
 import static java.util.Optional.ofNullable;
 import static org.apache.tika.metadata.HttpHeaders.*;
 
@@ -37,7 +36,7 @@ public class DatabaseSpewer extends Spewer {
         String content = toString(tikaDocument.getReader()).trim();
         Charset charset = Charset.forName(ofNullable(tikaDocument.getMetadata().get(CONTENT_ENCODING)).orElse("utf-8"));
         String contentType = ofNullable(tikaDocument.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN).split(";")[0];
-        Long contentLength = valueOf(ofNullable(tikaDocument.getMetadata().get(CONTENT_LENGTH)).orElse("-1"));
+        long contentLength = Long.parseLong(ofNullable(tikaDocument.getMetadata().get(CONTENT_LENGTH)).orElse("-1"));
         String parentId = parent == null ? null: parent.getId();
         String rootId = root == null ? null: root.getId();
 

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -186,7 +186,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
 
     @Override
     public List<BatchSearchRecord> getRecords(User user, List<String> projectsIds, WebQuery webQuery) {
-        try(DSLContext context = using(dataSource, dialect)) {
+        try(DSLContext context = DSL.using(dataSource, dialect)) {
             cacheNbQueries(webQuery, context);
 
             SelectConditionStep<Record12<String, String, String, String, Timestamp, String, Integer, Integer, String, String, String, Integer>> query = createBatchSearchRecordWithQueriesSelectStatement(context)
@@ -587,9 +587,9 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
         return context.update(BATCH_SEARCH).set(BATCH_SEARCH.NB_QUERIES,nbQueries).where(BATCH_SEARCH.UUID.eq(batchSearchUuid)).execute() > 0;
     }
 
-    boolean setNbQueries(String batchSearchUuid, int nbQueries){
+    boolean resetNbQueries(String batchSearchUuid){
         try (DSLContext context = DSL.using(dataSource, dialect)) {
-            return setNbQueries(context, batchSearchUuid, nbQueries);
+            return setNbQueries(context, batchSearchUuid, 0);
         }
     }
 

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -10,9 +10,6 @@ import org.icij.datashare.json.JsonUtils;
 import org.icij.datashare.text.*;
 import org.icij.datashare.text.nlp.Pipeline;
 import org.icij.datashare.user.User;
-// Keep these imports explicit otherwise the wildcard import of import org.jooq.Record will end up
-// in a "reference to Record is ambiguous" depending on your JRE since it will conflict with
-// java.util.Record
 import org.jooq.*;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -27,7 +24,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static java.nio.charset.Charset.forName;
 import static java.util.Arrays.asList;
@@ -295,10 +291,10 @@ public class JooqRepository implements Repository {
     @Override
     public Set<String> getRecommentationsBy(Project project, List<User> users){
         try(DSLContext create = DSL.using(connectionProvider,dialect)) {
-            return create.select(DOCUMENT_USER_RECOMMENDATION.DOC_ID).from(DOCUMENT_USER_RECOMMENDATION)
+            return new HashSet<>(create.select(DOCUMENT_USER_RECOMMENDATION.DOC_ID).from(DOCUMENT_USER_RECOMMENDATION)
                     .where(DOCUMENT_USER_RECOMMENDATION.USER_ID.in(users.stream().map(x -> x.id).collect(toList())))
                     .and(DOCUMENT_USER_RECOMMENDATION.PRJ_ID.eq(project.getId()))
-                    .fetch().getValues(DOCUMENT_USER_RECOMMENDATION.DOC_ID).stream().collect(Collectors.toSet());
+                    .fetch().getValues(DOCUMENT_USER_RECOMMENDATION.DOC_ID));
         }
     }
 

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -59,41 +59,43 @@ public class JooqRepository implements Repository {
 
     @Override
     public NamedEntity getNamedEntity(String id) {
-        return createFrom(DSL.using(connectionProvider, dialect).
-                selectFrom(NAMED_ENTITY).where(NAMED_ENTITY.ID.eq(id)).fetchOne());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return createFrom(ctx.selectFrom(NAMED_ENTITY).where(NAMED_ENTITY.ID.eq(id)).fetchOne());
+        }
     }
 
     @Override
     public void create(List<NamedEntity> neList) {
-        DSLContext create = DSL.using(connectionProvider, dialect);
-        InsertValuesStep9<NamedEntityRecord, String, String, String, Short, String, String, String, String, Boolean>
-                insertQuery = create.insertInto(NAMED_ENTITY,
-                NAMED_ENTITY.ID, NAMED_ENTITY.MENTION, NAMED_ENTITY.OFFSETS, NAMED_ENTITY.EXTRACTOR,
-                NAMED_ENTITY.CATEGORY, NAMED_ENTITY.DOC_ID, NAMED_ENTITY.ROOT_ID,
-                NAMED_ENTITY.EXTRACTOR_LANGUAGE, NAMED_ENTITY.HIDDEN);
-        neList.forEach(ne -> {
-            try {
-                insertQuery.values(
-                        ne.getId(), ne.getMention(), MAPPER.writeValueAsString(ne.getOffsets()), ne.getExtractor().code,
-                        ne.getCategory().getAbbreviation(), ne.getDocumentId(), ne.getRootDocument(),
-                        ne.getExtractorLanguage().iso6391Code(), ne.isHidden());
-            } catch (JsonProcessingException e) {
-                LOGGER.error("cannot serialize offsets {}", ne.getOffsets());
-            }
-        });
-        insertQuery.execute();
+        try (DSLContext create = DSL.using(connectionProvider, dialect)) {
+            InsertValuesStep9<NamedEntityRecord, String, String, String, Short, String, String, String, String, Boolean>
+                    insertQuery = create.insertInto(NAMED_ENTITY,
+                    NAMED_ENTITY.ID, NAMED_ENTITY.MENTION, NAMED_ENTITY.OFFSETS, NAMED_ENTITY.EXTRACTOR,
+                    NAMED_ENTITY.CATEGORY, NAMED_ENTITY.DOC_ID, NAMED_ENTITY.ROOT_ID,
+                    NAMED_ENTITY.EXTRACTOR_LANGUAGE, NAMED_ENTITY.HIDDEN);
+            neList.forEach(ne -> {
+                try {
+                    insertQuery.values(
+                            ne.getId(), ne.getMention(), MAPPER.writeValueAsString(ne.getOffsets()), ne.getExtractor().code,
+                            ne.getCategory().getAbbreviation(), ne.getDocumentId(), ne.getRootDocument(),
+                            ne.getExtractorLanguage().iso6391Code(), ne.isHidden());
+                } catch (JsonProcessingException e) {
+                    LOGGER.error("cannot serialize offsets {}", ne.getOffsets());
+                }
+            });
+            insertQuery.execute();
+        }
     }
 
     @Override
     public Document getDocument(final String id) {
-        return createDocumentFrom(DSL.using(connectionProvider, dialect).
-                selectFrom(DOCUMENT).where(DOCUMENT.ID.eq(id)).fetchOne());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return createDocumentFrom(ctx.selectFrom(DOCUMENT).where(DOCUMENT.ID.eq(id)).fetchOne());
+        }
     }
 
     @Override
     public void create(Document doc) {
-        DSLContext ctx = DSL.using(connectionProvider, dialect);
-        try {
+        try (DSLContext ctx = DSL.using(connectionProvider, dialect)) {
             ctx.insertInto(DOCUMENT, DOCUMENT.PROJECT_ID,
                     DOCUMENT.ID, DOCUMENT.PATH, DOCUMENT.CONTENT, DOCUMENT.STATUS,
                     DOCUMENT.CHARSET, DOCUMENT.LANGUAGE, DOCUMENT.CONTENT_TYPE,
@@ -111,17 +113,19 @@ public class JooqRepository implements Repository {
 
     @Override
     public List<Document> getDocumentsNotTaggedWithPipeline(Project project, Pipeline.Type type) {
-        DSLContext create = DSL.using(connectionProvider, dialect);
-        return create.selectFrom(DOCUMENT).where(
-                condition("(ner_mask & ?) = 0", type.mask)).
-                fetch().stream().map(this::createDocumentFrom).collect(toList());
+        try (DSLContext create = using(connectionProvider, dialect)) {
+            return create.selectFrom(DOCUMENT).where(
+                            condition("(ner_mask & ?) = 0", type.mask)).
+                    fetch().stream().map(this::createDocumentFrom).collect(toList());
+        }
     }
 
     @Override
     public List<Document> getStarredDocuments(User user) {
-        DSLContext create = DSL.using(connectionProvider, dialect);
-        return create.selectFrom(DOCUMENT.join(DOCUMENT_USER_STAR).on(DOCUMENT.ID.eq(DOCUMENT_USER_STAR.DOC_ID))).
-                where(DOCUMENT_USER_STAR.USER_ID.eq(user.id)).fetch().stream().map(this::createDocumentFrom).collect(toList());
+        try (DSLContext create = using(connectionProvider, dialect)) {
+            return create.selectFrom(DOCUMENT.join(DOCUMENT_USER_STAR).on(DOCUMENT.ID.eq(DOCUMENT_USER_STAR.DOC_ID))).
+                    where(DOCUMENT_USER_STAR.USER_ID.eq(user.id)).fetch().stream().map(this::createDocumentFrom).collect(toList());
+        }
     }
 
     // ------------- functions that don't need document migration/indexing
@@ -129,159 +133,181 @@ public class JooqRepository implements Repository {
     // this could be removed later
     @Override
     public int star(Project project, User user, List<String> documentIds) {
-        InsertValuesStep3<DocumentUserStarRecord, String, String, String>
-            query = using(connectionProvider, dialect).
-                insertInto(DOCUMENT_USER_STAR, DOCUMENT_USER_STAR.DOC_ID, DOCUMENT_USER_STAR.USER_ID, DOCUMENT_USER_STAR.PRJ_ID);
-        documentIds.forEach(t -> query.values(t, user.id, project.getId()));
-        return query.onConflictDoNothing().execute();
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            InsertValuesStep3<DocumentUserStarRecord, String, String, String>
+                    query = ctx.insertInto(DOCUMENT_USER_STAR, DOCUMENT_USER_STAR.DOC_ID, DOCUMENT_USER_STAR.USER_ID, DOCUMENT_USER_STAR.PRJ_ID);
+            documentIds.forEach(t -> query.values(t, user.id, project.getId()));
+            return query.onConflictDoNothing().execute();
+        }
     }
 
     @Override
     public int unstar(Project project, User user, List<String> documentIds) {
-        return DSL.using(connectionProvider, dialect).deleteFrom(DOCUMENT_USER_STAR).
-                where(DOCUMENT_USER_STAR.DOC_ID.in(documentIds),
-                        DOCUMENT_USER_STAR.USER_ID.eq(user.id),
-                        DOCUMENT_USER_STAR.PRJ_ID.eq(project.getId())).execute();
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.deleteFrom(DOCUMENT_USER_STAR).
+                    where(DOCUMENT_USER_STAR.DOC_ID.in(documentIds),
+                            DOCUMENT_USER_STAR.USER_ID.eq(user.id),
+                            DOCUMENT_USER_STAR.PRJ_ID.eq(project.getId())).execute();
+        }
     }
 
     @Override
     public List<String> getStarredDocuments(Project project, User user) {
-        DSLContext create = DSL.using(connectionProvider, dialect);
-        return create.select(DOCUMENT_USER_STAR.DOC_ID).from(DOCUMENT_USER_STAR).
-                where(DOCUMENT_USER_STAR.USER_ID.eq(user.id)).
-                and(DOCUMENT_USER_STAR.PRJ_ID.eq(project.getId())).
-                fetch().getValues(DOCUMENT_USER_STAR.DOC_ID);
+        try (DSLContext create = DSL.using(connectionProvider, dialect)) {
+            return create.select(DOCUMENT_USER_STAR.DOC_ID).from(DOCUMENT_USER_STAR).
+                    where(DOCUMENT_USER_STAR.USER_ID.eq(user.id)).
+                    and(DOCUMENT_USER_STAR.PRJ_ID.eq(project.getId())).
+                    fetch().getValues(DOCUMENT_USER_STAR.DOC_ID);
+        }
     }
 
     @Override
     public int recommend(Project project, User user, List<String> documentIds) {
-        InsertValuesStep4<DocumentUserRecommendationRecord, String, String, String, Timestamp> query = DSL.using(connectionProvider, dialect).
-                insertInto(DOCUMENT_USER_RECOMMENDATION, DOCUMENT_USER_RECOMMENDATION.DOC_ID, DOCUMENT_USER_RECOMMENDATION.USER_ID, DOCUMENT_USER_RECOMMENDATION.PRJ_ID, DOCUMENT_USER_RECOMMENDATION.CREATION_DATE);
-        Timestamp now = Timestamp.from(Instant.now());
-        documentIds.forEach(t -> query.values(t, user.id, project.getId(), now));
-        return query.execute();
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            InsertValuesStep4<DocumentUserRecommendationRecord, String, String, String, Timestamp> query = ctx.
+                    insertInto(DOCUMENT_USER_RECOMMENDATION, DOCUMENT_USER_RECOMMENDATION.DOC_ID, DOCUMENT_USER_RECOMMENDATION.USER_ID, DOCUMENT_USER_RECOMMENDATION.PRJ_ID, DOCUMENT_USER_RECOMMENDATION.CREATION_DATE);
+            Timestamp now = Timestamp.from(Instant.now());
+            documentIds.forEach(t -> query.values(t, user.id, project.getId(), now));
+            return query.execute();
+        }
     }
 
     @Override
     public int unrecommend(Project project, User user, List<String> documentIds) {
-        return DSL.using(connectionProvider, dialect).deleteFrom(DOCUMENT_USER_RECOMMENDATION).
-                where(DOCUMENT_USER_RECOMMENDATION.DOC_ID.in(documentIds),
-                        DOCUMENT_USER_RECOMMENDATION.USER_ID.eq(user.id),
-                        DOCUMENT_USER_RECOMMENDATION.PRJ_ID.eq(project.getId())).execute();
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.deleteFrom(DOCUMENT_USER_RECOMMENDATION).
+                    where(DOCUMENT_USER_RECOMMENDATION.DOC_ID.in(documentIds),
+                            DOCUMENT_USER_RECOMMENDATION.USER_ID.eq(user.id),
+                            DOCUMENT_USER_RECOMMENDATION.PRJ_ID.eq(project.getId())).execute();
+        }
     }
 
     @Override
     public AggregateList<User> getRecommendations(Project project, List<String> documentIds) {
-        DSLContext context = using(connectionProvider, dialect);
-        return new AggregateList<>(
-                createAggregateFromSelect(createSelectRecommendationLeftJoinInventory(context, project).and(DOCUMENT_USER_RECOMMENDATION.DOC_ID.in(documentIds))),
-                selectCount(context, project).and(DOCUMENT_USER_RECOMMENDATION.DOC_ID.in(documentIds)).fetchOne(0, int.class)
-        );
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return new AggregateList<>(
+                    createAggregateFromSelect(createSelectRecommendationLeftJoinInventory(ctx, project).and(DOCUMENT_USER_RECOMMENDATION.DOC_ID.in(documentIds))),
+                    selectCount(ctx, project).and(DOCUMENT_USER_RECOMMENDATION.DOC_ID.in(documentIds)).fetchOne(0, int.class)
+            );
+        }
     }
 
     @Override
     public boolean addToUserHistory(List<Project> projects, UserEvent userEvent) {
-        return using(connectionProvider, dialect).transactionResult(configuration -> {
-            DSLContext inner = using(configuration);
-            InsertValuesStep6<UserHistoryRecord, Timestamp, Timestamp, String, Short, String, String>
-                insertHistory = inner.
-                    insertInto(USER_HISTORY, USER_HISTORY.CREATION_DATE, USER_HISTORY.MODIFICATION_DATE,
-                            USER_HISTORY.USER_ID, USER_HISTORY.TYPE, USER_HISTORY.NAME, USER_HISTORY.URI);
-            insertHistory.values(new Timestamp(userEvent.creationDate.getTime()), new Timestamp(userEvent.modificationDate.getTime()),
-                    userEvent.user.id, userEvent.type.id, userEvent.name, userEvent.uri.toString());
-            try(InsertOnDuplicateSetMoreStep<UserHistoryRecord> innerSet = insertHistory.onConflict(USER_HISTORY.USER_ID, USER_HISTORY.URI)
-                    .doUpdate()
-                    .set(USER_HISTORY.MODIFICATION_DATE, new Timestamp(userEvent.modificationDate.getTime()))){
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.transactionResult(configuration -> {
+                try (DSLContext inner = using(configuration)) {
+                    InsertValuesStep6<UserHistoryRecord, Timestamp, Timestamp, String, Short, String, String>
+                            insertHistory = inner.
+                            insertInto(USER_HISTORY, USER_HISTORY.CREATION_DATE, USER_HISTORY.MODIFICATION_DATE,
+                                    USER_HISTORY.USER_ID, USER_HISTORY.TYPE, USER_HISTORY.NAME, USER_HISTORY.URI);
+                    insertHistory.values(new Timestamp(userEvent.creationDate.getTime()), new Timestamp(userEvent.modificationDate.getTime()),
+                            userEvent.user.id, userEvent.type.id, userEvent.name, userEvent.uri.toString());
+                    try (InsertOnDuplicateSetMoreStep<UserHistoryRecord> innerSet = insertHistory.onConflict(USER_HISTORY.USER_ID, USER_HISTORY.URI)
+                            .doUpdate()
+                            .set(USER_HISTORY.MODIFICATION_DATE, new Timestamp(userEvent.modificationDate.getTime()))) {
 
-                UserHistoryRecord insertHistoryRecord = innerSet
-                        .returning(USER_HISTORY.ID).fetchOne();
+                        UserHistoryRecord insertHistoryRecord = innerSet
+                                .returning(USER_HISTORY.ID).fetchOne();
 
-                if (insertHistoryRecord == null) {
-                    return false;
+                        if (insertHistoryRecord == null) {
+                            return false;
+                        }
+
+                        InsertValuesStep2<UserHistoryProjectRecord, Integer, String> insertProject = inner.
+                                insertInto(USER_HISTORY_PROJECT, USER_HISTORY_PROJECT.USER_HISTORY_ID, USER_HISTORY_PROJECT.PRJ_ID);
+                        projects.forEach(project -> insertProject.values(insertHistoryRecord.getValue(USER_HISTORY.ID), project.getId()));
+                        return insertProject.onConflictDoNothing().execute() >= 0;
+                    }
                 }
-
-                InsertValuesStep2<UserHistoryProjectRecord, Integer, String> insertProject = inner.
-                        insertInto(USER_HISTORY_PROJECT, USER_HISTORY_PROJECT.USER_HISTORY_ID, USER_HISTORY_PROJECT.PRJ_ID);
-                projects.forEach(project -> insertProject.values(insertHistoryRecord.getValue(USER_HISTORY.ID), project.getId()));
-                return insertProject.onConflictDoNothing().execute() >= 0;
-            }
-
-        });
+            });
+        }
     }
 
     @Override
     public List<UserEvent> getUserHistory(User user, UserEvent.Type type, int from, int size, String sort, boolean desc, String... projectIds) {
-        String sortName = Optional.ofNullable(sort).filter(Predicate.not(String::isBlank)).orElse(USER_HISTORY.MODIFICATION_DATE.getName());
-        Field<?> sortBy =  Optional.ofNullable(USER_HISTORY.field(sortName)).orElseThrow(() -> new IllegalArgumentException(String.format("Invalid sort attribute: %s", sortName)));
-        SortField<?> order  = desc ? sortBy.desc() : sortBy.asc();
-        if (projectIds.length>0) {
-            try(SelectConditionStep<Record1<Integer>> innerSelect = select(USER_HISTORY_PROJECT.USER_HISTORY_ID).from(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.in(projectIds))){
-                return using(connectionProvider, dialect)
-                    .selectFrom(USER_HISTORY)
-                    .where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id))
-                    .and(USER_HISTORY.ID
-                            .in(innerSelect)
-                    )
-                    .orderBy(order).offset(from).limit(size).stream().map(this::createUserEventFrom).collect(toList());
-            }
-        } else {
-            return using(connectionProvider, dialect).selectFrom(USER_HISTORY).
-                    where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id))
-                    .orderBy(order).offset(from).limit(size).stream().map(this::createUserEventFrom).collect(toList());
-        }
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            String sortName = Optional.ofNullable(sort).filter(Predicate.not(String::isBlank)).orElse(USER_HISTORY.MODIFICATION_DATE.getName());
+            Field<?> sortBy = Optional.ofNullable(USER_HISTORY.field(sortName)).orElseThrow(() -> new IllegalArgumentException(String.format("Invalid sort attribute: %s", sortName)));
+            SortField<?> order = desc ? sortBy.desc() : sortBy.asc();
+            if (projectIds.length > 0) {
 
+                SelectConditionStep<Record1<Integer>> innerSelect = ctx.select(USER_HISTORY_PROJECT.USER_HISTORY_ID).from(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.in(projectIds));
+                return ctx.selectFrom(USER_HISTORY)
+                        .where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id))
+                        .and(USER_HISTORY.ID
+                                .in(innerSelect)
+                        )
+                        .orderBy(order).offset(from).limit(size).stream().map(this::createUserEventFrom).collect(toList());
+
+            } else {
+                return ctx.selectFrom(USER_HISTORY).
+                        where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id))
+                        .orderBy(order).offset(from).limit(size).stream().map(this::createUserEventFrom).collect(toList());
+
+            }
+        }
     }
 
     @Override
     public int getUserHistorySize(User user, UserEvent.Type type, String... projectIds) {
-        SelectConditionStep<Record1<Integer>>
-            query = using(connectionProvider, dialect).selectCount().from(USER_HISTORY).
-                where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id));
-        if(projectIds.length>0){
-            query.and(USER_HISTORY.ID.in(select(USER_HISTORY_PROJECT.USER_HISTORY_ID).from(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.in(projectIds))));
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            SelectConditionStep<Record1<Integer>>
+                    query = ctx.selectCount().from(USER_HISTORY).
+                    where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id));
+            if (projectIds.length > 0) {
+                query.and(USER_HISTORY.ID.in(ctx.select(USER_HISTORY_PROJECT.USER_HISTORY_ID).from(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.in(projectIds))));
+            }
+            return query.fetchOne(0, int.class);
         }
-        return query.fetchOne(0, int.class);
-
     }
 
     @Override
     public boolean deleteUserHistory(User user, UserEvent.Type type) {
-        return using(connectionProvider, dialect).transactionResult(configuration -> {
-            try (SelectSelectStep<Record1<Integer>> innerSelect = select(USER_HISTORY.ID)){
-                DSLContext inner = using(configuration);
-                inner.deleteFrom(USER_HISTORY_PROJECT).
-                        where(USER_HISTORY_PROJECT.USER_HISTORY_ID.in(
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.transactionResult(configuration -> {
+                try (DSLContext inner = using(connectionProvider, dialect)) {
+                    SelectSelectStep<Record1<Integer>> innerSelect = inner.select(USER_HISTORY.ID);
+                    inner.deleteFrom(USER_HISTORY_PROJECT).
+                            where(USER_HISTORY_PROJECT.USER_HISTORY_ID.in(
                                     innerSelect.from(USER_HISTORY)
                                             .where(USER_HISTORY.TYPE.eq(type.id)).and(USER_HISTORY.USER_ID.eq(user.id))
-                        )).execute();
-                return inner.deleteFrom(USER_HISTORY).
-                        where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id)).execute() > 0;
-            }
-        });
+                            )).execute();
+                    return inner.deleteFrom(USER_HISTORY).
+                            where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.TYPE.eq(type.id)).execute() > 0;
+                }
+            });
+        }
     }
 
     @Override
     public boolean deleteUserHistoryEvent(User user, int eventId) {
-        return using(connectionProvider, dialect).transactionResult(configuration -> {
-            DSLContext inner = using(configuration);
-            inner.deleteFrom(USER_HISTORY_PROJECT).
-                    where(USER_HISTORY_PROJECT.USER_HISTORY_ID.eq(eventId)).execute();
-            return inner.deleteFrom(USER_HISTORY).
-                    where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.ID.eq(eventId)).execute() > 0;
-        });
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.transactionResult(configuration -> {
+                try (DSLContext inner = using(configuration)) {
+                    inner.deleteFrom(USER_HISTORY_PROJECT).
+                            where(USER_HISTORY_PROJECT.USER_HISTORY_ID.eq(eventId)).execute();
+                    return inner.deleteFrom(USER_HISTORY).
+                            where(USER_HISTORY.USER_ID.eq(user.id)).and(USER_HISTORY.ID.eq(eventId)).execute() > 0;
+                }
+            });
+        }
     }
 
     @Override
     public boolean renameSavedSearch(User user, int eventId, String newName) {
-        return using(connectionProvider, dialect).transactionResult(configuration -> {
-            try(UpdateSetMoreStep<UserHistoryRecord> setName = using(configuration).update(USER_HISTORY).set(USER_HISTORY.NAME, newName)){
-                UpdateConditionStep<UserHistoryRecord> updatedTuple =  setName
-                        .where(USER_HISTORY.USER_ID.eq(user.id))
-                        .and(USER_HISTORY.ID.eq(eventId))
-                        .and(USER_HISTORY.TYPE.eq(UserEvent.Type.SEARCH.id));
-                return updatedTuple.execute() > 0;
-            }
-        });
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.transactionResult(configuration -> {
+                try (DSLContext inner = using(configuration)) {
+                    UpdateSetMoreStep<UserHistoryRecord> setName = inner.update(USER_HISTORY).set(USER_HISTORY.NAME, newName);
+                    UpdateConditionStep<UserHistoryRecord> updatedTuple = setName
+                            .where(USER_HISTORY.USER_ID.eq(user.id))
+                            .and(USER_HISTORY.ID.eq(eventId))
+                            .and(USER_HISTORY.TYPE.eq(UserEvent.Type.SEARCH.id));
+                    return updatedTuple.execute() > 0;
+                }
+            });
+        }
     }
 
     @Override
@@ -306,100 +332,124 @@ public class JooqRepository implements Repository {
 
     @Override
     public boolean tag(Project prj, String documentId, Tag... tags) {
-        InsertValuesStep5<DocumentTagRecord, String, String, String, Timestamp, String> query = using(connectionProvider, dialect).insertInto(
-                DOCUMENT_TAG, DOCUMENT_TAG.DOC_ID, DOCUMENT_TAG.LABEL, DOCUMENT_TAG.PRJ_ID,
-                DOCUMENT_TAG.CREATION_DATE, DOCUMENT_TAG.USER_ID);
-        List<Tag> tagList = asList(tags);
-        tagList.forEach(t -> query.values(documentId, t.label, prj.getId(), new Timestamp(t.creationDate.getTime()), t.user.id));
-        return query.onConflictDoNothing().execute() > 0;
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            InsertValuesStep5<DocumentTagRecord, String, String, String, Timestamp, String> query = ctx.insertInto(
+                    DOCUMENT_TAG, DOCUMENT_TAG.DOC_ID, DOCUMENT_TAG.LABEL, DOCUMENT_TAG.PRJ_ID,
+                    DOCUMENT_TAG.CREATION_DATE, DOCUMENT_TAG.USER_ID);
+            List<Tag> tagList = asList(tags);
+            tagList.forEach(t -> query.values(documentId, t.label, prj.getId(), new Timestamp(t.creationDate.getTime()), t.user.id));
+            return query.onConflictDoNothing().execute() > 0;
+        }
     }
 
     @Override
     public boolean untag(Project prj, String documentId, Tag... tags) {
-        return DSL.using(connectionProvider, dialect).deleteFrom(DOCUMENT_TAG).
-                where(DOCUMENT_TAG.DOC_ID.eq(documentId),
-                        DOCUMENT_TAG.LABEL.in(stream(tags).map(t -> t.label).collect(toSet())),
-                        DOCUMENT_TAG.PRJ_ID.eq(prj.getId())).execute() > 0;
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.deleteFrom(DOCUMENT_TAG).
+                    where(DOCUMENT_TAG.DOC_ID.eq(documentId),
+                            DOCUMENT_TAG.LABEL.in(stream(tags).map(t -> t.label).collect(toSet())),
+                            DOCUMENT_TAG.PRJ_ID.eq(prj.getId())).execute() > 0;
+        }
     }
 
     @Override
     public boolean tag(Project prj, List<String> documentIds, Tag... tags) {
-        InsertValuesStep5<DocumentTagRecord, String, String, String, Timestamp, String> query = using(connectionProvider, dialect).insertInto(
-                DOCUMENT_TAG, DOCUMENT_TAG.DOC_ID, DOCUMENT_TAG.LABEL, DOCUMENT_TAG.PRJ_ID,
-                DOCUMENT_TAG.CREATION_DATE, DOCUMENT_TAG.USER_ID);
-        List<Tag> tagList = asList(tags);
-        documentIds.forEach(d -> tagList.forEach(t -> query.values(d, t.label, prj.getId(), new Timestamp(t.creationDate.getTime()), t.user.id)));
-        return query.onConflictDoNothing().execute() > 0;
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            InsertValuesStep5<DocumentTagRecord, String, String, String, Timestamp, String> query = ctx.insertInto(
+                    DOCUMENT_TAG, DOCUMENT_TAG.DOC_ID, DOCUMENT_TAG.LABEL, DOCUMENT_TAG.PRJ_ID,
+                    DOCUMENT_TAG.CREATION_DATE, DOCUMENT_TAG.USER_ID);
+            List<Tag> tagList = asList(tags);
+            documentIds.forEach(d -> tagList.forEach(t -> query.values(d, t.label, prj.getId(), new Timestamp(t.creationDate.getTime()), t.user.id)));
+            return query.onConflictDoNothing().execute() > 0;
+        }
     }
 
     @Override
     public boolean untag(Project prj, List<String> documentIds, Tag... tags) {
-        return DSL.using(connectionProvider, dialect).deleteFrom(DOCUMENT_TAG).
-                where(DOCUMENT_TAG.DOC_ID.in(documentIds),
-                        DOCUMENT_TAG.LABEL.in(stream(tags).map(t -> t.label).collect(toSet())),
-                        DOCUMENT_TAG.PRJ_ID.eq(prj.getId())).execute() > 0;
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.deleteFrom(DOCUMENT_TAG).
+                    where(DOCUMENT_TAG.DOC_ID.in(documentIds),
+                            DOCUMENT_TAG.LABEL.in(stream(tags).map(t -> t.label).collect(toSet())),
+                            DOCUMENT_TAG.PRJ_ID.eq(prj.getId())).execute() > 0;
+        }
     }
 
     @Override
     public List<String> getDocuments(Project project, Tag... tags) {
-        DSLContext create = DSL.using(connectionProvider, dialect);
-        return create.selectDistinct(DOCUMENT_TAG.DOC_ID).from(DOCUMENT_TAG).
-                where(DOCUMENT_TAG.LABEL.in(stream(tags).map(t -> t.label).collect(toSet()))).
-                and(DOCUMENT_TAG.PRJ_ID.eq(project.getId())).
-                fetch().getValues(DOCUMENT_TAG.DOC_ID);
+        try (DSLContext create = DSL.using(connectionProvider, dialect)) {
+            return create.selectDistinct(DOCUMENT_TAG.DOC_ID).from(DOCUMENT_TAG).
+                    where(DOCUMENT_TAG.LABEL.in(stream(tags).map(t -> t.label).collect(toSet()))).
+                    and(DOCUMENT_TAG.PRJ_ID.eq(project.getId())).
+                    fetch().getValues(DOCUMENT_TAG.DOC_ID);
+        }
     }
 
     @Override
     public List<Tag> getTags(Project project, String documentId) {
-        return DSL.using(connectionProvider, dialect).selectFrom(DOCUMENT_TAG).
-                where(DOCUMENT_TAG.DOC_ID.eq(documentId)).and(DOCUMENT_TAG.PRJ_ID.eq(project.getId())).
-                stream().map(this::createTagFrom).collect(toList());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.selectFrom(DOCUMENT_TAG).
+                    where(DOCUMENT_TAG.DOC_ID.eq(documentId)).and(DOCUMENT_TAG.PRJ_ID.eq(project.getId())).
+                    stream().map(this::createTagFrom).collect(toList());
+        }
     }
 
     @Override
     public boolean deleteAll(String projectId) {
-        return DSL.using(connectionProvider, dialect).transactionResult(configuration -> {
-            DSLContext inner = using(configuration);
-            int deleteTagResult = inner.deleteFrom(DOCUMENT_TAG).where(DOCUMENT_TAG.PRJ_ID.eq(projectId)).execute();
-            int deleteStarResult = inner.deleteFrom(DOCUMENT_USER_STAR).where(DOCUMENT_USER_STAR.PRJ_ID.eq(projectId)).execute();
-            int deleteUserRecommendationResult = inner.deleteFrom(DOCUMENT_USER_RECOMMENDATION).where(DOCUMENT_USER_RECOMMENDATION.PRJ_ID.eq(projectId)).execute();
-            int deleteUserHistoryResult = inner.deleteFrom(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.eq(projectId)).execute();
-            int deleteProject = inner.deleteFrom(PROJECT).where(PROJECT.ID.eq(projectId)).execute();
-            return deleteStarResult + deleteTagResult + deleteUserRecommendationResult + deleteUserHistoryResult + deleteProject > 0;
-        });
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.transactionResult(configuration -> {
+                try (DSLContext inner = using(configuration)) {
+                    int deleteTagResult = inner.deleteFrom(DOCUMENT_TAG).where(DOCUMENT_TAG.PRJ_ID.eq(projectId)).execute();
+                    int deleteStarResult = inner.deleteFrom(DOCUMENT_USER_STAR).where(DOCUMENT_USER_STAR.PRJ_ID.eq(projectId)).execute();
+                    int deleteUserRecommendationResult = inner.deleteFrom(DOCUMENT_USER_RECOMMENDATION).where(DOCUMENT_USER_RECOMMENDATION.PRJ_ID.eq(projectId)).execute();
+                    int deleteUserHistoryResult = inner.deleteFrom(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.eq(projectId)).execute();
+                    int deleteProject = inner.deleteFrom(PROJECT).where(PROJECT.ID.eq(projectId)).execute();
+                    return deleteStarResult + deleteTagResult + deleteUserRecommendationResult + deleteUserHistoryResult + deleteProject > 0;
+                }
+            });
+        }
     }
 
     @Override
     public Project getProject(String projectId) {
-        return createProjectFrom(DSL.using(connectionProvider, dialect).selectFrom(PROJECT).
-                where(PROJECT.ID.eq(projectId)).fetchOne());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return createProjectFrom(ctx.selectFrom(PROJECT).
+                    where(PROJECT.ID.eq(projectId)).fetchOne());
+        }
     }
 
     @Override
     public List<Project> getProjects() {
-        return DSL.using(connectionProvider, dialect).selectFrom(PROJECT).
-                stream().map(this::createProjectFrom).collect(toList());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.selectFrom(PROJECT).
+                    stream().map(this::createProjectFrom).collect(toList());
+        }
     }
 
     @Override
     public List<Project> getProjects(List<String> projectIds) {
-        return DSL.using(connectionProvider, dialect).selectFrom(PROJECT).
-                where(PROJECT.ID.in(projectIds)).
-                stream().map(this::createProjectFrom).collect(toList());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.selectFrom(PROJECT).
+                    where(PROJECT.ID.in(projectIds)).
+                    stream().map(this::createProjectFrom).collect(toList());
+        }
     }
 
     @Override
     public List<Note> getNotes(Project prj, String documentPath) {
-        return DSL.using(connectionProvider, dialect).selectFrom(NOTE).
-                where(NOTE.PROJECT_ID.eq(prj.getId())).and(value(documentPath).like(NOTE.PATH.concat('%'))).
-                stream().map(this::createNoteFrom).collect(toList());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.selectFrom(NOTE).
+                    where(NOTE.PROJECT_ID.eq(prj.getId())).and(value(documentPath).like(NOTE.PATH.concat('%'))).
+                    stream().map(this::createNoteFrom).collect(toList());
+        }
     }
 
     @Override
     public List<Note> getNotes(Project prj) {
-        return DSL.using(connectionProvider, dialect).selectFrom(NOTE).
-                where(NOTE.PROJECT_ID.eq(prj.getId())).
-                stream().map(this::createNoteFrom).collect(toList());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.selectFrom(NOTE).
+                    where(NOTE.PROJECT_ID.eq(prj.getId())).
+                    stream().map(this::createNoteFrom).collect(toList());
+        }
     }
 
     @Override
@@ -432,16 +482,18 @@ public class JooqRepository implements Repository {
 
     @Override
     public boolean save(Note note) {
-        return DSL.using(connectionProvider, dialect).insertInto(NOTE, NOTE.PROJECT_ID, NOTE.PATH, NOTE.NOTE_, NOTE.VARIANT).
-                values(note.project.name, note.path.toString(), note.note, note.variant.name()).execute() > 0;
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return ctx.insertInto(NOTE, NOTE.PROJECT_ID, NOTE.PATH, NOTE.NOTE_, NOTE.VARIANT).
+                    values(note.project.name, note.path.toString(), note.note, note.variant.name()).execute() > 0;
+        }
     }
 
     @Override
     public boolean save(Project project) {
         Timestamp projectCreationDate =  project.creationDate == null ? null: new Timestamp(project.creationDate.getTime());
         Timestamp projectUpdateDate =  project.updateDate == null ? null: new Timestamp(project.updateDate.getTime());
-        try(InsertOnDuplicateSetMoreStep<ProjectRecord> innerSet = using(connectionProvider, dialect).
-                insertInto(
+        try(DSLContext ctx = using(connectionProvider, dialect)) {
+            InsertOnDuplicateSetMoreStep<ProjectRecord> innerSet = ctx.insertInto(
                         PROJECT, PROJECT.ID, PROJECT.LABEL, PROJECT.DESCRIPTION, PROJECT.PATH, PROJECT.SOURCE_URL,
                         PROJECT.MAINTAINER_NAME, PROJECT.PUBLISHER_NAME, PROJECT.LOGO_URL,
                         PROJECT.ALLOW_FROM_MASK,
@@ -453,7 +505,7 @@ public class JooqRepository implements Repository {
                         projectCreationDate, projectUpdateDate).
                 onConflict(PROJECT.ID).
                 doUpdate().
-                set(PROJECT.LABEL, project.label)) {
+                set(PROJECT.LABEL, project.label);
             return innerSet.
                             set(PROJECT.DESCRIPTION, project.description).
                             set(PROJECT.SOURCE_URL, project.sourceUrl).
@@ -464,18 +516,17 @@ public class JooqRepository implements Repository {
                             set(PROJECT.UPDATE_DATE, projectUpdateDate).
                     execute() > 0;
         }
-
     }
 
     public boolean save(User user) {
-        try (InsertOnDuplicateSetMoreStep<UserInventoryRecord> innerSet = using(connectionProvider, dialect).
-                insertInto(
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+        InsertOnDuplicateSetMoreStep<UserInventoryRecord> innerSet = ctx.insertInto(
                         USER_INVENTORY, USER_INVENTORY.ID, USER_INVENTORY.EMAIL,
                         USER_INVENTORY.NAME, USER_INVENTORY.PROVIDER, USER_INVENTORY.DETAILS).
                 values(user.id, user.email, user.name, user.provider, JsonUtils.serialize(user.details)).
                 onConflict(USER_INVENTORY.ID).
                 doUpdate().
-                set(USER_INVENTORY.EMAIL, user.email)) {
+                set(USER_INVENTORY.EMAIL, user.email);
             return innerSet.
                     set(USER_INVENTORY.DETAILS, JsonUtils.serialize(user.details)).
                     set(USER_INVENTORY.NAME, user.name).
@@ -486,13 +537,15 @@ public class JooqRepository implements Repository {
     }
 
     public User getUser(String uid) {
-        return createUserFrom(DSL.using(connectionProvider, dialect).selectFrom(USER_INVENTORY).where(USER_INVENTORY.ID.eq(uid)).fetchOne());
+        try (DSLContext ctx = using(connectionProvider, dialect)) {
+            return createUserFrom(ctx.selectFrom(USER_INVENTORY).where(USER_INVENTORY.ID.eq(uid)).fetchOne());
+        }
     }
 
     @Override
     public boolean getHealth(){
-        try {
-            return DSL.using(connectionProvider, dialect).select().fetchOne().toString().contains("1");
+        try (DSLContext ctx = DSL.using(connectionProvider, dialect)) {
+            return ctx.select().fetchOne().toString().contains("1");
         } catch (DataAccessException ex){
             LoggerFactory.getLogger(getClass()).error("Database Health error : ",ex);
             return false;

--- a/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
@@ -6,7 +6,6 @@ import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
-import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
@@ -43,10 +42,14 @@ public class RepositoryFactoryImpl implements RepositoryFactory {
 
     void initDatabase(final DataSource dataSource) {
         try (Connection connection = dataSource.getConnection()){
-            Liquibase liquibase = new liquibase.Liquibase("liquibase/changelog/db.changelog.yml", new ClassLoaderResourceAccessor(),
-                            DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection)));
-            liquibase.update(new Contexts());
-        } catch (LiquibaseException | SQLException e) {
+            try (Liquibase liquibase = new Liquibase("liquibase/changelog/db.changelog.yml",
+                    new ClassLoaderResourceAccessor(),
+                    DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection)))) {
+                liquibase.update(new Contexts());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } catch ( SQLException e) {
             throw new RuntimeException(e);
         }
     }

--- a/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
@@ -19,6 +19,7 @@ import java.util.function.BiFunction;
 
 public class RepositoryFactoryImpl implements RepositoryFactory {
     private final PropertiesProvider propertiesProvider;
+    private final DataSource dataSource;
 
     RepositoryFactoryImpl() {
         this(new PropertiesProvider());
@@ -27,6 +28,7 @@ public class RepositoryFactoryImpl implements RepositoryFactory {
     public RepositoryFactoryImpl(final PropertiesProvider propertiesProvider) {
         this.propertiesProvider = propertiesProvider;
         System.getProperties().setProperty("org.jooq.no-logo", "true");
+        this.dataSource = createDatasource();
     }
 
     public Repository createRepository() {
@@ -55,13 +57,11 @@ public class RepositoryFactoryImpl implements RepositoryFactory {
     }
 
     public void initDatabase() {
-        try (HikariDataSource datasource = (HikariDataSource) createDatasource()) {
-            initDatabase(datasource);
-        }
+        initDatabase(dataSource);
     }
 
     private <T> T createRepository(BiFunction<DataSource, SQLDialect, T> constructor) {
-        return constructor.apply(createDatasource(), guessSqlDialectFrom(getDataSourceUrl()));
+        return constructor.apply(dataSource, guessSqlDialectFrom(getDataSourceUrl()));
     }
 
     static SQLDialect guessSqlDialectFrom(String dataSourceUrl) {

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -201,7 +201,7 @@ public class JooqBatchSearchRepositoryTest {
         IntStream.range(0, 5).mapToObj(i -> new BatchSearch(singletonList(proxy("prj1")), "name" + i, "description" + i, asSet("q1/" + i, "q2/" + i), User.local(),
                 true, asList("application/json", "image/jpeg"), singletonList("tag"), asList("/path/to/docs", "/path/to/pdfs"), 3, true)).
                 forEach(bs -> {
-                            boolean saved = repository.save(bs);
+                            repository.save(bs);
                             DatashareTime.getInstance().addMilliseconds(1000);
                         }
                 );
@@ -220,13 +220,13 @@ public class JooqBatchSearchRepositoryTest {
         BatchSearch batchSearch1 = new BatchSearch(singletonList(proxy("prj1")),"foo","baz",asSet("q1", "q2"), User.local(),
                 false,asList("application/json", "application/text"),null, asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         BatchSearch batchSearch2 = new BatchSearch(singletonList(proxy("prj1")),"bar","baz",asSet("q3", "q2"), User.local(),
-                true,asList("application/json"), null,asList("/path/to/docs", "/path/to/pdfs"),  3,true);
-        BatchSearch batchSearch3 = new BatchSearch(asList(proxy("prj1")),"bar","baz",asSet("q3", "q2"), User.local(),
+                true, List.of("application/json"), null,asList("/path/to/docs", "/path/to/pdfs"),  3,true);
+        BatchSearch batchSearch3 = new BatchSearch(List.of(proxy("prj1")),"bar","baz",asSet("q3", "q2"), User.local(),
                 true,null, null,asList("/path/to/docs", "/path/to/pdfs"),  3,true);
         repository.save(batchSearch1);
         repository.save(batchSearch2);
         repository.save(batchSearch3);
-        List<BatchSearchRecord> all = repository.getRecords(User.local(), asList("prj1"), WebQueryBuilder.createWebQuery().queryAll().withContentTypes(asList("application/json")).build());
+        List<BatchSearchRecord> all = repository.getRecords(User.local(), List.of("prj1"), WebQueryBuilder.createWebQuery().queryAll().withContentTypes(List.of("application/json")).build());
         assertThat(all).hasSize(1);
     }
 
@@ -425,14 +425,14 @@ public class JooqBatchSearchRepositoryTest {
         repository.save(batchSearch);
         repository.saveResults(batchSearch.uuid, "q1", asList(createDoc("doc1").ofMimeType("application/pdf").build(), createDoc("doc2").ofMimeType("content/type").build()));
         repository.saveResults(batchSearch.uuid, "q2", asList(createDoc("doc3").ofMimeType("application/pdf").build(), createDoc("doc4").build()));
-        List<SearchResult> results = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withContentTypes(asList("application/pdf")).build());
+        List<SearchResult> results = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withContentTypes(List.of("application/pdf")).build());
         assertThat(results).hasSize(2);
         assertThat(results).containsExactly(
                 resultFrom(createDoc("doc1").ofMimeType("application/pdf").build(), 1, "q1"),
                 resultFrom(createDoc("doc3").ofMimeType("application/pdf").build(), 1, "q2")
         );
         //empty list means all and no content types
-        List<SearchResult> results2 = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withContentTypes(asList()).build());
+        List<SearchResult> results2 = repository.getResults(User.local(), batchSearch.uuid, WebQueryBuilder.createWebQuery().queryAll().withContentTypes(List.of()).build());
         assertThat(results2).hasSize(4);
 
     }
@@ -475,7 +475,7 @@ public class JooqBatchSearchRepositoryTest {
 
     @Test
     public void test_get_batch_search_queries_order(){
-        LinkedHashSet<String> queryList = new LinkedHashSet<String>() {{
+        LinkedHashSet<String> queryList = new LinkedHashSet<>() {{
             add("q4");
             add("q3");
             add("q2");
@@ -653,7 +653,7 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_queries() {
         List<ProjectProxy> project = singletonList(proxy("prj"));
-        LinkedHashSet<String> bsQueries = new LinkedHashSet<String>() {{
+        LinkedHashSet<String> bsQueries = new LinkedHashSet<>() {{
             add("q2");
             add("q1");
         }};
@@ -675,7 +675,7 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_queries_with_zero_results() {
         List<ProjectProxy> project = singletonList(proxy("prj"));
-        LinkedHashSet<String> bsQueries = new LinkedHashSet<String>() {{
+        LinkedHashSet<String> bsQueries = new LinkedHashSet<>() {{
             add("q1");
             add("q2");
             add("q3");
@@ -694,7 +694,7 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_queries_with_two_as_max_results() {
         List<ProjectProxy> project = singletonList(proxy("foo"));
-        LinkedHashSet<String> bsQueries = new LinkedHashSet<String>() {{
+        LinkedHashSet<String> bsQueries = new LinkedHashSet<>() {{
             add("q1");
             add("q2");
         }};
@@ -713,7 +713,7 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_queries_with_no_max_results() {
         List<ProjectProxy> project = singletonList(proxy("prj"));
-        LinkedHashSet<String> bsQueries = new LinkedHashSet<String>() {{
+        LinkedHashSet<String> bsQueries = new LinkedHashSet<>() {{
             add("q1");
             add("q2");
         }};
@@ -777,7 +777,10 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_queries_with_search_filter() {
         BatchSearch batchSearch = new BatchSearch("uuid", singletonList(proxy("prj")), "name1", "description1",
-                new LinkedHashSet<String>() {{add("query abc");add("def query");}}, new Date(), State.RUNNING, User.local());
+                new LinkedHashSet<>() {{
+                    add("query abc");
+                    add("def query");
+                }}, new Date(), State.RUNNING, User.local());
         repository.save(batchSearch);
         assertThat(repository.getQueries(User.local(), "uuid", 0, 0, "query", null)).hasSize(2);
         assertThat(repository.getQueries(User.local(), "uuid", 0, 0, "def", null)).hasSize(1);
@@ -787,7 +790,10 @@ public class JooqBatchSearchRepositoryTest {
     @Test
     public void test_get_batch_search_queries_with_orderBy_param() {
         BatchSearch batchSearch = new BatchSearch("uuid", singletonList(proxy("prj")), "name1", "description1",
-                new LinkedHashSet<String>() {{add("q2"); add("q1");}}, new Date(), State.RUNNING, User.local());
+                new LinkedHashSet<>() {{
+                    add("q2");
+                    add("q1");
+                }}, new Date(), State.RUNNING, User.local());
         repository.save(batchSearch);
 
         Map<String, Integer> queries = repository.getQueries(User.local(), "uuid", 0, 0, null, "query");

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -747,7 +747,7 @@ public class JooqBatchSearchRepositoryTest {
                 asList("/path/to/docs", "/path/to/pdfs"), 3,true);
 
         repository.save(batchSearch);
-        boolean ok = repository.setNbQueries(batchSearch.uuid,0);
+        boolean ok = repository.resetNbQueries(batchSearch.uuid);
         assertThat(ok).isTrue();
         List<BatchSearchRecord> batchSearchList = repository.getRecords(User.local(), asList("prj1", "prj2"));
         assertThat(batchSearchList).hasSize(1);


### PR DESCRIPTION
The goal of this PR is to use only one DB connection pool for all repositories.

* RepositoryFactory is caching the pool and instantiate each repository with the same pool.
* the LocalMode that was manually creating a pool is using guice injection 