### PR TITLE
fix: log when embedded content is not found

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -56,7 +56,7 @@ public class SourceExtractor {
         }
     }
 
-    public InputStream getEmbeddedSource(final Project project, final Document document) throws FileNotFoundException {
+    public InputStream getEmbeddedSource(final Project project, final Document document) {
         Hasher hasher = Hasher.valueOf(document.getId().length());
         String algorithm = hasher.toString();
         List<DigestingParser.Digester> digesters = new ArrayList<>(List.of());
@@ -77,14 +77,14 @@ public class SourceExtractor {
                     return new ByteArrayInputStream(metadataCleaner.clean(inputStream).getContent());
                 }
                 return inputStream;
-            } catch (FileNotFoundException | ContentNotFoundException _e) {
-                continue;
+            } catch (ContentNotFoundException _e) {
+                // will throw it later
             } catch (SAXException | TikaException | IOException exception) {
                 String message = String.format("extract error for embedded document in project %s / id : %s / routing_id : %s", document.getProject().getName(), document.getId(), document.getRootDocument());
                 throw new ExtractException(message, exception);
             }
         }
 
-        throw new FileNotFoundException();
+        throw new ContentNotFoundException(document.getRootDocument(), document.getId());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <guice.version>4.1.0</guice.version>
         <amazon.version>1.11.327</amazon.version>
 
-        <extract.version>6.1.2</extract.version>
+        <extract.version>6.2.0</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>7.10.2</elasticsearch.version>
         <lucene.version>8.7.0</lucene.version>


### PR DESCRIPTION
when extracting source from a file, we can't know if the file is not found or the content is not found.

Besides there is no logs, we can't know what is going on.