### PR TITLE
fix: previous plugin installation

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/Plugin.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Plugin.java
@@ -55,7 +55,9 @@ public class Plugin extends Extension {
 
     @Override
     public void install(File pluginFile, Path pluginsDir) throws IOException {
-        File[] candidateFiles = ofNullable(pluginsDir.toFile().listFiles((file, s) -> file.isDirectory())).orElse(new File[0]);
+        File[] pluginDirDirectories = pluginsDir.toFile()
+            .listFiles((dir, fileName) -> dir.toPath().resolve(fileName).toFile().isDirectory());
+        File[] candidateFiles = ofNullable(pluginDirDirectories).orElse(new File[0]);
         List<File> previousVersionInstalled = getPreviousVersionInstalled(candidateFiles, getBaseName(getUrlFileName()));
         if (previousVersionInstalled.size() > 0) {
             logger.info("removing previous versions {}", previousVersionInstalled);

--- a/datashare-app/src/test/java/org/icij/datashare/PluginServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/PluginServiceTest.java
@@ -236,6 +236,7 @@ public class PluginServiceTest {
     @Test
     public void test_delete_previous_extension_if_version_differs_with_id() throws Exception {
         pluginFolder.newFolder("my-plugin-1.0.0");
+        pluginFolder.newFile("my-plugin-0.5.0.tar.gz");
         PluginService pluginService = new PluginService(pluginFolder.getRoot().toPath(), new ByteArrayInputStream(("{\"deliverableList\": [" +
                                         "{\"id\":\"my-plugin\", \"version\": \"1.1.0\", \"url\": \"" + ClassLoader.getSystemResource("my-plugin-1.1.0.tgz") + "\"}" +
                                         "]}").getBytes()));


### PR DESCRIPTION
# Bug description

Previous installation removal was failing whenever a file in the `pluginsDir` was matching a plugin pattern.
The remove code was bug and was returning both plugin directories and plugin files with a plugin pattern.

When deleting the file a exception was thrown since we were attempting `FileUtils.deleteDirectory(file)` on files and not directories

# Changes
## `datashare-app`
### Fixed
- fixed the remove of previous plugin installation to attempt to remove only directories matching the plugin pattern inside the `pluginsDir`