### PR TITLE
chore: bump neo4j extension and plugin to `0.3.1`

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -49,9 +49,9 @@
       "id": "datashare-extension-neo4j",
       "name": "neo4j",
       "description": "A Datashare extension to perform graph analysis using neo4j",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.0/datashare-extension-neo4j-0.3.0-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.1/datashare-extension-neo4j-0.3.1-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "type": "WEB"
     }
   ]

--- a/datashare-app/src/main/resources/plugins.json
+++ b/datashare-app/src/main/resources/plugins.json
@@ -66,9 +66,9 @@
     {
       "id": "datashare-plugin-neo4j-graph-widget",
       "description": "A Datashare plugin to create a neo4j graph from Datashare's projects",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.0/datashare-plugin-neo4j-graph-widget-0.3.0.tgz",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.1/datashare-plugin-neo4j-graph-widget-0.3.1.tgz",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "extensions": ["datashare-extension-neo4j"],
       "type": "PLUGIN"
     }


### PR DESCRIPTION
https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.3.1