### PR TITLE
fix: returns a FileResult with size/path #1081

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadLoop.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadLoop.java
@@ -41,8 +41,8 @@ public class BatchDownloadLoop implements Callable<Integer> {
 
                 if (currentTask != null && !POISON.equals(currentTask)) {
                     BatchDownloadRunner downloadRunner = factory.createDownloadRunner(currentTask, taskSupplier::progress);
-                    File zipResult = downloadRunner.call();
-                    taskSupplier.result(currentTask.id, zipResult);
+                    FileResult result = downloadRunner.call();
+                    taskSupplier.result(currentTask.id, result);
                     nbTasks++;
                 }
             } catch (Throwable ex) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/FileResult.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/FileResult.java
@@ -1,0 +1,25 @@
+package org.icij.datashare.tasks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.File;
+import java.io.Serializable;
+
+import static java.lang.String.format;
+
+public class FileResult implements Serializable {
+    public final File file;
+    public final long size;
+
+    @JsonCreator
+    public FileResult(@JsonProperty("file") File file, @JsonProperty("size") long size) {
+        this.file = file;
+        this.size = size;
+    }
+
+    @Override
+    public String toString() {
+        return format("%s (%d bytes)", file, size);
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.tasks;
 
-import org.icij.datashare.batch.BatchDownload;
 import org.icij.datashare.batch.BatchSearch;
 import org.icij.datashare.function.TerFunction;
 import org.icij.datashare.nlp.NlpApp;
@@ -8,13 +7,11 @@ import org.icij.datashare.text.Document;
 import org.icij.datashare.text.nlp.Pipeline;
 import org.icij.datashare.user.User;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 public interface TaskFactory {
     ResumeNlpTask createResumeNlpTask(final User user, Set<Pipeline.Type> pipelines, Properties taskProperties);

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import net.codestory.http.Context;
 import net.codestory.http.annotations.*;
 import net.codestory.http.errors.ForbiddenException;
@@ -94,11 +93,11 @@ public class TaskResource {
     public Payload getTaskResult(@Parameter(name = "id", description = "task id", in = ParameterIn.PATH) String id, Context context) {
         TaskView<?> task = forbiddenIfNotSameUser(context, notFoundIfNull(taskManager.getTask(id)));
         Object result = task.getResult();
-        if (result instanceof File) {
-            final Path appPath = ((File) result).isAbsolute() ?
+        if (result instanceof FileResult) {
+            final Path appPath = ((FileResult) result).file.isAbsolute() ?
                     get(System.getProperty("user.dir")).resolve(context.env().appFolder()) :
                     get(context.env().appFolder());
-            Path resultPath = appPath.relativize(((File) result).toPath());
+            Path resultPath = appPath.relativize(((FileResult) result).file.toPath());
             return new Payload(resultPath).withHeader("Content-Disposition", "attachment;filename=\"" + resultPath.getFileName() + "\"");
         }
         return result == null ? new Payload(204) : new Payload(result);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerIntTest.java
@@ -90,10 +90,9 @@ public class BatchDownloadRunnerIntTest {
         new IndexerHelper(es.client).indexFile("doc2.txt", "Portez ce vieux whisky au juge blond qui fume", fs);
 
         BatchDownload bd = createBatchDownload("*");
-        long sizeAtCreation = bd.zipSize;
-        new BatchDownloadRunner(indexer, createProvider(), createTaskView(bd), taskModifier::progress).call();
+        FileResult result = new BatchDownloadRunner(indexer, createProvider(), createTaskView(bd), taskModifier::progress).call();
 
-        assertThat(bd.zipSize).isGreaterThan(sizeAtCreation);
+        assertThat(result.size).isGreaterThan(0);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerTest.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.zip.ZipFile;
 
@@ -49,24 +48,24 @@ public class BatchDownloadRunnerTest {
         Document[] documents = IntStream.range(0, 3).mapToObj(i -> createDoc("doc" + i).with(createFile(i)).build()).toArray(Document[]::new);
         mockSearch.willReturn(2, documents);
         BatchDownload batchDownload = new BatchDownload(singletonList(project("test-datashare")), User.local(), "query");
-        File zip = new BatchDownloadRunner(indexer, new PropertiesProvider(new HashMap<>() {{
+        FileResult result = new BatchDownloadRunner(indexer, new PropertiesProvider(new HashMap<>() {{
                     put(BATCH_DOWNLOAD_MAX_NB_FILES, "3");
                     put(SCROLL_SIZE, "3");
                 }}), getTaskView(batchDownload), updater::progress).call();
 
-        assertThat(new ZipFile(zip).size()).isEqualTo(3);
+        assertThat(new ZipFile(result.file).size()).isEqualTo(3);
     }
 
     @Test
     public void test_max_zip_size() throws Exception {
         Document[] documents = IntStream.range(0, 3).mapToObj(i -> createDoc("doc" + i).with(createFile(i)).with("hello world " + i).build()).toArray(Document[]::new);
         mockSearch.willReturn(2, documents);
-        File zip = new BatchDownloadRunner(indexer, new PropertiesProvider(new HashMap<>() {{
+        FileResult result = new BatchDownloadRunner(indexer, new PropertiesProvider(new HashMap<>() {{
             put(BATCH_DOWNLOAD_MAX_SIZE, valueOf("hello world 1".getBytes(StandardCharsets.UTF_8).length * 3));
             put(SCROLL_SIZE, "3");
         }}), getTaskView(new BatchDownload(singletonList(project("test-datashare")), User.local(), "query")), updater::progress).call();
 
-        assertThat(new ZipFile(zip).size()).isEqualTo(4);
+        assertThat(new ZipFile(result.file).size()).isEqualTo(4);
     }
 
     @Test(expected = ElasticsearchStatusException.class)

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
@@ -17,6 +17,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -82,9 +83,11 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_get_task_result_with_file_result__should_relativize_result_with_app_folder() {
+    public void test_get_task_result_with_file_result__should_relativize_result_with_app_folder() throws Exception {
         setupAppWith("foo");
-        TaskView<File> t = taskManager.startTask(new DummyUserTask<>("foo", () -> Paths.get("app", "index.html").toFile()));
+        File file = new File(ClassLoader.getSystemResource("app/index.html").toURI());
+        FileResult indexHtml = new FileResult(file, Files.size(file.toPath()));
+        TaskView<FileResult> t = taskManager.startTask(new DummyUserTask<>("foo", () -> indexHtml));
         get("/api/task/" + t.id + "/result").withPreemptiveAuthentication("foo", "qux").
                 should().respond(200).
                 should().haveType("text/html;charset=UTF-8").
@@ -95,8 +98,9 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_task_result_with_file_result_and_absolute_path__should_relativize_result_with_app_folder() throws Exception {
         setupAppWith("foo");
-        File indexHtml = new File(ClassLoader.getSystemResource("app/index.html").toURI());
-        TaskView<File> t = taskManager.startTask(new DummyUserTask<>("foo", () -> indexHtml));
+        File file = new File(ClassLoader.getSystemResource("app/index.html").toURI());
+        FileResult indexHtml = new FileResult(file, Files.size(file.toPath()));
+        TaskView<FileResult> t = taskManager.startTask(new DummyUserTask<>("foo", () -> indexHtml));
 
         get("/api/task/" + t.id + "/result").withPreemptiveAuthentication("foo", "qux").should().respond(200);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>12.4.2</datashare-api.version>
+        <datashare-api.version>12.4.3</datashare-api.version>
         <datashare-cli.version>13.5.0</datashare-cli.version>
 
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
This PR to avoid side effect on BatchDownload object (removed the `setSize` method in `datashare-api`).

Instead, the size of the zip is returned to front by the result of the task.