### PR TITLE
chore: bump neo4j extension and plugin to `0.3.6`

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -49,9 +49,9 @@
       "id": "datashare-extension-neo4j",
       "name": "neo4j",
       "description": "A Datashare extension to perform graph analysis using neo4j",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.2/datashare-extension-neo4j-0.3.2-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.6/datashare-extension-neo4j-0.3.6-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.3.2",
+      "version": "0.3.6",
       "type": "WEB"
     }
   ]

--- a/datashare-app/src/main/resources/plugins.json
+++ b/datashare-app/src/main/resources/plugins.json
@@ -66,9 +66,9 @@
     {
       "id": "datashare-plugin-neo4j-graph-widget",
       "description": "A Datashare plugin to create a neo4j graph from Datashare's projects",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.2/datashare-plugin-neo4j-graph-widget-0.3.2.tgz",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.6/datashare-plugin-neo4j-graph-widget-0.3.6.tgz",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.3.2",
+      "version": "0.3.6",
       "extensions": ["datashare-extension-neo4j"],
       "type": "PLUGIN"
     }


### PR DESCRIPTION
Bump from [`0.3.2` to `0.3.6`](https://github.com/ICIJ/datashare-extension-neo4j/compare/0.3.2...0.3.6):
- https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.3.2
- https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.3.3
- https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.3.4
- https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.3.5
- https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.3.6