### PR TITLE
chore: bump neo4j to `0.3.12`

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -49,9 +49,9 @@
       "id": "datashare-extension-neo4j",
       "name": "neo4j",
       "description": "A Datashare extension to perform graph analysis using neo4j",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.6/datashare-extension-neo4j-0.3.6-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.12/datashare-extension-neo4j-0.3.12-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.3.6",
+      "version": "0.3.12",
       "type": "WEB"
     }
   ]

--- a/datashare-app/src/main/resources/plugins.json
+++ b/datashare-app/src/main/resources/plugins.json
@@ -66,9 +66,9 @@
     {
       "id": "datashare-plugin-neo4j-graph-widget",
       "description": "A Datashare plugin to create a neo4j graph from Datashare's projects",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.6/datashare-plugin-neo4j-graph-widget-0.3.6.tgz",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.3.12/datashare-plugin-neo4j-graph-widget-0.3.12.tgz",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.3.6",
+      "version": "0.3.12",
       "extensions": ["datashare-extension-neo4j"],
       "type": "PLUGIN"
     }

--- a/launchBack.sh
+++ b/launchBack.sh
@@ -36,6 +36,5 @@ $JAVA -agentlib:jdwp=transport=dt_socket,server=y,address=$JDWP_TRANSPORT_PORT,s
  --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED \
  -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \
  -Djavax.net.ssl.trustStorePassword=changeit \
-  -Djava.net.preferIPv4Stack=true \
  -Ddatashare.loghost=udp:localhost -Dlogback.configurationFile=logback.xml \
  -Xmx4g -DPROD_MODE=true -cp "$DIR/dist/:${CLASSPATH}" org.icij.datashare.Main $OAUTH_LOCAL_OPTIONS "$@"


### PR DESCRIPTION
# Changes
## `neo4j-app`
### Changed
- bump the neo4j extension to [0.3.12](https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.3.12)
- reverted change committed by error in `launchBack.sh`
