### PR TITLE
Feat: AMQP embedded Qpid

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/com/bus/amqp/QpidAmqpServer.java
+++ b/datashare-app/src/main/java/org/icij/datashare/com/bus/amqp/QpidAmqpServer.java
@@ -21,7 +21,7 @@ public class QpidAmqpServer {
         System.setProperty("qpid.amqp_port", String.valueOf(port));
     }
 
-    public void start() throws Exception {
+    public void start() {
         try {
             systemLauncher.startup(createSystemConfig());
         } catch (Exception e) {

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -304,7 +304,7 @@ public abstract class CommonMode extends AbstractModule {
     }
 
     @NotNull
-    private static Mode getMode(Properties properties) {
+    public static Mode getMode(Properties properties) {
         return Mode.valueOf(ofNullable(properties).orElse(new Properties()).getProperty("mode"));
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadCleaner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadCleaner.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
 import static java.util.regex.Pattern.compile;
 
 public class BatchDownloadCleaner implements Runnable {
@@ -27,7 +28,7 @@ public class BatchDownloadCleaner implements Runnable {
     @Override
     public void run() {
         logger.debug("deleting temporary zip files from {}", downloadDir);
-        stream(requireNonNull(downloadDir.toFile().listFiles()))
+        stream(ofNullable(downloadDir.toFile().listFiles()).orElse(new File[] {}))
                 .filter(f -> filePattern.matcher(f.getName()).matches())
                 .filter(f -> DatashareTime.getInstance().currentTimeMillis() - f.lastModified() >= ttlHour * 1000L * 60 * 60)
                 .forEach(File::delete);


### PR DESCRIPTION
Adds the start of AMQP [Qpid](https://qpid.apache.org) broker in local mode to interact with tasks written in other languages via AMQP.

It will be started if:
* it is in embedded mode
* there is an AMQP queue in options

Plus a small fix on BatchDownloadCleaner when the batch download dir doesn't exist.

