### PR TITLE
chore: bump neo4j extension and plugin to `0.4.2`

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -49,9 +49,9 @@
       "id": "datashare-extension-neo4j",
       "name": "Neo4j",
       "description": "A Datashare extension to perform graph analysis using neo4j",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.4.0/datashare-extension-neo4j-0.4.0-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.4.2/datashare-extension-neo4j-0.4.2-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "type": "WEB"
     }
   ]

--- a/datashare-app/src/main/resources/plugins.json
+++ b/datashare-app/src/main/resources/plugins.json
@@ -67,9 +67,9 @@
       "id": "datashare-plugin-neo4j-graph-widget",
       "name": "Neo4j Graph Widget",
       "description": "A Datashare plugin to create a neo4j graph from Datashare's projects",
-      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.4.0/datashare-plugin-neo4j-graph-widget-0.4.0.tgz",
+      "url": "https://github.com/ICIJ/datashare-extension-neo4j/releases/download/0.4.2/datashare-plugin-neo4j-graph-widget-0.4.2.tgz",
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "extensions": ["datashare-extension-neo4j"],
       "type": "PLUGIN"
     }


### PR DESCRIPTION
https://github.com/ICIJ/datashare-extension-neo4j/releases/tag/0.4.2