### PR TITLE
feat: optional plugins and extensions dirs

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -272,7 +272,7 @@ public abstract class CommonMode extends AbstractModule {
                 new ExtensionLoader(Paths.get(extensionsDir)).load((Consumer<Class<?>>)routes::add,
                         c -> c.isAnnotationPresent(Prefix.class) || c.isAnnotationPresent(Get.class));
             } catch (FileNotFoundException e) {
-                logger.info("extensions dir not found", e);
+                logger.warn("Extensions directory not found: " + extensionsDir);
             }
         }
         return routes;

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -68,6 +68,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
+import java.util.function.Consumer;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT;
 import static java.util.Optional.ofNullable;
@@ -306,7 +307,7 @@ public abstract class CommonMode extends AbstractModule {
         try {
             Path extensionsPath = Paths.get(extensionsDir);
             ExtensionLoader loader = new ExtensionLoader(extensionsPath);
-            loader.load(routes::add, this::isEligibleForLoading);
+            loader.load((Consumer<Class<?>>) routes::add, this::isEligibleForLoading);
         } catch (FileNotFoundException e) {
             logger.warn("Extensions directory not found: " + extensionsDir);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
@@ -52,7 +52,7 @@ public class RootResource {
             content = new String(Files.readAllBytes(index), Charset.defaultCharset());
         }
         List<String> projectNames = context.currentUser() == null ? new LinkedList<>() : ((DatashareUser)context.currentUser()).getProjectNames();
-        if (propertiesProvider.get(PLUGINS_DIR).isPresent()) {
+        if (this.hasPluginsDir()) {
             ExtensionService extensionService = propertiesProvider.get(EXTENSIONS_DIR).isPresent() ? new ExtensionService(propertiesProvider): null;
             return new PluginService(propertiesProvider, extensionService)
                 .addPlugins(content, projectNames);
@@ -89,5 +89,10 @@ public class RootResource {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private boolean hasPluginsDir() {
+        String pluginsDir = propertiesProvider.get(PLUGINS_DIR).orElse(null);
+        return pluginsDir != null && new File(pluginsDir).isDirectory();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
@@ -52,10 +52,9 @@ public class RootResource {
             content = new String(Files.readAllBytes(index), Charset.defaultCharset());
         }
         List<String> projectNames = context.currentUser() == null ? new LinkedList<>() : ((DatashareUser)context.currentUser()).getProjectNames();
-        if (this.hasPluginsDir()) {
-            ExtensionService extensionService = propertiesProvider.get(EXTENSIONS_DIR).isPresent() ? new ExtensionService(propertiesProvider): null;
-            return new PluginService(propertiesProvider, extensionService)
-                .addPlugins(content, projectNames);
+        PluginService pluginService = createPluginService();
+        if (pluginService != null) {
+            return pluginService.addPlugins(content, projectNames);
         }
         return content;
     }
@@ -94,5 +93,24 @@ public class RootResource {
     private boolean hasPluginsDir() {
         String pluginsDir = propertiesProvider.get(PLUGINS_DIR).orElse(null);
         return pluginsDir != null && new File(pluginsDir).isDirectory();
+    }
+
+    private boolean hasExtensionsDir() {
+        String pluginsDir = propertiesProvider.get(EXTENSIONS_DIR).orElse(null);
+        return pluginsDir != null && new File(pluginsDir).isDirectory();
+    }
+
+    private ExtensionService createExtensionService() {
+        if (this.hasExtensionsDir()) {
+            return new ExtensionService(propertiesProvider);
+        }
+        return null;
+    }
+
+    private PluginService createPluginService() {
+        if (this.hasPluginsDir()) {
+            return new PluginService(propertiesProvider, createExtensionService());
+        }
+        return null;
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeWebExtensionTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeWebExtensionTest.java
@@ -51,7 +51,7 @@ public class CommonModeWebExtensionTest extends AbstractProdWebServerTest {
                 "    }\n" +
                 "}", method, method, method);
         createJar(pluginFolder.getRoot().toPath(), "extension", source);
-        configure(routes -> mode.addExtensionConfiguration(routes));
+        configure(routes -> mode.addExtensionsConfiguration(routes));
 
         Method restAssertMethod = FluentRestTest.class.getMethod(method.toLowerCase(), String.class);
         return (RestAssert) restAssertMethod.invoke(this, ofNullable(prefix).orElse("") + "/url");

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeWebExtensionTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeWebExtensionTest.java
@@ -3,7 +3,6 @@ package org.icij.datashare.mode;
 import net.codestory.rest.FluentRestTest;
 import net.codestory.rest.RestAssert;
 import org.icij.datashare.cli.Mode;
-import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
 import org.junit.Rule;
@@ -25,7 +24,8 @@ import static org.icij.datashare.test.JarUtil.createJar;
 @RunWith(Parameterized.class)
 public class CommonModeWebExtensionTest extends AbstractProdWebServerTest {
     private final String method;
-    @Rule public TemporaryFolder pluginFolder = new TemporaryFolder();
+    @Rule public TemporaryFolder pluginsDir = new TemporaryFolder();
+    @Rule public TemporaryFolder extensionsDir = new TemporaryFolder();
     CommonMode mode;
     @Parameterized.Parameters
     public static Collection<Object[]> methods() {
@@ -50,7 +50,7 @@ public class CommonModeWebExtensionTest extends AbstractProdWebServerTest {
                 "        return \"hello from foo extension with %s\";\n" +
                 "    }\n" +
                 "}", method, method, method);
-        createJar(pluginFolder.getRoot().toPath(), "extension", source);
+        createJar(extensionsDir.getRoot().toPath(), "extension", source);
         configure(routes -> mode.addExtensionsConfiguration(routes));
 
         Method restAssertMethod = FluentRestTest.class.getMethod(method.toLowerCase(), String.class);
@@ -63,7 +63,8 @@ public class CommonModeWebExtensionTest extends AbstractProdWebServerTest {
     public void setUp() {
         mode = CommonMode.create(new HashMap<>() {{
             put("mode", Mode.LOCAL.name());
-            put("extensionsDir", pluginFolder.getRoot().toString());
+            put("pluginsDir", pluginsDir.getRoot().toString());
+            put("extensionsDir", extensionsDir.getRoot().toString());
         }});
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
@@ -74,15 +74,7 @@ public class RootResourcePluginTest implements FluentRestTest {
         get("/").should().respond(200).contain("datashare-client");
         get("").should().respond(200).contain("datashare-client");
     }
-
-
-    @Test
-    public void test_invalid_folder_should_throw_error() {
-        server.configure(routes -> routes.add(new RootResource(new PropertiesProvider(new HashMap<String, String>() {{
-            put("pluginsDir", "unknown");
-        }}))));
-        get("/").should().respond(500);
-    }
+    
 
     @Test
     public void test_get_with_empty_plugin_directory() {

--- a/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/RootResourcePluginTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import static java.nio.file.Files.copy;
 import static java.util.Arrays.asList;
@@ -65,6 +66,15 @@ public class RootResourcePluginTest implements FluentRestTest {
         get("/").should().respond(200).contain("datashare-client");
         get("").should().respond(200).contain("datashare-client");
     }
+
+    @Test
+    public void test_get_with_missing_plugin_directory() {
+        propertiesProvider = new PropertiesProvider(Map.of("pluginsDir", "/something/missing/"));
+        server.configure(routes -> routes.add(new RootResource(propertiesProvider)));
+        get("/").should().respond(200).contain("datashare-client");
+        get("").should().respond(200).contain("datashare-client");
+    }
+
 
     @Test
     public void test_invalid_folder_should_throw_error() {


### PR DESCRIPTION
## PR description

This PR ensures that invalid plugins and extensions dirs won't crash the application (#1329).

## Changes

* feat: check for plugins dir existence before loading it in `RootResource`
* feat: check for extensions dir existence before loading it in `RootResource`
* feat: check for plugins dir existence before adding to the CommonMode routes
* refactor: show warnings at startup when using invalid plugins and extensions dirs