### PR TITLE
fix: batch search relaunch

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -99,7 +99,7 @@ public class BatchSearchRunner implements Callable<Integer>, Monitorable, UserTa
                             .withPrefixQuery("path", batchSearch.paths.toArray(new String[]{}))
                             .with(batchSearch.fuzziness, batchSearch.phraseMatches)
                             .withoutSource("content").limit(scrollSize);
-                    docsToProcess = searcher.scroll(query).collect(toList());
+                    docsToProcess = searcher.scroll().collect(toList());
                 }
 
                 long beforeScrollLoop = DatashareTime.getInstance().currentTimeMillis();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -99,7 +99,7 @@ public class BatchSearchRunner implements Callable<Integer>, Monitorable, UserTa
                             .withPrefixQuery("path", batchSearch.paths.toArray(new String[]{}))
                             .with(batchSearch.fuzziness, batchSearch.phraseMatches)
                             .withoutSource("content").limit(scrollSize);
-                    docsToProcess = searcher.scroll().collect(toList());
+                    docsToProcess = searcher.scroll(query).collect(toList());
                 }
 
                 long beforeScrollLoop = DatashareTime.getInstance().currentTimeMillis();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
@@ -163,6 +163,32 @@ public class BatchSearchRunnerIntTest {
     }
 
     @Test
+    public void test_search_with_query_template() throws Exception {
+        String queryBody = "{\"bool\":{\"must\":[{\"match_all\":{}},{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"<query>\"}}]}},{\"match\":{\"type\":\"Document\"}}]}}";
+        Document mydoc = createDoc("docId").with("mydoc to find").build();
+        indexer.add(TEST_INDEX, mydoc);
+        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(),false, null, queryBody,
+                null, 0);
+
+        new BatchSearchRunner(indexer, new PropertiesProvider(), searchOk, resultConsumer).call();
+
+        verify(resultConsumer).apply(searchOk.uuid, "mydoc", singletonList(mydoc));
+    }
+
+
+    @Test
+    public void test_search_without_query_template() throws Exception {
+        Document mydoc = createDoc("docId").with("mydoc to find").build();
+        indexer.add(TEST_INDEX, mydoc);
+        BatchSearch searchOk = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(),false, null, null,
+                null, 0);
+
+        new BatchSearchRunner(indexer, new PropertiesProvider(), searchOk, resultConsumer).call();
+
+        verify(resultConsumer).apply(searchOk.uuid, "mydoc", singletonList(mydoc));
+    }
+
+    @Test
     public void test_search_with_error() throws Exception {
         Document mydoc = createDoc("docId1").with("mydoc").build();
         indexer.add(TEST_INDEX, mydoc);

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -54,7 +54,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                                     BATCH_SEARCH.PATHS, BATCH_SEARCH.FUZZINESS, BATCH_SEARCH.PHRASE_MATCHES, BATCH_SEARCH.NB_QUERIES).
                             values(batchSearch.uuid, batchSearch.name, batchSearch.description, batchSearch.user.id,
                                     new Timestamp(batchSearch.date.getTime()), batchSearch.state.name(), batchSearch.published ? 1 : 0,
-                                    join(LIST_SEPARATOR, batchSearch.fileTypes), join(LIST_SEPARATOR, batchSearch.queryTemplate.toString()),
+                                    join(LIST_SEPARATOR, batchSearch.fileTypes), batchSearch.queryTemplate.toString(),
                                     join(LIST_SEPARATOR, batchSearch.paths), batchSearch.fuzziness, batchSearch.phraseMatches ? 1 : 0, batchSearch.nbQueries).execute();
 
                     InsertValuesStep4<BatchSearchQueryRecord, String, String, Integer, Integer> insertQuery = inner.insertInto(BATCH_SEARCH_QUERY, BATCH_SEARCH_QUERY.SEARCH_UUID, BATCH_SEARCH_QUERY.QUERY, BATCH_SEARCH_QUERY.QUERY_NUMBER, BATCH_SEARCH_QUERY.QUERY_RESULTS);

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -5,6 +5,7 @@ import org.icij.datashare.batch.BatchSearchRecord.State;
 import org.icij.datashare.test.DatashareTimeRule;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.ProjectProxy;
+import org.icij.datashare.text.indexing.SearchQuery;
 import org.icij.datashare.time.DatashareTime;
 import org.icij.datashare.user.User;
 import org.jooq.exception.DataAccessException;
@@ -70,6 +71,32 @@ public class JooqBatchSearchRepositoryTest {
         assertThat(batchSearchFromGet.projects).isEqualTo(batchSearch.projects);
         assertThat(batchSearchFromGet.user).isEqualTo(User.local());
     }
+
+    @Test
+    public void test_save_and_get_batch_search_null_query_template() {
+        BatchSearch batchSearch = new BatchSearch(asList(proxy("prj1"), proxy("prj2")), "name1", "description1",
+                asSet("q1", "q2"), User.local(), true, asList("application/json", "image/jpeg"), null,
+                asList("/path/to/docs", "/path/to/pdfs"), 3,true);
+
+        repository.save(batchSearch);
+
+        BatchSearch batchSearchFromGet = repository.get(batchSearch.uuid);
+
+        assertThat(batchSearchFromGet.name).isEqualTo(batchSearch.name);
+        assertThat(batchSearchFromGet.published).isEqualTo(batchSearch.published);
+        assertThat(batchSearchFromGet.fileTypes).isEqualTo(batchSearch.fileTypes);
+        assertThat(batchSearchFromGet.queryTemplate).isEqualTo(new SearchQuery(null));
+        assertThat(batchSearchFromGet.paths).isEqualTo(batchSearch.paths);
+        assertThat(batchSearchFromGet.fuzziness).isEqualTo(batchSearch.fuzziness);
+        assertThat(batchSearchFromGet.description).isEqualTo(batchSearch.description);
+        assertThat(batchSearchFromGet.nbResults).isEqualTo(batchSearch.nbResults);
+        assertThat(batchSearchFromGet.phraseMatches).isEqualTo(batchSearch.phraseMatches);
+        assertThat(batchSearchFromGet.queries).isEqualTo(batchSearch.queries);
+        assertThat(batchSearchFromGet.nbQueries).isEqualTo(batchSearch.nbQueries);
+        assertThat(batchSearchFromGet.projects).isEqualTo(batchSearch.projects);
+        assertThat(batchSearchFromGet.user).isEqualTo(User.local());
+    }
+
 
     @Test
     public void test_get_batch_search_by_user_with_projects_without_queries() {


### PR DESCRIPTION
Related to [this issue](https://github.com/ICIJ/datashare/issues/1322)

This PR implements : 

- Fix the saving function for the Batch Search into the DB, the query template field couldn't be saved as a null value
- Without the previous fix it was impossible for the runner to do the search properly

The last thing to do is to migrate the `query_template` field by replacing empty values ("") by null values