### PR TITLE
feat: ensure consistancy when creating/deleting queues in LOCAL mode

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -297,9 +297,34 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_delete_project_and_its_queue() {
+    public void test_delete_project_and_it_legacy_queue() {
         Project foo = new Project("foo");
         DocumentQueue<Path> queue = documentCollectionFactory.createQueue("extract:queue:foo", Path.class);
+        when(repository.getProjects(any())).thenReturn(List.of(foo));
+        when(repository.deleteAll("foo")).thenReturn(true);
+        queue.add(Path.of("/"));
+        assertThat(queue.size()).isEqualTo(1);
+        delete("/api/project/foo").should().respond(204);
+        assertThat(queue.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_delete_project_and_it_index_queue() {
+        Project foo = new Project("foo");
+        DocumentQueue<Path> queue = documentCollectionFactory.createQueue("extract:queue:foo:index", Path.class);
+        when(repository.getProjects(any())).thenReturn(List.of(foo));
+        when(repository.deleteAll("foo")).thenReturn(true);
+        queue.add(Path.of("/"));
+        assertThat(queue.size()).isEqualTo(1);
+        delete("/api/project/foo").should().respond(204);
+        assertThat(queue.size()).isEqualTo(0);
+    }
+
+
+    @Test
+    public void test_delete_project_and_it_nlp_queue() {
+        Project foo = new Project("foo");
+        DocumentQueue<Path> queue = documentCollectionFactory.createQueue("extract:queue:foo:index", Path.class);
         when(repository.getProjects(any())).thenReturn(List.of(foo));
         when(repository.deleteAll("foo")).thenReturn(true);
         queue.add(Path.of("/"));


### PR DESCRIPTION
## PR description

While debugging #1333 we discovered the queues are not correctly deleted when deleting a project. To avoid this issue from happening again, this PR adds more constraints to the queues created in LOCAL (from the client).

## Changes

* feat: scan and index endpoint constraint the queueName based on the project name 
* feat: project deletion endpoint deletes queues from every stage
* refactor: find queues to delete using the PipelineHelper class