### PR TITLE
fix: scan index task project

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -9,7 +9,6 @@ import org.icij.datashare.tasks.TaskFactory;
 import org.icij.datashare.tasks.TaskManagerMemory;
 import org.icij.datashare.tasks.TaskView;
 import org.icij.datashare.text.indexing.Indexer;
-import org.icij.datashare.text.nlp.Pipeline;
 import org.icij.extract.queue.DocumentQueue;
 import org.redisson.api.RedissonClient;
 import org.slf4j.Logger;
@@ -22,7 +21,6 @@ import java.util.Properties;
 
 import static java.util.Optional.ofNullable;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.icij.datashare.PropertiesProvider.MAP_NAME_OPTION;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
 import static org.icij.datashare.user.User.localUser;
 import static org.icij.datashare.user.User.nullUser;
@@ -107,7 +105,7 @@ class CliApp {
         }
 
         if (pipeline.has(Stage.SCANIDX)) {
-            TaskView<Long> taskView = taskManager.startTask(taskFactory.createScanIndexTask(nullUser(), ofNullable(properties.getProperty(MAP_NAME_OPTION)).orElse("extract:report")));
+            TaskView<Long> taskView = taskManager.startTask(taskFactory.createScanIndexTask(nullUser(), properties));
             logger.info("scanned {}", taskView.getResult(true));
         }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -28,9 +28,9 @@ public class DeduplicateTask extends PipelineTask<Path> {
 
     @Override
     public Long call() throws Exception {
-        int duplicates = queue.removeDuplicates();
+        int duplicates = inputQueue.removeDuplicates();
         transferToOutputQueue();
-        logger.info("removed {} duplicate paths in queue {}", duplicates, queue.getName());
+        logger.info("removed {} duplicate paths in inputQueue {}", duplicates, inputQueue.getName());
         return (long)duplicates;
     }
 
@@ -39,10 +39,10 @@ public class DeduplicateTask extends PipelineTask<Path> {
     }
 
     long transferToOutputQueue(Predicate<Path> filter) throws Exception {
-        long originalSize = queue.size();
+        long originalSize = inputQueue.size();
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
             Path path;
-            while (!(path = queue.take()).equals(PATH_POISON)) {
+            while (!(path = inputQueue.take()).equals(PATH_POISON)) {
                 if (filter.test(path)) {
                     outputQueue.add(path);
                 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -51,10 +51,10 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
 
     @Override
     public Long call() throws Exception {
-        logger.info("extracting Named Entities with pipeline {} for {} from queue {}", nlpPipeline.getType(), project, queue.getName());
+        logger.info("extracting Named Entities with pipeline {} for {} from queue {}", nlpPipeline.getType(), project, inputQueue.getName());
         String docId;
         long nbMessages = 0;
-        while (!(STRING_POISON.equals(docId = queue.poll(60, TimeUnit.SECONDS)))) {
+        while (!(STRING_POISON.equals(docId = inputQueue.poll(60, TimeUnit.SECONDS)))) {
             try {
                 if (docId != null) {
                     findNamedEntities(project, docId);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -55,7 +55,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
             logger.info("report map enabled with name set to {}", propertiesProvider.getProperties().get(MAP_NAME_OPTION));
             consumer.setReporter(new Reporter(factory.createMap(propertiesProvider.getProperties().get(MAP_NAME_OPTION).toString())));
         }
-        drainer = new DocumentQueueDrainer<>(queue, consumer).configure(allTaskOptions);
+        drainer = new DocumentQueueDrainer<>(inputQueue, consumer).configure(allTaskOptions);
     }
 
     @Override
@@ -83,7 +83,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
 
     @Override
     public double getProgressRate() {
-        totalToProcess = max(queue.size(), totalToProcess);
-        return (double)(totalToProcess - queue.size()) / totalToProcess;
+        totalToProcess = max(inputQueue.size(), totalToProcess);
+        return (double)(totalToProcess - inputQueue.size()) / totalToProcess;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -13,26 +13,47 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserTask {
-    protected final DocumentQueue<T> queue;
+    protected final DocumentQueue<T> inputQueue;
+    protected final DocumentQueue<T> outputQueue;
     protected final Stage stage;
     protected final User user;
     protected final PropertiesProvider propertiesProvider;
+    private final DocumentCollectionFactory<T> factory;
     public static Path PATH_POISON = Paths.get("POISON");
     public static String STRING_POISON = "POISON";
 
-    public PipelineTask(Stage stage, User user, String queueName, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz) {
-        this.queue = factory.createQueue(queueName, clazz);
+
+    public PipelineTask(Stage stage, User user, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz) {
         this.propertiesProvider = propertiesProvider;
         this.stage = stage;
         this.user = user;
-    }
-
-    public PipelineTask(Stage stage, User user, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz) {
-        this(stage, user, new PipelineHelper(propertiesProvider).getQueueNameFor(stage), factory, propertiesProvider, clazz);
+        this.factory = factory;
+        this.inputQueue = getInputQueue(clazz);
+        this.outputQueue = getOutputQueue(clazz);
     }
 
     @Override
     public User getUser() { return user;}
+
+    protected DocumentQueue<T> getInputQueue(Class<T> clazz) {
+        String queueName = getInputQueueName();
+        if (queueName != null) {
+            return factory.createQueue(queueName, clazz);
+        }
+        return null;
+    }
+
+    protected DocumentQueue<T> getOutputQueue(Class<T> clazz) {
+        String queueName = getOutputQueueName();
+        if (queueName != null) {
+            return factory.createQueue(queueName, clazz);
+        }
+        return null;
+    }
+
+    protected String getInputQueueName() {
+        return new PipelineHelper(propertiesProvider).getQueueNameFor(stage);
+    }
 
     protected String getOutputQueueName() {
         return new PipelineHelper(propertiesProvider).getOutputQueueNameFor(stage);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.IntStream;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 
@@ -40,8 +41,8 @@ public class ScanIndexTask extends PipelineTask<Path> implements UserTask {
     private final int scrollSlices;
 
     @Inject
-    public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer, @Assisted User user, @Assisted PropertiesProvider propertiesProvider) {
-        super(Stage.SCANIDX, user, new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.SCANIDX), factory, propertiesProvider, Path.class);
+    public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer, @Assisted User user, @Assisted Properties properties) {
+        super(Stage.SCANIDX, user, factory, new PropertiesProvider(properties), Path.class);
         this.user = user;
         this.scrollSize = parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse("1000"));
         this.scrollSlices = parseInt(propertiesProvider.get("scrollSlices").orElse("1"));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
@@ -40,14 +40,13 @@ public class ScanIndexTask extends PipelineTask<Path> implements UserTask {
     private final int scrollSlices;
 
     @Inject
-    public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer, final PropertiesProvider propertiesProvider,
-                         @Assisted User user, @Assisted String reportName) {
+    public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer, @Assisted User user, @Assisted PropertiesProvider propertiesProvider) {
         super(Stage.SCANIDX, user, new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.SCANIDX), factory, propertiesProvider, Path.class);
         this.user = user;
         this.scrollSize = parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse("1000"));
         this.scrollSlices = parseInt(propertiesProvider.get("scrollSlices").orElse("1"));
-        this.projectName = propertiesProvider.get("defaultProject").orElse("local-datashare");
-        this.reportMap = factory.createMap(reportName);
+        this.projectName = propertiesProvider.get(PropertiesProvider.DEFAULT_PROJECT_OPTION).orElse("local-datashare");
+        this.reportMap = factory.createMap(propertiesProvider.get(PropertiesProvider.MAP_NAME_OPTION).orElse("extract:report"));
         this.indexer = indexer;
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
@@ -23,18 +23,17 @@ public class ScanTask extends PipelineTask<Path> {
 
     @Inject
     public ScanTask(final DocumentCollectionFactory<Path> factory, @Assisted User user, @Assisted Path path, @Assisted final Properties properties) {
-        super(Stage.SCAN, user, new PipelineHelper(new PropertiesProvider(properties)).getOutputQueueNameFor(Stage.SCAN),
-                factory, new PropertiesProvider(properties), Path.class);
+        super(Stage.SCAN, user, factory, new PropertiesProvider(properties), Path.class);
         this.path = path;
         Options<String> allOptions = options().createFrom(Options.from(properties));
-        scanner = new Scanner(queue).configure(allOptions);
+        scanner = new Scanner(outputQueue).configure(allOptions);
     }
 
     @Override
     public Long call() throws Exception {
         ScannerVisitor scannerVisitor = scanner.createScannerVisitor(path);
         Long scanned = scannerVisitor.call();
-        queue.add(PATH_POISON);
+        outputQueue.add(PATH_POISON);
         return scanned;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
@@ -19,7 +19,7 @@ public interface TaskFactory {
     DelApiKeyTask createDelApiKey(User user);
     GetApiKeyTask createGetApiKey(User user);
 
-    ScanIndexTask createScanIndexTask(final User user, final Properties properties);
+    ScanIndexTask createScanIndexTask(final User user, Properties properties);
     ScanTask createScanTask(final User user, final Path path, Properties properties);
     IndexTask createIndexTask(final User user, final Properties properties);
     ExtractNlpTask createNlpTask(final User user, final Properties properties);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
@@ -19,7 +19,7 @@ public interface TaskFactory {
     DelApiKeyTask createDelApiKey(User user);
     GetApiKeyTask createGetApiKey(User user);
 
-    ScanIndexTask createScanIndexTask(User user, String reportName);
+    ScanIndexTask createScanIndexTask(final User user, final Properties properties);
     ScanTask createScanTask(final User user, final Path path, Properties properties);
     IndexTask createIndexTask(final User user, final Properties properties);
     ExtractNlpTask createNlpTask(final User user, final Properties properties);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFactory.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.tasks;
 
+import com.fasterxml.jackson.databind.annotation.JsonAppend;
+import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.batch.BatchSearch;
 import org.icij.datashare.function.TerFunction;
 import org.icij.datashare.text.Document;
@@ -19,7 +21,7 @@ public interface TaskFactory {
     DelApiKeyTask createDelApiKey(User user);
     GetApiKeyTask createGetApiKey(User user);
 
-    ScanIndexTask createScanIndexTask(final User user, Properties properties);
+    ScanIndexTask createScanIndexTask(final User user, final Properties properties);
     ScanTask createScanTask(final User user, final Path path, Properties properties);
     IndexTask createIndexTask(final User user, final Properties properties);
     ExtractNlpTask createNlpTask(final User user, final Properties properties);

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -158,12 +158,10 @@ public class TaskResource {
     public List<TaskView<Long>> indexFile(@Parameter(name = "filePath", description = "path of the directory", in = ParameterIn.PATH) final String filePath, final OptionsWrapper<String> optionsWrapper, Context context) throws Exception {
         TaskView<Long> scanResponse = scanFile(filePath, optionsWrapper, context);
         Properties properties = applyProjectProperties(optionsWrapper);
-        String reportName = properties.get(MAP_NAME_OPTION).toString();
         User user = (User) context.currentUser();
         // Use a report map only if the request's body contains a "filter" attribute
         if (properties.get("filter") != null && parseBoolean(properties.getProperty("filter"))) {
-            taskFactory.createScanIndexTask(user, reportName).call();
-            properties.put(MAP_NAME_OPTION, reportName);
+            taskFactory.createScanIndexTask(user, properties).call();
         } else {
             properties.remove(MAP_NAME_OPTION); // avoid use of reportMap to override ES docs
         }
@@ -269,10 +267,6 @@ public class TaskResource {
         clone.setProperty(QUEUE_NAME_OPTION, "extract:queue"); // Override any given queue name value
         clone.setProperty(MAP_NAME_OPTION, getReportMapNameFor(properties));
         return new PropertiesProvider(clone).overrideQueueNameWithHash().getProperties();
-    }
-
-    public static Properties applyProjectTo(PropertiesProvider propertiesProvider) {
-        return applyProjectTo(propertiesProvider.getProperties());
     }
 
     public static String getReportMapNameFor(Properties properties) {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -41,13 +41,13 @@ public class DeduplicateTaskTest {
 
     @Test(timeout = 2000)
     public void test_pipeline_task_transfer_to_output_queue() throws Exception {
-        task.queue.put(get("/path/to/doc1"));
-        task.queue.put(get("/path/to/doc2"));
-        task.queue.put(PATH_POISON);
+        task.inputQueue.put(get("/path/to/doc1"));
+        task.inputQueue.put(get("/path/to/doc2"));
+        task.inputQueue.put(PATH_POISON);
 
         task.transferToOutputQueue();
 
-        assertThat(task.queue.isEmpty()).isTrue();
+        assertThat(task.inputQueue.isEmpty()).isTrue();
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
         assertThat(outputQueue.size()).isEqualTo(3);
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");
@@ -57,13 +57,13 @@ public class DeduplicateTaskTest {
 
     @Test(timeout = 2000)
     public void test_pipeline_task_conditional_transfer_to_output_queue() throws Exception {
-        task.queue.put(get("/path/to/doc1"));
-        task.queue.put(get("/path/to/doc2"));
-        task.queue.put(PATH_POISON);
+        task.inputQueue.put(get("/path/to/doc1"));
+        task.inputQueue.put(get("/path/to/doc2"));
+        task.inputQueue.put(PATH_POISON);
 
         task.transferToOutputQueue(p -> p.toString().contains("1"));
 
-        assertThat(task.queue.isEmpty()).isTrue();
+        assertThat(task.inputQueue.isEmpty()).isTrue();
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
         assertThat(outputQueue.size()).isEqualTo(2);
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
@@ -28,6 +28,7 @@ public class ScanIndexTaskTest {
     public static ElasticsearchRule es = new ElasticsearchRule();
     private final PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
         put("defaultProject", TEST_INDEX);
+        put("reportName", "test:report");
         put("stages", "SCANIDX");
     }});
     private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
@@ -35,7 +36,7 @@ public class ScanIndexTaskTest {
 
     @Test
     public void test_empty_index() throws Exception {
-        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, propertiesProvider, User.nullUser(), "test:report").call()).isEqualTo(0);
+        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, User.nullUser(), propertiesProvider).call()).isEqualTo(0);
     }
 
     @Test
@@ -43,7 +44,7 @@ public class ScanIndexTaskTest {
         indexer.add(TEST_INDEX, DocumentBuilder.createDoc("id1").build());
         indexer.add(TEST_INDEX, DocumentBuilder.createDoc("id2").build());
 
-        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, propertiesProvider, User.nullUser(), "test:report").call()).isEqualTo(2);
+        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, User.nullUser(), propertiesProvider).call()).isEqualTo(2);
 
         ReportMap actualReportMap = documentCollectionFactory.createMap("test:report");
         assertThat(actualReportMap).includes(

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
@@ -36,7 +36,7 @@ public class ScanIndexTaskTest {
 
     @Test
     public void test_empty_index() throws Exception {
-        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, User.nullUser(), propertiesProvider).call()).isEqualTo(0);
+        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, User.nullUser(), propertiesProvider.getProperties()).call()).isEqualTo(0);
     }
 
     @Test
@@ -44,7 +44,7 @@ public class ScanIndexTaskTest {
         indexer.add(TEST_INDEX, DocumentBuilder.createDoc("id1").build());
         indexer.add(TEST_INDEX, DocumentBuilder.createDoc("id2").build());
 
-        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, User.nullUser(), propertiesProvider).call()).isEqualTo(2);
+        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, User.nullUser(), propertiesProvider.getProperties()).call()).isEqualTo(2);
 
         ReportMap actualReportMap = documentCollectionFactory.createMap("test:report");
         assertThat(actualReportMap).includes(


### PR DESCRIPTION
Ensure the project is used when creating a report map (as part of the ScanIndex task). See https://github.com/ICIJ/datashare/issues/1344.