### PR TITLE
feat: adds scrollSize for batch and enqueue tasks

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -76,10 +76,10 @@ public class BatchDownloadRunner implements Callable<FileResult>, Monitorable, U
 
     @Override
     public FileResult call() throws Exception {
-        int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse("0"));
+        int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse(DEFAULT_BATCH_THROTTLE));
         int maxResultSize = parseInt(propertiesProvider.get(BATCH_DOWNLOAD_MAX_NB_FILES_OPT).orElse(valueOf(MAX_BATCH_RESULT_SIZE)));
-        int scrollSize = min(parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse("1000")), MAX_SCROLL_SIZE);
-        long maxZipSizeBytes = HumanReadableSize.parse(propertiesProvider.get(BATCH_DOWNLOAD_MAX_SIZE_OPT).orElse("100M"));
+        int scrollSize = min(parseInt(propertiesProvider.get(BATCH_DOWNLOAD_SCROLL_SIZE_OPT).orElse(valueOf(DEFAULT_SCROLL_SIZE))), MAX_SCROLL_SIZE);
+        long maxZipSizeBytes = HumanReadableSize.parse(propertiesProvider.get(BATCH_DOWNLOAD_MAX_SIZE_OPT).orElse(DEFAULT_BATCH_DOWNLOAD_MAX_SIZE));
         long zippedFilesSize = 0;
         BatchDownload batchDownload = getBatchDownload();
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -78,7 +78,10 @@ public class BatchDownloadRunner implements Callable<FileResult>, Monitorable, U
     public FileResult call() throws Exception {
         int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse(DEFAULT_BATCH_THROTTLE));
         int maxResultSize = parseInt(propertiesProvider.get(BATCH_DOWNLOAD_MAX_NB_FILES_OPT).orElse(valueOf(MAX_BATCH_RESULT_SIZE)));
-        int scrollSize = min(parseInt(propertiesProvider.get(BATCH_DOWNLOAD_SCROLL_SIZE_OPT).orElse(valueOf(DEFAULT_SCROLL_SIZE))), MAX_SCROLL_SIZE);
+        int scrollSizeFromParams = parseInt(propertiesProvider.get(BATCH_DOWNLOAD_SCROLL_SIZE_OPT)
+                .orElse(propertiesProvider.get(SCROLL_SIZE_OPT)
+                .orElse(valueOf(DEFAULT_SCROLL_SIZE))));
+        int scrollSize = min(scrollSizeFromParams, MAX_SCROLL_SIZE);
         long maxZipSizeBytes = HumanReadableSize.parse(propertiesProvider.get(BATCH_DOWNLOAD_MAX_SIZE_OPT).orElse(DEFAULT_BATCH_DOWNLOAD_MAX_SIZE));
         long zippedFilesSize = 0;
         BatchDownload batchDownload = getBatchDownload();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -77,7 +77,10 @@ public class BatchSearchRunner implements Callable<Integer>, Monitorable, UserTa
         int numberOfResults = 0;
         int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse(DEFAULT_BATCH_THROTTLE));
         int maxTimeSeconds = parseInt(propertiesProvider.get(BATCH_SEARCH_MAX_TIME_OPT).orElse(DEFAULT_BATCH_SEARCH_MAX_TIME));
-        int scrollSize = min(parseInt(propertiesProvider.get(BATCH_SEARCH_SCROLL_SIZE_OPT).orElse(valueOf(DEFAULT_SCROLL_SIZE))), MAX_SCROLL_SIZE);
+        int scrollSizeFromParams = parseInt(propertiesProvider.get(BATCH_SEARCH_SCROLL_SIZE_OPT)
+                .orElse(propertiesProvider.get(SCROLL_SIZE_OPT)
+                .orElse(valueOf(DEFAULT_SCROLL_SIZE))));
+        int scrollSize = min(scrollSizeFromParams, MAX_SCROLL_SIZE);
         callThread = Thread.currentThread();
         callWaiterLatch.countDown(); // for tests
         logger.info("running {} queries for batch search {} on projects {} with throttle {}ms and scroll size of {}",

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import static java.lang.Integer.min;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
+import static java.lang.String.valueOf;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
@@ -74,9 +75,9 @@ public class BatchSearchRunner implements Callable<Integer>, Monitorable, UserTa
     @Override
     public Integer call() throws SearchException {
         int numberOfResults = 0;
-        int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse("0"));
-        int maxTimeSeconds = parseInt(propertiesProvider.get(BATCH_SEARCH_MAX_TIME_OPT).orElse("100000"));
-        int scrollSize = min(parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse("1000")), MAX_SCROLL_SIZE);
+        int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse(DEFAULT_BATCH_THROTTLE));
+        int maxTimeSeconds = parseInt(propertiesProvider.get(BATCH_SEARCH_MAX_TIME_OPT).orElse(DEFAULT_BATCH_SEARCH_MAX_TIME));
+        int scrollSize = min(parseInt(propertiesProvider.get(BATCH_SEARCH_SCROLL_SIZE_OPT).orElse(valueOf(DEFAULT_SCROLL_SIZE))), MAX_SCROLL_SIZE);
         callThread = Thread.currentThread();
         callWaiterLatch.countDown(); // for tests
         logger.info("running {} queries for batch search {} on projects {} with throttle {}ms and scroll size of {}",

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.valueOf;
 import static java.util.Optional.ofNullable;
-import static org.icij.datashare.cli.DatashareCliOptions.NLP_PIPELINE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.*;
 import static org.icij.extract.document.Identifier.shorten;
 
 public class ExtractNlpTask extends PipelineTask<String> implements Monitorable {
@@ -44,8 +44,8 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
     ExtractNlpTask(Indexer indexer, Pipeline nlpPipeline, final DocumentCollectionFactory<String> factory, User user, final Properties properties) {
         super(Stage.NLP, user, factory, new PropertiesProvider(properties), String.class);
         this.nlpPipeline = nlpPipeline;
-        project = Project.project(ofNullable(properties.getProperty("defaultProject")).orElse("local-datashare"));
-        maxContentLengthChars = (int) HumanReadableSize.parse(ofNullable(properties.getProperty("maxContentLength")).orElse(valueOf(DEFAULT_MAX_CONTENT_LENGTH)));
+        project = Project.project(ofNullable(properties.getProperty(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
+        maxContentLengthChars = (int) HumanReadableSize.parse(ofNullable(properties.getProperty(MAX_CONTENT_LENGTH_OPT)).orElse(valueOf(DEFAULT_MAX_CONTENT_LENGTH)));
         this.indexer = indexer;
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
@@ -26,10 +26,11 @@ import java.util.stream.IntStream;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 
 import static java.lang.Integer.parseInt;
+import static java.lang.String.valueOf;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
-import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_SIZE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.*;
 
 public class ScanIndexTask extends PipelineTask<Path> implements UserTask {
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -44,10 +45,10 @@ public class ScanIndexTask extends PipelineTask<Path> implements UserTask {
     public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer, @Assisted User user, @Assisted Properties properties) {
         super(Stage.SCANIDX, user, factory, new PropertiesProvider(properties), Path.class);
         this.user = user;
-        this.scrollSize = parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse("1000"));
-        this.scrollSlices = parseInt(propertiesProvider.get("scrollSlices").orElse("1"));
-        this.projectName = propertiesProvider.get(PropertiesProvider.DEFAULT_PROJECT_OPTION).orElse("local-datashare");
-        this.reportMap = factory.createMap(propertiesProvider.get(PropertiesProvider.MAP_NAME_OPTION).orElse("extract:report"));
+        this.scrollSize = parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse(valueOf(DEFAULT_SCROLL_SIZE)));
+        this.scrollSlices = parseInt(propertiesProvider.get(SCROLL_SLICES_OPT).orElse(valueOf(DEFAULT_SCROLL_SLICES)));
+        this.projectName = propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT);
+        this.reportMap = factory.createMap(propertiesProvider.get(REPORT_NAME_OPT).orElse("extract:report"));
         this.indexer = indexer;
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerMemory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerMemory.java
@@ -22,6 +22,7 @@ import static java.lang.Integer.parseInt;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static org.icij.datashare.cli.DatashareCliOptions.PARALLELISM_OPT;
 
 @Singleton
 public class TaskManagerMemory implements TaskManager, TaskSupplier {
@@ -33,7 +34,7 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
     @Inject
     public TaskManagerMemory(final PropertiesProvider provider, BlockingQueue<TaskView<?>> taskQueue) {
         this.taskQueue = taskQueue;
-        Optional<String> parallelism = provider.get("parallelism");
+        Optional<String> parallelism = provider.get(PARALLELISM_OPT);
         executor = parallelism.map(s -> newFixedThreadPool(parseInt(s))).
                    orElseGet( () -> newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
@@ -17,12 +17,14 @@ import org.junit.*;
 import org.mockito.Mock;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.CollectionUtils.asSet;
+import static org.icij.datashare.cli.DatashareCliOptions.*;
 import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
 import static org.icij.datashare.text.Project.project;
@@ -197,6 +199,27 @@ public class BatchSearchRunnerIntTest {
         ElasticsearchException eex = assertThrows(ElasticsearchException.class,() -> new BatchSearchRunner(indexer, new PropertiesProvider(), search, resultConsumer).call());
 
         assertThat(eex.error().toString()).contains("Failed to parse query [AND mydoc]");
+    }
+
+    @Test(expected = ElasticsearchException.class)
+    public void test_use_batch_search_scroll_size_value_over_scroll_size_value() {
+        PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
+            put(SCROLL_SIZE_OPT, "100");
+            put(BATCH_SEARCH_SCROLL_SIZE_OPT, "0");
+        }});
+        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(), false, null, null,null, 0);
+
+        new BatchSearchRunner(indexer, propertiesProvider, searchKo, resultConsumer).call();
+    }
+
+    @Test(expected = ElasticsearchException.class)
+    public void test_use_scroll_size_value() {
+        PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<String, String>() {{
+            put(SCROLL_SIZE_OPT, "0");
+        }});
+        BatchSearch searchKo = new BatchSearch(singletonList(project(TEST_INDEX)), "name", "desc", asSet("mydoc"), User.local(), false, null, null,null, 0);
+
+        new BatchSearchRunner(indexer, propertiesProvider, searchKo, resultConsumer).call();
     }
 
     @Before

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -121,6 +121,8 @@ public class DatashareCli {
         DatashareCliOptions.resume(parser);
         DatashareCliOptions.scrollSize(parser);
         DatashareCliOptions.scrollSlices(parser);
+        DatashareCliOptions.batchSearchScrollSize(parser);
+        DatashareCliOptions.batchDownloadScrollSize(parser);
         DatashareCliOptions.redisPoolSize(parser);
         DatashareCliOptions.elasticsearchDataPath(parser);
         DatashareCliOptions.reportName(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -29,9 +29,11 @@ public final class DatashareCliOptions {
     public static final String BATCH_DOWNLOAD_ENCRYPT_OPT = "batchDownloadEncrypt";
     public static final String BATCH_DOWNLOAD_MAX_NB_FILES_OPT = "batchDownloadMaxNbFiles";
     public static final String BATCH_DOWNLOAD_MAX_SIZE_OPT = "batchDownloadMaxSize";
+    public static final String BATCH_DOWNLOAD_SCROLL_SIZE_OPT = "batchDownloadScrollSize";
     public static final String BATCH_DOWNLOAD_ZIP_TTL_OPT = "batchDownloadTimeToLive";
     public static final String BATCH_QUEUE_TYPE_OPT = "batchQueueType";
     public static final String BATCH_SEARCH_MAX_TIME_OPT = "batchSearchMaxTimeSeconds";
+    public static final String BATCH_SEARCH_SCROLL_SIZE_OPT = "batchSearchScrollSize";
     public static final String BATCH_THROTTLE_OPT = "batchThrottleMilliseconds";
     public static final String BROWSER_OPEN_LINK_OPT = "browserOpenLink";
     public static final String BUS_TYPE_OPT = "busType";
@@ -125,8 +127,10 @@ public final class DatashareCliOptions {
     public static final QueueType DEFAULT_BUS_TYPE = QueueType.MEMORY;
     public static final QueueType DEFAULT_QUEUE_TYPE = QueueType.MEMORY;
     public static final QueueType DEFAULT_SESSION_STORE_TYPE = QueueType.MEMORY;
+    public static final String DEFAULT_BATCH_THROTTLE = "0";
     public static final String DEFAULT_BATCH_DOWNLOAD_DIR = DEFAULT_DATASHARE_HOME.resolve("tmp").toString();
     public static final String DEFAULT_BATCH_DOWNLOAD_MAX_SIZE = "100M";
+    public static final String DEFAULT_BATCH_SEARCH_MAX_TIME = "100000";
     public static final String DEFAULT_CHARSET = Charset.defaultCharset().toString();
     public static final String DEFAULT_CLUSTER_NAME = "datashare";
     public static final String DEFAULT_CORS = "no-cors";
@@ -415,6 +419,23 @@ public final class DatashareCliOptions {
                 .withRequiredArg()
                 .ofType(Integer.class)
                 .defaultsTo(DEFAULT_SCROLL_SLICES);
+    }
+
+
+    public static void batchSearchScrollSize(OptionParser parser) {
+        parser.acceptsAll(
+                singletonList(BATCH_SEARCH_SCROLL_SIZE_OPT), "Scroll size used for elasticsearch scrolls (Batch Search)")
+                .withRequiredArg()
+                .ofType(Integer.class)
+                .defaultsTo(DEFAULT_SCROLL_SIZE);
+    }
+
+    public static void batchDownloadScrollSize(OptionParser parser) {
+        parser.acceptsAll(
+                singletonList(BATCH_DOWNLOAD_SCROLL_SIZE_OPT), "Scroll size used for elasticsearch scrolls (Batch Download)")
+                .withRequiredArg()
+                .ofType(Integer.class)
+                .defaultsTo(DEFAULT_SCROLL_SIZE);
     }
 
      public static void redisPoolSize(OptionParser parser) {


### PR DESCRIPTION
Related to [this issue](https://github.com/ICIJ/datashare/issues/1270)

This PR aims to add the scroll size option for Batch Search/Download and EnqueueTask.
It also define more default constants values options.

Scroll slice option for the other tasks can be issued in another story as the implementation is very specific for each tasks (we can also dig into the using of elasticsearch's [PIT](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/point-in-time-api.html#point-in-time-keep-alive)