### PR TITLE
fix: move --add-opens from command line to MANIFEST.MF #1367

### DIFF
--- a/datashare-dist/pom.xml
+++ b/datashare-dist/pom.xml
@@ -76,6 +76,7 @@
                                 <manifestEntries>
                                     <Build-Time>${maven.build.timestamp}</Build-Time>
                                     <Implementation-Version>${version}</Implementation-Version>
+                                    <Add-Opens>java.base/java.util java.base/java.lang</Add-Opens>
                                     <Multi-Release>true</Multi-Release>
                                 </manifestEntries>
                             </archive>

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -43,8 +43,6 @@ mkdir -p \
 cd $datashare_home || exit
 
 $java_bin $java_opts \
-    --add-opens java.base/java.lang=ALL-UNNAMED \
-    --add-opens java.base/java.util=ALL-UNNAMED \
     -DPROD_MODE=true \
     -Dfile.encoding=UTF-8 \
     -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \

--- a/datashare-dist/src/main/docker/entrypoint.sh
+++ b/datashare-dist/src/main/docker/entrypoint.sh
@@ -13,8 +13,6 @@ then
     exec "$@"
 else
     $java_bin $java_opts \
-      --add-opens java.base/java.lang=ALL-UNNAMED \
-      --add-opens java.base/java.util=ALL-UNNAMED \
       -DPROD_MODE=true \
       -Dfile.encoding=UTF-8 \
       -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <datashare-api.version>13.7.1</datashare-api.version>
+        <datashare-api.version>13.7.2</datashare-api.version>
         <datashare-cli.version>13.5.0</datashare-cli.version>
 
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
this PR allows to run datashare with : 

```shell
java -jar datashare-dist/target/datashare-dist-15.1.2-all.jar
```

Or with 

```shell
java --add-opens java.base/java.lang=ALL-UNNAMED -cp datashare-dist/target/datashare-dist-15.1.2-all.jar org.icij.datashare.Main
```