### PR TITLE
Fix/read end dead exception

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -60,7 +60,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         String docType = parent == null ? "Document" : "Child";
         if (parent == null && isDuplicate(doc.getId())) {
             doc.setDuplicate(true);
-            copy(doc.getReader()., OutputStream.nullOutputStream()); // flush document content reader
+            copy(doc.getReader(), OutputStream.nullOutputStream()); // flush document content reader
             indexer.add(indexName, new Duplicate(doc.getPath(), doc.getId(), digestAlgorithm));
             docType = "Duplicate";
         } else {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -59,6 +60,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         String docType = parent == null ? "Document" : "Child";
         if (parent == null && isDuplicate(doc.getId())) {
             doc.setDuplicate(true);
+            copy(doc.getReader()., OutputStream.nullOutputStream()); // flush document content reader
             indexer.add(indexName, new Duplicate(doc.getPath(), doc.getId(), digestAlgorithm));
             docType = "Duplicate";
         } else {


### PR DESCRIPTION
This fixes the #1364.

But it has drawback : the duplicate process is longer because for flushing the duplicate reader.... we read it. So it takes as long as processing the file. 

I tried to close the reader but it generates the same exceptions.
I haven't find a way to seek the file descriptor to the end.

