### PR TITLE
fix: TaskManager name and rename redis queue #1080

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/extract/RedisBlockingQueue.java
+++ b/datashare-app/src/main/java/org/icij/datashare/extract/RedisBlockingQueue.java
@@ -24,10 +24,6 @@ public class RedisBlockingQueue<T> extends RedissonBlockingQueue<T> implements C
         this(new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create(), queueName);
     }
 
-    public RedisBlockingQueue(PropertiesProvider propertiesProvider) {
-        this(propertiesProvider, CommonMode.DS_BATCHSEARCH_QUEUE_NAME);
-    }
-
     public RedisBlockingQueue(RedissonClient redissonClient, String queueName) {
         super(new JsonJacksonCodec(), new CommandSyncService(((Redisson)redissonClient).getConnectionManager(), new RedissonObjectBuilder(redissonClient)), queueName, redissonClient);
         this.redissonClient = redissonClient;

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -73,9 +73,7 @@ import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfig
 
 public abstract class CommonMode extends AbstractModule {
     protected Logger logger = LoggerFactory.getLogger(getClass());
-    public static final String DS_BATCHSEARCH_QUEUE_NAME = "ds:batchsearch:queue";
-    public static final String DS_BATCHDOWNLOAD_QUEUE_NAME = "ds:batchdownload:queue";
-    public static final String DS_TASK_MANAGER_QUEUE_NAME = "ds:task:manager";
+    public static final String DS_TASKS_QUEUE_NAME = "ds:task:manager:queue";
     public static final String DS_TASK_MANAGER_MAP_NAME = "ds:task:manager:tasks";
     protected final PropertiesProvider propertiesProvider;
     protected final Mode mode;
@@ -189,13 +187,11 @@ public abstract class CommonMode extends AbstractModule {
     }
 
     private void configureBatchQueuesMemory(PropertiesProvider propertiesProvider) {
-        bind(new TypeLiteral<BlockingQueue<String>>(){}).toInstance(new MemoryBlockingQueue<>(propertiesProvider, DS_BATCHSEARCH_QUEUE_NAME));
-        bind(new TypeLiteral<BlockingQueue<TaskView<?>>>(){}).toInstance(new MemoryBlockingQueue<>(propertiesProvider, DS_BATCHDOWNLOAD_QUEUE_NAME));
+        bind(new TypeLiteral<BlockingQueue<TaskView<?>>>(){}).toInstance(new MemoryBlockingQueue<>(propertiesProvider, DS_TASKS_QUEUE_NAME));
     }
 
     private void configureBatchQueuesRedis(RedissonClient redissonClient) {
-        bind(new TypeLiteral<BlockingQueue<String>>(){}).toInstance(new RedisBlockingQueue<>(redissonClient, DS_BATCHSEARCH_QUEUE_NAME));
-        bind(new TypeLiteral<BlockingQueue<TaskView<?>>>(){}).toInstance(new RedisBlockingQueue<>(redissonClient, DS_BATCHDOWNLOAD_QUEUE_NAME));
+        bind(new TypeLiteral<BlockingQueue<TaskView<?>>>(){}).toInstance(new RedisBlockingQueue<>(redissonClient, DS_TASKS_QUEUE_NAME));
     }
 
     public Properties properties() {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerAmqp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerAmqp.java
@@ -44,7 +44,7 @@ public class TaskManagerAmqp implements TaskManager {
     TaskManagerAmqp(AmqpInterlocutor amqp, RedissonClient redissonClient, Runnable eventCallback) throws IOException {
         this.amqp = amqp;
         CommandSyncService commandSyncService = new CommandSyncService(((Redisson) redissonClient).getConnectionManager(), new RedissonObjectBuilder(redissonClient));
-        tasks = new RedissonMap<>(new TaskManagerRedis.TaskViewCodec(), commandSyncService, CommonMode.DS_TASK_MANAGER_QUEUE_NAME, redissonClient, null, null);
+        tasks = new RedissonMap<>(new TaskManagerRedis.TaskViewCodec(), commandSyncService, CommonMode.DS_TASK_MANAGER_MAP_NAME, redissonClient, null, null);
 
         eventConsumer = new AmqpConsumer<>(amqp, event ->
                 ofNullable(TaskManager.super.handleAck(event)).flatMap(t ->

--- a/datashare-app/src/test/java/org/icij/datashare/extract/RedisBlockingQueueTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/extract/RedisBlockingQueueTest.java
@@ -8,15 +8,16 @@ import org.junit.Test;
 import org.redisson.api.RedissonClient;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 public class RedisBlockingQueueTest {
-    RedisBlockingQueue<String> queue = new RedisBlockingQueue<>(new PropertiesProvider(new HashMap<>() {{
-        put("redisAddress", "redis://redis:6379");
-        put("redisPoolSize", "5");
-    }}));
+    RedisBlockingQueue<String> queue = new RedisBlockingQueue<>(new PropertiesProvider(Map.of(
+            "redisAddress", "redis://redis:6379",
+            "redisPoolSize", "5"
+    )), "test:queue");
 
     @Test
     public void test_redisson_connection(){


### PR DESCRIPTION
there was an old constant name for the shared hashmap in redis that contains all the tasks.

We also renamed `ds:batchdownload:queue` in `ds:task:manager:queue` for `RedisTaskManager`.