### PR TITLE
fix: set DATASHARE_HOME in `./launckBack` to launch dev jar

### DIFF
--- a/launchBack.sh
+++ b/launchBack.sh
@@ -9,6 +9,7 @@ export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,address=$JDWP_TRAN
   -Djavax.net.ssl.trustStorePassword=changeit"
 
 DATASHARE_POM_VERSION=$(cat $DIR/pom.xml | grep '<version>[0-9.]\+' | sed 's/<version>\([0-9a-z.\-]\+\)<\/version>/\1/g' | tr -d '[:space:]')
+export DATASHARE_HOME=$DIR
 export DATASHARE_VERSION=${DATASHARE_VERSION:-$DATASHARE_POM_VERSION}
 export DATASHARE_JAR=${DATASHARE_JAR:-$DIR/datashare-dist/target/datashare-dist-${DATASHARE_VERSION}-all.jar}
 export DATASHARE_SYNC_NLP_MODELS=${DATASHARE_SYNC_NLP_MODELS:-true}


### PR DESCRIPTION
# Changes

### Fixed
- set `DATASHARE_HOME` in `./launckBack` to launch dev jar