### PR TITLE
Build/release datashare tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,4 +509,6 @@ workflows:
       - deploy_datashare_tasks:
           filters:
             tags:
-              only: /datashare-tasks\/[0-9]+\..*/
+              only: /^datashare-tasks\/[0-9]+\..*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,6 +420,25 @@ jobs:
             curl -X POST -s -m 120 -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/vnd.debian.binary-package" --data-binary "@/tmp/datashare/datashare-dist/target/datashare-dist-${CIRCLE_TAG}.deb" "$upload_url?name=datashare-${CIRCLE_TAG}.deb&label=datashare-${CIRCLE_TAG}.deb"
             curl -X POST -s -m 120 -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/gzip" --data-binary "@/tmp/datashare/datashare-dist/target/datashare-dist-${CIRCLE_TAG}.tgz" "$upload_url?name=datashare-${CIRCLE_TAG}.tgz&label=datashare-${CIRCLE_TAG}.tgz"
 
+  deploy_datashare_tasks:
+    docker:
+      - image: cimg/openjdk:11.0.16
+      - image: redis:4.0.1-alpine
+        name: redis
+      - image: rabbitmq:3
+        name: rabbitmq
+        environment:
+          RABBITMQ_DEFAULT_USER: admin
+          RABBITMQ_DEFAULT_PASS: admin
+
+    environment:
+      MAVEN_OPTS: "-Xms512m -Xmx512m -Xss10M"
+
+    steps:
+      - checkout
+      - run:
+          name: Build and deploy datashare-tasks
+          command: mvn -s .circleci/maven-release-settings.xml -pl datashare-tasks -am deploy
 
 workflows:
   version: 2
@@ -480,3 +499,7 @@ workflows:
                   only: /^[0-9]+\..*/
               branches:
                   ignore: /.*/
+      - deploy_datashare_tasks:
+          filters:
+            tags:
+              only: /datashare-tasks\/[0-9]+\..*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,9 +436,17 @@ jobs:
 
     steps:
       - checkout
-      - run:
+      - steps:
+        - run:
+            name: Configure GPG private key for signing project artifacts in OSS Sonatype
+            shell: /bin/bash
+            command: |
+              echo ${RELEASES_GPG_PRIV_BASE64} | base64 --decode | gpg --batch --no-tty --import --yes
+
+        - run:
           name: Build and deploy datashare-tasks
           command: mvn -s .circleci/maven-release-settings.xml -pl datashare-tasks -am deploy
+          no_output_timeout: 30m
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,14 +436,13 @@ jobs:
 
     steps:
       - checkout
-      - steps:
-        - run:
-            name: Configure GPG private key for signing project artifacts in OSS Sonatype
-            shell: /bin/bash
-            command: |
-              echo ${RELEASES_GPG_PRIV_BASE64} | base64 --decode | gpg --batch --no-tty --import --yes
+      - run:
+          name: Configure GPG private key for signing project artifacts in OSS Sonatype
+          shell: /bin/bash
+          command: |
+            echo ${RELEASES_GPG_PRIV_BASE64} | base64 --decode | gpg --batch --no-tty --import --yes
 
-        - run:
+      - run:
           name: Build and deploy datashare-tasks
           command: mvn -s .circleci/maven-release-settings.xml -pl datashare-tasks -am deploy
           no_output_timeout: 30m

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ update-db:
 help-db:
 		mvn help:describe -DgroupId=org.liquibase -DartifactId=liquibase-maven-plugin -Dversion=2.0.1 -Dfull=true
 
+release-%:
+		mvn -pl datashare-$* versions:set -DnewVersion=${NEW_VERSION}
+		git commit -am "[release] datashare-$*/${NEW_VERSION}"
+		git tag datashare-$*/${NEW_VERSION}
+		echo "If everything is OK, you can push with tags i.e. git push origin master --tags"
+
 release:
 		mvn versions:set -DnewVersion=${NEW_VERSION}
 		git commit -am "[release] ${NEW_VERSION}"


### PR DESCRIPTION
Circle CI update to be able to release the `datashare-tasks` module.

To release the module you can do:

```shell
make release-tasks NEW_VERSION=1.2.3
```

It will change the `datashare-tasks/pom.xml` version and put a tag `datashare-tasks/1.2.3`.