### PR TITLE
build: bump/jooq 3.12.3 to 3.19.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
 
   build_back:
     docker:
-      - image: cimg/openjdk:11.0.16
+      - image: cimg/openjdk:17.0.11
       - image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
         environment:
           - "discovery.type=single-node"

--- a/datashare-api/pom.xml
+++ b/datashare-api/pom.xml
@@ -113,7 +113,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Djava.system.class.loader=org.icij.datashare.DynamicClassLoader</argLine>
+                    <argLine>-Djava.system.class.loader=org.icij.datashare.DynamicClassLoader -ea
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/sun.nio.cs=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/datashare-api/src/main/java/org/icij/datashare/Repository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/Repository.java
@@ -21,6 +21,7 @@ public interface Repository {
     boolean addToUserHistory(List<Project> project, UserEvent userEvent);
     boolean renameSavedSearch(User user, int eventId, String newName);
     List<UserEvent> getUserHistory(User user, UserEvent.Type type, int from, int size, String sort, boolean desc, String... projectIds);
+    List<UserEvent> getUserEvents(User user);
     int getUserHistorySize(User user, UserEvent.Type type, String... projectIds);
     boolean deleteUserHistory(User user, UserEvent.Type type);
     boolean deleteUserHistoryEvent(User user, int eventId);

--- a/datashare-db/pom.xml
+++ b/datashare-db/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <liquibase.version>4.27.0</liquibase.version>
-        <jooq.version>3.12.3</jooq.version>
+        <jooq.version>3.19.10</jooq.version>
     </properties>
 
     <dependencies>

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -40,7 +40,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -287,6 +286,12 @@ public class JooqRepository implements Repository {
         }
         return query.fetchOne(0, int.class);
 
+    }
+
+    @Override
+    public List<UserEvent> getUserEvents(User user) {
+        DSLContext ctx = using(connectionProvider, dialect);
+        return ctx.selectFrom(USER_HISTORY).where(USER_HISTORY.USER_ID.eq(user.id)).fetch().map(this::createUserEventFrom);
     }
 
     @Override

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -432,10 +432,10 @@ public class JooqRepository implements Repository {
             int deleteTagResult = inner.deleteFrom(DOCUMENT_TAG).where(DOCUMENT_TAG.PRJ_ID.eq(projectId)).execute();
             int deleteStarResult = inner.deleteFrom(DOCUMENT_USER_STAR).where(DOCUMENT_USER_STAR.PRJ_ID.eq(projectId)).execute();
             int deleteUserRecommendationResult = inner.deleteFrom(DOCUMENT_USER_RECOMMENDATION).where(DOCUMENT_USER_RECOMMENDATION.PRJ_ID.eq(projectId)).execute();
-            int deleteUserHistoryResult = inner.deleteFrom(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.eq(projectId)).execute();
+            List<Integer> deletedUserHistoryProjectIds = inner.deleteFrom(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.eq(projectId)).returning().fetch().getValues(USER_HISTORY_PROJECT.USER_HISTORY_ID);
+            int deleteUserHistoryResult = inner.deleteFrom(USER_HISTORY).where(USER_HISTORY.ID.in(deletedUserHistoryProjectIds)).execute();
             int deleteProject = inner.deleteFrom(PROJECT).where(PROJECT.ID.eq(projectId)).execute();
-            return deleteStarResult + deleteTagResult + deleteUserRecommendationResult + deleteUserHistoryResult + deleteProject > 0;
-
+            return deleteStarResult + deleteTagResult + deleteUserRecommendationResult + deletedUserHistoryProjectIds.size() + deleteUserHistoryResult + deleteProject > 0;
         });
 
     }

--- a/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
@@ -32,6 +32,7 @@ public class RepositoryFactoryImpl implements RepositoryFactory {
     public RepositoryFactoryImpl(final PropertiesProvider propertiesProvider) {
         this.propertiesProvider = propertiesProvider;
         System.getProperties().setProperty("org.jooq.no-logo", "true");
+        System.getProperties().setProperty("org.jooq.no-tips", "true");
         this.dataSource = createDatasource();
     }
 

--- a/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
@@ -33,6 +33,7 @@ public class RepositoryFactoryImpl implements RepositoryFactory {
         this.propertiesProvider = propertiesProvider;
         System.getProperties().setProperty("org.jooq.no-logo", "true");
         System.getProperties().setProperty("org.jooq.no-tips", "true");
+        System.getProperties().setProperty("org.jooq.log.org.jooq.impl.DefaultExecuteContext.logVersionSupport", "ERROR");
         this.dataSource = createDatasource();
     }
 

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -388,6 +388,17 @@ public class JooqRepositoryTest {
     }
 
     @Test
+    public void test_get_user_events_items() {
+        User user = new User("userid");
+        UserEvent userEvent1 = new UserEvent(user, DOCUMENT, "doc_id", Paths.get("doc_uri").toUri());
+        UserEvent userEvent2 = new UserEvent(user, SEARCH, "search_id", Paths.get("searcb_uri").toUri());
+        repository.addToUserHistory(singletonList(project("prj")), userEvent1);
+        repository.addToUserHistory(singletonList(project("prj")), userEvent2);
+
+        assertThat(repository.getUserEvents(user)).containsExactly(userEvent1, userEvent2);
+    }
+
+    @Test
     public void test_delete_all_project() {
         User user = new User("userid");
         repository.star(project("prj"), user, singletonList("doc_id"));
@@ -402,6 +413,7 @@ public class JooqRepositoryTest {
         assertThat(repository.getStarredDocuments(user)).isEmpty();
         assertThat(repository.getRecommentationsBy(project("prj"), List.of(user))).isEmpty();
         assertThat(repository.getUserHistory(user, DOCUMENT, 0, 10, "modification_date",true, "prj")).isEmpty();
+        assertThat(repository.getUserEvents(user)).isEmpty();
     }
 
     @Test

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -393,6 +393,7 @@ public class JooqRepositoryTest {
         repository.star(project("prj"), user, singletonList("doc_id"));
         repository.tag(project("prj"), "doc_id", tag("tag1"), tag("tag2"));
         repository.recommend(project("prj"), user, List.of("doc_id"));
+        repository.addToUserHistory(singletonList(project("prj")), new UserEvent(user, DOCUMENT, "doc_id", Paths.get("doc_uri").toUri()));
 
         assertThat(repository.deleteAll("prj")).isTrue();
         assertThat(repository.deleteAll("prj")).isFalse();
@@ -400,6 +401,7 @@ public class JooqRepositoryTest {
         assertThat(repository.getDocuments(project("prj"), tag("tag1"), tag("tag2"))).isEmpty();
         assertThat(repository.getStarredDocuments(user)).isEmpty();
         assertThat(repository.getRecommentationsBy(project("prj"), List.of(user))).isEmpty();
+        assertThat(repository.getUserHistory(user, DOCUMENT, 0, 10, "modification_date",true, "prj")).isEmpty();
     }
 
     @Test

--- a/datashare-dist/src/main/deb/control/control
+++ b/datashare-dist/src/main/deb/control/control
@@ -6,5 +6,5 @@ Priority: low
 Architecture: all
 Description: [[description]]
 Maintainer: ICIJ <datashare@icij.org>
-Depends: default-jre | openjdk-11-jre | openjdk-17-jre | openjdk-18-jre, tesseract-ocr
+Depends: default-jre | openjdk-17-jre | openjdk-18-jre, tesseract-ocr
 Recommends: tesseract-ocr-all

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
         <datashare-api.version>14.1.1</datashare-api.version>
         <datashare-cli.version>13.5.0</datashare-cli.version>


### PR DESCRIPTION
# Reason
The reason of this PR is [this issue](https://github.com/ICIJ/datashare/issues/1411) where the user history wasn't deleted properly. One of the solution was to use a `RETURNING` clause in SQL to delete entries in `USER_HISTORY_PROJECT` and `USER_HISTORY`. This clause is not implemented for SQLite in Jooq 3.12.3 so an update was needed.

# Implementation

One of the important changes is the [removal](https://github.com/jOOQ/jOOQ/issues/10512) of `AutoClosable` from `DSLContext` and the use of `ClosableDSLContext` instead. ([related commit](https://github.com/ICIJ/datashare/commit/b6e94381eabb62674dbbb67e9da0d82305084e06))
The other change is the use of `LocalDateTime` format by Jooq functions instead of `Timestamp` ([related commit](https://github.com/ICIJ/datashare/commit/b6e94381eabb62674dbbb67e9da0d82305084e06))
The last major change is the fact that Jooq uses Java 17 as [base](https://github.com/jOOQ/jOOQ/issues/12430) so we had to modify the CI to use Java 17 accordingly. 