### PR TITLE
feat: add streamReadConstraints for the objectmapper

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/json/JsonObjectMapper.java
+++ b/datashare-api/src/main/java/org/icij/datashare/json/JsonObjectMapper.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.json;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,6 +41,13 @@ public class JsonObjectMapper {
 
     // JSON - Object mapper
     public static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static final int MAX_NESTING_DEPTH = 20;
+
+    public static final int MAX_NUMBER_LENGTH = 100;
+
+    public static final int MAX_STRING_LENGTH = 1000000000;
+
     static {
         // Handle Optional and other JDK 8 only features
         MAPPER.registerModule(new Jdk8Module());
@@ -48,6 +57,10 @@ public class JsonObjectMapper {
         //  Making domain entities' private fields visible to Jackson
         MAPPER.setVisibility(FIELD, ANY);
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        MAPPER.getFactory().setStreamReadConstraints(StreamReadConstraints.builder()
+                .maxNestingDepth(MAX_NESTING_DEPTH)
+                .maxNumberLength(MAX_NUMBER_LENGTH)
+                .maxStringLength(MAX_STRING_LENGTH).build());
     }
 
     /**

--- a/datashare-api/src/test/java/org/icij/datashare/json/JsonObjectMapperTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/json/JsonObjectMapperTest.java
@@ -3,10 +3,12 @@ package org.icij.datashare.json;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.json.JsonObjectMapper.*;
 
 public class JsonObjectMapperTest {
     @Test
@@ -33,6 +35,15 @@ public class JsonObjectMapperTest {
         assertThat(wrapper.throwable.getClass()).isEqualTo(RuntimeException.class);
         assertThat(wrapper.throwable.getMessage()).isEqualTo("hello");
     }
+
+    @Test
+    public void test_check_stream_read_constraints() throws Exception {
+        StreamReadConstraints streamReadConstraints = JsonObjectMapper.MAPPER.getFactory().streamReadConstraints();
+        assertThat(streamReadConstraints.getMaxNestingDepth()).isEqualTo(MAX_NESTING_DEPTH);
+        assertThat(streamReadConstraints.getMaxNumberLength()).isEqualTo(MAX_NUMBER_LENGTH);
+        assertThat(streamReadConstraints.getMaxStringLength()).isEqualTo(MAX_STRING_LENGTH);
+    }
+
 
     static class ExceptionWrapper {
         private final Throwable throwable;


### PR DESCRIPTION
Related to [this issue](https://github.com/ICIJ/datashare/issues/1426)
This PR aims to set up a max string length for Jackson other than the default 20MB value.
It is done by setting up the `streamReadConstraints` at the creation of the `ObjectMapper`
We set up these parameters : 
- `maxNestingDepth` : 20 (originally 1000)
- `maxNumLength` : 100 (originally 1000)
- `maxStringLength`: [1GB](https://github.com/ICIJ/datashare/blob/6107c1a2ddf4ec99d080a8157e94b8627ae18e3c/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java#L61) (originally 2MB)