### PR TITLE
feat: embedded artifacts

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -26,7 +26,7 @@ import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 import org.icij.datashare.user.User;
 import org.icij.datashare.user.UserTask;
 import org.icij.datashare.utils.DocumentVerifier;
-import org.icij.extract.extractor.EmbeddedDocumentMemoryExtractor.ContentNotFoundException;
+import org.icij.extract.extractor.EmbeddedDocumentExtractor.ContentNotFoundException;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -33,7 +33,7 @@ import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 import org.icij.datashare.user.User;
 import org.icij.datashare.utils.DocumentVerifier;
 import org.icij.datashare.utils.PayloadFormatter;
-import org.icij.extract.extractor.EmbeddedDocumentMemoryExtractor;
+import org.icij.extract.extractor.EmbeddedDocumentExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -410,7 +410,7 @@ public class DocumentResource {
             Payload payload = new Payload(contentType, from);
             String fileName = doc.isRootDocument() ? doc.getName(): doc.getId().substring(0, 10) + "." + FileExtension.get(contentType);
             return inline ? payload: payload.withHeader("Content-Disposition", "attachment;filename=\"" + fileName + "\"");
-        } catch (FileNotFoundException | EmbeddedDocumentMemoryExtractor.ContentNotFoundException fnf) {
+        } catch (FileNotFoundException | EmbeddedDocumentExtractor.ContentNotFoundException fnf) {
             logger.error("unable to read document source file", fnf);
             return Payload.notFound();
         }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -114,6 +114,7 @@ public class DatashareCli {
         DatashareCliOptions.charset(parser);
         DatashareCliOptions.stages(parser);
         DatashareCliOptions.dataDir(parser);
+        DatashareCliOptions.artifactDir(parser);
         DatashareCliOptions.enableOcr(parser);
         DatashareCliOptions.language(parser);
         DatashareCliOptions.ocrLanguage(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -346,10 +346,8 @@ public final class DatashareCliOptions {
     static void artifactDir(OptionParser parser) {
         parser.acceptsAll(
                 asList(ARTIFACT_DIR_OPT),
-                "Artifact directory for embedded caching" )
-                .withRequiredArg()
-                .ofType(File.class)
-                .defaultsTo(new File(DEFAULT_ARTIFACT_DIR));
+                "Artifact directory for embedded caching. If not provided datashare will use memory." )
+                .withRequiredArg();
     }
 
     static void rootHost(OptionParser parser) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -119,6 +119,7 @@ public final class DatashareCliOptions {
     public static final String TCP_LISTEN_PORT_OPT = "tcpListenPort";
     public static final String VERSION_ABBR_OPT = "v";
     public static final String VERSION_OPT = "version";
+    public static final String ARTIFACT_DIR_OPT = "artifactDir";
 
     private static final Path DEFAULT_DATASHARE_HOME = Paths.get(System.getProperty("user.home"), ".local/share/datashare");
     private static final Integer DEFAULT_NLP_PARALLELISM = 1;
@@ -126,6 +127,7 @@ public final class DatashareCliOptions {
     private static final Integer DEFAULT_PARSER_PARALLELISM = 1;
     public static final DigestAlgorithm DEFAULT_DIGEST_METHOD = DigestAlgorithm.SHA_384;
     public static final String DEFAULT_DATA_DIR = Paths.get(System.getProperty("user.home")).resolve("Datashare").toString();
+    public static final String DEFAULT_ARTIFACT_DIR = DEFAULT_DATA_DIR;
     public static final Mode DEFAULT_MODE = Mode.LOCAL;
     public static final QueueType DEFAULT_BATCH_QUEUE_TYPE = QueueType.MEMORY;
     public static final QueueType DEFAULT_BUS_TYPE = QueueType.MEMORY;
@@ -339,6 +341,15 @@ public final class DatashareCliOptions {
                 .withRequiredArg()
                 .ofType(File.class)
                 .defaultsTo(new File(DEFAULT_DATA_DIR));
+    }
+
+    static void artifactDir(OptionParser parser) {
+        parser.acceptsAll(
+                asList(ARTIFACT_DIR_OPT),
+                "Artifact directory for embedded caching" )
+                .withRequiredArg()
+                .ofType(File.class)
+                .defaultsTo(new File(DEFAULT_ARTIFACT_DIR));
     }
 
     static void rootHost(OptionParser parser) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -127,7 +127,6 @@ public final class DatashareCliOptions {
     private static final Integer DEFAULT_PARSER_PARALLELISM = 1;
     public static final DigestAlgorithm DEFAULT_DIGEST_METHOD = DigestAlgorithm.SHA_384;
     public static final String DEFAULT_DATA_DIR = Paths.get(System.getProperty("user.home")).resolve("Datashare").toString();
-    public static final String DEFAULT_ARTIFACT_DIR = DEFAULT_DATA_DIR;
     public static final Mode DEFAULT_MODE = Mode.LOCAL;
     public static final QueueType DEFAULT_BATCH_QUEUE_TYPE = QueueType.MEMORY;
     public static final QueueType DEFAULT_BUS_TYPE = QueueType.MEMORY;

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
@@ -9,7 +9,7 @@ import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Language;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.document.TikaDocument;
-import org.icij.extract.extractor.EmbeddedDocumentMemoryExtractor;
+import org.icij.extract.extractor.EmbeddedDocumentExtractor;
 import org.icij.extract.extractor.Extractor;
 import org.icij.spewer.FieldNames;
 import org.icij.task.Options;
@@ -45,7 +45,7 @@ public class SourceExtractorTest {
         new SourceExtractor(tmpDir.getRoot().toPath()).getSource(document);
     }
 
-    @Test(expected = EmbeddedDocumentMemoryExtractor.ContentNotFoundException.class)
+    @Test(expected = EmbeddedDocumentExtractor.ContentNotFoundException.class)
     public void test_content_not_found() {
         Document document = DocumentBuilder.createDoc(project("project"), get(getClass().getResource("/docs/embedded_doc.eml").getPath()))
                 .with("it has been parsed")
@@ -222,7 +222,7 @@ public class SourceExtractorTest {
         assertThat(getBytes(source)).hasSize(49779);
     }
 
-    @Test(expected = EmbeddedDocumentMemoryExtractor.ContentNotFoundException.class)
+    @Test(expected = EmbeddedDocumentExtractor.ContentNotFoundException.class)
     public void test_not_get_source_for_embedded_doc_with_digest_project_name_using_legacy_value_in_server() throws Exception {
         PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
             put("digestAlgorithm", Document.DEFAULT_DIGESTER.toString());

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
@@ -42,7 +42,7 @@ public class SourceExtractorTest {
         File file = tmpDir.newFile("foo.bar");
         Document document = DocumentBuilder.createDoc(project("project"), file.toPath()).build();
         assertThat(file.delete()).isTrue();
-        new SourceExtractor().getSource(document);
+        new SourceExtractor(tmpDir.getRoot().toPath()).getSource(document);
     }
 
     @Test(expected = EmbeddedDocumentMemoryExtractor.ContentNotFoundException.class)
@@ -55,7 +55,7 @@ public class SourceExtractorTest {
                 .with(new HashMap<>())
                 .with(Document.Status.INDEXED)
                 .withContentLength(45L).build();
-        new SourceExtractor().getEmbeddedSource(project("project"), document);
+        new SourceExtractor(tmpDir.getRoot().toPath()).getEmbeddedSource(project("project"), document);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class SourceExtractorTest {
                 .with(Document.Status.INDEXED)
                 .withContentLength(45L).build();
 
-        InputStream source = new SourceExtractor().getSource(document);
+        InputStream source = new SourceExtractor(tmpDir.getRoot().toPath()).getSource(document);
         assertThat(source).isNotNull();
         assertThat(getBytes(source)).hasSize(70574);
     }
@@ -85,8 +85,8 @@ public class SourceExtractorTest {
                 .with(Document.Status.INDEXED)
                 .withContentLength(0L).build();
 
-        InputStream inputStreamWithMetadata = new SourceExtractor(false).getSource(document);
-        InputStream inputStreamWithoutMetadata = new SourceExtractor(true).getSource(document);
+        InputStream inputStreamWithMetadata = new SourceExtractor(tmpDir.getRoot().toPath(), false).getSource(document);
+        InputStream inputStreamWithoutMetadata = new SourceExtractor(tmpDir.getRoot().toPath(), true).getSource(document);
         assertThat(inputStreamWithMetadata).isNotNull();
         assertThat(inputStreamWithoutMetadata).isNotNull();
         assertThat(getBytes(inputStreamWithMetadata).length).isEqualTo(9216);
@@ -118,7 +118,7 @@ public class SourceExtractorTest {
 
         assertThat(attachedPdf).isNotNull();
         assertThat(attachedPdf.getContentType()).isEqualTo("application/pdf");
-        InputStream source = new SourceExtractor().getSource(project(TEST_INDEX), attachedPdf);
+        InputStream source = new SourceExtractor(tmpDir.getRoot().toPath()).getSource(project(TEST_INDEX), attachedPdf);
         assertThat(source).isNotNull();
         assertThat(getBytes(source)).hasSize(49779);
     }
@@ -155,7 +155,7 @@ public class SourceExtractorTest {
                 get(TEST_INDEX, "1bf2b6aa27dd8b45c7db58875004b8cb27a78ced5200b4976b63e351ebbae5ececb86076d90e156a7cdea06cde9573ca",
                         "f4078910c3e73a192e3a82d205f3c0bdb749c4e7b23c1d05a622db0f07d7f0ededb335abdb62aef41ace5d3cdb9298bc");
 
-        InputStream source = new SourceExtractor(true).getSource(project(TEST_INDEX), attachedPdf);
+        InputStream source = new SourceExtractor(tmpDir.getRoot().toPath(), true).getSource(project(TEST_INDEX), attachedPdf);
         assertThat(source).isNotNull();
         assertThat(getBytes(source).length).isNotEqualTo(49779);
     }
@@ -184,7 +184,7 @@ public class SourceExtractorTest {
                 get(TEST_INDEX, "754ea07d66c2ec23d2849b4d44f276a7ebe719e586c20d15c7b772dcd4a620b0117e7396b76496ed5c10a066bf19d907",
                         "c78925fb478426ccc4c5a7cb975bc0f35d4079cd8a55d7a340bdccb3a46379e4940daa198c0be0dfd247cde338194105");
 
-        InputStream source = new SourceExtractor().getSource(project(TEST_INDEX), attachedPdf);
+        InputStream source = new SourceExtractor(tmpDir.getRoot().toPath()).getSource(project(TEST_INDEX), attachedPdf);
         assertThat(source).isNotNull();
         assertThat(getBytes(source)).hasSize(49779);
     }
@@ -194,6 +194,7 @@ public class SourceExtractorTest {
         PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
             put("digestAlgorithm", Document.DEFAULT_DIGESTER.toString());
             put("digestProjectName", "local-datashare");
+            put("artifactDir", tmpDir.newFolder("local_mode").toString());
             put("mode", "LOCAL");
         }});
         Options<String> options = Options.from(propertiesProvider.getProperties());
@@ -226,6 +227,7 @@ public class SourceExtractorTest {
         PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
             put("digestAlgorithm", Document.DEFAULT_DIGESTER.toString());
             put("digestProjectName", "local-datashare");
+            put("artifactDir", tmpDir.newFolder("server_mode").toString());
             put("mode", "SERVER");
         }});
         Options<String> options = Options.from(propertiesProvider.getProperties());

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <guice.version>4.2.3</guice.version>
         <amazon.version>1.12.411</amazon.version>
 
-        <extract.version>7.1.0</extract.version>
+        <extract.version>7.1.1</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>7.17.9</elasticsearch.version>
         <lucene.version>8.11.1</lucene.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <guice.version>4.2.3</guice.version>
         <amazon.version>1.12.411</amazon.version>
 
-        <extract.version>6.7.3</extract.version>
+        <extract.version>7.1.0</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>7.17.9</elasticsearch.version>
         <lucene.version>8.11.1</lucene.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <guice.version>4.2.3</guice.version>
         <amazon.version>1.12.411</amazon.version>
 
-        <extract.version>7.1.1</extract.version>
+        <extract.version>7.2.0</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>7.17.9</elasticsearch.version>
         <lucene.version>8.11.1</lucene.version>


### PR DESCRIPTION
See #1165 for the list of commits. Changes are made in extract-lib. https://github.com/ICIJ/extract/commit/f09254eb0d05c54c8df657acf73641d3193e2f5b

If null is provided in the [EmbeddedDocumentExtractor](https://github.com/ICIJ/extract/blob/7ed996daa13e211bb2df488f712b2b46d30473a8/extract-lib/src/main/java/org/icij/extract/extractor/EmbeddedDocumentExtractor.java) as the `artifactPath` then memory is used, else the provided path will be used as file cache for embedded files.