### PR TITLE
feature: batch ner

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/function/Pair.java
+++ b/datashare-api/src/main/java/org/icij/datashare/function/Pair.java
@@ -17,6 +17,10 @@ public class Pair<T1, T2> {
         second = snd;
     }
 
+    public static <T1, T2>  Pair<T1, T2> of(T1 fst, T2 snd) {
+        return new Pair<>(fst, snd);
+    }
+
     public T1 _1() { return first; }
     public T2 _2() { return second; }
 
@@ -27,12 +31,10 @@ public class Pair<T1, T2> {
 
     @Override
     public boolean equals(Object o) {
-        if ( ! (o instanceof Pair) ) {
+        if ( ! (o instanceof Pair<?, ?> objPair) ) {
             return false;
         }
-        Pair objPair = (Pair) o;
-        return  first .equals(objPair._1()) &&
-                second.equals(objPair._2());
+        return  first .equals(objPair._1()) && second.equals(objPair._2());
     }
 
 }

--- a/datashare-api/src/main/java/org/icij/datashare/text/NamedEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/NamedEntity.java
@@ -135,8 +135,8 @@ public final class NamedEntity implements Entity {
     }
 
     public static NamedEntity from(String text, NlpTag tag, Annotations annotations) {
-        String mention = ThrowingFunctions.removeNewLines.apply(text.substring(tag.getBegin(), tag.getEnd()));
-        return NamedEntity.create(tag.getCategory(), mention, List.of((long) tag.getBegin()),
+        String mention = ThrowingFunctions.removeNewLines.apply(text.substring(tag.begin(), tag.end()));
+        return NamedEntity.create(tag.category(), mention, List.of((long) tag.begin()),
                 annotations.documentId, annotations.rootId, annotations.pipelineType, annotations.language
         );
     }

--- a/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
@@ -33,7 +33,7 @@ public interface Indexer extends Closeable {
     <T extends Entity> boolean bulkUpdate(String indexName, List<T> entities) throws IOException;
     <T extends Entity> void add(String indexName, T obj) throws IOException;
     <T extends Entity> void update(String indexName, T obj) throws IOException;
-    <T extends Entity> boolean exists(String indexName, String id) throws IOException;
+    boolean exists(String indexName, String id) throws IOException;
 
     <T extends Entity> T get(String indexName, String id);
     <T extends Entity> T get(String indexName, String id, List<String> sourceExcludes);
@@ -61,9 +61,11 @@ public interface Indexer extends Closeable {
         Searcher withoutSource(String... fields);
         Searcher withSource(boolean source);
         Searcher limit(int maxCount);
+        Searcher sort(String field, SortOrder order);
         void clearScroll() throws IOException;
         long totalHits();
         Searcher with(int fuzziness, boolean phraseMatches);
+        enum SortOrder { ASC, DESC }
     }
 
     interface QueryBuilderSearcher extends Searcher {

--- a/datashare-api/src/main/java/org/icij/datashare/text/nlp/AbstractPipeline.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/nlp/AbstractPipeline.java
@@ -1,7 +1,6 @@
 package org.icij.datashare.text.nlp;
 
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Language;
 import org.icij.datashare.text.NamedEntity;
 import org.slf4j.Logger;
@@ -64,11 +63,6 @@ public abstract class AbstractPipeline implements Pipeline {
         LOGGER.info("initializing " + getType());
         return true;
     }
-
-    /**
-     * Apply all specified stages/annotators on input
-     *  @param doc is the document source to process */
-    public abstract List<NamedEntity> process(Document doc) throws InterruptedException;
 
     /**
      * Post-processing operations

--- a/datashare-api/src/main/java/org/icij/datashare/text/nlp/NlpTag.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/nlp/NlpTag.java
@@ -2,34 +2,24 @@ package org.icij.datashare.text.nlp;
 
 import static java.util.Comparator.comparingInt;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Comparator;
 import org.icij.datashare.text.NamedEntity;
 
-public class NlpTag {
+public record NlpTag(int begin, int end, NamedEntity.Category category) {
 
-    public static final Comparator<NlpTag> comparator = comparingInt(NlpTag::getBegin);
+    public static final Comparator<NlpTag> comparator = comparingInt(NlpTag::begin);
 
-    private final int begin;
-    private final int end;
-    private final NamedEntity.Category category;
-
-
-    public NlpTag(int begin, int end, NamedEntity.Category category) {
+    @JsonCreator
+    public NlpTag(
+        @JsonProperty("begin") int begin,
+        @JsonProperty("start") int end,
+        @JsonProperty("category") NamedEntity.Category category
+    ) {
         this.begin = begin;
         this.end = end;
         this.category = category;
-    }
-
-    public int getBegin() {
-        return begin;
-    }
-
-    public int getEnd() {
-        return end;
-    }
-
-    public NamedEntity.Category getCategory() {
-        return category;
     }
 
 }

--- a/datashare-api/src/main/java/org/icij/datashare/text/nlp/NlpTag.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/nlp/NlpTag.java
@@ -14,7 +14,7 @@ public class NlpTag {
     private final NamedEntity.Category category;
 
 
-    NlpTag(int begin, int end, NamedEntity.Category category) {
+    public NlpTag(int begin, int end, NamedEntity.Category category) {
         this.begin = begin;
         this.end = end;
         this.category = category;

--- a/datashare-api/src/main/java/org/icij/datashare/text/nlp/Pipeline.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/nlp/Pipeline.java
@@ -116,9 +116,9 @@ public interface Pipeline {
         this.processText(Stream.of(docContent.substring(contentOffset, contentOffset + contentLength)), doc.getLanguage())
             .get(0)
             .forEach(tag -> {
-                int begin = tag.getBegin() + contentOffset;
-                int end = tag.getEnd() + contentOffset;
-                annotations.add(begin, end, tag.getCategory());
+                int begin = tag.begin() + contentOffset;
+                int end = tag.end() + contentOffset;
+                annotations.add(begin, end, tag.category());
             });
         return NamedEntity.allFrom(docContent, annotations);
     }

--- a/datashare-api/src/main/java/org/icij/datashare/text/nlp/Pipeline.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/nlp/Pipeline.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.nlp;
 
+import java.util.stream.Stream;
 import org.icij.datashare.reflect.EnumTypeToken;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Language;
@@ -21,6 +22,9 @@ public interface Pipeline {
     static Set<Type> set(Type ...types) {
         return new HashSet<>(Arrays.asList(types));
     }
+
+    record PipelineInput (Document doc, int contentLength, int contentOffset) {}
+
 
     enum Type implements EnumTypeToken {
         TEST((short)-1),
@@ -98,6 +102,15 @@ public interface Pipeline {
 
     List<NamedEntity> process(Document doc) throws InterruptedException;
     List<NamedEntity> process(Document doc, int contentLength, int contentOffset) throws InterruptedException;
+    default List<List<NamedEntity>> process(Stream<PipelineInput> inputs) throws InterruptedException {
+        return inputs.map(i -> {
+            try {
+                return process(i.doc, i.contentLength, i.contentOffset);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.toList());
+    }
 
     void terminate(Language language) throws InterruptedException;
 

--- a/datashare-api/src/test/java/org/icij/datashare/extension/PipelineRegistryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/extension/PipelineRegistryTest.java
@@ -73,61 +73,62 @@ public class PipelineRegistryTest {
         loader = new ExtensionLoader(folder.getRoot().toPath());
     }
 
-    String EXTENSION_PIPELINE_SOURCE = "package org.icij.datashare.text.nlp.test;\n" +
-            "\n" +
-            "import org.icij.datashare.PropertiesProvider;\n" +
-            "import org.icij.datashare.text.Document;\n" +
-            "import org.icij.datashare.text.Language;\n" +
-            "import org.icij.datashare.text.NamedEntity;\n" +
-            "import org.icij.datashare.text.nlp.Annotations;\n" +
-            "import org.icij.datashare.text.nlp.Pipeline;\n" +
-            "\n" +
-            "import java.nio.charset.Charset;\n" +
-            "import java.util.List;\n" +
-            "import java.util.Optional;\n" +
-            "\n" +
-            "public class ExtensionPipeline implements Pipeline {\n" +
-            "    @Override\n" +
-            "    public Type getType() {\n" +
-            "        return Type.TEST;\n" +
-            "    }\n" +
-            "\n" +
-            "    public ExtensionPipeline(PropertiesProvider provider) {}\n" +
-            "    @Override\n" +
-            "    public boolean initialize(Language language) throws InterruptedException {\n" +
-            "        return false;\n" +
-            "    }\n" +
-            "    @Override\n" +
-            "    public List<NamedEntity> process(Document doc) throws InterruptedException  {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "    @Override\n" +
-            "    public List<NamedEntity> process(Document doc, int contentLength, int offset) throws InterruptedException  {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "    @Override\n" +
-            "    public void terminate(Language language) throws InterruptedException {\n" +
-            "\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public boolean supports(Language language) {\n" +
-            "        return false;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public List<NamedEntity.Category> getTargetEntities() {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public boolean isCaching() {\n" +
-            "        return false;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public Charset getEncoding() {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "}\n";
+    String EXTENSION_PIPELINE_SOURCE = """
+        package org.icij.datashare.text.nlp.test;
+
+        import org.icij.datashare.PropertiesProvider;
+        import org.icij.datashare.text.Document;
+        import org.icij.datashare.text.Language;
+        import org.icij.datashare.text.NamedEntity;
+        import org.icij.datashare.text.nlp.Annotations;
+        import org.icij.datashare.text.nlp.Pipeline;
+        import org.icij.datashare.text.nlp.NlpTag;
+
+        import java.nio.charset.Charset;
+        import java.util.List;
+        import java.util.stream.Stream;
+        import java.util.Optional;
+
+        public class ExtensionPipeline implements Pipeline {
+            @Override
+            public Type getType() {
+                return Type.TEST;
+            }
+
+            public ExtensionPipeline(PropertiesProvider provider) {}
+            @Override
+            public boolean initialize(Language language) throws InterruptedException {
+                return false;
+            }
+            @Override
+            public List<List<NlpTag>> processText(Stream<String> batch, Language language)  {
+                return null;
+            }
+
+            @Override
+            public void terminate(Language language) throws InterruptedException {
+
+            }
+
+            @Override
+            public boolean supports(Language language) {
+                return false;
+            }
+
+            @Override
+            public List<NamedEntity.Category> getTargetEntities() {
+                return null;
+            }
+
+            @Override
+            public boolean isCaching() {
+                return false;
+            }
+
+            @Override
+            public Charset getEncoding() {
+                return null;
+            }
+        }
+        """;
 }

--- a/datashare-api/src/test/java/org/icij/datashare/text/nlp/test/TestPipeline.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/nlp/test/TestPipeline.java
@@ -1,9 +1,10 @@
 package org.icij.datashare.text.nlp.test;
 
+import java.util.stream.Stream;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Language;
 import org.icij.datashare.text.NamedEntity;
+import org.icij.datashare.text.nlp.NlpTag;
 import org.icij.datashare.text.nlp.Pipeline;
 
 import java.nio.charset.Charset;
@@ -22,15 +23,9 @@ public class TestPipeline implements Pipeline {
     }
 
     @Override
-    public List<NamedEntity> process(Document doc) {
+    public List<List<NlpTag>> processText(Stream<String> batch, Language language) {
         return null;
     }
-
-    @Override
-    public List<NamedEntity> process(Document doc, int contentLength, int contentOffset) {
-        return null;
-    }
-
     @Override
     public void terminate(Language language) {
     }

--- a/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
+++ b/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
@@ -106,8 +106,8 @@ public class EmailPipeline extends AbstractPipeline {
         this.processText(Stream.of(chunkContent), doc.getLanguage())
             .get(0)
             .forEach(t -> {
-                String mention = chunkContent.substring(t.getBegin(), t.getEnd());
-                namedEntitiesBuilder.add(NamedEntity.Category.EMAIL, mention, t.getBegin() + contentOffset);
+                String mention = chunkContent.substring(t.begin(), t.end());
+                namedEntitiesBuilder.add(NamedEntity.Category.EMAIL, mention, t.begin() + contentOffset);
             });
         List<NamedEntity> entities = namedEntitiesBuilder.build();
         if ("message/rfc822".equals(doc.getContentType())) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
@@ -54,7 +54,8 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
     public Long call() throws Exception {
         super.call();
         Indexer.Searcher searcher = indexer.search(singletonList(projectName), Document.class)
-                .without(nlpPipeline).withSource("rootDocument").limit(scrollSize);
+            .without(nlpPipeline).withSource("rootDocument").limit(scrollSize)
+            .sort("language", Indexer.Searcher.SortOrder.ASC);
         logger.info("resuming NLP name finding for index {} and {} with {} scroll and size of {} : {} documents found", projectName, nlpPipeline,
                 scrollDuration, scrollSize, searcher.totalHits());
         List<? extends Entity> docsToProcess = searcher.scroll(scrollDuration).collect(toList());

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -1,7 +1,21 @@
 package org.icij.datashare.tasks;
 
+import static java.lang.String.valueOf;
+import static java.util.Optional.ofNullable;
+import static org.icij.datashare.cli.DatashareCliOptions.BATCH_SIZE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.MAX_CONTENT_LENGTH_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.NLP_PIPELINE_OPT;
+import static org.icij.extract.document.Identifier.shorten;
+
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.icij.datashare.HumanReadableSize;
 import org.icij.datashare.PropertiesProvider;
@@ -11,32 +25,28 @@ import org.icij.datashare.extension.PipelineRegistry;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.monitoring.Monitorable;
 import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Language;
 import org.icij.datashare.text.NamedEntity;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.nlp.Annotations;
+import org.icij.datashare.text.nlp.NlpTag;
 import org.icij.datashare.text.nlp.Pipeline;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static java.lang.String.valueOf;
-import static java.util.Optional.ofNullable;
-import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
-import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
-import static org.icij.datashare.cli.DatashareCliOptions.MAX_CONTENT_LENGTH_OPT;
-import static org.icij.datashare.cli.DatashareCliOptions.NLP_PIPELINE_OPT;
-import static org.icij.extract.document.Identifier.shorten;
-
 public class ExtractNlpTask extends PipelineTask<String> implements Monitorable {
-    private static final int DEFAULT_MAX_CONTENT_LENGTH = 1024 * 1024;
+    private static final int DEFAULT_MAX_LENGTH = 4096;
+    private static final int DEFAULT_BATCH_SIZE = 256;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Indexer indexer;
     private final Pipeline nlpPipeline;
     private final Project project;
-    private final int maxContentLengthChars;
+    private final int maxContentLength;
+    private final int batchSize;
+
+    record BatchItem(Document doc, String text, int offset) {
+    }
 
     @Inject
     public ExtractNlpTask(Indexer indexer, PipelineRegistry registry, final DocumentCollectionFactory<String> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
@@ -44,11 +54,12 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
     }
 
 
-    ExtractNlpTask(Indexer indexer, Pipeline pipeline, final DocumentCollectionFactory<String> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
+    ExtractNlpTask(Indexer indexer, Pipeline pipeline, final DocumentCollectionFactory<String> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> ignored) {
         super(Stage.NLP, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class);
         this.nlpPipeline = pipeline;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
-        maxContentLengthChars = (int) HumanReadableSize.parse(ofNullable((String)taskView.args.get(MAX_CONTENT_LENGTH_OPT)).orElse(valueOf(DEFAULT_MAX_CONTENT_LENGTH)));
+        maxContentLength = (int) HumanReadableSize.parse(ofNullable((String)taskView.args.get(MAX_CONTENT_LENGTH_OPT)).orElse(valueOf(DEFAULT_MAX_LENGTH)));
+        batchSize = (int) HumanReadableSize.parse(ofNullable((String)taskView.args.get(BATCH_SIZE_OPT)).orElse(valueOf(DEFAULT_BATCH_SIZE)));
         this.indexer = indexer;
     }
 
@@ -56,38 +67,126 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
     public Long call() throws Exception {
         super.call();
         logger.info("extracting Named Entities with pipeline {} for {} from queue {}", nlpPipeline.getType(), project, inputQueue.getName());
+        long nbMessages;
+        if (this.nlpPipeline.getType().extractFromDoc()) {
+            nbMessages = extractFromDocs();
+        } else {
+            nbMessages = extractFromTexts();
+        }
+        logger.info("exiting ExtractNlpTask loop after {} messages.", nbMessages);
+        return nbMessages;
+    }
+
+    long extractFromTexts() throws InterruptedException {
+        // NLP models are loaded/initialized by language, to avoid loading overhead, docs are
+        // received grouped by language and sent batched to the pipeline to avoid model reload.
+        long nDocs = 0;
+        String docId;
+        Language currentLanguage = null;
+        boolean languageInitialized = false;
+        ArrayList<BatchItem> batch = new ArrayList<>(batchSize);
+        while (!(STRING_POISON.equals(docId = inputQueue.poll(60, TimeUnit.SECONDS)))) {
+            Document doc = indexer.get(project.getName(), docId);
+            nDocs++;
+            if (doc != null) {
+                String docContent = doc.getContent();
+                if (!doc.getLanguage().equals(currentLanguage)) {
+                    if (!batch.isEmpty()) {
+                        consumeBatch(batch, currentLanguage);
+                    }
+                    if (currentLanguage != null) {
+                        nlpPipeline.terminate(currentLanguage);
+                    }
+                    currentLanguage = doc.getLanguage();
+                    languageInitialized = nlpPipeline.initialize(currentLanguage);
+                }
+                if (!languageInitialized) {
+                    continue;
+                }
+                int docLength = docContent.length();
+                for (int begin = 0; begin < docLength; begin += maxContentLength) {
+                    int end = Math.min(begin + maxContentLength, docLength);
+                    String text = docContent.substring(begin, end);
+                    batch.add(new BatchItem(doc, text, begin));
+                    if (batch.size() >= batchSize) {
+                        consumeBatch(batch, currentLanguage);
+                    }
+                }
+            } else {
+                logger.warn("no document found in index with id " + docId);
+            }
+        }
+        if (!batch.isEmpty()) {
+            consumeBatch(batch, currentLanguage);
+        }
+        if (currentLanguage != null) {
+            nlpPipeline.terminate(currentLanguage);
+        }
+        return nDocs;
+    }
+
+    private void consumeBatch(List<BatchItem> batch, Language language) throws InterruptedException {
+        List<List<NlpTag>> entities = nlpPipeline.processText(batch.stream().map(i -> i.text), language);
+        Iterator<BatchItem> batchIt = batch.iterator();
+        entities.forEach(chunkTags -> {
+            BatchItem item = batchIt.next();
+            Document doc = item.doc;
+            Annotations annotations =
+                new Annotations(doc.getId(), nlpPipeline.getType(), doc.getLanguage());
+            int offset = item.offset;
+            chunkTags.forEach(tag -> {
+                int begin = tag.getBegin() + offset;
+                int end = tag.getEnd() + offset;
+                annotations.add(begin, end, tag.getCategory());
+            });
+            List<NamedEntity> chunkEntities = NamedEntity.allFrom(doc.getContent(), annotations);
+            boolean isComplete = offset + item.text.length() == doc.getContentTextLength();
+            try {
+                if (isComplete) {
+                    indexer.bulkAdd(project.getName(), nlpPipeline.getType(), chunkEntities, doc);
+                } else {
+                    indexer.bulkAdd(project.getName(), chunkEntities);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        batch.clear();
+    }
+
+    private long extractFromDocs() throws InterruptedException {
         String docId;
         long nbMessages = 0;
         while (!(STRING_POISON.equals(docId = inputQueue.poll(60, TimeUnit.SECONDS)))) {
             try {
                 if (docId != null) {
-                    findNamedEntities(project, docId);
+                    findDocNamedEntities(project, docId);
                     nbMessages++;
                 }
             } catch (Throwable e) {
                 logger.error("error in ExtractNlpTask loop", e);
             }
         }
-        logger.info("exiting ExtractNlpTask loop after {} messages.", nbMessages);
         return nbMessages;
     }
 
-    void findNamedEntities(final Project project, final String id) throws InterruptedException {
+    void findDocNamedEntities(final Project project, final String id) throws InterruptedException {
         try {
             Document doc = indexer.get(project.getName(), id);
             if (doc != null) {
                 logger.info("extracting {} entities for document {}", nlpPipeline.getType(), shorten(doc.getId(), 4));
                 if (nlpPipeline.initialize(doc.getLanguage())) {
                     int nbEntities = 0;
-                    if (doc.getContent().length() < this.maxContentLengthChars) {
-                        List<NamedEntity> namedEntities = nlpPipeline.process(doc);
+                    if (doc.getContent().length() < this.maxContentLength) {
+                        List<NamedEntity> namedEntities = nlpPipeline.processDoc(doc);
                         indexer.bulkAdd(project.getName(), nlpPipeline.getType(), namedEntities, doc);
                         nbEntities = namedEntities.size();
                     } else {
-                        int nbChunks = doc.getContent().length() / this.maxContentLengthChars + 1;
+                        int nbChunks = doc.getContent().length() / this.maxContentLength + 1;
                         logger.info("document is too large, extracting entities for {} document chunks", nbChunks);
                         for (int chunkIndex = 0; chunkIndex < nbChunks; chunkIndex++) {
-                            List<NamedEntity> namedEntities = nlpPipeline.process(doc, maxContentLengthChars, chunkIndex * maxContentLengthChars);
+                            List<NamedEntity> namedEntities =
+                                nlpPipeline.processDoc(doc, maxContentLength, chunkIndex * maxContentLength);
                             if (chunkIndex < nbChunks - 1) {
                                 indexer.bulkAdd(project.getName(), namedEntities);
                             } else {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -135,9 +135,9 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
                 new Annotations(doc.getId(), nlpPipeline.getType(), doc.getLanguage());
             int offset = item.offset;
             chunkTags.forEach(tag -> {
-                int begin = tag.getBegin() + offset;
-                int end = tag.getEnd() + offset;
-                annotations.add(begin, end, tag.getCategory());
+                int begin = tag.begin() + offset;
+                int end = tag.end() + offset;
+                annotations.add(begin, end, tag.category());
             });
             List<NamedEntity> chunkEntities = NamedEntity.allFrom(doc.getContent(), annotations);
             boolean isComplete = offset + item.text.length() == doc.getContentTextLength();

--- a/datashare-app/src/main/java/org/icij/datashare/web/NerResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/NerResource.java
@@ -10,6 +10,7 @@ import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Post;
 import net.codestory.http.annotations.Prefix;
 import org.icij.datashare.extension.PipelineRegistry;
+import org.icij.datashare.text.Document;
 import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Language;
 import org.icij.datashare.text.NamedEntity;
@@ -51,7 +52,8 @@ public class NerResource {
         Pipeline p = pipelineRegistry.get(Pipeline.Type.parse(pipeline));
         Language language = languageGuesser.guess(text);
         if (p.initialize(language)) {
-            return p.process(DocumentBuilder.createDoc("inline").with(text).with(language).build());
+            Document doc = DocumentBuilder.createDoc("inline").with(text).with(language).build();
+            return p.processDoc(doc);
         }
         return emptyList();
     }

--- a/datashare-app/src/test/java/org/icij/datashare/nlp/CoreNlpTestManual.java
+++ b/datashare-app/src/test/java/org/icij/datashare/nlp/CoreNlpTestManual.java
@@ -22,7 +22,7 @@ public class CoreNlpTestManual {
         systemClassLoader.add(distDir.toURI().toURL());
         CorenlpPipeline corenlpPipeline = new CorenlpPipeline(new PropertiesProvider());
         corenlpPipeline.initialize(Language.ENGLISH);
-        List<NamedEntity> process = corenlpPipeline.process(DocumentBuilder.createDoc("my_doc_id").with("this is Dwight's document").build());
+        List<NamedEntity> process = corenlpPipeline.processDoc(DocumentBuilder.createDoc("my_doc_id").with("this is Dwight's document").build());
         assertThat(process.size()).isGreaterThan(0);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
@@ -5,6 +5,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
+import java.util.stream.Stream;
 import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import static java.util.Arrays.asList;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
 import static org.icij.datashare.text.Language.ENGLISH;
+import static org.icij.datashare.text.Language.FRENCH;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -50,21 +52,53 @@ public class ExtractNlpTaskIntTest {
     }
 
     @Test(timeout = 2000)
-    public void test_loop_consume_two_documents() throws Exception {
+    public void test_loop_consume_two_doc_texts() throws Exception {
         when(pipeline.getType()).thenReturn(Pipeline.Type.CORENLP);
         when(pipeline.initialize(any())).thenReturn(true);
-        Document doc = createDoc("content").build();
-        when(indexer.get(anyString(), eq("docId"))).thenReturn(doc);
+        Document enDoc = createDoc("enId").with("content").with(ENGLISH).build();
+        Document frDoc = createDoc("fr").with("contenu").with(FRENCH).build();
+        when(indexer.get(anyString(), eq("enId"))).thenReturn(enDoc);
+        when(indexer.get(anyString(), eq("frId"))).thenReturn(frDoc);
 
         String queueName = new PipelineHelper(new PropertiesProvider()).getQueueNameFor(Stage.NLP);
         DocumentQueue<String> queue = factory.createQueue(queueName, String.class);
-        queue.add("docId");
+        queue.add("enId");
+        queue.add("frId");
         queue.add(PipelineTask.STRING_POISON);
 
         nlpTask.call();
 
         verify(pipeline).initialize(ENGLISH);
-        verify(pipeline).process(doc);
+        verify(pipeline).processText(any(Stream.class), eq(ENGLISH));
+        verify(pipeline).terminate(ENGLISH);
+        verify(pipeline).processText(any(Stream.class), eq(ENGLISH));
+        verify(pipeline).initialize(FRENCH);
+        verify(pipeline).terminate(FRENCH);
+    }
+
+    @Test(timeout = 2000)
+    public void test_loop_consume_two_docs() throws Exception {
+        when(pipeline.getType()).thenReturn(Pipeline.Type.EMAIL);
+        when(pipeline.initialize(any())).thenReturn(true);
+        Document enDoc = createDoc("enId").with(ENGLISH).build();
+        Document frDoc = createDoc("frId").with(FRENCH).build();
+        when(indexer.get(anyString(), eq("enId"))).thenReturn(enDoc);
+        when(indexer.get(anyString(), eq("frId"))).thenReturn(frDoc);
+
+        String queueName = new PipelineHelper(new PropertiesProvider()).getQueueNameFor(Stage.NLP);
+        DocumentQueue<String> queue = factory.createQueue(queueName, String.class);
+        queue.add("enId");
+        queue.add("frId");
+        queue.add(PipelineTask.STRING_POISON);
+
+        nlpTask.call();
+
+        verify(pipeline).initialize(ENGLISH);
+        verify(pipeline).processDoc(eq(enDoc));
+        verify(pipeline).terminate(ENGLISH);
+        verify(pipeline).initialize(FRENCH);
+        verify(pipeline).processDoc(eq(frDoc));
+        verify(pipeline).terminate(FRENCH);
     }
 
     @Parameterized.Parameters
@@ -93,7 +127,8 @@ public class ExtractNlpTaskIntTest {
     public void setUp() {
         initMocks(this);
         nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
-            put("maxContentLength", "32");
+            put("maxContentLength", "8");
+            put("batchSize", "1");
         }}), null);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
@@ -1,5 +1,25 @@
 package org.icij.datashare.tasks;
 
+import static java.util.Collections.emptyList;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.tasks.PipelineTask.STRING_POISON;
+import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.icij.datashare.text.Language.ENGLISH;
+import static org.icij.datashare.text.Language.FRENCH;
+import static org.icij.datashare.text.Project.project;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.text.Document;
@@ -7,80 +27,120 @@ import org.icij.datashare.text.Language;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.nlp.AbstractPipeline;
 import org.icij.datashare.user.User;
+import org.icij.extract.queue.DocumentQueue;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-import java.util.HashMap;
-
-import static java.util.Collections.emptyList;
-import static org.icij.datashare.text.DocumentBuilder.createDoc;
-import static org.icij.datashare.text.Language.ENGLISH;
-import static org.icij.datashare.text.Project.project;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-
 public class ExtractNlpTaskTest {
-    @Mock private Indexer indexer;
-    @Mock private AbstractPipeline pipeline;
+    @Mock
+    private Indexer indexer;
+    @Mock
+    private AbstractPipeline pipeline;
     private final MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
     private ExtractNlpTask nlpTask;
+    private final String INPUT_QUEUE_NAME = "extract:queue:nlp";
 
     @Before
     public void setUp() {
         initMocks(this);
-        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
-            put("maxContentLength", "32");
-        }}), null);
+        nlpTask =
+            new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(),
+                Map.of("maxContentLength", "8", "batchSize", "2")),
+                null
+            );
+        factory.queues.values().forEach(q -> q.drainTo(new ArrayList<>()));
     }
 
     @Test
-    public void test_on_message_does_nothing__when_doc_not_found_in_index() throws Exception {
-        nlpTask.findNamedEntities(project("projectName"),"unknownId");
+    public void test_find_doc_named_entities_does_nothing_when_doc_not_found_in_index() throws Exception {
+        nlpTask.findDocNamedEntities(project("projectName"), "unknownId");
 
         verify(pipeline, never()).initialize(any(Language.class));
-        verify(pipeline, never()).process(any());
+        verify(pipeline, never()).processDoc(any());
+        verify(pipeline, never()).processDoc(any(), anyInt(), anyInt());
     }
 
     @Test
-    public void test_on_message_do_not_processNLP__when_init_fails() throws Exception {
+    public void test_extract_from_texts_does_nothing_when_doc_not_found_in_index() throws Exception {
+        DocumentQueue<String> inputQueue = factory.getQueues(INPUT_QUEUE_NAME, String.class).get(0);
+        inputQueue.add("unknownId");
+        inputQueue.add(STRING_POISON);
+        nlpTask.extractFromTexts();
+
+        verify(pipeline, never()).initialize(any(Language.class));
+        verify(pipeline, never()).processText(any(), any());
+    }
+
+    @Test
+    public void test_find_doc_named_entities_does_nothing_when_init_fails() throws Exception {
         when(pipeline.initialize(any())).thenReturn(false);
         when(indexer.get(anyString(), anyString(), anyString())).thenReturn(createDoc("content").build());
 
-        nlpTask.findNamedEntities(project("projectName"),"id");
-        verify(pipeline, never()).process(any());
+        nlpTask.findDocNamedEntities(project("projectName"), "id");
+        verify(pipeline, never()).processDoc(any());
+        verify(pipeline, never()).processDoc(any(), anyInt(), anyInt());
     }
 
     @Test
-    public void test_on_message_processNLP__when_doc_found_in_index() throws Exception {
-        when(pipeline.initialize(any())).thenReturn(true);
-        Document doc = createDoc("content").build();
-        when(pipeline.process(doc)).thenReturn(emptyList());
-        when(indexer.get("projectName", doc.getId())).thenReturn(doc);
+    public void test_extract_from_texts_does_nothing_when_init_fails() throws Exception {
+        when(pipeline.initialize(any())).thenReturn(false);
+        DocumentQueue<String> inputQueue = factory.getQueues(INPUT_QUEUE_NAME, String.class).get(0);
+        inputQueue.add("docId");
+        inputQueue.add(STRING_POISON);
 
-        nlpTask.findNamedEntities(project("projectName"), doc.getId());
+        nlpTask.extractFromTexts();
 
-        verify(pipeline).initialize(ENGLISH);
-        verify(pipeline).process(doc);
+        verify(pipeline, never()).processText(any(), any());
     }
 
     @Test
-    public void test_on_message_process__chunked_doc_when_doc_is_large()  throws Exception  {
+    public void test_find_doc_named_entities_chunks_doc_when_too_large() throws InterruptedException {
         when(pipeline.initialize(any())).thenReturn(true);
         Document doc = createDoc("huge_doc").with("0123456789abcdef0123456789abcdef+").build();
-        when(pipeline.process(doc)).thenReturn(emptyList());
-        when(indexer.get("projectName", doc.getId())).thenReturn(doc);
+        when(pipeline.processDoc(doc)).thenReturn(emptyList());
+        when(indexer.get(anyString(), anyString())).thenReturn(doc);
 
-        nlpTask.findNamedEntities(project("projectName"), doc.getId());
+        nlpTask.findDocNamedEntities(project("projectName"), doc.getId());
 
         verify(pipeline).initialize(ENGLISH);
-        verify(pipeline).process(doc, 32, 0);
-        verify(pipeline).process(doc, 32, 32);
+        verify(pipeline).processDoc(doc, 8, 0);
+        verify(pipeline).processDoc(doc, 8, 8);
+        verify(pipeline).processDoc(doc, 8, 16);
+        verify(pipeline).processDoc(doc, 8, 24);
+    }
+
+    @Test
+    public void test_should_process_docs_by_batch_grouped_by_language() throws InterruptedException {
+        // Given
+        when(pipeline.initialize(any())).thenReturn(true);
+        Document enDoc0 = createDoc("enId0").with("content").with(ENGLISH).build();
+        Document enDoc1 = createDoc("enId1").with("long content").with(ENGLISH).build();
+        Document frDoc0 = createDoc("frId0").with("contenu long").with(FRENCH).build();
+        Document frDoc1 = createDoc("frId1").with("contenu").with(FRENCH).build();
+        when(indexer.get(anyString(), same(enDoc0.getId()))).thenReturn(enDoc0);
+        when(indexer.get(anyString(), same(enDoc1.getId()))).thenReturn(enDoc1);
+        when(indexer.get(anyString(), same(frDoc0.getId()))).thenReturn(frDoc0);
+        when(indexer.get(anyString(), same(frDoc1.getId()))).thenReturn(frDoc1);
+        DocumentQueue<String> inputQueue = factory.getQueues(INPUT_QUEUE_NAME, String.class).get(0);
+        inputQueue.add(enDoc0.getId());
+        inputQueue.add(enDoc1.getId());
+        inputQueue.add(frDoc0.getId());
+        inputQueue.add(frDoc1.getId());
+        inputQueue.add(STRING_POISON);
+
+        // When
+        nlpTask.extractFromTexts();
+
+        // Then
+        verify(pipeline).initialize(ENGLISH);
+        verify(pipeline).terminate(ENGLISH);
+        verify(pipeline).initialize(FRENCH);
+        verify(pipeline).terminate(FRENCH);
+        ArgumentCaptor<Stream<String>> streamCaptor = ArgumentCaptor.forClass(Stream.class);
+        verify(pipeline, times(2)).processText(streamCaptor.capture(), same(ENGLISH));
+        verify(pipeline, times(2)).processText(streamCaptor.capture(), same(FRENCH));
+        assertThat(streamCaptor.getAllValues().size()).isEqualTo(4);
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -37,6 +37,7 @@ public final class DatashareCliOptions {
     public static final String BATCH_SEARCH_MAX_TIME_OPT = "batchSearchMaxTimeSeconds";
     public static final String BATCH_SEARCH_SCROLL_DURATION_OPT = "batchSearchScroll";
     public static final String BATCH_SEARCH_SCROLL_SIZE_OPT = "batchSearchScrollSize";
+    public static final String BATCH_SIZE_OPT = "batchSize";
     public static final String BATCH_THROTTLE_OPT = "batchThrottleMilliseconds";
     public static final String BROWSER_OPEN_LINK_OPT = "browserOpenLink";
     public static final String BUS_TYPE_OPT = "busType";
@@ -212,7 +213,7 @@ public final class DatashareCliOptions {
                 singletonList(FOLLOW_SYMLINKS_OPT), "Follow symlinks while scanning documents")
                 .withRequiredArg()
                 .ofType(Boolean.class)
-                .defaultsTo(DEFAULT_FOLLOW_SYMLINKS);;
+                .defaultsTo(DEFAULT_FOLLOW_SYMLINKS);
     }
 
     static void cors(OptionParser parser) {
@@ -344,7 +345,7 @@ public final class DatashareCliOptions {
 
     static void artifactDir(OptionParser parser) {
         parser.acceptsAll(
-                asList(ARTIFACT_DIR_OPT),
+                List.of(ARTIFACT_DIR_OPT),
                 "Artifact directory for embedded caching. If not provided datashare will use memory." )
                 .withRequiredArg();
     }
@@ -790,7 +791,7 @@ public final class DatashareCliOptions {
     }
 
     public static ValueConverter<String> toAbsolute() {
-        return new ValueConverter<String>() {
+        return new ValueConverter<>() {
             @Override
             public String convert(String value) {
                 Path path = Paths.get(value);

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSearcher.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSearcher.java
@@ -9,7 +9,6 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
-import co.elastic.clients.json.JsonpMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.json.JsonException;
@@ -64,7 +63,7 @@ class ElasticsearchSearcher implements Indexer.Searcher {
     }
 
     static <T extends Entity> T hitToObject(Hit<ObjectNode> searchHit, Class<T> cls) {
-        return (T) JsonObjectMapper.getObject(searchHit.id(), searchHit.index(), JsonUtils.nodeToMap(searchHit.source()), cls);
+        return JsonObjectMapper.getObject(searchHit.id(), searchHit.index(), JsonUtils.nodeToMap(searchHit.source()), cls);
     }
 
     @Override
@@ -177,6 +176,14 @@ class ElasticsearchSearcher implements Indexer.Searcher {
         return this;
     }
 
+    @Override
+    public Searcher sort(String field, SortOrder order) {
+        sourceBuilder.sort(builder ->
+            builder.field(fieldBuilder -> fieldBuilder.field(field).order(esSortOrder(order)))
+        );
+        return this;
+    }
+
 
     @Override
     public void clearScroll() throws IOException {
@@ -193,5 +200,12 @@ class ElasticsearchSearcher implements Indexer.Searcher {
     @Override
     public String toString() {
         return "query : " + jsonBoolQuery;
+    }
+
+    private co.elastic.clients.elasticsearch._types.SortOrder esSortOrder(SortOrder sortOrder) {
+        return switch (sortOrder) {
+            case ASC -> co.elastic.clients.elasticsearch._types.SortOrder.Asc;
+            case DESC -> co.elastic.clients.elasticsearch._types.SortOrder.Desc;
+        };
     }
 }


### PR DESCRIPTION
# TODO
- [ ] merge #1538

# PR description

Implemenent batch text processing for NER, this change is made in the context of #1452, as batch processing is necessary for Spacy.

# Changes

## `datashare-api` ⚠️

### Added
- added the batch text processing API `List<List<NlpTag>> processText(Stream<String> batch, Language language) throws InterruptedException` to `Pipeline`

### Changed
- made `NlpTag` a record and json serializable class

## `datashare-core-nlp`

### Added
- implemented batch processing for stanford core nlp)


## `datashare-app`
### Added
- added `bool Pipeline.Type.extractFromDoc()` which indicates if the pipeline should preferrably used on full documents or can be used on text chunks
- implemented batch text processing inside the `ExtractNlpTask` for pipelines which do not require prediction on documents


