### PR TITLE
Feat: oauth2 parametrize ICIJ identity provider specific values

### DIFF
--- a/datashare-api/src/test/java/org/icij/datashare/user/UserTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/user/UserTest.java
@@ -2,15 +2,19 @@ package org.icij.datashare.user;
 
 
 import org.icij.datashare.json.JsonObjectMapper;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
+import static org.icij.datashare.text.Project.project;
 import static org.icij.datashare.user.User.fromJson;
 
 public class UserTest {
@@ -144,6 +148,21 @@ public class UserTest {
     }
 
     @Test
+    public void test_get_project_key() {
+        System.setProperty("datashare.user.projects", "projects");
+        assertThat(User.getDefaultProjectsKey()).isEqualTo("projects");
+    }
+
+    @Test
+    public void test_get_projects() {
+        assertThat(new User(Map.of("groups_by_applications", Map.of("datashare", List.of("my_project")))).getProjects())
+                .contains(project("my_project"));
+        System.setProperty("datashare.user.projects", "projects");
+        assertThat(new User(Map.of("projects", List.of("my_project"))).getProjects())
+                .contains(project("my_project"));
+    }
+
+    @Test
     public void test_can_set_several_projects_in_addition_to_json_detail() {
         User user = new User("id", "name", "email", "provider", "{ \"groups_by_applications\": { \"datashare\": [\"foo\"] } }");
         user.setProjectNames(Collections.singletonList("bar"));
@@ -169,5 +188,10 @@ public class UserTest {
         assertThat(user.getProjectNames()).hasSize(1);
         user.clearProjects();
         assertThat(user.getProjectNames()).hasSize(0);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.setProperty("datashare.user.projects", "");
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/session/OAuth2CookieFilterIcij.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/OAuth2CookieFilterIcij.java
@@ -1,0 +1,29 @@
+package org.icij.datashare.session;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.codestory.http.security.SessionIdStore;
+import org.icij.datashare.PropertiesProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+
+@Singleton
+public class OAuth2CookieFilterIcij extends OAuth2CookieFilter {
+    @Inject
+    public OAuth2CookieFilterIcij(PropertiesProvider propertiesProvider, UsersWritable users, SessionIdStore sessionIdStore) {
+        super(propertiesProvider, users, sessionIdStore);
+    }
+
+    @NotNull
+    @Override
+    protected DatashareUser createUser(Map<String, Object> userMap) {
+        if (!oauthDefaultProject.isEmpty()) {
+            userMap.put("provider", "icij");
+            userMap.put("groups_by_applications", Map.of("datashare", singletonList(oauthDefaultProject)));
+        }
+        return new DatashareUser(userMap);
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/session/YesCookieAuthFilter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/YesCookieAuthFilter.java
@@ -41,15 +41,8 @@ public class YesCookieAuthFilter extends CookieAuthFilter {
     private User createUser(String userName) {
         List<Project> projects = getProjects();
         List<String> projectNames = getProjectNames();
-        // Build user properties
-        HashMap<String, Object> userProperties = new HashMap<>() {{
-            put("uid", userName);
-            put(DatashareUser.XEMX_APPLICATIONS_KEY, new HashMap<String, Object>() {{
-                put(DatashareUser.XEMX_DATASHARE_KEY, projectNames);
-            }});
-        }};
         // Build datashare user
-        DatashareUser user = new DatashareUser(userProperties);
+        DatashareUser user = new DatashareUser(org.icij.datashare.user.User.localUser(userName));
         user.setProjects(projects);
         // Finally, store the user in redis so the session can be retrieved
         ((UsersInRedis) users).saveOrUpdate(user);

--- a/datashare-app/src/test/java/org/icij/datashare/session/YesCookieAuthFilterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/session/YesCookieAuthFilterTest.java
@@ -55,7 +55,7 @@ public class YesCookieAuthFilterTest {
         assertThat(payload).isSameAs(next);
         verify(context).setCurrentUser(user.capture());
         assertThat(user.getValue().login()).isNotEmpty();
-        assertThat(((DatashareUser)user.getValue()).getProjectNames()).containsExactly("demo");
+        assertThat(((DatashareUser)user.getValue()).getProjectNames()).contains("demo");
         assertThat(user.getValue().isInRole("local")).isFalse();
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -6,6 +6,7 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.cli.spi.CliExtension;
+import org.icij.datashare.user.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +18,7 @@ import java.util.Properties;
 
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.OAUTH_USER_PROJECTS_KEY;
 import static org.icij.datashare.cli.DatashareCliOptions.DIGEST_PROJECT_NAME_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.NO_DIGEST_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.OPT_ALIASES;
@@ -72,6 +74,10 @@ public class DatashareCli {
             if (!Boolean.parseBoolean(properties.getProperty(NO_DIGEST_PROJECT_OPT))
                     && properties.getProperty(DIGEST_PROJECT_NAME_OPT) == null) {
                 properties.setProperty(DIGEST_PROJECT_NAME_OPT, properties.getProperty(DEFAULT_PROJECT_OPT));
+            }
+            if (!User.DEFAULT_PROJECTS_KEY.equals(properties.getProperty(OAUTH_USER_PROJECTS_KEY))) {
+                LOGGER.info("settings system property {} to {}", User.JVM_PROJECT_KEY, properties.getProperty(OAUTH_USER_PROJECTS_KEY));
+                System.setProperty(User.JVM_PROJECT_KEY, properties.getProperty(OAUTH_USER_PROJECTS_KEY));
             }
             // Retro-compatibility so the alias options is are mapped to the right property
             for (String alias : OPT_ALIASES.keySet()) {
@@ -150,6 +156,7 @@ public class DatashareCli {
         DatashareCliOptions.clusterName(parser);
         DatashareCliOptions.createIndex(parser);
         DatashareCliOptions.defaultUser(parser);
+        DatashareCliOptions.defaultUserProjectKey(parser);
         DatashareCliOptions.defaultProject(parser);
         DatashareCliOptions.oauthClaimIdAttribute(parser);
         DatashareCliOptions.esHost(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -18,9 +18,9 @@ import java.util.Properties;
 
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
-import static org.icij.datashare.cli.DatashareCliOptions.OAUTH_USER_PROJECTS_KEY;
 import static org.icij.datashare.cli.DatashareCliOptions.DIGEST_PROJECT_NAME_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.NO_DIGEST_PROJECT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.OAUTH_USER_PROJECTS_KEY_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.OPT_ALIASES;
 
 
@@ -75,9 +75,9 @@ public class DatashareCli {
                     && properties.getProperty(DIGEST_PROJECT_NAME_OPT) == null) {
                 properties.setProperty(DIGEST_PROJECT_NAME_OPT, properties.getProperty(DEFAULT_PROJECT_OPT));
             }
-            if (!User.DEFAULT_PROJECTS_KEY.equals(properties.getProperty(OAUTH_USER_PROJECTS_KEY))) {
-                LOGGER.info("settings system property {} to {}", User.JVM_PROJECT_KEY, properties.getProperty(OAUTH_USER_PROJECTS_KEY));
-                System.setProperty(User.JVM_PROJECT_KEY, properties.getProperty(OAUTH_USER_PROJECTS_KEY));
+            if (!User.DEFAULT_PROJECTS_KEY.equals(properties.getProperty(OAUTH_USER_PROJECTS_KEY_OPT))) {
+                LOGGER.info("settings system property {} to {}", User.JVM_PROJECT_KEY, properties.getProperty(OAUTH_USER_PROJECTS_KEY_OPT));
+                System.setProperty(User.JVM_PROJECT_KEY, properties.getProperty(OAUTH_USER_PROJECTS_KEY_OPT));
             }
             // Retro-compatibility so the alias options is are mapped to the right property
             for (String alias : OPT_ALIASES.keySet()) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -125,7 +125,7 @@ public final class DatashareCliOptions {
     public static final String SEARCH_QUERY_OPT = "searchQuery";
     public static final String TASK_ROUTING_STRATEGY_OPT = "taskRoutingStrategy";
     public static final String TASK_ROUTING_KEY_OPT = "taskRoutingKey";
-    public static final String OAUTH_USER_PROJECTS_KEY = "oauthUserProjectsKey";
+    public static final String OAUTH_USER_PROJECTS_KEY_OPT = "oauthUserProjectsAttribute";
 
 
     private static final Path DEFAULT_DATASHARE_HOME = Paths.get(System.getProperty("user.home"), ".local/share/datashare");
@@ -217,8 +217,8 @@ public final class DatashareCliOptions {
 
     static void defaultUserProjectKey(OptionParser parser) {
         parser.acceptsAll(
-                        List.of(OAUTH_USER_PROJECTS_KEY),
-                "User json key to use for finding user's project list from identity provider")
+                        List.of(OAUTH_USER_PROJECTS_KEY_OPT),
+                "Json field name sent by the Identity Provider that contains user projects.")
                 .withRequiredArg()
                 .ofType(String.class)
                 .defaultsTo(User.DEFAULT_PROJECTS_KEY);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -5,6 +5,7 @@ import joptsimple.OptionSpec;
 import joptsimple.ValueConverter;
 import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.Stage;
+import org.icij.datashare.user.User;
 import org.slf4j.event.Level;
 import org.icij.datashare.tasks.RoutingStrategy;
 
@@ -124,6 +125,8 @@ public final class DatashareCliOptions {
     public static final String SEARCH_QUERY_OPT = "searchQuery";
     public static final String TASK_ROUTING_STRATEGY_OPT = "taskRoutingStrategy";
     public static final String TASK_ROUTING_KEY_OPT = "taskRoutingKey";
+    public static final String OAUTH_USER_PROJECTS_KEY = "oauthUserProjectsKey";
+
 
     private static final Path DEFAULT_DATASHARE_HOME = Paths.get(System.getProperty("user.home"), ".local/share/datashare");
     private static final Integer DEFAULT_NLP_PARALLELISM = 1;
@@ -210,6 +213,15 @@ public final class DatashareCliOptions {
                 .withRequiredArg()
                 .ofType(String.class)
                 .defaultsTo(DEFAULT_USER);
+    }
+
+    static void defaultUserProjectKey(OptionParser parser) {
+        parser.acceptsAll(
+                        List.of(OAUTH_USER_PROJECTS_KEY),
+                "User json key to use for finding user's project list from identity provider")
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo(User.DEFAULT_PROJECTS_KEY);
     }
 
     static void followSymlinks(OptionParser parser) {

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -132,7 +132,7 @@ public class DatashareCliTest {
 
     @Test
     public void test_user_projects_key() {
-        cli.parseArguments(new String[] {"--oauthUserProjectsKey", "foo.bar.baz"});
+        cli.parseArguments(new String[] {"--oauthUserProjectsAttribute", "foo.bar.baz"});
         assertThat(System.getProperty("datashare.user.projects")).isEqualTo("foo.bar.baz");
     }
 

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -131,6 +131,12 @@ public class DatashareCliTest {
     }
 
     @Test
+    public void test_user_projects_key() {
+        cli.parseArguments(new String[] {"--oauthUserProjectsKey", "foo.bar.baz"});
+        assertThat(System.getProperty("datashare.user.projects")).isEqualTo("foo.bar.baz");
+    }
+
+    @Test
     public void test_absolute_batch_download_dir() {
         cli.parseArguments(new String[] {"--batchDownloadDir", "/home/foo"});
         assertThat(cli.properties).includes(entry("batchDownloadDir", "/home/foo"));


### PR DESCRIPTION
This PR isolate ICIJ settings in a new class.
And adds a `--oauthUserProjectsAttribute` option to be able to specify a custom JSON attribute path (dot separated).
see #1585 