### PR TITLE
feature: implement `CreateNlpBatchesFromIndexTask` and `BatchNlpTask`

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
+++ b/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
@@ -2,7 +2,6 @@ package org.icij.datashare;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;

--- a/datashare-api/src/main/java/org/icij/datashare/Stage.java
+++ b/datashare-api/src/main/java/org/icij/datashare/Stage.java
@@ -11,6 +11,8 @@ public enum Stage {
     INDEX(true),
     ENQUEUEIDX(false),
     NLP(true),
+    CREATENLPBATCHESFROMIDX(false),
+    BATCHNLP(false),
     ARTIFACT(false);
 
     public static final Comparator<Stage> comparator = Comparator.comparing(Stage::ordinal);

--- a/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
@@ -33,7 +33,7 @@ public interface Indexer extends Closeable {
     <T extends Entity> boolean bulkUpdate(String indexName, List<T> entities) throws IOException;
     <T extends Entity> void add(String indexName, T obj) throws IOException;
     <T extends Entity> void update(String indexName, T obj) throws IOException;
-    <T extends Entity> boolean exists(String indexName, String id) throws IOException;
+    boolean exists(String indexName, String id) throws IOException;
 
     <T extends Entity> T get(String indexName, String id);
     <T extends Entity> T get(String indexName, String id, List<String> sourceExcludes);
@@ -61,9 +61,11 @@ public interface Indexer extends Closeable {
         Searcher withoutSource(String... fields);
         Searcher withSource(boolean source);
         Searcher limit(int maxCount);
+        Searcher sort(String field, SortOrder order);
         void clearScroll() throws IOException;
         long totalHits();
         Searcher with(int fuzziness, boolean phraseMatches);
+        enum SortOrder { ASC, DESC }
     }
 
     interface QueryBuilderSearcher extends Searcher {

--- a/datashare-api/src/test/java/org/icij/datashare/PipelineHelperTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/PipelineHelperTest.java
@@ -42,6 +42,38 @@ public class PipelineHelperTest {
     }
 
     @Test
+    public void test_get_queue_names_for_batch_nlp_pipeline() {
+        PipelineHelper pipelineHelper = new PipelineHelper(new PropertiesProvider(new HashMap<>() {{
+            put("stages", "SCAN,INDEX,BATCHNLP");
+        }}));
+        assertThat(pipelineHelper.getQueueNameFor(Stage.BATCHNLP)).isEqualTo("extract:queue:batchnlp");
+    }
+
+    @Test
+    public void test_get_queue_names_for_batch_nlp_pipeline_from_index() {
+        PipelineHelper pipelineHelper = new PipelineHelper(new PropertiesProvider(new HashMap<>() {{
+            put("stages", "CREATENLPBATCHESFROMIDX,BATCHNLP");
+        }}));
+        assertThat(pipelineHelper.getQueueNameFor(Stage.BATCHNLP)).isEqualTo("extract:queue:batchnlp");
+    }
+
+    @Test
+    public void test_get_queue_names_for_batch_nlp() {
+        PipelineHelper pipelineHelper = new PipelineHelper(new PropertiesProvider(new HashMap<>() {{
+            put("stages", "SCAN,INDEX,NLP");
+        }}));
+        assertThat(pipelineHelper.getQueueNameFor(Stage.NLP)).isEqualTo("extract:queue:nlp");
+    }
+
+    @Test
+    public void test_get_queue_names_for_nlp_pipeline_from_index() {
+        PipelineHelper pipelineHelper = new PipelineHelper(new PropertiesProvider(new HashMap<>() {{
+            put("stages", "ENQUEUEIDX,NLP");
+        }}));
+        assertThat(pipelineHelper.getQueueNameFor(Stage.NLP)).isEqualTo("extract:queue:nlp");
+    }
+
+    @Test
     public void test_get_queue_name_scan_index() {
         PipelineHelper pipelineHelper = new PipelineHelper(new PropertiesProvider(new HashMap<>() {{
             put("stages", "SCAN,INDEX");

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -5,6 +5,8 @@ import org.icij.datashare.cli.CliExtensionService;
 import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.ArtifactTask;
+import org.icij.datashare.tasks.CreateNlpBatchesFromIndex;
+import org.icij.datashare.tasks.BatchNlpTask;
 import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
@@ -117,6 +119,10 @@ class CliApp {
 
         if (pipeline.has(Stage.ENQUEUEIDX)) {
             taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties));
+        }
+
+        if (pipeline.has(Stage.CREATENLPBATCHESFROMIDX)) {
+            taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.NLP)) {

--- a/datashare-app/src/main/java/org/icij/datashare/nlp/NlpHelper.java
+++ b/datashare-app/src/main/java/org/icij/datashare/nlp/NlpHelper.java
@@ -1,0 +1,13 @@
+package org.icij.datashare.nlp;
+
+import java.util.Map;
+import org.icij.datashare.text.nlp.Pipeline;
+
+public class NlpHelper {
+    public static Map<String, Object> pipelineExtras(Pipeline.Type pipeline) {
+        if (pipeline == Pipeline.Type.SPACY) {
+            return Map.of("modelSize", "md");
+        }
+        return Map.of();
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -23,9 +23,10 @@ import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_POLLING_INTERVAL_SEC;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class ArtifactTask extends PipelineTask<String> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Indexer indexer;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadCleaner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadCleaner.java
@@ -17,8 +17,9 @@ import java.util.regex.Pattern;
 import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
 import static java.util.regex.Pattern.compile;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class BatchDownloadCleaner implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Pattern filePattern = compile(BatchDownload.ZIP_FORMAT.replace("%s", "[a-z0-9\\.:|_Z\\-\\[GMT\\]]+"));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -51,8 +51,9 @@ import static java.lang.Integer.parseInt;
 import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toList;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class BatchDownloadRunner implements Callable<UriResult>, Monitorable, UserTask, CancellableTask {
     private final static Logger logger = LoggerFactory.getLogger(BatchDownloadRunner.class);
     static final int MAX_SCROLL_SIZE = 3500;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchNlpTask.java
@@ -5,6 +5,7 @@ import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -51,7 +52,7 @@ public class BatchNlpTask extends DefaultTask<Long> implements UserTask, Cancell
     }
 
     @Override
-    public Long call() throws Exception {
+    public Long call() throws IOException, InterruptedException {
         taskThread = Thread.currentThread();
         if (this.docs.isEmpty()) {
             return 0L;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchNlpTask.java
@@ -1,0 +1,106 @@
+package org.icij.datashare.tasks;
+
+import static java.util.Optional.ofNullable;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
+
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.icij.datashare.asynctasks.CancellableTask;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskGroup;
+import org.icij.datashare.extension.PipelineRegistry;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Language;
+import org.icij.datashare.text.NamedEntity;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.nlp.Pipeline;
+import org.icij.datashare.user.User;
+import org.icij.datashare.user.UserTask;
+import org.icij.task.DefaultTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@TaskGroup(JAVA_GROUP)
+public class BatchNlpTask extends DefaultTask<Long> implements UserTask, CancellableTask {
+    private static final List<String> EXCLUDED_SOURCES = List.of("contentTranslated");
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final User user;
+    private final Function<Double, Void> progress;
+    private volatile Thread taskThread;
+    private final Indexer indexer;
+    private final List<CreateNlpBatchesFromIndex.BatchDocument> docs;
+    private final Pipeline pipeline;
+    private final int maxLength;
+
+    @Inject
+    public BatchNlpTask(Indexer indexer, PipelineRegistry registry, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progress) {
+        this(indexer, registry.get(Pipeline.Type.parse((String) taskView.args.get("pipeline"))), taskView, progress);
+    }
+
+
+    BatchNlpTask(Indexer indexer, Pipeline pipeline, Task<Long> taskView, final Function<Double, Void> progress) {
+        this.user = taskView.getUser();
+        this.indexer = indexer;
+        this.pipeline = pipeline;
+        this.docs = (List<CreateNlpBatchesFromIndex.BatchDocument>) taskView.args.get("docs");
+        this.maxLength = (int) taskView.args.get("maxLength");
+        this.progress = progress;
+    }
+
+    @Override
+    public Long call() throws Exception {
+        taskThread = Thread.currentThread();
+        if (this.docs.isEmpty()) {
+            return 0L;
+        }
+        int batchSize = this.docs.size();
+        int updateRate = Integer.max(batchSize / 10, 1);
+        Language language = this.docs.get(0).language();
+        pipeline.initialize(language);
+        logger.info("performing NER on {} docs in {}...", batchSize, language);
+        // TODO: for now None of the Java NER seems to support batch processing, we just iterate docs one by one
+        // TODO: we could improve perfs by fetching docs and processing them concurrently...
+        int nProcessed = 0;
+        Optional.ofNullable(this.progress).ifPresent(p -> p.apply(0.0));
+        for (CreateNlpBatchesFromIndex.BatchDocument doc : this.docs) {
+            String project = doc.project();
+            Document indexDoc = indexer.get(doc.id(), doc.rootDocument(), EXCLUDED_SOURCES);
+            if (indexDoc.getContentTextLength() < this.maxLength) {
+                List<NamedEntity> namedEntities = pipeline.process(indexDoc);
+                indexer.bulkAdd(project, pipeline.getType(), namedEntities, indexDoc);
+            } else {
+                int nbChunks = indexDoc.getContentTextLength() / this.maxLength + 1;
+                for (int chunkIndex = 0; chunkIndex < nbChunks; chunkIndex++) {
+                    List<NamedEntity> namedEntities =
+                        pipeline.process(indexDoc, maxLength, chunkIndex * maxLength);
+                    if (chunkIndex < nbChunks - 1) {
+                        indexer.bulkAdd(project, namedEntities);
+                    } else {
+                        indexer.bulkAdd(project, pipeline.getType(), namedEntities, indexDoc);
+                    }
+                }
+            }
+            nProcessed += 1;
+            if (nProcessed % updateRate == 0) {
+                Double prog = (double) nProcessed / (double) batchSize;
+                Optional.ofNullable(this.progress).ifPresent(p -> p.apply(prog));
+            }
+        }
+        pipeline.terminate(language);
+        Optional.ofNullable(this.progress).ifPresent(p -> p.apply(1.0));
+        return (long) batchSize;
+    }
+
+    @Override
+    public void cancel(boolean requeue) {
+        ofNullable(taskThread).ifPresent(Thread::interrupt);
+    }
+
+    @Override
+    public User getUser() {
+        return user;
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -43,9 +43,10 @@ import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_BATCH_THROTTLE;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_SCROLL_DURATION;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_SCROLL_SIZE;
 import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_SIZE_OPT;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 import static org.icij.datashare.text.ProjectProxy.asCommaConcatNames;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Integer> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndex.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndex.java
@@ -1,0 +1,203 @@
+package org.icij.datashare.tasks;
+
+import static java.util.Collections.singletonList;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.groupingBy;
+import static org.icij.datashare.asynctasks.Task.GROUP_KEY;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_NLP_BATCH_SIZE;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_NLP_MAX_TEXT_LENGTH;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_SCROLL_DURATION;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_SCROLL_SIZE;
+import static org.icij.datashare.cli.DatashareCliOptions.NLP_BATCH_SIZE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.NLP_MAX_TEXT_LENGTH_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.NLP_PIPELINE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_DURATION_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_SIZE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.SEARCH_QUERY_OPT;
+import static org.icij.datashare.nlp.NlpHelper.pipelineExtras;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
+import static org.icij.datashare.tasks.GroupHelper.nlpGroup;
+
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.icij.datashare.Entity;
+import org.icij.datashare.asynctasks.CancellableTask;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskGroup;
+import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Language;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.SearchQuery;
+import org.icij.datashare.text.nlp.Pipeline;
+import org.icij.datashare.time.DatashareTime;
+import org.icij.datashare.user.User;
+import org.icij.datashare.user.UserTask;
+import org.icij.task.DefaultTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@TaskGroup(JAVA_GROUP)
+public class CreateNlpBatchesFromIndex extends DefaultTask<List<String>> implements UserTask, CancellableTask {
+    Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final User user;
+    private volatile Thread taskThread;
+    private final TaskManager taskManager;
+    private final String searchQuery;
+    private final Map<String, Object> batchTaskArgs;
+    private final Pipeline.Type nlpPipeline;
+    private final int batchSize;
+    private final int maxTextLength;
+    private final String projectName;
+    private final Indexer indexer;
+    private final String scrollDuration;
+    private final int scrollSize;
+    private Language currentLanguage = null;
+
+    public record BatchDocument(String id, String rootDocument, String project, Language language) {
+        public static BatchDocument fromDocument(Document document) {
+            return new BatchDocument(document.getId(), document.getRootDocument(), document.getProjectId(), document.getLanguage());
+        }
+    }
+
+    @Inject
+    public CreateNlpBatchesFromIndex(
+        final TaskManager taskManager, final Indexer indexer, @Assisted Task<List<String>> taskView,
+        @Assisted final Function<Double, Void> ignored
+    ) {
+        this.user = taskView.getUser();
+        this.taskManager = taskManager;
+        this.indexer = indexer;
+        this.nlpPipeline = Pipeline.Type.parse((String) taskView.args.getOrDefault(NLP_PIPELINE_OPT, Pipeline.Type.CORENLP.name()));
+        this.batchTaskArgs = batchTaskArgs();
+        this.batchSize = (int) taskView.args.getOrDefault(NLP_BATCH_SIZE_OPT, DEFAULT_NLP_BATCH_SIZE);
+        this.maxTextLength = (int) taskView.args.getOrDefault(NLP_MAX_TEXT_LENGTH_OPT, DEFAULT_NLP_MAX_TEXT_LENGTH);
+        this.projectName = (String) taskView.args.getOrDefault(DEFAULT_PROJECT_OPT, DEFAULT_DEFAULT_PROJECT);
+        this.scrollDuration = (String) taskView.args.getOrDefault(SCROLL_DURATION_OPT, DEFAULT_SCROLL_DURATION);
+        this.scrollSize = (int) taskView.args.getOrDefault(SCROLL_SIZE_OPT, DEFAULT_SCROLL_SIZE);
+        this.searchQuery = (String) taskView.args.get(SEARCH_QUERY_OPT);
+    }
+
+    @Override
+    public List<String> call() throws Exception {
+        ArrayList<String> taskIds = new ArrayList<>();
+        taskThread = Thread.currentThread();
+        Indexer.Searcher searcher;
+        if (searchQuery == null) {
+            searcher = indexer.search(singletonList(projectName), Document.class).without(nlpPipeline);
+        } else {
+            searcher = indexer.search(singletonList(projectName), Document.class, new SearchQuery(searchQuery));
+        }
+        searcher = searcher.limit(scrollSize)
+            .withoutSource("language", "rootDocument")
+            .withoutSource("content", "contentTranslated")
+            .sort("language", Indexer.Searcher.SortOrder.ASC);
+        Map<Language, ? extends List<? extends Entity>> scrolledDocsByLanguage = searcher
+            .scroll(scrollDuration)
+            .collect(groupingBy(d -> ((Document) d).getLanguage()));
+        ArrayList<Document> batch = new ArrayList<>(this.batchSize);
+        long totalHits = searcher.totalHits();
+        logger.info(
+            "pushing batches of {} docs ids for index {}, pipeline {} with {} scroll and size of {}",
+            totalHits, projectName, nlpPipeline, scrollDuration, scrollSize
+        );
+        do {
+            // For each scrolled page, we fill the batch...
+            taskIds.addAll(this.enqueueScrollBatches(scrolledDocsByLanguage, batch));
+            // and keep scrolling...
+            scrolledDocsByLanguage = searcher
+                .scroll(scrollDuration)
+                .collect(groupingBy(d -> ((Document) d).getLanguage()));
+            // until we reach a page smaller than the scroll size aka the last page of the scroll
+        } while (scrolledDocsByLanguage.values().stream().map(List::size).mapToInt(Integer::intValue).sum() >= scrollSize);
+        // Let's fill the batches for that last page
+        taskIds.addAll(this.enqueueScrollBatches(scrolledDocsByLanguage, batch));
+        // ... and enqueue that last batch if not done yet
+        if (!batch.isEmpty()) {
+            taskIds.add(this.enqueueBatch(batch));
+        }
+        logger.info("queued batches for {} docs", totalHits);
+        searcher.clearScroll();
+        return taskIds;
+    }
+
+    private List<String> enqueueScrollBatches(Map<Language, ? extends List<? extends Entity>> docsByLanguage, ArrayList<Document> batch) {
+        ArrayList<String> batchTaskIds = new ArrayList<>();
+        // Make sure we consume the languages in order
+        Iterator<? extends Map.Entry<Language, ? extends List<? extends Entity>>> docsIt = docsByLanguage.entrySet()
+            .stream().sorted(Comparator.comparing(e -> e.getKey().name())).iterator();
+        while (docsIt.hasNext()) {
+            Map.Entry<Language, ? extends List<? extends Entity>> entry = docsIt.next();
+            Language language = entry.getKey();
+            // If we switch language, we need to queue the batch
+            if (!language.equals(currentLanguage)) {
+                if (!batch.isEmpty()) {
+                    batchTaskIds.add(this.enqueueBatch(batch));
+                }
+                currentLanguage = language;
+            }
+            // and then we fill the current batch which can already be partially filled
+            List<Document> languageDocs = (List<Document>) entry.getValue();
+            int start = 0;
+            int end = 0;
+            while (end < languageDocs.size()) {
+                end = start + Integer.min(batchSize - batch.size(), languageDocs.size() - start);
+                batch.addAll(languageDocs.subList(start, end));
+                if (batch.size() >= batchSize) {
+                    batchTaskIds.add(this.enqueueBatch(batch));
+                }
+                start = end;
+            }
+        }
+        return batchTaskIds;
+    }
+
+    protected String enqueueBatch(List<Document> batch) {
+        String taskId;
+        HashMap<String, Object> args = new HashMap<>(this.batchTaskArgs);
+        args.put("docs", batch.stream().map(BatchDocument::fromDocument).toList());
+        try {
+            // TODO: here we bind the task name to the Java class name which is not ideal since it leaks Java inners
+            //  bolts to Python, it could be nice to decouple task names from class names since they can change and
+            //  are bound to languages
+            logger.info("{} - {}", DatashareTime.getNow().getTime(), ((List<BatchDocument>)args.get("docs")).get(0).language());
+            taskId = this.taskManager.startTask(BatchNlpTask.class, this.user, args);
+        } catch (IOException e) {
+            throw new RuntimeException("failed to queue task " + args, e);
+        }
+        batch.clear();
+        return taskId;
+    }
+
+    @Override
+    public void cancel(boolean requeue) {
+        ofNullable(taskThread).ifPresent(Thread::interrupt);
+    }
+
+    @Override
+    public User getUser() {
+        return user;
+    }
+
+    private Map<String, Object> batchTaskArgs() {
+        Map<String, Object> args = new HashMap<>(Map.of(
+            "pipeline", this.nlpPipeline.name(),
+            "maxLength", this.maxTextLength,
+            GROUP_KEY, nlpGroup(this.nlpPipeline)
+        ));
+        args.putAll(pipelineExtras(this.nlpPipeline));
+        return args;
+    }
+
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskFactory.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import java.util.List;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.user.User;
 
@@ -15,6 +16,8 @@ public interface DatashareTaskFactory extends org.icij.datashare.asynctasks.Task
     ScanIndexTask createScanIndexTask(Task<Long> taskView, Function<Double, Void> updateCallback);
     ExtractNlpTask createExtractNlpTask(Task<Long> taskView, Function<Double, Void> updateCallback);
     EnqueueFromIndexTask createEnqueueFromIndexTask(Task<Long> taskView, Function<Double, Void> updateCallback);
+    CreateNlpBatchesFromIndex createBatchEnqueueFromIndexTask(Task<List<String>> taskView, Function<Double, Void> updateCallback);
+    BatchNlpTask createBatchNlpTask(Task<Long> taskView, Function<Double, Void> updateCallback);
     DeduplicateTask createDeduplicateTask(Task<Long> taskView, Function<Double, Void> updateCallback);
     ArtifactTask createArtifactTask(Task<Long> taskView, Function<Double, Void> updateCallback);
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.tasks;
 
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
+
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.icij.datashare.PropertiesProvider;
@@ -18,7 +20,7 @@ import java.util.function.Predicate;
 /**
  * filters the document queue with extracted docs
  */
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class DeduplicateTask extends PipelineTask<Path> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final DocumentCollectionFactory<Path> factory;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DelApiKeyTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DelApiKeyTask.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.tasks;
 
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
+
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.icij.datashare.asynctasks.TaskGroup;
@@ -10,7 +12,7 @@ import org.icij.task.DefaultTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class DelApiKeyTask extends DefaultTask<Boolean> implements UserTask {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ApiKeyRepository apiKeyRepository;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -31,9 +31,10 @@ import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.MAX_CONTENT_LENGTH_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.NLP_PIPELINE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 import static org.icij.extract.document.Identifier.shorten;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class ExtractNlpTask extends PipelineTask<String> implements Monitorable {
     private static final int DEFAULT_MAX_CONTENT_LENGTH = 1024 * 1024;
     public static final int NB_MAX_POLLS = 3;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/GenApiKeyTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/GenApiKeyTask.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.tasks;
 
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
+
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.icij.datashare.asynctasks.TaskGroup;
@@ -13,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.SecretKey;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class GenApiKeyTask extends DefaultTask<String> implements UserTask {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ApiKeyRepository apiKeyRepository;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/GetApiKeyTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/GetApiKeyTask.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.tasks;
 
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
+
 import com.google.inject.assistedinject.Assisted;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.user.ApiKey;
@@ -10,7 +12,7 @@ import org.icij.task.DefaultTask;
 
 import javax.inject.Inject;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class GetApiKeyTask extends DefaultTask<String> implements UserTask  {
     private final ApiKeyRepository apiKeyRepository;
     private final User user;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/GroupHelper.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/GroupHelper.java
@@ -1,0 +1,17 @@
+package org.icij.datashare.tasks;
+
+import java.util.Objects;
+import org.icij.datashare.text.nlp.Pipeline;
+
+public class GroupHelper {
+    // Later we could use enums if we have more groups
+    public static final String PYTHON_GROUP = "Python";
+    public static final String JAVA_GROUP = "Java";
+
+    public static String nlpGroup(Pipeline.Type pipeline) {
+        if (Objects.requireNonNull(pipeline) == Pipeline.Type.SPACY) {
+            return PYTHON_GROUP;
+        }
+        return JAVA_GROUP;
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -28,13 +28,14 @@ import static java.lang.Math.max;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 
 @OptionsClass(Extractor.class)
 @OptionsClass(DocumentFactory.class)
 @OptionsClass(DocumentQueueDrainer.class)
 @Option(name = DEFAULT_PROJECT_OPT, description = "the default project name")
 @Option(name = "projectName", description = "task project name")
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class IndexTask extends PipelineTask<Path> implements Monitorable{
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final DocumentQueueDrainer<Path> drainer;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import java.util.List;
 import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
@@ -39,9 +39,10 @@ import static org.icij.datashare.cli.DatashareCliOptions.REPORT_NAME_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_DURATION_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_SIZE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_SLICES_OPT;
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
 import static org.icij.datashare.text.indexing.ScrollQueryBuilder.createScrollQuery;
 
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class ScanIndexTask extends PipelineTask<Path> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Indexer indexer;
@@ -53,7 +54,7 @@ public class ScanIndexTask extends PipelineTask<Path> {
 
     @Inject
     public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer,
-                         @Assisted Task<Long> taskView, @Assisted Function<Double, Void> updateCallback) {
+                         @Assisted Task<Long> taskView, @Assisted Function<Double, Void> ignored) {
         super(Stage.SCANIDX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
         this.scrollDuration = propertiesProvider.get(SCROLL_DURATION_OPT).orElse(DEFAULT_SCROLL_DURATION);
         this.scrollSize = parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse(valueOf(DEFAULT_SCROLL_SIZE)));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.tasks;
 
+import static org.icij.datashare.tasks.GroupHelper.JAVA_GROUP;
+
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import java.util.function.Function;
@@ -18,7 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 @OptionsClass(Scanner.class)
-@TaskGroup("Java")
+@TaskGroup(JAVA_GROUP)
 public class ScanTask extends PipelineTask<Path> {
     private final Scanner scanner;
     private final Path path;

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchNlpTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchNlpTest.java
@@ -1,0 +1,76 @@
+package org.icij.datashare.tasks;
+
+import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
+import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.List;
+import java.util.Map;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Language;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.nlp.AbstractPipeline;
+import org.icij.datashare.text.nlp.Pipeline;
+import org.icij.datashare.user.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class BatchNlpTest {
+    @Mock
+    private Indexer indexer;
+    @Mock
+    private AbstractPipeline pipeline;
+    private AutoCloseable mocks;
+
+    @Before
+    public void setUp() {
+        this.mocks = openMocks(this);
+    }
+
+    @Before
+    public void tearDow() throws Exception {
+        this.mocks.close();
+    }
+
+    @Test(timeout = 2000)
+    public void test_batch_nlp() throws Exception {
+        // Given
+        int maxLength = 20;
+        String rootId = "rootId";
+        Language language = Language.ENGLISH;
+        Document doc0 = createDoc("doc0").with(language).withRootId(rootId)
+            .with("hello world").build();
+        Document doc1 = createDoc("doc1").with(language).withRootId(rootId)
+            .with("this is too long to be processed all at once").build();
+        when(pipeline.getType()).thenReturn(Pipeline.Type.CORENLP);
+        when(pipeline.initialize(any())).thenReturn(true);
+
+        when(indexer.get(anyString(), anyString(), any(List.class))).thenReturn(doc0, doc1);
+        List<CreateNlpBatchesFromIndex.BatchDocument> batchDocs = List.of(
+            new CreateNlpBatchesFromIndex.BatchDocument(doc0.getId(), doc0.getRootDocument(), TEST_INDEX, language),
+            new CreateNlpBatchesFromIndex.BatchDocument(doc1.getId(), doc1.getRootDocument(), TEST_INDEX, language)
+        );
+        Map<String, Object> properties = Map.of(
+            "docs", batchDocs,
+            "pipeline", "OPENNLP",
+            "maxLength", maxLength,
+            "group", "JAVA"
+        );
+        BatchNlpTask nlpTask = new BatchNlpTask(
+            indexer, pipeline, new Task<>(BatchNlpTask.class.getName(), new User("test"), properties), null
+        );
+        // When
+        nlpTask.call();
+        // Then
+        verify(pipeline).process(eq(doc0));
+        verify(pipeline).process(eq(doc1), eq(maxLength), eq(0));
+        verify(pipeline).process(eq(doc1), eq(maxLength), eq(maxLength));
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
@@ -1,0 +1,146 @@
+package org.icij.datashare.tasks;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
+import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.test.DatashareTimeRule;
+import org.icij.datashare.test.ElasticsearchRule;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Language;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
+import org.icij.datashare.text.nlp.Pipeline;
+import org.icij.datashare.time.DatashareTime;
+import org.icij.datashare.user.User;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class CreateNlpBatchesFromIndexParametrizedTest {
+    private final int batchSize;
+    private final int scrollSize;
+    private final List<List<Language>> expectedLanguages;
+
+    @Rule
+    public DatashareTimeRule time = new DatashareTimeRule();
+
+    static class TestableCreateNlpBatchesFromIndex extends CreateNlpBatchesFromIndex {
+        public TestableCreateNlpBatchesFromIndex(
+            TaskManager taskManager, Indexer indexer, Task<List<String>> taskView, Function<Double, Void> ignored) {
+            super(taskManager, indexer, taskView, ignored);
+        }
+
+        protected String enqueueBatch(List<Document> batch) {
+            DatashareTime.getInstance().addMilliseconds(1);
+            return super.enqueueBatch(batch);
+        }
+    }
+
+    @ClassRule
+    public static ElasticsearchRule es = new ElasticsearchRule();
+    private static final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider())
+        .withRefresh(Refresh.True);
+    private static TaskManager taskManager;
+
+    @Before
+    public void setUp() {
+        DatashareTaskFactory factory = mock(DatashareTaskFactory.class);
+        when(factory.createBatchNlpTask(any(), any())).thenReturn(mock(BatchNlpTask.class));
+        taskManager = new TaskManagerMemory(factory, new PropertiesProvider());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        es.removeAll();
+        taskManager.close();
+    }
+
+
+    public CreateNlpBatchesFromIndexParametrizedTest(int batchSize, int scrollSize,
+                                                     List<List<Language>> expectedLanguages) {
+        this.batchSize = batchSize;
+        this.scrollSize = scrollSize;
+        this.expectedLanguages = expectedLanguages;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> taskParams() {
+        return List.of(
+            new Object[] {7, 3, List.of(
+                List.of(Language.ENGLISH, Language.ENGLISH, Language.ENGLISH, Language.ENGLISH, Language.ENGLISH,
+                    Language.ENGLISH, Language.ENGLISH),
+                List.of(Language.ENGLISH, Language.ENGLISH, Language.ENGLISH),
+                List.of(Language.FRENCH, Language.FRENCH, Language.FRENCH, Language.FRENCH, Language.FRENCH),
+                List.of(Language.SPANISH, Language.SPANISH, Language.SPANISH, Language.SPANISH, Language.SPANISH)
+            )},
+            new Object[] {3, 7, List.of(
+                List.of(Language.ENGLISH, Language.ENGLISH, Language.ENGLISH),
+                List.of(Language.ENGLISH, Language.ENGLISH, Language.ENGLISH),
+                List.of(Language.ENGLISH, Language.ENGLISH, Language.ENGLISH),
+                List.of(Language.ENGLISH),
+                List.of(Language.FRENCH, Language.FRENCH, Language.FRENCH),
+                List.of(Language.FRENCH, Language.FRENCH),
+                List.of(Language.SPANISH, Language.SPANISH, Language.SPANISH),
+                List.of(Language.SPANISH, Language.SPANISH)
+            )}
+        );
+    }
+
+    @Test
+    public void test_queue_for_batch_nlp_by_batch() throws Exception {
+        // Given
+        int numDocs = 20;
+        for (int i = 0; i < numDocs; i++) {
+            Language language = switch (i % 4) {
+                case 2 -> Language.FRENCH;
+                case 3 -> Language.SPANISH;
+                default -> Language.ENGLISH;
+            };
+            indexer.add(TEST_INDEX, createDoc("doc" + i).with(language).with(Pipeline.Type.OPENNLP).build());
+        }
+        // Already processed
+        indexer.add(TEST_INDEX,
+            createDoc("docAlreadyProcessed").with(Language.ITALIAN).with(Pipeline.Type.CORENLP).build());
+        indexer.add(TEST_INDEX,
+            createDoc("docAlsoAlreadyProcessed").with(Language.ITALIAN).with(Pipeline.Type.CORENLP).build());
+        Map<String, Object> properties = Map.of(
+            "defaultProject", "test-datashare",
+            "stages", "BATCHENQUEUEIDX",
+            "queueName", "test:queue",
+            "nlpPipeline", "CORENLP",
+            "batchSize", this.batchSize,
+            "scrollSize", this.scrollSize
+        );
+        TestableCreateNlpBatchesFromIndex enqueueFromIndex = new TestableCreateNlpBatchesFromIndex(taskManager, indexer,
+                new Task<>(CreateNlpBatchesFromIndex.class.getName(), new User("test"), properties), null);
+        // When
+        List<String> taskIds = enqueueFromIndex.call();
+        List<List<Language>> queued = taskManager.getTasks().stream()
+            .sorted(Comparator.comparing(t -> t.createdAt))
+            .map(t -> ((List<CreateNlpBatchesFromIndex.BatchDocument>) t.args.get("docs")).stream().map(
+                CreateNlpBatchesFromIndex.BatchDocument::language).toList())
+            .toList();
+        // Then
+        assertThat(queued).isEqualTo(this.expectedLanguages);
+        assertThat(taskIds.size()).isEqualTo(expectedLanguages.size());
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
@@ -49,7 +49,7 @@ public class CreateNlpBatchesFromIndexParametrizedTest {
             super(taskManager, indexer, taskView, ignored);
         }
 
-        protected String enqueueBatch(List<Document> batch) {
+        protected String enqueueBatch(List<Document> batch) throws IOException {
             DatashareTime.getInstance().addMilliseconds(1);
             return super.enqueueBatch(batch);
         }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
@@ -1,0 +1,89 @@
+package org.icij.datashare.tasks;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.test.ElasticsearchRule.TEST_INDEX;
+import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.icij.datashare.text.Project.project;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.test.DatashareTimeRule;
+import org.icij.datashare.test.ElasticsearchRule;
+import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
+import org.icij.datashare.text.nlp.Pipeline;
+import org.icij.datashare.user.User;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CreateNlpBatchesFromIndexTest {
+    @Rule
+    public DatashareTimeRule time = new DatashareTimeRule();
+
+    @ClassRule
+    public static ElasticsearchRule es = new ElasticsearchRule();
+    private static final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider())
+        .withRefresh(Refresh.True);
+    private static TaskManager taskManager;
+
+    @Before
+    public void setUp() {
+        DatashareTaskFactory factory = mock(DatashareTaskFactory.class);
+        when(factory.createBatchNlpTask(any(), any())).thenReturn(mock(BatchNlpTask.class));
+        taskManager = new TaskManagerMemory(factory, new PropertiesProvider());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        es.removeAll();
+        taskManager.close();
+    }
+
+    @Test
+    public void test_queue_for_batch_nlp_by_batch_with_body() throws Exception {
+        // Given
+        int batchSize = 3;
+        int scrollSize = 5;
+        indexer.add(TEST_INDEX, createDoc("my_id").with("this is my precious doc")
+            .with(Pipeline.Type.CORENLP).with(project(TEST_INDEX)).build());
+        indexer.add(TEST_INDEX, createDoc("my_other_id").with("this is not my precious doc")
+            .withExtractionLevel((short) 1)
+            .with(Pipeline.Type.CORENLP).with(project(TEST_INDEX)).build());
+        Map<String, Object> properties = Map.of(
+            "defaultProject", "test-datashare",
+            "stages", "BATCHENQUEUEIDX",
+            "queueName", "test:queue",
+            "nlpPipeline", "OPENNLP",
+            "batchSize", batchSize,
+            "scrollSize", scrollSize,
+            "searchQuery", """
+                {
+                    "match": {
+                      "extractionLevel": 0
+                    }
+                }
+                """
+        );
+        CreateNlpBatchesFromIndex enqueueFromIndex = new CreateNlpBatchesFromIndex(taskManager, indexer,
+            new Task<>(CreateNlpBatchesFromIndex.class.getName(), new User("test"), properties), null);
+        // When
+        enqueueFromIndex.call();
+        List<List<String>> queued = taskManager.getTasks().stream()
+            .map(t -> ((List<CreateNlpBatchesFromIndex.BatchDocument>) t.args.get("docs")).stream().map(
+                CreateNlpBatchesFromIndex.BatchDocument::id).toList())
+            .toList();
+        // Then
+        List<List<String>> expected = List.of(List.of("my_id"));
+        assertThat(queued).isEqualTo(expected);
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/web/WebLocalAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/WebLocalAcceptanceTest.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.codestory.rest.Response;
 import org.icij.datashare.Repository;
-import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -14,19 +14,20 @@ import org.mockito.Mock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import static java.lang.String.format;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class WebLocalAcceptanceTest extends AbstractProdWebServerTest {
     @Mock Repository jooqRepository;
 
+    private static AutoCloseable mocks;
+
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
+        mocks = openMocks(this);
         when(jooqRepository.getProjects()).thenReturn(new ArrayList<>());
         HashMap<String, Object> properties = new HashMap<>() {{
             put("mode", "LOCAL");
@@ -36,6 +37,11 @@ public class WebLocalAcceptanceTest extends AbstractProdWebServerTest {
         }};
         configure(CommonMode.create(properties).createWebConfiguration());
         waitForDatashare();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        mocks.close();
     }
 
     @Test
@@ -61,12 +67,12 @@ public class WebLocalAcceptanceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_get_extensions_list_installed() throws Exception {
+    public void test_get_extensions_list_installed() {
         get("/api/extensions").should().haveType("application/json").contain("\"installed\":true");
     }
 
     @Test
-    public void test_get_plugins_list_installed() throws Exception {
+    public void test_get_plugins_list_installed() {
         get("/api/plugins").should().haveType("application/json").contain("\"installed\":true");
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -125,6 +125,8 @@ public class DatashareCli {
         DatashareCliOptions.language(parser);
         DatashareCliOptions.ocrLanguage(parser);
         DatashareCliOptions.nlpPipeline(parser);
+        DatashareCliOptions.nlpMaxTextLength(parser);
+        DatashareCliOptions.nlpBatchSize(parser);
         DatashareCliOptions.resume(parser);
         DatashareCliOptions.scroll(parser);
         DatashareCliOptions.scrollSize(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -77,7 +77,9 @@ public final class DatashareCliOptions {
     public static final String MESSAGE_BUS_OPT = "messageBusAddress";
     public static final String MODE_ABBR_OPT = "m";
     public static final String MODE_OPT = "mode";
+    public static final String NLP_BATCH_SIZE_OPT = "batchSize";
     public static final String NLP_PARALLELISM_ABBR_OPT = "np";
+    public static final String NLP_MAX_TEXT_LENGTH_OPT = "maxTextLength";
     public static final String NLP_PARALLELISM_OPT = "nlpParallelism";
     public static final String NLP_PIPELINE_ABBR_OPT = "nlpp";
     public static final String NLP_PIPELINE_OPT = "nlpPipeline";
@@ -157,6 +159,8 @@ public final class DatashareCliOptions {
     public static final String DEFAULT_LOG_LEVEL = Level.INFO.toString();
     public static final String DEFAULT_MESSAGE_BUS_ADDRESS = "redis://redis:6379";
     public static final String DEFAULT_NLP_PIPELINE = "CORENLP";
+    public static final int DEFAULT_NLP_BATCH_SIZE = 1024;
+    public static final int DEFAULT_NLP_MAX_TEXT_LENGTH = 1024;
     public static final String DEFAULT_PROTECTED_URI_PREFIX = "/api/";
     public static final String DEFAULT_QUEUE_NAME = "extract:queue";
     public static final String DEFAULT_REDIS_ADDRESS = "redis://redis:6379";
@@ -231,7 +235,7 @@ public final class DatashareCliOptions {
                 singletonList(FOLLOW_SYMLINKS_OPT), "Follow symlinks while scanning documents")
                 .withRequiredArg()
                 .ofType(Boolean.class)
-                .defaultsTo(DEFAULT_FOLLOW_SYMLINKS);;
+                .defaultsTo(DEFAULT_FOLLOW_SYMLINKS);
     }
 
     static void cors(OptionParser parser) {
@@ -433,6 +437,24 @@ public final class DatashareCliOptions {
     }
 
     static void nlpParallelism(OptionParser parser) {
+        parser.acceptsAll(
+                asList(NLP_PARALLELISM_ABBR_OPT, NLP_PARALLELISM_OPT),
+                "Number of NLP extraction threads per pipeline.")
+                .withRequiredArg()
+                .ofType( Integer.class )
+                .defaultsTo(DEFAULT_NLP_PARALLELISM);
+    }
+
+    static void nlpBatchSize(OptionParser parser) {
+        parser.acceptsAll(
+                List.of(NLP_BATCH_SIZE_OPT),
+                "Batch size of NLP extraction task in number of documents.")
+                .withRequiredArg()
+                .ofType( Integer.class )
+                .defaultsTo(DEFAULT_NLP_BATCH_SIZE);
+    }
+
+    static void nlpMaxTextLength(OptionParser parser) {
         parser.acceptsAll(
                 asList(NLP_PARALLELISM_ABBR_OPT, NLP_PARALLELISM_OPT),
                 "Number of NLP extraction threads per pipeline.")
@@ -846,7 +868,7 @@ public final class DatashareCliOptions {
 
 
     public static ValueConverter<String> toAbsolute() {
-        return new ValueConverter<String>() {
+        return new ValueConverter<>() {
             @Override
             public String convert(String value) {
                 Path path = Paths.get(value);


### PR DESCRIPTION
# TODO
- [x] merge #1538
- [x] wait for CLI tasks polling and implement it here too

# PR description

Implemenent batch processing for NER, this change is made in the context of #1452, as batch processing is necessary for Spacy.

# Notes
In this PR we made the choice not to implement `PipelineTask` but in contrast fully rely on the task bus to distribute the batches across workers

# Changes

## `datashare-api`
### Added
- added the `Searcher sort(String field, SortOrder order)` method to `Indexer.Searcher` to sort search results and be able to return documents grouped by language (to avoid model reload)

## `datashare-app`
### Added
- added the `CreateNlpBatchesFromIndexTask` task which scan the index for document sorted by language. Documents are then added by batch to the `BatchNlpTask` queue, where workers will process document to perform NER by batch
- added the `BatchNlpTask` which consumes document by batches, fetches them from the index and performs the NLP task (NER only)
