### PR TITLE
feature: support arbitrary extensions

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/DeliverableHelper.java
+++ b/datashare-app/src/main/java/org/icij/datashare/DeliverableHelper.java
@@ -1,0 +1,71 @@
+package org.icij.datashare;
+
+import static org.apache.commons.io.FilenameUtils.getExtension;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.apache.commons.io.FilenameUtils;
+
+public class DeliverableHelper {
+    private static final String OS = System.getProperty("os.name").toLowerCase();
+    private static final String ARCH = System.getProperty("os.arch").toLowerCase();
+    private static final boolean IS_MACOS = OS.contains("mac");
+    private static final boolean IS_WINDOWS = OS.contains("windows");
+    private static final boolean IS_UNIX = OS.contains("nix") || OS.contains("nux") || OS.indexOf("aix") > 0;
+    private static final boolean IS_X86_64 = ARCH.contains("amd64") || ARCH.contains("x86_64");
+    private static final boolean IS_ARM = ARCH.contains("aarch64") || ARCH.contains("arm64");
+
+    static String getUrlFileName(URL url) { return FilenameUtils.getName(url.getFile().replaceAll("/$",""));}
+
+    static URL hostSpecificUrl(URL url, String version) {
+        String extFileName = getUrlFileName(url);
+        String hostSpecificName = extFileName.replace("-" + version, "") + hostSpecificSuffix() + "-" + version;
+        String urlFile = url.getFile();
+        StringBuilder b = new StringBuilder(urlFile);
+        int last = urlFile.lastIndexOf(extFileName);
+        b.replace(last, last + extFileName.length(), "");
+        urlFile = b.toString();
+        String hostSpecificFile = urlFile + hostSpecificName;
+        try {
+            return new URL(url.getProtocol(), url.getHost(), hostSpecificFile);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static String hostSpecificSuffix() {
+        String arch;
+        if (IS_ARM) {
+            // We assume 64 arch here...
+            arch = "aarch64";
+        } else if (IS_X86_64) {
+            arch = "x86_64";
+        } else {
+            throw new RuntimeException("unsupported architecture " + ARCH);
+        }
+        String os;
+        if (IS_WINDOWS) {
+            os = "windows";
+        } else if (IS_MACOS) {
+            os = "macos";
+        } else if (IS_UNIX) {
+            os = "linux";
+        } else {
+            throw new RuntimeException("unsupported os " + OS);
+        }
+        return "-" + os + "-" + arch;
+    }
+
+    static String getExtensionFileExt(String fileName) {
+        // We have to strip the version otherwise the patch it's identified as the extension for binary ext
+        if (fileName.isEmpty()) {
+            return "";
+        }
+        String[] split = fileName.split("-");
+        String[] lastSplit = split[split.length - 1].split("\\.");
+        if (lastSplit.length == 1) {
+            return "";
+        }
+        return getExtension(lastSplit[lastSplit.length - 1]);
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/DeliverableHelper.java
+++ b/datashare-app/src/main/java/org/icij/datashare/DeliverableHelper.java
@@ -1,68 +1,23 @@
 package org.icij.datashare;
 
-import static java.lang.String.format;
-import static java.lang.String.join;
-import static java.util.Arrays.stream;
-import static java.util.Optional.ofNullable;
 import static org.apache.commons.io.FilenameUtils.getExtension;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
 
 public class DeliverableHelper {
-    enum OS {
-        macos("mac.*"), linux(".*(nux|nix|aix).*"), windows("windows.*");
-        private final Pattern osPattern;
-
-        OS(String regexp) {
-            this.osPattern = Pattern.compile(regexp);
-        }
-
-        static OS fromSystem() {return fromSystemString(System.getProperty("os.name"));}
-        static OS fromSystemString(String osName) {
-            String normalizedOsName = normalize(osName);
-            return stream(values()).filter(os -> os.osPattern.matcher(normalizedOsName).matches())
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException(format("Unknown OS: %s", osName)));
-        }
-    }
-    enum ARCH {
-        aarch64("(aarch64|arm64).*"), x86_64("(amd64|x86_64).*");
-        private final Pattern archPattern;
-
-        ARCH(String archPattern) {
-            this.archPattern = Pattern.compile(archPattern);
-        }
-
-        static ARCH fromSystem() {return fromSystemString(System.getProperty("os.arch"));}
-        static ARCH fromSystemString(String archName) {
-            String normalizedArchName = normalize(archName);
-            return stream(values()).filter(os -> os.archPattern.matcher(normalizedArchName).matches())
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException(format("Unknown ARCH: %s", archName)));
-        }
-    }
-
-    static String normalize(String string) {
-        return ofNullable(string).orElse("").toLowerCase();
-    }
     static String getUrlFileName(URL url) { return FilenameUtils.getName(url.getFile().replaceAll("/$",""));}
 
-    static URL hostSpecificUrl(URL url, String version) {
+    static URL hostSpecificUrl(OsArchDetector osArchDetector, URL url, String version) {
         String fileName = url.getFile();
-        String fileNameWithOsAndArch = fileName.replace(version, String.format("%s-%s", osArchSuffix(), version));
+        String fileNameWithOsAndArch = fileName.replace(version, String.format("%s-%s", osArchDetector.osArchSuffix(), version));
         try {
             return new URL(url.getProtocol(), url.getHost(), fileNameWithOsAndArch);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    static String osArchSuffix() {
-        return OS.fromSystem() + "-" + ARCH.fromSystem();
     }
 
     static String getExtensionFileExt(String fileName) {

--- a/datashare-app/src/main/java/org/icij/datashare/Extension.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Extension.java
@@ -1,16 +1,19 @@
 package org.icij.datashare;
 
+import static java.nio.file.Files.copy;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.io.FilenameUtils.getBaseName;
+import static org.apache.commons.io.FilenameUtils.getExtension;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.io.FilenameUtils;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.Channels;
@@ -26,17 +29,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.nio.file.Files.copy;
-import static java.util.Objects.requireNonNull;
-import static java.util.Optional.ofNullable;
-import static org.apache.commons.io.FilenameUtils.getBaseName;
-import static org.apache.commons.io.FilenameUtils.getExtension;
+import org.apache.commons.io.FilenameUtils;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Extension implements Deliverable {
     @JsonIgnore
     protected final Logger logger = LoggerFactory.getLogger(getClass());
-    static Pattern extensionFormat = Pattern.compile("([[^\\W_][\\-.]]*)-v?([0-9.]*)(?<!-)([-\\w]*)?$"); //of form: id-with-numb3r-1.2.3-suffix with negative lookbehind for suffix dash
+    static Pattern extensionFormat = Pattern.compile("([[^\\W_]\\-.]*)-v?([0-9.]*)(?<!-)([-\\w]*)?$"); //of form: id-with-numb3r-1.2.3-suffix with negative lookbehind for suffix dash
     static Pattern endsWithExtension = Pattern.compile("(.*)(\\.[a-zA-Z]+$)");
     public static final String TMP_PREFIX = "tmp";
     public final String id;
@@ -46,6 +47,14 @@ public class Extension implements Deliverable {
     public final URL homepage;
     public final String version;
     public final Type type;
+    protected boolean hostSpecific;
+    private static final String OS = System.getProperty("os.name").toLowerCase();
+    private static final String ARCH = System.getProperty("os.arch").toLowerCase();
+    private static final boolean IS_MACOS = OS.contains("mac");
+    private static final boolean IS_WINDOWS = OS.contains("windows");
+    private static final boolean IS_UNIX = OS.contains("nix") || OS.contains("nux") || OS.indexOf("aix") > 0;
+    private static final boolean IS_X86_64 = ARCH.contains("amd64") || ARCH.contains("x86_64");
+    private static final boolean IS_ARM = ARCH.contains("aarch64") || ARCH.contains("arm64");
 
     @JsonCreator
     public Extension(@JsonProperty("id") String id,
@@ -62,6 +71,7 @@ public class Extension implements Deliverable {
         this.version = version;
         this.description = description;
         this.type = type;
+        this.hostSpecific = this.isHostSpecific();
     }
 
     Extension(URL url, Type type) {
@@ -73,17 +83,25 @@ public class Extension implements Deliverable {
         this.name = res.getKey();
         this.description = null;
         this.type = type;
+        this.hostSpecific = isHostSpecific();
     }
 
     Extension(URL url) {this(url, Type.UNKNOWN);}
 
     @Override
-    public File download() throws IOException { return download(url);}
+    public File download() throws IOException {
+        return download(hostSpecificUrl());
+    }
 
     @NotNull
     protected File download(URL url) throws IOException {
         ReadableByteChannel readableByteChannel = Channels.newChannel(url.openStream());
-        File tmpFile = Files.createTempFile(TMP_PREFIX, "." + getExtension(url.toString())).toFile();
+        String suffix = "";
+        String ext = getExtensionFileExt(url.toString());
+        if (!ext.isEmpty()) {
+            suffix = "." + ext;
+        }
+        File tmpFile = Files.createTempFile(TMP_PREFIX, suffix).toFile();
         logger.info("downloading from url {}", url);
         try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)) {
            fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
@@ -101,9 +119,17 @@ public class Extension implements Deliverable {
 
     @Override
     public void install(File extensionFile, Path extensionsDir) throws IOException {
-        File[] candidateFiles = ofNullable(extensionsDir.toFile().listFiles((file, s) -> s.endsWith(".jar"))).orElse(new File[0]);
+        String ext = this.getExtensionFileExt(extensionFile.getName());
+        File[] candidateFiles;
+        FilenameFilter filenameFilter;
+        if (!ext.isEmpty()) {
+            filenameFilter = (file, s) -> s.endsWith("." + ext);
+        } else {
+            filenameFilter = (file, s) -> getExtensionFileExt(s).isEmpty();
+        }
+        candidateFiles = ofNullable(extensionsDir.toFile().listFiles(filenameFilter)).orElse(new File[0]);
         List<File> previousVersionInstalled = getPreviousVersionInstalled(candidateFiles, getBaseName(getUrlFileName()));
-        if (previousVersionInstalled.size() > 0) {
+        if (!previousVersionInstalled.isEmpty()) {
             logger.info("removing previous versions {}", previousVersionInstalled);
             previousVersionInstalled.forEach(File::delete);
         }
@@ -117,10 +143,10 @@ public class Extension implements Deliverable {
     public void delete(Path installDir) throws IOException {
         Path extensionPath = installDir.resolve(getUrlFileName());
         if (extensionPath.toFile().exists()) {
-            logger.info("removing extension {} jar: {}", id, extensionPath);
+            logger.info("removing extension {} binary: {}", id, extensionPath);
             extensionPath.toFile().delete();
         } else {
-            logger.info("could not remove extension {} jar: {}", id, extensionPath);
+            logger.info("could not remove extension {} binary: {}", id, extensionPath);
         }
     }
 
@@ -201,8 +227,7 @@ public class Extension implements Deliverable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Extension)) return false;
-        Extension extension = (Extension) o;
+        if (!(o instanceof Extension extension)) return false;
         if(version == null || extension.version == null){
             if(version == null && extension.version == null)
                 return id.equals(extension.id);
@@ -222,4 +247,64 @@ public class Extension implements Deliverable {
         int idCompare = this.id.compareTo(deliverable.getId());
         return idCompare == 0 ? ofNullable(this.version).orElse("-1").compareTo(ofNullable(deliverable.getVersion()).orElse("-1")) : idCompare;
     }
+
+    protected URL hostSpecificUrl() {
+        if (!hostSpecific) {
+            return url;
+        }
+        String extFileName = getUrlFileName();
+        String hostSpecificName = extFileName.replace("-" + version, "") + hostSpecificSuffix() + "-" + version;
+        String urlFile = url.getFile();
+        StringBuilder b = new StringBuilder(urlFile);
+        int last = urlFile.lastIndexOf(extFileName);
+        b.replace(last, last + extFileName.length(), "" );
+        urlFile = b.toString();
+        String hostSpecificFile = urlFile + hostSpecificName;
+        try {
+            return new URL(url.getProtocol(), url.getHost(), hostSpecificFile);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected String hostSpecificSuffix() {
+        String arch;
+        if (IS_ARM) {
+            // We assume 64 arch here...
+            arch = "aarch64";
+        } else if (IS_X86_64) {
+            arch = "x86_64";
+        } else {
+            throw new RuntimeException("unsupported architecture " + ARCH);
+        }
+        String os;
+        if (IS_WINDOWS) {
+            os = "windows";
+        } else if (IS_MACOS) {
+            os = "macos";
+        } else if (IS_UNIX) {
+            os = "linux";
+        } else {
+            throw new RuntimeException("unsupported os " + OS);
+        }
+        return "-" + os + "-" + arch;
+    }
+
+    private String getExtensionFileExt(String fileName) {
+        // We have to strip the version otherwise the patch it's identified as the extension for binary ext
+        if (fileName.isEmpty()) {
+            return "";
+        }
+        String[] split = fileName.split("-");
+        String[] lastSplit = split[split.length -1].split("\\.");
+        if (lastSplit.length == 1) {
+            return "";
+        }
+        return getExtension(lastSplit[lastSplit.length - 1]);
+    }
+
+    protected boolean isHostSpecific() {
+        return !FilenameUtils.getName(this.url.getFile().replaceAll("/$","")).endsWith(".jar");
+    }
+
 }

--- a/datashare-app/src/main/java/org/icij/datashare/Extension.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Extension.java
@@ -82,8 +82,8 @@ public class Extension implements Deliverable {
     @Override
     public File download() throws IOException {
         URL hostSpecificUrl = url;
-        if (isHostSpecific()) {
-            hostSpecificUrl = DeliverableHelper.hostSpecificUrl(url, version);
+        if (this.hostSpecific) {
+            hostSpecificUrl = DeliverableHelper.hostSpecificUrl(new OsArchDetector(), url, version);
         }
         return download(hostSpecificUrl);
     }

--- a/datashare-app/src/main/java/org/icij/datashare/OsArchDetector.java
+++ b/datashare-app/src/main/java/org/icij/datashare/OsArchDetector.java
@@ -1,0 +1,70 @@
+package org.icij.datashare;
+
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static java.util.Optional.ofNullable;
+
+import java.util.regex.Pattern;
+
+public class OsArchDetector {
+    private final OS os;
+    private final ARCH arch;
+
+    public OsArchDetector() {
+        this.os = OS.fromSystem();
+        this.arch = ARCH.fromSystem();
+    }
+
+    OsArchDetector(OS os, ARCH arch) {
+        this.os = os;
+        this.arch = arch;
+    }
+
+    enum OS {
+        macos("mac.*"), linux(".*(nux|nix|aix).*"), windows("windows.*");
+        private final Pattern osPattern;
+
+        OS(String regexp) {
+            this.osPattern = Pattern.compile(regexp);
+        }
+
+        static OS fromSystem() {
+            return fromSystemString(System.getProperty("os.name"));
+        }
+
+        static OS fromSystemString(String osName) {
+            String normalizedOsName = normalize(osName);
+            return stream(values()).filter(os -> os.osPattern.matcher(normalizedOsName).matches())
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(format("Unknown OS: %s", osName)));
+        }
+    }
+
+    enum ARCH {
+        aarch64("(aarch64|arm64).*"), x86_64("(amd64|x86_64).*");
+        private final Pattern archPattern;
+
+        ARCH(String archPattern) {
+            this.archPattern = Pattern.compile(archPattern);
+        }
+
+        static ARCH fromSystem() {
+            return fromSystemString(System.getProperty("os.arch"));
+        }
+
+        static ARCH fromSystemString(String archName) {
+            String normalizedArchName = normalize(archName);
+            return stream(values()).filter(os -> os.archPattern.matcher(normalizedArchName).matches())
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(format("Unknown ARCH: %s", archName)));
+        }
+    }
+
+    static String normalize(String string) {
+        return ofNullable(string).orElse("").toLowerCase();
+    }
+
+    String osArchSuffix() {
+        return os + "-" + arch;
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/DeliverableHelperTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/DeliverableHelperTest.java
@@ -1,0 +1,70 @@
+package org.icij.datashare;
+
+import org.icij.datashare.DeliverableHelper.ARCH;
+import org.icij.datashare.DeliverableHelper.OS;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class DeliverableHelperTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void test_os_unknown() {
+        OS.fromSystemString("freebsd");
+    }
+
+    @Test
+    public void test_os_enum_this_computer() {
+        assertThat(OS.fromSystem()).isEqualTo(OS.fromSystemString(System.getProperty("os.name")));
+    }
+
+    @Test
+    public void test_os_enum_mac() {
+        assertThat(OS.fromSystemString("macosx")).isEqualTo(OS.macos);
+        assertThat(OS.fromSystemString("macos")).isEqualTo(OS.macos);
+        assertThat(OS.fromSystemString("mac")).isEqualTo(OS.macos);
+    }
+
+    @Test
+    public void test_os_enum_windows() {
+        assertThat(OS.fromSystemString("Windows 11")).isEqualTo(OS.windows);
+    }
+
+    @Test
+    public void test_os_enum_linux() {
+        assertThat(OS.fromSystemString("Linux")).isEqualTo(OS.linux);
+        assertThat(OS.fromSystemString("nux")).isEqualTo(OS.linux);
+        assertThat(OS.fromSystemString("nix")).isEqualTo(OS.linux);
+        assertThat(OS.fromSystemString("aix")).isEqualTo(OS.linux);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_arch_unknown() {
+        OS.fromSystemString("x86_32");
+    }
+
+    @Test
+    public void test_arch_this_computer() {
+        assertThat(ARCH.fromSystem()).isEqualTo(ARCH.fromSystemString(System.getProperty("os.arch")));
+    }
+
+    @Test
+    public void test_arch_arm() {
+        assertThat(ARCH.fromSystemString("aarch64")).isEqualTo(ARCH.aarch64);
+        assertThat(ARCH.fromSystemString("arm64")).isEqualTo(ARCH.aarch64);
+    }
+
+    @Test
+    public void test_arch_64() {
+        assertThat(ARCH.fromSystemString("amd64")).isEqualTo(ARCH.x86_64);
+        assertThat(ARCH.fromSystemString("x86_64")).isEqualTo(ARCH.x86_64);
+    }
+
+    @Test
+    public void test_url() throws MalformedURLException {
+        assertThat(DeliverableHelper.hostSpecificUrl(new URL("http://foo/bar/baz-1.2.3"), "1.2.3").toString())
+                .isEqualTo("http://foo/bar/baz-linux-x86_64-1.2.3");
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/DeliverableHelperTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/DeliverableHelperTest.java
@@ -1,7 +1,7 @@
 package org.icij.datashare;
 
-import org.icij.datashare.DeliverableHelper.ARCH;
-import org.icij.datashare.DeliverableHelper.OS;
+import org.icij.datashare.OsArchDetector.ARCH;
+import org.icij.datashare.OsArchDetector.OS;
 import org.junit.Test;
 
 import java.net.MalformedURLException;
@@ -10,61 +10,10 @@ import java.net.URL;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class DeliverableHelperTest {
-    @Test(expected = IllegalArgumentException.class)
-    public void test_os_unknown() {
-        OS.fromSystemString("freebsd");
-    }
-
-    @Test
-    public void test_os_enum_this_computer() {
-        assertThat(OS.fromSystem()).isEqualTo(OS.fromSystemString(System.getProperty("os.name")));
-    }
-
-    @Test
-    public void test_os_enum_mac() {
-        assertThat(OS.fromSystemString("macosx")).isEqualTo(OS.macos);
-        assertThat(OS.fromSystemString("macos")).isEqualTo(OS.macos);
-        assertThat(OS.fromSystemString("mac")).isEqualTo(OS.macos);
-    }
-
-    @Test
-    public void test_os_enum_windows() {
-        assertThat(OS.fromSystemString("Windows 11")).isEqualTo(OS.windows);
-    }
-
-    @Test
-    public void test_os_enum_linux() {
-        assertThat(OS.fromSystemString("Linux")).isEqualTo(OS.linux);
-        assertThat(OS.fromSystemString("nux")).isEqualTo(OS.linux);
-        assertThat(OS.fromSystemString("nix")).isEqualTo(OS.linux);
-        assertThat(OS.fromSystemString("aix")).isEqualTo(OS.linux);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void test_arch_unknown() {
-        OS.fromSystemString("x86_32");
-    }
-
-    @Test
-    public void test_arch_this_computer() {
-        assertThat(ARCH.fromSystem()).isEqualTo(ARCH.fromSystemString(System.getProperty("os.arch")));
-    }
-
-    @Test
-    public void test_arch_arm() {
-        assertThat(ARCH.fromSystemString("aarch64")).isEqualTo(ARCH.aarch64);
-        assertThat(ARCH.fromSystemString("arm64")).isEqualTo(ARCH.aarch64);
-    }
-
-    @Test
-    public void test_arch_64() {
-        assertThat(ARCH.fromSystemString("amd64")).isEqualTo(ARCH.x86_64);
-        assertThat(ARCH.fromSystemString("x86_64")).isEqualTo(ARCH.x86_64);
-    }
-
     @Test
     public void test_url() throws MalformedURLException {
-        assertThat(DeliverableHelper.hostSpecificUrl(new URL("http://foo/bar/baz-1.2.3"), "1.2.3").toString())
+        OsArchDetector detector = new OsArchDetector(OS.linux, ARCH.x86_64);
+        assertThat(DeliverableHelper.hostSpecificUrl(detector, new URL("http://foo/bar/baz-1.2.3"), "1.2.3").toString())
                 .isEqualTo("http://foo/bar/baz-linux-x86_64-1.2.3");
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
@@ -126,8 +126,9 @@ public class ExtensionServiceTest {
 
     @Test
     public void test_delete_previous_extension_if_version_differs_for_executable_ext() throws Exception {
-        String v0Path = "my-extension-" + DeliverableHelper.osArchSuffix() + "-1.2.3";
-        String v1path = "my-extension-" + DeliverableHelper.osArchSuffix() + "-1.2.4";
+        OsArchDetector detector = new OsArchDetector();
+        String v0Path = "my-extension-" + detector.osArchSuffix() + "-1.2.3";
+        String v1path = "my-extension-" + detector.osArchSuffix() + "-1.2.4";
         otherFolder.newFile(v0Path);
         otherFolder.newFile(v1path);
         ExtensionService extensionService = new ExtensionService(extensionFolder.getRoot().toPath());

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
@@ -126,10 +126,8 @@ public class ExtensionServiceTest {
 
     @Test
     public void test_delete_previous_extension_if_version_differs_for_executable_ext() throws Exception {
-        Extension extV0 = new Extension(otherFolder.getRoot().toPath().resolve("my-extension-1.2.3").toUri().toURL());
-        Extension extV1 = new Extension(otherFolder.getRoot().toPath().resolve("my-extension-1.2.4").toUri().toURL());
-        String v0Path = "my-extension" + extV0.hostSpecificSuffix() + "-1.2.3";
-        String v1path = "my-extension" + extV1.hostSpecificSuffix() + "-1.2.4";
+        String v0Path = "my-extension" + DeliverableHelper.hostSpecificSuffix() + "-1.2.3";
+        String v1path = "my-extension" + DeliverableHelper.hostSpecificSuffix() + "-1.2.4";
         otherFolder.newFile(v0Path);
         otherFolder.newFile(v1path);
         ExtensionService extensionService = new ExtensionService(extensionFolder.getRoot().toPath());

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
@@ -125,13 +125,33 @@ public class ExtensionServiceTest {
     }
 
     @Test
+    public void test_delete_previous_extension_if_version_differs_for_executable_ext() throws Exception {
+        Extension extV0 = new Extension(otherFolder.getRoot().toPath().resolve("my-extension-1.2.3").toUri().toURL());
+        Extension extV1 = new Extension(otherFolder.getRoot().toPath().resolve("my-extension-1.2.4").toUri().toURL());
+        String v0Path = "my-extension" + extV0.hostSpecificSuffix() + "-1.2.3";
+        String v1path = "my-extension" + extV1.hostSpecificSuffix() + "-1.2.4";
+        otherFolder.newFile(v0Path);
+        otherFolder.newFile(v1path);
+        ExtensionService extensionService = new ExtensionService(extensionFolder.getRoot().toPath());
+
+        extensionService.downloadAndInstall(otherFolder.getRoot().toPath().resolve("my-extension-1.2.3").toUri().toURL());
+        extensionService.downloadAndInstall(otherFolder.getRoot().toPath().resolve("my-extension-1.2.4").toUri().toURL());
+
+        assertThat(extensionFolder.getRoot().toPath().resolve("my-extension-1.2.3").toFile()).doesNotExist();
+        assertThat(extensionFolder.getRoot().toPath().resolve("my-extension-1.2.4").toFile()).exists();
+    }
+
+    @Test
     public void test_list_installed_extensions() throws Exception {
         extensionFolder.newFile("extension-1.jar");
         extensionFolder.newFile("extension-2.jar");
+        extensionFolder.newFile("extension-3");
 
         assertThat(new ExtensionService(extensionFolder.getRoot().toPath()).listInstalled().stream().map(File::toString).collect(Collectors.toSet())).
                 contains(extensionFolder.getRoot().toPath().resolve("extension-1.jar").toString(),
-                        extensionFolder.getRoot().toPath().resolve("extension-2.jar").toString());
+                        extensionFolder.getRoot().toPath().resolve("extension-2.jar").toString(),
+                    extensionFolder.getRoot().toPath().resolve("extension-3").toString()
+                    );
     }
 
     @Test
@@ -151,7 +171,7 @@ public class ExtensionServiceTest {
         assertThat(extensionsIterator.next().isInstalled()).isTrue();
         assertThat(extensionsIterator.next().isInstalled()).isTrue();
     }
-    
+
     @Test
     public void test_list_merges_with_possible_upgrade() throws IOException {
         extensionFolder.newFile( "official-extension-7.0.0.jar");

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionServiceTest.java
@@ -126,8 +126,8 @@ public class ExtensionServiceTest {
 
     @Test
     public void test_delete_previous_extension_if_version_differs_for_executable_ext() throws Exception {
-        String v0Path = "my-extension" + DeliverableHelper.hostSpecificSuffix() + "-1.2.3";
-        String v1path = "my-extension" + DeliverableHelper.hostSpecificSuffix() + "-1.2.4";
+        String v0Path = "my-extension-" + DeliverableHelper.osArchSuffix() + "-1.2.3";
+        String v1path = "my-extension-" + DeliverableHelper.osArchSuffix() + "-1.2.4";
         otherFolder.newFile(v0Path);
         otherFolder.newFile(v1path);
         ExtensionService extensionService = new ExtensionService(extensionFolder.getRoot().toPath());

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionTest.java
@@ -1,7 +1,5 @@
 package org.icij.datashare;
 
-import java.io.IOException;
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -101,46 +99,14 @@ public class ExtensionTest {
 
     @Test
     public void test_has_previous_version() throws Exception {
-        File[] files = new File[] {extensionsDir.newFile("ext3nsion-1.0.0.jar"), extensionsDir.newFile("ext3nsion-1.0.0")};
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-0.1.0")).hasSize(2);
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1.0")).hasSize(2);
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1")).hasSize(2);
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion")).hasSize(2);
+        File[] files = new File[] {extensionsDir.newFile("ext3nsion-1.0.0.jar")};
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-0.1.0")).hasSize(1);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1.0")).hasSize(1);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1")).hasSize(1);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion")).hasSize(1);
 
         assertThat(Extension.getPreviousVersionInstalled(files, "ext_3nsion-1.1")).isEmpty();
         assertThat(Extension.getPreviousVersionInstalled(files, "other-extension")).isEmpty();
         assertThat(Extension.getPreviousVersionInstalled(files, "extension-other-1.2.3")).isEmpty();
-    }
-
-    @Test
-    public void test_host_specific_url_jar() throws IOException {
-        // Given
-        URL url = new URL("https://some-repository/path/to/my-favorite-executabe-extension.jar");
-        Extension extension = new Extension(url);
-        // When
-        URL hostSpecificUrl = extension.hostSpecificUrl();
-        // Then
-        assertThat(hostSpecificUrl).isEqualTo(url);
-    }
-
-    @Test
-    public void test_host_specific_url() throws IOException {
-        // Given
-        URL url = new URL("https://some-repository/path/to/my-favorite-executable-extension-6.0");
-        Extension extension = new Extension(url);
-        // When
-        URL hostSpecificUrl = extension.hostSpecificUrl();
-        // Then
-        List<String> expectedEnds = List.of(
-            "my-favorite-executable-extension-linux-aarch64-6.0",
-            "my-favorite-executable-extension-linux-x86_64-6.0",
-            "my-favorite-executable-extension-macos-aarch64-6.0",
-            "my-favorite-executable-extension-macos-x86_64-6.0",
-            "my-favorite-executable-extension-windows-aarch64-6.0",
-            "my-favorite-executable-extension-windows-x86_64-6.0"
-        );
-        boolean isPlatformSpecific = !expectedEnds.stream().filter(end -> hostSpecificUrl.toString().endsWith(end))
-            .toList().isEmpty();
-        assertThat(isPlatformSpecific).isTrue();
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/ExtensionTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/ExtensionTest.java
@@ -1,5 +1,7 @@
 package org.icij.datashare;
 
+import java.io.IOException;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -8,7 +10,6 @@ import java.io.File;
 import java.net.URL;
 import java.util.AbstractMap.SimpleEntry;
 
-import static org.apache.commons.io.FilenameUtils.getBaseName;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class ExtensionTest {
@@ -100,14 +101,46 @@ public class ExtensionTest {
 
     @Test
     public void test_has_previous_version() throws Exception {
-        File[] files = new File[] {extensionsDir.newFile("ext3nsion-1.0.0.jar")};
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-0.1.0")).hasSize(1);
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1.0")).hasSize(1);
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1")).hasSize(1);
-        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion")).hasSize(1);
+        File[] files = new File[] {extensionsDir.newFile("ext3nsion-1.0.0.jar"), extensionsDir.newFile("ext3nsion-1.0.0")};
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-0.1.0")).hasSize(2);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1.0")).hasSize(2);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion-1.1")).hasSize(2);
+        assertThat(Extension.getPreviousVersionInstalled(files, "ext3nsion")).hasSize(2);
 
         assertThat(Extension.getPreviousVersionInstalled(files, "ext_3nsion-1.1")).isEmpty();
         assertThat(Extension.getPreviousVersionInstalled(files, "other-extension")).isEmpty();
         assertThat(Extension.getPreviousVersionInstalled(files, "extension-other-1.2.3")).isEmpty();
+    }
+
+    @Test
+    public void test_host_specific_url_jar() throws IOException {
+        // Given
+        URL url = new URL("https://some-repository/path/to/my-favorite-executabe-extension.jar");
+        Extension extension = new Extension(url);
+        // When
+        URL hostSpecificUrl = extension.hostSpecificUrl();
+        // Then
+        assertThat(hostSpecificUrl).isEqualTo(url);
+    }
+
+    @Test
+    public void test_host_specific_url() throws IOException {
+        // Given
+        URL url = new URL("https://some-repository/path/to/my-favorite-executable-extension-6.0");
+        Extension extension = new Extension(url);
+        // When
+        URL hostSpecificUrl = extension.hostSpecificUrl();
+        // Then
+        List<String> expectedEnds = List.of(
+            "my-favorite-executable-extension-linux-aarch64-6.0",
+            "my-favorite-executable-extension-linux-x86_64-6.0",
+            "my-favorite-executable-extension-macos-aarch64-6.0",
+            "my-favorite-executable-extension-macos-x86_64-6.0",
+            "my-favorite-executable-extension-windows-aarch64-6.0",
+            "my-favorite-executable-extension-windows-x86_64-6.0"
+        );
+        boolean isPlatformSpecific = !expectedEnds.stream().filter(end -> hostSpecificUrl.toString().endsWith(end))
+            .toList().isEmpty();
+        assertThat(isPlatformSpecific).isTrue();
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/OsDetectorTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/OsDetectorTest.java
@@ -1,0 +1,59 @@
+package org.icij.datashare;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class OsDetectorTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void test_os_unknown() {
+        OsArchDetector.OS.fromSystemString("freebsd");
+    }
+
+    @Test
+    public void test_os_enum_this_computer() {
+        assertThat(OsArchDetector.OS.fromSystem()).isEqualTo(OsArchDetector.OS.fromSystemString(System.getProperty("os.name")));
+    }
+
+    @Test
+    public void test_os_enum_mac() {
+        assertThat(OsArchDetector.OS.fromSystemString("macosx")).isEqualTo(OsArchDetector.OS.macos);
+        assertThat(OsArchDetector.OS.fromSystemString("macos")).isEqualTo(OsArchDetector.OS.macos);
+        assertThat(OsArchDetector.OS.fromSystemString("mac")).isEqualTo(OsArchDetector.OS.macos);
+    }
+
+    @Test
+    public void test_os_enum_windows() {
+        assertThat(OsArchDetector.OS.fromSystemString("Windows 11")).isEqualTo(OsArchDetector.OS.windows);
+    }
+
+    @Test
+    public void test_os_enum_linux() {
+        assertThat(OsArchDetector.OS.fromSystemString("Linux")).isEqualTo(OsArchDetector.OS.linux);
+        assertThat(OsArchDetector.OS.fromSystemString("nux")).isEqualTo(OsArchDetector.OS.linux);
+        assertThat(OsArchDetector.OS.fromSystemString("nix")).isEqualTo(OsArchDetector.OS.linux);
+        assertThat(OsArchDetector.OS.fromSystemString("aix")).isEqualTo(OsArchDetector.OS.linux);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_arch_unknown() {
+        OsArchDetector.OS.fromSystemString("x86_32");
+    }
+
+    @Test
+    public void test_arch_this_computer() {
+        assertThat(OsArchDetector.ARCH.fromSystem()).isEqualTo(OsArchDetector.ARCH.fromSystemString(System.getProperty("os.arch")));
+    }
+
+    @Test
+    public void test_arch_arm() {
+        assertThat(OsArchDetector.ARCH.fromSystemString("aarch64")).isEqualTo(OsArchDetector.ARCH.aarch64);
+        assertThat(OsArchDetector.ARCH.fromSystemString("arm64")).isEqualTo(OsArchDetector.ARCH.aarch64);
+    }
+
+    @Test
+    public void test_arch_64() {
+        assertThat(OsArchDetector.ARCH.fromSystemString("amd64")).isEqualTo(OsArchDetector.ARCH.x86_64);
+        assertThat(OsArchDetector.ARCH.fromSystemString("x86_64")).isEqualTo(OsArchDetector.ARCH.x86_64);
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/PluginServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/PluginServiceTest.java
@@ -1,7 +1,6 @@
 package org.icij.datashare;
 
 
-import java.net.URISyntaxException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ExtensionResourceTest.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.web;
 
-import org.icij.datashare.ExtensionService;
 import org.icij.datashare.ExtensionServiceTest;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.db.JooqRepository;


### PR DESCRIPTION
# PR description

In order to download and execute the binary running the Spacy worker (https://github.com/ICIJ/datashare/issues/1452 ), we need the extension mechanism to be able to support installing non-jar binary executable.

This PR extends the `Extension` to support any type of extension with the following convention:
- URLs with an extension (`.jar` or others) are expected to be non platform specific
- URLs with non extension are expected to be platform specific (and thus download a platform specific binary given the extension name)

The convention could be changed to be more explicit however this will probably imply updating the data model of the `Extension` in a breaking manner (might not be an issue).

# Changes

## `datashare-app`

### Added
- added support to extend Datashare with any kind of binary extension