### PR TITLE
feature: start python NLP workers in embedded mode

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/ExecutableExtensionHelper.java
+++ b/datashare-app/src/main/java/org/icij/datashare/ExecutableExtensionHelper.java
@@ -1,0 +1,59 @@
+package org.icij.datashare;
+
+import static org.icij.datashare.Extension.extractIdVersion;
+
+import com.google.inject.Inject;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExecutableExtensionHelper {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ExtensionService extensionService;
+    private final String extensionId;
+    private final String extensionPattern;
+
+    @Inject
+    public ExecutableExtensionHelper(ExtensionService extensionService, String extensionId) {
+        this.extensionService = extensionService;
+        this.extensionId = extensionId;
+        this.extensionPattern = fileNamePattern();
+    }
+
+    public ProcessBuilder buildProcess(String... args) {
+        Path executablePath = locateExtension();
+        List<String> cmd = Stream.concat(Stream.of(executablePath.toString()), Arrays.stream(args)).toList();
+        return new ProcessBuilder(cmd);
+    }
+
+    public String getPidFilePattern() {
+        return extensionPattern.substring(0, extensionPattern.length() - 1) + "\\.pid";
+    }
+
+    private Path locateExtension() {
+        Set<File> extensionBins = extensionService.listInstalled(extensionPattern);
+        return switch (extensionBins.size()) {
+            case 0 -> throw new RuntimeException("Couldn't find any executable for extension " + extensionId + " (matching " + extensionPattern
+                + "), extension must be installed !");
+            case 1 -> extensionBins.iterator().next().toPath();
+            default -> throw new RuntimeException("Found several executable extension " + extensionId + " (matching " + extensionPattern
+                + "), extension must be installed !");
+        };
+    }
+
+    private String fileNamePattern() {
+        Map.Entry<String, String> res = extractIdVersion(((Extension) this.extensionService.list().stream().filter(ext -> ext.getId().equals(this.extensionId)).findAny()
+            .orElseThrow(() -> new RuntimeException("couldn't find any extension matching " + extensionId)).reference())
+            .url);
+        String filename = res.getKey();
+        return "^" + Pattern.quote(filename) + ".*$";
+    }
+
+}

--- a/datashare-app/src/main/java/org/icij/datashare/mode/EmbeddedMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/EmbeddedMode.java
@@ -1,7 +1,9 @@
 package org.icij.datashare.mode;
 
+import java.io.IOException;
+import org.icij.datashare.ExtensionService;
+import org.icij.datashare.nlp.PythonNlpWorkerPool;
 import org.icij.datashare.asynctasks.bus.amqp.QpidAmqpServer;
-import org.icij.datashare.cli.Mode;
 import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration;
 import org.icij.datashare.text.indexing.elasticsearch.EsEmbeddedServer;
@@ -10,6 +12,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class EmbeddedMode extends LocalMode {
+    public static int AMQP_PORT = 5672;
     EmbeddedMode(Properties properties) { super(properties);}
     public EmbeddedMode(Map<String, Object> properties) { super(properties);}
 
@@ -18,7 +21,20 @@ public class EmbeddedMode extends LocalMode {
         String elasticsearchDataPath = propertiesProvider.get("elasticsearchDataPath").orElse("/home/datashare/es");
         addCloseable(new EsEmbeddedServer(ElasticsearchConfiguration.ES_CLUSTER_NAME, elasticsearchDataPath, elasticsearchDataPath, "9200").start());
         if (propertiesProvider.getProperties().contains(QueueType.AMQP.name())) {
-            addCloseable(new QpidAmqpServer(5672).start());
+            addCloseable(new QpidAmqpServer(AMQP_PORT).start());
+            ExtensionService extensionService = new ExtensionService(propertiesProvider);
+            bind(ExtensionService.class).toInstance(extensionService);
+            boolean isSpacyInstalled = ! extensionService
+            .listInstalled("datashare-extension-nlp-spacy.*")
+            .isEmpty();
+            if (isSpacyInstalled) {
+                PythonNlpWorkerPool workerPool = new PythonNlpWorkerPool(extensionService, propertiesProvider);
+                try {
+                    addCloseable(workerPool.start());
+                } catch (IOException | InterruptedException e) {
+                    throw new RuntimeException("failed to start Python worker pull !", e);
+                }
+            }
         }
         Properties properties = new Properties();
         properties.put(ElasticsearchConfiguration.INDEX_ADDRESS_PROP, "http://localhost:9200");

--- a/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
@@ -1,8 +1,6 @@
 package org.icij.datashare.mode;
 
 import net.codestory.http.routes.Routes;
-import org.icij.datashare.db.JooqRepository;
-import org.icij.datashare.db.RepositoryFactoryImpl;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.web.*;
 

--- a/datashare-app/src/main/java/org/icij/datashare/nlp/PythonNlpWorkerPool.java
+++ b/datashare-app/src/main/java/org/icij/datashare/nlp/PythonNlpWorkerPool.java
@@ -1,0 +1,92 @@
+package org.icij.datashare.nlp;
+
+import static org.icij.datashare.cli.DatashareCliOptions.NLP_PARALLELISM_OPT;
+import static org.icij.datashare.mode.EmbeddedMode.AMQP_PORT;
+import static org.icij.datashare.utils.ProcessHandler.dumpPid;
+import static org.icij.datashare.utils.ProcessHandler.findPidPaths;
+import static org.icij.datashare.utils.ProcessHandler.isProcessRunning;
+import static org.icij.datashare.utils.ProcessHandler.killProcessById;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.icij.datashare.ExecutableExtensionHelper;
+import org.icij.datashare.ExtensionService;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.json.JsonObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class PythonNlpWorkerPool implements Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PythonNlpWorkerPool.class);
+
+    private final ExtensionService extensionService;
+    private final int nWorkers;
+    private Process workerProcess;
+    protected Path pidPath;
+
+    @Inject
+    public PythonNlpWorkerPool(ExtensionService extensionService, PropertiesProvider propertiesProvider) {
+        this.extensionService = extensionService;
+        nWorkers = propertiesProvider.get(NLP_PARALLELISM_OPT).map(Integer::parseInt).orElse(1);
+    }
+
+    public PythonNlpWorkerPool start() throws IOException, InterruptedException {
+        workerProcess = buildProcess().redirectErrorStream(true).inheritIO().start();
+        pidPath = Files.createTempFile("datashare-extension-nlp-spacy-", ".pid");
+        dumpPid(pidPath.toFile(), workerProcess.pid());
+        LOGGER.debug("dumping worker pid to " + pidPath);
+        return this;
+    }
+
+    protected ProcessBuilder buildProcess() throws IOException, InterruptedException {
+        ExecutableExtensionHelper extensionHelper = new ExecutableExtensionHelper(
+            extensionService, "datashare-extension-nlp-spacy"
+        );
+        Path tmpRoot = Path.of(System.getProperty("java.io.tmpdir"));
+        for (Path p : findPidPaths("regex:" + extensionHelper.getPidFilePattern(), tmpRoot)) {
+            if (isProcessRunning(p, 1, TimeUnit.SECONDS)) {
+                String pid = Files.readAllLines(p).get(0);
+                String msg = "found phantom worker running in process " + pid
+                    + ", kill this process before restarting datashare !";
+                throw new RuntimeException(msg);
+            }
+            Files.deleteIfExists(p);
+        }
+        // If not we start them
+        Path workerConfigPath = dumpNlpWorkerConfig();
+        return extensionHelper.buildProcess(workerConfigPath.toString(), "-n", String.valueOf(nWorkers));
+    }
+
+    private static Path dumpNlpWorkerConfig() throws IOException {
+        Map<String, String> workerConfig = Map.of(
+            "type", "amqp",
+            "rabbitmq_host", "localhost",
+            "rabbitmq_port", String.valueOf(AMQP_PORT),
+            "rabbitmq_user", "admin",
+            "rabbitmq_password", "admin"
+        );
+        Path workerConfigPath = Files.createTempFile("datashare-extension-nlp-spacy-config-", ".json");
+        File tempFile = workerConfigPath.toFile();
+        // Write the JSON object to the temporary file
+        JsonObjectMapper.MAPPER.writeValue(tempFile, workerConfig);
+        return workerConfigPath;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (workerProcess != null && workerProcess.isAlive()) {
+            killProcessById(workerProcess.pid());
+        }
+        if (pidPath != null && pidPath.toFile().exists()) {
+            Files.delete(pidPath);
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/utils/ProcessHandler.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/ProcessHandler.java
@@ -1,0 +1,82 @@
+package org.icij.datashare.utils;
+
+import static java.lang.System.getProperty;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+public class ProcessHandler {
+
+    public static void dumpPid(File pidFile, Long pid) throws IOException {
+        boolean ignored = pidFile.getParentFile().mkdirs();
+        try (FileOutputStream fos = new FileOutputStream(pidFile)) {
+            fos.write(pid.toString().getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    public static boolean isProcessRunning(Path pidPath, int timeout, TimeUnit timeunit) throws IOException, InterruptedException {
+        try (Stream<String> lines = Files.lines(pidPath)) {
+            Long pid = Long.parseLong(
+                lines.findFirst()
+                    .orElseThrow(() -> new RuntimeException("PID file is empty"))
+                    .strip()
+            );
+            return isProcessRunning(pid, timeout, timeunit);
+        }
+    }
+
+    public static boolean isProcessRunning(Long pid, int timeout, TimeUnit timeunit) throws IOException, InterruptedException {
+        ProcessBuilder builder = new ProcessBuilder();
+        if (getProperty("os.name").toLowerCase().contains("windows")) {
+            builder.command("ps", "-p", pid.toString());
+        } else {
+            builder.command("ps", "-p", pid.toString());
+        }
+        Process process = builder.start();
+        process.waitFor(timeout, timeunit);
+        return process.exitValue() == 0;
+    }
+
+    public static void killProcessById(Long pid) {
+        killProcessById(pid, false);
+    }
+
+    public static void killProcessById(Long pid, boolean force) {
+        Stream<ProcessHandle> liveProcesses = ProcessHandle.allProcesses();
+        liveProcesses
+            .filter(handle -> handle.isAlive() && pid.equals(handle.pid()))
+            .findFirst()
+            .ifPresent(parent -> {
+                    parent.descendants()
+                        .forEach(child -> {
+                            if (force) {
+                                child.destroyForcibly();
+                            } else {
+                                child.destroy();
+                            }
+                        });
+                    if (force) {
+                        parent.destroyForcibly();
+                    } else {
+                        parent.destroy();
+                    }
+                }
+            );
+    }
+
+    public static List<Path> findPidPaths(String pattern, Path dir) throws IOException {
+        PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher(pattern);
+        try (Stream<Path> paths = Files.list(dir)) {
+            return paths.filter(file -> !Files.isDirectory(file) && pathMatcher.matches(file.getFileName())).toList();
+        }
+    }
+}

--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -53,6 +53,14 @@
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
       "version": "0.4.5",
       "type": "WEB"
+    },
+    {
+      "id": "datashare-extension-nlp-spacy",
+      "description": "Extension to extract NER entities with Spacy",
+      "url": "https://github.com/ICIJ/datashare-extension-nlp-spacy/releases/download/0.1.5/datashare-extension-nlp-spacy-0.1.5",
+      "homepage": "https://github.com/ICIJ/datashare-extension-nlp-spacy",
+      "version": "0.1.5",
+      "type": "NLP"
     }
   ]
 }

--- a/datashare-app/src/test/java/org/icij/datashare/nlp/PythonNlpWorkerPoolTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/nlp/PythonNlpWorkerPoolTest.java
@@ -1,0 +1,83 @@
+package org.icij.datashare.nlp;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
+import static org.icij.datashare.utils.ProcessHandler.dumpPid;
+import static org.junit.Assert.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.icij.datashare.ExtensionService;
+import org.icij.datashare.PropertiesProvider;
+import org.junit.After;
+import org.junit.Test;
+
+public class PythonNlpWorkerPoolTest {
+    private PythonNlpWorkerPool processPool;
+
+    private static final Path extDir = Path.of(Objects.requireNonNull(
+        PythonNlpWorkerPoolTest.class.getClassLoader().getResource("extensions")).getPath());
+
+    public static final String extRepoContent = "{\"deliverableList\": ["
+        + "{\"id\":\"datashare-extension-nlp-spacy\", \"url\": \""
+        + "https://github.com/ICIJ/datashare-extension-nlp-spacy/releases/download/0.1.3/datashare-extension-nlp-spacy-0.1.3"
+        + "\"}"
+        + "]}";
+
+    private static final ExtensionService extensionService = new ExtensionService(extDir, new ByteArrayInputStream(extRepoContent.getBytes()));
+
+    @After
+    public void tearDown() {
+        if (processPool != null) {
+            try {
+                processPool.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Test
+    public void test_python_nlp_worker_pool() throws IOException, InterruptedException {
+        // Given
+        PropertiesProvider propertiesProvider = new PropertiesProvider(Map.of("nlpParallelism", "6"));
+        processPool = new PythonNlpWorkerPool(extensionService, propertiesProvider);
+        // When
+        Process p = processPool.buildProcess().start();
+        // Then
+        int timeout = 2;
+        TimeUnit unit = TimeUnit.SECONDS;
+        if (!p.waitFor(timeout, unit)) {
+            throw new AssertionError("failed to get process output in less than " + timeout + unit.name().toLowerCase());
+        }
+        Map<String, Object> output = (Map<String, Object>) MAPPER.readValue(p.getInputStream().readAllBytes(), Map.class);
+        assertThat(output.get("n_workers")).isEqualTo(6);
+        assertThat((String) output.get("config_file")).contains("datashare-extension-nlp-spacy-config-");
+    }
+
+    @Test(timeout = 20000)
+    public void test_nlp_workers_process_should_throw_when_worker_pool_is_running() throws IOException {
+        // Given
+        PropertiesProvider propertiesProvider = new PropertiesProvider(Map.of("nlpParallelism", "1"));
+        processPool = new PythonNlpWorkerPool(extensionService, propertiesProvider);
+        // When
+        Process p = null;
+        try {
+            p = new ProcessBuilder("sleep", "100000").start();
+            Path pidPath = Files.createTempFile("datashare-extension-nlp-spacy-1.9.0", ".pid");
+            dumpPid(pidPath.toFile(), p.pid());
+            // When/Then
+            assertThat(assertThrows(RuntimeException.class, () -> processPool.buildProcess().start()).getMessage())
+                .matches("found phantom worker running in process.*");
+        } finally {
+            if (p != null) {
+                p.destroyForcibly();
+            }
+        }
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/utils/ProcessHandlerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/ProcessHandlerTest.java
@@ -1,0 +1,76 @@
+package org.icij.datashare.utils;
+
+import static java.lang.String.join;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.utils.ProcessHandler.dumpPid;
+import static org.icij.datashare.utils.ProcessHandler.findPidPaths;
+import static org.icij.datashare.utils.ProcessHandler.isProcessRunning;
+import static org.icij.datashare.utils.ProcessHandler.killProcessById;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProcessHandlerTest {
+    private static final String pidFileDir = "/tmp";
+
+    @Before
+    public void setUp() throws Exception {
+        Arrays.stream(
+                Objects.requireNonNull(Path.of(pidFileDir)
+                    .toFile()
+                    .listFiles((ignored, name) -> name.matches("test-process-handler-.*\\.pid"))))
+            .forEach(File::delete);
+    }
+
+    @Test(timeout = 10000)
+    public void test_process_handler_int() throws IOException, InterruptedException {
+        // Given
+        int sleepDuration = 1000;
+        ProcessBuilder builder = new ProcessBuilder(List.of("sleep", String.valueOf(sleepDuration)));
+        Process childProcess = builder.start();
+
+        Path tmpRoot = Path.of(FileSystems.getDefault().getSeparator(), pidFileDir);
+
+        // When
+        long pid = childProcess.pid();
+        Path pidPath = Files.createTempFile(tmpRoot, "test-process-handler-", ".pid");
+        File pidFile = pidPath.toFile();
+        dumpPid(pidFile, pid);
+
+        // Then
+        assertThat(pidFile.exists()).isTrue();
+        String pidContent = join("\n", Files.readAllLines(pidPath));
+        String expectedContent = String.valueOf(pid);
+        assertThat(pidContent).isEqualTo(expectedContent);
+
+        // When
+        String pidFilePattern = "glob:test-process-handler-*.pid";
+        List<Path> foundPaths = findPidPaths(pidFilePattern, Path.of(pidFileDir));
+        // Then
+        assertThat(foundPaths.size()).isEqualTo(1);
+        assertThat(foundPaths.get(0).toString()).isEqualTo(pidPath.toString());
+
+        // When
+        boolean isRunning = isProcessRunning(pid, 2, TimeUnit.SECONDS);
+        // Then
+        assertThat(isRunning).isTrue();
+        // When
+        boolean isRunningFromFile = isProcessRunning(pidPath, 2, TimeUnit.SECONDS);
+        // Then
+        assertThat(isRunningFromFile).isTrue();
+
+        // When
+        killProcessById(pid, true);
+        boolean isRunningAfterKilled = isProcessRunning(pid, 2, TimeUnit.SECONDS);
+        assertThat(isRunningAfterKilled).isFalse();
+    }
+}

--- a/datashare-app/src/test/resources/extensions/datashare-extension-nlp-spacy-0.9.0
+++ b/datashare-app/src/test/resources/extensions/datashare-extension-nlp-spacy-0.9.0
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+config_file=$1
+n_workers=$3
+echo { \"n_workers\": $n_workers, \"config_file\": \"$config_file\" }


### PR DESCRIPTION
# PR description
Following #1611 and to address #1452

This PR adds the ability to start worker pool of NLP Python workers when in `EMBEDDED` mode with `AMQP` support/bus type.

# TODO
- [x] merge #1611

# Changes

## `datashare-app`

### Added
- added a `ExecutableExtensionHelper` in charge of executing DS executable extension (non JAR)
- created a `ProcessHandler` to cleanly handle external processes (dump pids, find running process of some type, kill process etc)


### Changed
- updated `WebApp` to spawn NLP workers when in `EMBEDDED` mode with `AMQP`, if such process are already running the application will ask the user to clean the phantom process (could be otherwise)
