### PR TITLE
⚠️ chore: remove group from task args and move task user to datashare app

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
@@ -4,6 +4,7 @@ import org.icij.datashare.asynctasks.TaskFactory;
 import org.icij.datashare.asynctasks.TaskWorkerLoop;
 import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.mode.CommonMode;
+import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.text.indexing.Indexer;
 import org.redisson.api.RedissonClient;
 
@@ -13,7 +14,7 @@ import java.util.Properties;
 public class BatchDownloadApp {
     public static void start(Properties properties) throws Exception {
         CommonMode commonMode = CommonMode.create(properties);
-        TaskWorkerLoop taskWorkerLoop = new TaskWorkerLoop(commonMode.get(TaskFactory.class), commonMode.get(TaskSupplier.class));
+        TaskWorkerLoop taskWorkerLoop = new TaskWorkerLoop(commonMode.get(DatashareTaskFactory.class), commonMode.get(TaskSupplier.class));
         taskWorkerLoop.call();
         commonMode.get(Indexer.class).close();
         commonMode.get(RedissonClient.class).shutdown();

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -1,11 +1,11 @@
 package org.icij.datashare;
 
 import com.google.inject.ConfigurationException;
-import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.cli.CliExtensionService;
 import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.ArtifactTask;
+import org.icij.datashare.tasks.DatashareTask;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
 
@@ -111,38 +110,37 @@ class CliApp {
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
         if (pipeline.has(Stage.DEDUPLICATE)) {
-            taskManager.startTask(
-                    new Task<>(DeduplicateTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(DatashareTask.task(DeduplicateTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.SCANIDX)) {
             taskManager.startTask(
-                    new Task<>(ScanIndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
+                    DatashareTask.task(ScanIndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.SCAN)) {
             taskManager.startTask(
-                    new Task<>(ScanTask.class.getName(), nullUser(), propertiesToMap(properties)));
+                    DatashareTask.task(ScanTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.INDEX)) {
             taskManager.startTask(
-                    new Task<>(IndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
+                    DatashareTask.task(IndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.ENQUEUEIDX)) {
             taskManager.startTask(
-                    new Task<>(EnqueueFromIndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
+                    DatashareTask.task(EnqueueFromIndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.NLP)) {
             taskManager.startTask(
-                    new Task<>(ExtractNlpTask.class.getName(), nullUser(), propertiesToMap(properties)));
+                    DatashareTask.task(ExtractNlpTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.ARTIFACT)) {
             taskManager.startTask(
-                    new Task<>(ArtifactTask.class.getName(), nullUser(), propertiesToMap(properties)));
+                    DatashareTask.task(ArtifactTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
         taskManager.shutdownAndAwaitTermination(Integer.MAX_VALUE, SECONDS);
         indexer.close();

--- a/datashare-app/src/main/java/org/icij/datashare/WebApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/WebApp.java
@@ -1,7 +1,6 @@
 package org.icij.datashare;
 
 import net.codestory.http.WebServer;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.bus.amqp.QpidAmqpServer;
 import org.icij.datashare.batch.BatchSearch;
 import org.icij.datashare.batch.BatchSearchRepository;
@@ -16,6 +15,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.net.URI;
 import java.util.Properties;
+import org.icij.datashare.tasks.DatashareTaskManager;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -48,7 +48,7 @@ public class WebApp {
             waitForServerToBeUp(parseInt(mode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT)));
             Desktop.getDesktop().browse(URI.create(new URI("http://localhost:")+mode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT)));
         }
-        requeueDatabaseBatchSearches(mode.get(BatchSearchRepository.class), mode.get(TaskManager.class));
+        requeueDatabaseBatchSearches(mode.get(BatchSearchRepository.class), mode.get(DatashareTaskManager.class));
         webServerThread.join();
     }
 
@@ -66,7 +66,7 @@ public class WebApp {
         }
     }
 
-    private static void requeueDatabaseBatchSearches(BatchSearchRepository repository, TaskManager taskManager) throws IOException {
+    private static void requeueDatabaseBatchSearches(BatchSearchRepository repository, DatashareTaskManager taskManager) throws IOException {
         for (String batchSearchUuid: repository.getQueued()) {
             BatchSearch batchSearch = repository.get(batchSearchUuid);
             taskManager.startTask(batchSearchUuid, BatchSearchRunner.class, batchSearch.user);

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -21,7 +21,6 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
 import org.icij.datashare.TesseractOCRParserWrapper;
 import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpInterlocutor;
@@ -37,6 +36,7 @@ import org.icij.datashare.extract.*;
 import org.icij.datashare.nlp.EmailPipeline;
 import org.icij.datashare.nlp.OptimaizeLanguageGuesser;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.tasks.TaskManagerAmqp;
 import org.icij.datashare.tasks.TaskManagerMemory;
 import org.icij.datashare.tasks.TaskManagerRedis;
@@ -156,19 +156,19 @@ public abstract class CommonMode extends AbstractModule {
         switch ( batchQueueType ) {
             case REDIS:
                 configureBatchQueuesRedis(redissonClient);
-                bind(TaskManager.class).to(TaskManagerRedis.class);
+                bind(DatashareTaskManager.class).to(TaskManagerRedis.class);
                 bind(TaskModifier.class).to(TaskSupplierRedis.class);
                 bind(TaskSupplier.class).to(TaskSupplierRedis.class);
                 break;
             case AMQP:
                 configureBatchQueuesRedis(redissonClient);
-                bind(TaskManager.class).to(TaskManagerAmqp.class);
+                bind(DatashareTaskManager.class).to(TaskManagerAmqp.class);
                 bind(TaskSupplier.class).to(TaskSupplierAmqp.class);
                 bind(TaskModifier.class).to(TaskSupplierAmqp.class);
                 break;
             default:
                 configureBatchQueuesMemory();
-                bind(TaskManager.class).to(TaskManagerMemory.class);
+                bind(DatashareTaskManager.class).to(TaskManagerMemory.class);
                 bind(TaskModifier.class).to(TaskManagerMemory.class);
                 bind(TaskSupplier.class).to(TaskManagerMemory.class);
         }
@@ -199,7 +199,7 @@ public abstract class CommonMode extends AbstractModule {
     }
 
     private void configureBatchQueuesRedis(RedissonClient redissonClient) {
-        bind(new TypeLiteral<BlockingQueue<Task<?>>>(){}).toInstance(new RedisBlockingQueue<>(redissonClient, DS_TASKS_QUEUE_NAME, new org.icij.datashare.asynctasks.TaskManagerRedis.TaskViewCodec()));
+        bind(new TypeLiteral<BlockingQueue<Task<?>>>(){}).toInstance(new RedisBlockingQueue<>(redissonClient, DS_TASKS_QUEUE_NAME, new org.icij.datashare.asynctasks.TaskManagerRedis.RedisCodec<>(Task.class)));
     }
 
     public Properties properties() {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -7,7 +7,6 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.extract.DocumentCollectionFactory;
-import org.icij.datashare.function.Pair;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static java.util.Optional.ofNullable;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
@@ -34,7 +32,7 @@ public class ArtifactTask extends PipelineTask<String> {
 
     @Inject
     public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
-        super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class);
+        super(Stage.ARTIFACT, DatashareTask.getUser(taskView), factory, propertiesProvider, String.class);
         this.indexer = indexer;
         project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTask.java
@@ -1,0 +1,29 @@
+package org.icij.datashare.tasks;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.user.User;
+
+public class DatashareTask {
+    public static final String USER_KEY = "user";
+
+    public static <V> Task<V> task(String name, User user, Map<String, Object> args) {
+        return new Task<>(name, addTo(args, user));
+    }
+
+    public static <V> Task<V> task(String id, String name, User user) {
+        return new Task<>(id, name, addTo(new HashMap<>(), user));
+    }
+
+    public static User getUser(Task<?> task) {
+        return (User) task.args.get(USER_KEY);
+    }
+
+    private static Map<String, Object> addTo(Map<String, Object> properties, User user) {
+        LinkedHashMap<String, Object> result = new LinkedHashMap<>(properties);
+        result.put(USER_KEY, user);
+        return result;
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskManager.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskManager.java
@@ -1,0 +1,50 @@
+package org.icij.datashare.tasks;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.icij.datashare.asynctasks.Group;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskGroup;
+import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.user.User;
+
+public interface DatashareTaskManager extends TaskManager {
+    // TODO: can we do better using generics instead of casts ?
+    default String startTask(Class<?> taskClass, User user, Map<String, Object> properties) throws IOException {
+        return startTask(DatashareTask.task(taskClass.getName(), user, properties), new Group(taskClass.getAnnotation(
+           TaskGroup.class).value()));
+    }
+
+    default  String startTask(String id, Class<?> taskClass, User user) throws IOException {
+        return startTask(DatashareTask.task(id, taskClass.getName(), user), new Group(taskClass.getAnnotation(TaskGroup.class).value()));
+    }
+
+    default List<Task<?>> getTasks(Stream<Task<?>> stream, User user, Pattern pattern) {
+        return getTasks(stream, pattern).stream().map( t -> ( Task<?> ) t)
+            .filter(t -> user.equals(DatashareTask.getUser(t))).collect(Collectors.toList());
+    }
+
+    default List<Task<?>> getTasks(User user, Pattern pattern) throws IOException {
+        return getTasks(this.getTasks().stream(), user, pattern);
+    }
+
+    default Map<String, Boolean> stopAllTasks(User user) throws IOException {
+        return getTasks().stream()
+            .filter(t -> user.equals(DatashareTask.getUser(t)))
+            .filter(t -> t.getState() == Task.State.RUNNING || t.getState() == Task.State.QUEUED).collect(
+                        toMap(t -> t.id, t -> {
+                            try {
+                                return stopTask(t.id);
+                            } catch (IOException e) {
+                                logger.error("cannot stop task {}", t.id, e);
+                                return false;
+                            }
+                        }));
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -25,7 +25,7 @@ public class DeduplicateTask extends PipelineTask<Path> {
 
     @Inject
     public DeduplicateTask(final DocumentCollectionFactory<Path> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
-        super(Stage.DEDUPLICATE, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
+        super(Stage.DEDUPLICATE, DatashareTask.getUser(taskView), factory, new PropertiesProvider(taskView.args), Path.class);
         this.factory = factory;
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
@@ -3,7 +3,6 @@ package org.icij.datashare.tasks;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
-import java.util.Optional;
 import java.util.function.Function;
 import org.icij.datashare.Entity;
 import org.icij.datashare.PropertiesProvider;
@@ -12,7 +11,6 @@ import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.text.Document;
-import org.icij.datashare.text.ProjectProxy;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.SearchQuery;
 import org.icij.datashare.text.nlp.Pipeline;
@@ -46,9 +44,8 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
     private final int scrollSize;
 
     @Inject
-    public EnqueueFromIndexTask(final DocumentCollectionFactory<String> factory, final Indexer indexer,
-                                @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
-        super(Stage.ENQUEUEIDX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class);
+    public EnqueueFromIndexTask(final DocumentCollectionFactory<String> factory, final Indexer indexer, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
+        super(Stage.ENQUEUEIDX, DatashareTask.getUser(taskView), factory, new PropertiesProvider(taskView.args), String.class);
         this.factory = factory;
         this.indexer = indexer;
         this.nlpPipeline = Pipeline.Type.parse((String) taskView.args.getOrDefault(NLP_PIPELINE_OPT, Pipeline.Type.CORENLP.name()));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -47,7 +47,7 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
 
 
     ExtractNlpTask(Indexer indexer, Pipeline pipeline, final DocumentCollectionFactory<String> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
-        super(Stage.NLP, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class);
+        super(Stage.NLP, DatashareTask.getUser(taskView), factory, new PropertiesProvider(taskView.args), String.class);
         this.nlpPipeline = pipeline;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
         maxContentLengthChars = (int) HumanReadableSize.parse(ofNullable((String)taskView.args.get(MAX_CONTENT_LENGTH_OPT)).orElse(valueOf(DEFAULT_MAX_CONTENT_LENGTH)));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -44,7 +44,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
 
     @Inject
     public IndexTask(final ElasticsearchSpewer spewer, final DocumentCollectionFactory<Path> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) throws IOException {
-        super(Stage.INDEX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
+        super(Stage.INDEX, DatashareTask.getUser(taskView), factory, new PropertiesProvider(taskView.args), Path.class);
         parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(Runtime.getRuntime().availableProcessors());
 
         Options<String> allTaskOptions = options().createFrom(Options.from(taskView.args));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanIndexTask.java
@@ -52,9 +52,8 @@ public class ScanIndexTask extends PipelineTask<Path> {
     private final int scrollSlices;
 
     @Inject
-    public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer,
-                         @Assisted Task<Long> taskView, @Assisted Function<Double, Void> updateCallback) {
-        super(Stage.SCANIDX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
+    public ScanIndexTask(DocumentCollectionFactory<Path> factory, final Indexer indexer, @Assisted Task<Long> taskView, @Assisted Function<Double, Void> updateCallback) {
+        super(Stage.SCANIDX, DatashareTask.getUser(taskView), factory, new PropertiesProvider(taskView.args), Path.class);
         this.scrollDuration = propertiesProvider.get(SCROLL_DURATION_OPT).orElse(DEFAULT_SCROLL_DURATION);
         this.scrollSize = parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse(valueOf(DEFAULT_SCROLL_SIZE)));
         this.scrollSlices = parseInt(propertiesProvider.get(SCROLL_SLICES_OPT).orElse(valueOf(DEFAULT_SCROLL_SLICES)));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
@@ -25,7 +25,7 @@ public class ScanTask extends PipelineTask<Path> {
 
     @Inject
     public ScanTask(DocumentCollectionFactory<Path> factory, @Assisted Task<Long> task, @Assisted Function<Double, Void> updateCallback) {
-        super(Stage.SCAN, task.getUser(), factory, new PropertiesProvider(task.args), Path.class);
+        super(Stage.SCAN, DatashareTask.getUser(task), factory, new PropertiesProvider(task.args), Path.class);
         scanner = new Scanner(outputQueue).configure(options().createFrom(Options.from(task.args)));
         path = Paths.get((String)task.args.get(DatashareCliOptions.DATA_DIR_OPT));
     }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerAmqp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerAmqp.java
@@ -6,11 +6,9 @@ import java.io.IOException;
 
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.TaskManagerRedis;
-import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskMetadata;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpInterlocutor;
-import org.icij.datashare.cli.DatashareCliOptions;
 import org.icij.datashare.mode.CommonMode;
-import org.jetbrains.annotations.NotNull;
 import org.redisson.Redisson;
 import org.redisson.RedissonMap;
 import org.redisson.api.RedissonClient;
@@ -18,7 +16,7 @@ import org.redisson.command.CommandSyncService;
 import org.redisson.liveobject.core.RedissonObjectBuilder;
 
 @Singleton
-public class TaskManagerAmqp extends org.icij.datashare.asynctasks.TaskManagerAmqp {
+public class TaskManagerAmqp extends org.icij.datashare.asynctasks.TaskManagerAmqp implements DatashareTaskManager {
 
     @Inject
     public TaskManagerAmqp(AmqpInterlocutor amqp, RedissonClient redissonClient, PropertiesProvider propertiesProvider)
@@ -26,14 +24,14 @@ public class TaskManagerAmqp extends org.icij.datashare.asynctasks.TaskManagerAm
         this(amqp, redissonClient, propertiesProvider, null);
     }
 
-    TaskManagerAmqp(AmqpInterlocutor amqp, RedissonClient redissonClient, PropertiesProvider propertiesProvider, Runnable eventCallback)  throws IOException {
+   TaskManagerAmqp(AmqpInterlocutor amqp, RedissonClient redissonClient, PropertiesProvider propertiesProvider, Runnable eventCallback)  throws IOException {
         // We start with a fresh list of known task everytime, we could decide to allow inheriting
         // existing tasks
         super(amqp, createTaskQueue(redissonClient), Utils.getRoutingStrategy(propertiesProvider), eventCallback);
     }
 
-    private static RedissonMap<String, Task<?>> createTaskQueue(RedissonClient redissonClient) {
-        return new RedissonMap<>(new TaskManagerRedis.TaskViewCodec(),
+    private static RedissonMap<String, TaskMetadata<?>> createTaskQueue(RedissonClient redissonClient) {
+        return new RedissonMap<>(new TaskManagerRedis.RedisCodec<>(TaskMetadata.class),
             new CommandSyncService(((Redisson) redissonClient).getConnectionManager(),
                 new RedissonObjectBuilder(redissonClient)),
             CommonMode.DS_TASK_MANAGER_QUEUE_NAME,
@@ -42,4 +40,5 @@ public class TaskManagerAmqp extends org.icij.datashare.asynctasks.TaskManagerAm
             null
         );
     }
+
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerMemory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerMemory.java
@@ -3,21 +3,22 @@ package org.icij.datashare.tasks;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.asynctasks.Task;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskFactory;
 
 
 @Singleton
-public class TaskManagerMemory extends org.icij.datashare.asynctasks.TaskManagerMemory {
+public class TaskManagerMemory extends org.icij.datashare.asynctasks.TaskManagerMemory implements DatashareTaskManager {
 
     @Inject
     public TaskManagerMemory(BlockingQueue<Task<?>> taskQueue, DatashareTaskFactory taskFactory, PropertiesProvider propertiesProvider) {
         this(taskQueue, taskFactory, propertiesProvider, new CountDownLatch(1));
     }
 
-    TaskManagerMemory(BlockingQueue<Task<?>> taskQueue, DatashareTaskFactory taskFactory, PropertiesProvider propertiesProvider, CountDownLatch latch) {
+   TaskManagerMemory(BlockingQueue<Task<?>> taskQueue, DatashareTaskFactory taskFactory, PropertiesProvider propertiesProvider, CountDownLatch latch) {
         super(taskQueue, taskFactory, propertiesProvider, latch);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
@@ -3,15 +3,13 @@ package org.icij.datashare.tasks;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.cli.DatashareCliOptions;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.extract.redis.RedissonClientFactory;
 import org.icij.task.Options;
-import org.jetbrains.annotations.NotNull;
 import org.redisson.api.RedissonClient;
 
 @Singleton
-public class TaskManagerRedis extends org.icij.datashare.asynctasks.TaskManagerRedis {
+public class TaskManagerRedis extends org.icij.datashare.asynctasks.TaskManagerRedis implements DatashareTaskManager {
 
     // Convenience class made to ease injection and test
     @Inject
@@ -23,11 +21,11 @@ public class TaskManagerRedis extends org.icij.datashare.asynctasks.TaskManagerR
         this(propertiesProvider, CommonMode.DS_TASK_MANAGER_MAP_NAME, null);
     }
 
-    TaskManagerRedis(PropertiesProvider propertiesProvider, String taskMapName, Runnable eventCallback) {
+   TaskManagerRedis(PropertiesProvider propertiesProvider, String taskMapName, Runnable eventCallback) {
         this(new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create(), taskMapName, Utils.getRoutingStrategy(propertiesProvider), eventCallback);
     }
 
-    TaskManagerRedis(RedissonClient redissonClient, String taskMapName, RoutingStrategy routingStrategy, Runnable eventCallback) {
+   TaskManagerRedis(RedissonClient redissonClient, String taskMapName, RoutingStrategy routingStrategy, Runnable eventCallback) {
         super(redissonClient, taskMapName, routingStrategy, eventCallback);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskSupplierRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskSupplierRedis.java
@@ -16,7 +16,7 @@ public class TaskSupplierRedis extends org.icij.datashare.asynctasks.TaskSupplie
         super(redissonClient, Utils.getRoutingKey(propertiesProvider));
     }
 
-    TaskSupplierRedis(PropertiesProvider propertiesProvider) {
+   TaskSupplierRedis(PropertiesProvider propertiesProvider) {
         this(new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create(), propertiesProvider);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -19,11 +19,11 @@ import net.codestory.http.errors.NotFoundException;
 import net.codestory.http.errors.UnauthorizedException;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.batch.*;
 import org.icij.datashare.db.JooqBatchSearchRepository;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.tasks.BatchSearchRunner;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.ProjectProxy;
 import org.icij.datashare.user.User;
@@ -48,13 +48,13 @@ import static org.icij.datashare.function.ThrowingFunctions.parseBoolean;
 @Singleton
 @Prefix("/api/batch")
 public class BatchSearchResource {
-    private final TaskManager taskManager;
+    private final DatashareTaskManager taskManager;
     private final BatchSearchRepository batchSearchRepository;
     private final PropertiesProvider propertiesProvider;
     private final int MAX_BATCH_SIZE = 60000;
 
     @Inject
-    public BatchSearchResource(PropertiesProvider propertiesProvider, TaskManager taskManager, final BatchSearchRepository batchSearchRepository) {
+    public BatchSearchResource(PropertiesProvider propertiesProvider,  DatashareTaskManager taskManager, final BatchSearchRepository batchSearchRepository) {
         this.taskManager = taskManager;
         this.batchSearchRepository = batchSearchRepository;
         this.propertiesProvider = propertiesProvider;

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
@@ -5,6 +5,7 @@ import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.asynctasks.TaskWorkerLoop;
 import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.text.indexing.Indexer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,7 +57,7 @@ public class CliModeWorkerAcceptanceTest {
         workerApp.start();
         workerStarted.await();
 
-        mode.get(TaskManager.class).shutdownAndAwaitTermination(1, TimeUnit.SECONDS); // to send shutdown
+        mode.get(DatashareTaskManager.class).shutdownAndAwaitTermination(1, TimeUnit.SECONDS); // to send shutdown
         workerApp.join();
         mode.get(Indexer.class).close();
     }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -3,11 +3,11 @@ package org.icij.datashare.mode;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.cli.Mode;
 import org.icij.datashare.cli.QueueType;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -38,8 +38,8 @@ public class CommonModeTest {
             put("mode", Mode.LOCAL.name());
             put("queueType", QueueType.MEMORY.name());
         }}));
-        assertThat(injector.getInstance(TaskManager.class)).isSameAs(injector.getInstance(TaskModifier.class));
-        assertThat(injector.getInstance(TaskManager.class)).isSameAs(injector.getInstance(TaskSupplier.class));
+        assertThat(injector.getInstance(DatashareTaskManager.class)).isSameAs(injector.getInstance(TaskModifier.class));
+        assertThat(injector.getInstance(DatashareTaskManager.class)).isSameAs(injector.getInstance(TaskSupplier.class));
     }
     @Test
     public void test_check_queue_type_with_default_value() {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -28,7 +28,7 @@ public class ArtifactTaskTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_missing_artifact_dir() {
-        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
+        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), DatashareTask.task(ArtifactTask.class.getName(), User.local(), Map.of()), null);
     }
 
     @Test
@@ -42,7 +42,7 @@ public class ArtifactTaskTest {
         queue.add("POISON");
 
         Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of("artifactDir", artifactDir.getRoot().toString(), "defaultProject", "prj")),
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                DatashareTask.task(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 
         assertThat(numberOfDocuments).isEqualTo(1);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerEncryptedIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerEncryptedIntTest.java
@@ -40,8 +40,8 @@ public class BatchDownloadRunnerEncryptedIntTest {
         new IndexerHelper(es.client).indexFile("mydoc.txt", "content", fs);
         BatchDownload batchDownload = createBatchDownload("*");
         MailSender mailSender = mock(MailSender.class);
-        Task<Object> taskView =
-            new Task<>(BatchDownloadRunner.class.getName(), batchDownload.user,
+         Task<Object> taskView =
+            DatashareTask.task(BatchDownloadRunner.class.getName(), batchDownload.user,
                 new HashMap<>() {{
                     put("batchDownload", batchDownload);
                 }});

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchDownloadRunnerTest.java
@@ -43,7 +43,7 @@ public class BatchDownloadRunnerTest {
 
     @Test(expected = AssertionError.class)
     public void test_task_with_no_batch_download() {
-        new BatchDownloadRunner(indexer, new PropertiesProvider(), new Task<Serializable>("name", User.local(), new HashMap<>()), null);
+        new BatchDownloadRunner(indexer, new PropertiesProvider(), DatashareTask.task("name", User.local(), new HashMap<>()), null);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class BatchDownloadRunnerTest {
         Document[] documents = IntStream.range(0, 3).mapToObj(i -> createDoc("doc" + i).with(createFile(i)).build()).toArray(Document[]::new);
         mockSearch.willReturn(2, documents);
         BatchDownload batchDownload = new BatchDownload(singletonList(project("test-datashare")), User.local(), "query");
-        Task<File> taskView = getTaskView(batchDownload);
+         Task<File> taskView = getTaskView(batchDownload);
         UriResult result = new BatchDownloadRunner(indexer, new PropertiesProvider(new HashMap<>() {{
                     put(BATCH_DOWNLOAD_MAX_NB_FILES_OPT, "3");
                     put(SCROLL_SIZE_OPT, "3");
@@ -64,7 +64,7 @@ public class BatchDownloadRunnerTest {
     public void test_max_zip_size() throws Exception {
         Document[] documents = IntStream.range(0, 3).mapToObj(i -> createDoc("doc" + i).with(createFile(i)).with("hello world " + i).build()).toArray(Document[]::new);
         mockSearch.willReturn(2, documents);
-        Task<File> taskView = getTaskView(new BatchDownload(singletonList(project("test-datashare")), User.local(), "query"));
+         Task<File> taskView = getTaskView(new BatchDownload(singletonList(project("test-datashare")), User.local(), "query"));
         UriResult result = new BatchDownloadRunner(indexer, new PropertiesProvider(new HashMap<>() {{
             put(BATCH_DOWNLOAD_MAX_SIZE_OPT, valueOf("hello world 1".getBytes(StandardCharsets.UTF_8).length * 3 - 1)); // to avoid adding the 4th doc
             put(SCROLL_SIZE_OPT, "3");
@@ -76,7 +76,7 @@ public class BatchDownloadRunnerTest {
     @Test(expected = ElasticsearchException.class)
     public void test_elasticsearch_status_exception__should_be_sent() throws Exception {
         mockSearch.willThrow(new ElasticsearchException("error", RestStatus.BAD_REQUEST, new RuntimeException()));
-        Task<File> taskView = getTaskView(new BatchDownload(singletonList(project("test-datashare")), User.local(), "query"));
+         Task<File> taskView = getTaskView(new BatchDownload(singletonList(project("test-datashare")), User.local(), "query"));
         new BatchDownloadRunner(indexer, new PropertiesProvider(), taskView, taskView.progress(updater::progress)).call();
     }
 
@@ -92,8 +92,8 @@ public class BatchDownloadRunnerTest {
     }
 
     @NotNull
-    private static Task<File> getTaskView(BatchDownload batchDownload) {
-        return new Task<>(BatchDownloadRunner.class.toString(), batchDownload.user, new HashMap<>() {{
+    private static  Task<File> getTaskView(BatchDownload batchDownload) {
+        return DatashareTask.task(BatchDownloadRunner.class.toString(), batchDownload.user, new HashMap<>() {{
             put("batchDownload", batchDownload);
         }});
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
@@ -65,7 +65,7 @@ public class BatchSearchRunnerIntTest {
     }
 
     private Task<?> taskView(BatchSearch search) {
-        return new Task<>(search.uuid, BatchSearchRunner.class.getName(), User.local(), new Group("TestGroup"));
+        return DatashareTask.task(search.uuid, BatchSearchRunner.class.getName(), User.local());
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
@@ -64,8 +64,8 @@ public class BatchSearchRunnerTest {
         verify(progressCb).apply( 1.0);
     }
 
-    private Task<?> taskView(BatchSearch search) {
-        return new Task<>(search.uuid, BatchSearchRunner.class.getName(), local(), new Group("TestGroup"));
+    private  Task<?> taskView(BatchSearch search) {
+        return DatashareTask.task(search.uuid, BatchSearchRunner.class.getName(), local());
     }
 
     @Test(expected = RuntimeException.class)

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -17,12 +17,12 @@ import static org.icij.datashare.tasks.PipelineTask.PATH_POISON;
 public class DeduplicateTaskTest {
     DocumentCollectionFactory<Path> docCollectionFactory = new MemoryDocumentCollectionFactory<>();
     Map<String, Object> defaultOpts = Map.of("queueName", "test:queue", "stages", "DEDUPLICATE");
-    DeduplicateTask task = new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(),  defaultOpts), null);
+    DeduplicateTask task = new DeduplicateTask(docCollectionFactory, DatashareTask.task(DeduplicateTask.class.getName(), User.local(),  defaultOpts), null);
 
     @Test(timeout = 2000)
     public void test_filter_empty() throws Exception {
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).add(PATH_POISON);
-        assertThat(new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
+        assertThat(new DeduplicateTask(docCollectionFactory, DatashareTask.task(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
     }
 
     @Test(timeout = 2000)
@@ -31,7 +31,7 @@ public class DeduplicateTaskTest {
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).add(PATH_POISON);
 
-        assertThat(new DeduplicateTask(docCollectionFactory,  new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
+        assertThat(new DeduplicateTask(docCollectionFactory, DatashareTask.task(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
 
         assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(2); // with POISON
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
@@ -39,7 +39,7 @@ public class EnqueueFromIndexTaskTest {
                 "queueName", "test:queue",
                 NLP_PIPELINE_OPT, Pipeline.Type.OPENNLP.name());
         MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
-        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
+        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, DatashareTask.task(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
         enqueueFromIndex.call();
         assertThat(factory.queues.get("test:queue:nlp")).hasSize(21); // with poison
     }
@@ -61,7 +61,7 @@ public class EnqueueFromIndexTaskTest {
                         """);
 
         MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
-        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
+        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, DatashareTask.task(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
         enqueueFromIndex.call();
         assertThat(factory.queues.get("test:queue:nlp")).hasSize(2); // with poison
     }
@@ -77,7 +77,7 @@ public class EnqueueFromIndexTaskTest {
                 "searchQuery", "extractionLevel:0");
 
         MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
-        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
+        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, DatashareTask.task(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
         enqueueFromIndex.call();
         assertThat(factory.queues.get("test:queue:nlp")).hasSize(2); // with poison
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
@@ -92,7 +92,7 @@ public class ExtractNlpTaskIntTest {
     @Before
     public void setUp() {
         initMocks(this);
-        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
+        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, DatashareTask.task(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
             put("maxContentLength", "32");
         }}), null);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
@@ -35,7 +35,7 @@ public class ExtractNlpTaskTest {
     @Before
     public void setUp() {
         initMocks(this);
-        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
+        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, DatashareTask.task(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
             put("maxContentLength", "32");
         }}), null);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -42,7 +42,7 @@ public class IndexTaskIntTest {
         DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        Long nbDocs = new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        Long nbDocs = new IndexTask(spewer, inputQueueFactory, DatashareTask.task(IndexTask.class.getName(), User.local(), map), null).call();
 
         assertThat(nbDocs).isEqualTo(1);
         DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -24,7 +24,7 @@ public class IndexTaskTest {
     public void test_options_include_ocr() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), DatashareTask.task(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -35,7 +35,7 @@ public class IndexTaskTest {
     public void test_options_include_ocr_language() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), DatashareTask.task(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -46,7 +46,7 @@ public class IndexTaskTest {
     public void test_options_include_language() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), DatashareTask.task(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("language", "FRENCH");
             put("queueName", "test:queue");
         }}), null);
@@ -60,7 +60,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), Map.of("charset", "UTF-16")), null);
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), DatashareTask.task(IndexTask.class.getName(), nullUser(), Map.of("charset", "UTF-16")), null);
 
         ArgumentCaptor<Options> captor = ArgumentCaptor.forClass(Options.class);
         verify(spewer).configure(captor.capture());
@@ -73,7 +73,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), Map.of("defaultProject", "foo", "projectName", "bar")), null);
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), DatashareTask.task(IndexTask.class.getName(), nullUser(), Map.of("defaultProject", "foo", "projectName", "bar")), null);
 
         ArgumentCaptor<Options> captor = ArgumentCaptor.forClass(Options.class);
         verify(spewer).configure(captor.capture());

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ScanIndexTaskTest.java
@@ -38,7 +38,7 @@ public class ScanIndexTaskTest {
 
     @Test
     public void test_empty_index() throws Exception {
-        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, new Task<>(
+        assertThat(new ScanIndexTask(documentCollectionFactory, indexer, DatashareTask.task(
                 ScanIndexTask.class.getName(), User.nullUser(), propertiesToMap(propertiesProvider.getProperties())), null).call()).isEqualTo(0);
     }
 
@@ -47,7 +47,7 @@ public class ScanIndexTaskTest {
         indexer.add(TEST_INDEX, DocumentBuilder.createDoc("id1").build());
         indexer.add(TEST_INDEX, DocumentBuilder.createDoc("id2").build());
 
-        assertThat(new ScanIndexTask(documentCollectionFactory, indexer,  new Task<>(
+        assertThat(new ScanIndexTask(documentCollectionFactory, indexer,  DatashareTask.task(
                 ScanIndexTask.class.getName(), User.nullUser(), propertiesToMap(propertiesProvider.getProperties())), null).call()).isEqualTo(2);
 
         ReportMap actualReportMap = documentCollectionFactory.createMap("test:report");

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ScanTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ScanTaskTest.java
@@ -1,7 +1,6 @@
 package org.icij.datashare.tasks;
 
 import junit.framework.TestCase;
-import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.user.User;
 import org.icij.extract.queue.DocumentQueue;
@@ -18,14 +17,14 @@ public class ScanTaskTest extends TestCase {
     private final MemoryDocumentCollectionFactory<Path> documentCollectionFactory = new MemoryDocumentCollectionFactory<>();
 
     public void test_scan() throws Exception {
-        assertThat(new ScanTask(documentCollectionFactory, new Task<>("org.icij.datashare.tasks.ScanTask", User.local(),
+        assertThat(new ScanTask(documentCollectionFactory, DatashareTask.task("org.icij.datashare.tasks.ScanTask", User.local(),
                 Map.of(DATA_DIR_OPT, Paths.get(ClassLoader.getSystemResource("docs").getPath()).toString())), null).call()).isEqualTo(3);
         DocumentQueue<Path> queue = documentCollectionFactory.createQueue("extract:queue:index", Path.class);
         assertThat(queue.size()).isEqualTo(4); // with POISON
     }
 
     public void test_scan_with_queue_name() throws Exception {
-        assertThat(new ScanTask(documentCollectionFactory, new Task<>("org.icij.datashare.tasks.ScanTask", User.local(),
+        assertThat(new ScanTask(documentCollectionFactory, DatashareTask.task("org.icij.datashare.tasks.ScanTask", User.local(),
                 Map.of(DATA_DIR_OPT, Paths.get(ClassLoader.getSystemResource("docs").getPath()).toString(),
                         QUEUE_NAME_OPT, "foo")), null).call()).isEqualTo(3);
         DocumentQueue<Path> queue = documentCollectionFactory.createQueue("foo:index", Path.class);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
@@ -4,7 +4,6 @@ import java.util.concurrent.BlockingQueue;
 import org.icij.datashare.CollectionUtils;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.CancelException;
-import org.icij.datashare.asynctasks.Group;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.batch.BatchSearch;
 import org.icij.datashare.batch.BatchSearchRepository;
@@ -93,7 +92,7 @@ public class TaskManagerMemoryForBatchSearchTest {
     public void test_run_batch_search_failure() throws Exception {
         when(factory.createBatchSearchRunner(any(), any())).thenReturn(batchSearchRunner);
         mockSearch.willThrow(new IOException("io exception"));
-        batchSearchQueue.add(new Task<>(testBatchSearch.uuid, BatchSearchRunner.class.getName(), local(), new Group("TestGroup")));
+        batchSearchQueue.add(DatashareTask.task(testBatchSearch.uuid, BatchSearchRunner.class.getName(), local()));
 
         taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
 
@@ -143,7 +142,7 @@ public class TaskManagerMemoryForBatchSearchTest {
         taskManager = new TaskManagerMemory(batchSearchQueue, factory, new PropertiesProvider(), startLoop);
         mockSearch = new MockSearch<>(indexer, Indexer.QueryBuilderSearcher.class);
 
-        Task<Object> taskView = new Task<>(testBatchSearch.uuid, BatchSearchRunner.class.getName(), local(), new Group("TestGroup"));
+         Task<Object> taskView = DatashareTask.task(testBatchSearch.uuid, BatchSearchRunner.class.getName(), local());
         batchSearchRunner = new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView, taskView.progress(taskManager::progress));
         when(repository.get(eq(local()), anyString())).thenReturn(testBatchSearch);
         when(factory.createBatchSearchRunner(any(), any())).thenReturn(batchSearchRunner);
@@ -159,7 +158,7 @@ public class TaskManagerMemoryForBatchSearchTest {
         private final CountDownLatch countDownLatch;
 
         public SleepingBatchSearchRunner(int sleepingMilliseconds, CountDownLatch countDownLatch, BatchSearch bs) {
-            super(mock(Indexer.class), new PropertiesProvider(), repository, new Task<>(bs.uuid, BatchSearchRunner.class.getName(), local(), new Group("TestGroup")), (b) -> null);
+            super(mock(Indexer.class), new PropertiesProvider(), repository, DatashareTask.task(bs.uuid, BatchSearchRunner.class.getName(), local()), (b) -> null);
             this.sleepingMilliseconds = sleepingMilliseconds;
             this.countDownLatch = countDownLatch;
         }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerIntTest.java
@@ -59,7 +59,7 @@ public class TaskWorkerIntTest {
         File file = new IndexerHelper(es.client).indexFile("mydoc.txt", content, fs);
         BatchDownload bd = createBatchDownload("fox");
 
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(bd.filename.toFile()).isFile();
@@ -75,7 +75,7 @@ public class TaskWorkerIntTest {
         new IndexerHelper(es.client).indexFile("mydoc.txt", content, fs);
         BatchDownload bd = createBatchDownload("{\"match_all\":{}}");
 
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(bd.filename.toFile()).isFile();
@@ -88,7 +88,7 @@ public class TaskWorkerIntTest {
         new IndexerHelper(es.client).indexFile("doc2.txt", "Portez ce vieux whisky au juge blond qui fume", fs);
 
         BatchDownload bd = createBatchDownload("*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(bd.filename.toFile()).isFile();
@@ -102,7 +102,7 @@ public class TaskWorkerIntTest {
         new IndexerHelper(es.client).indexFile("doc2.txt", "Portez ce vieux whisky au juge blond qui fume", fs);
 
         BatchDownload bd = createBatchDownload("*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         UriResult result = new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(result.size()).isGreaterThan(0);
@@ -114,7 +114,7 @@ public class TaskWorkerIntTest {
         new IndexerHelper(es.client).indexFile("doc2.txt", "Portez ce vieux whisky au juge blond qui fume", fs);
 
         BatchDownload bd = createBatchDownload("juge");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(bd.filename.toFile()).isFile();
@@ -127,7 +127,7 @@ public class TaskWorkerIntTest {
         File doc2 = new IndexerHelper(es.client).indexFile("dir2/doc2.txt", "Portez ce vieux whisky au juge blond qui fume", fs);
 
         BatchDownload bd = createBatchDownload("*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(bd.filename.toFile()).isFile();
@@ -142,7 +142,7 @@ public class TaskWorkerIntTest {
         File doc2 = new IndexerHelper(es.client).indexFile("dir2/doc2.txt", "Portez ce vieux whisky au juge blond qui fume", fs, TEST_INDEXES[2]);
 
         BatchDownload bd = createBatchDownload(asList(project(TEST_INDEXES[1]), project(TEST_INDEXES[2])),"*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(bd.filename.toFile()).isFile();
@@ -154,7 +154,7 @@ public class TaskWorkerIntTest {
     @Test
     public void test_progress_rate() throws Exception {
         new IndexerHelper(es.client).indexFile("mydoc.txt", "content", fs);
-        Task<File> taskView = createTaskView(createBatchDownload("*"));
+         Task<File> taskView = createTaskView(createBatchDownload("*"));
         BatchDownloadRunner batchDownloadRunner = new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress));
         assertThat(batchDownloadRunner.getProgressRate()).isEqualTo(0);
         batchDownloadRunner.call();
@@ -166,7 +166,7 @@ public class TaskWorkerIntTest {
         File file = new IndexerHelper(es.client).indexEmbeddedFile(TEST_INDEX, "/docs/embedded_doc.eml");
 
         BatchDownload bd = createBatchDownload("*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(new ZipFile(bd.filename.toFile()).size()).isEqualTo(2);
@@ -178,7 +178,7 @@ public class TaskWorkerIntTest {
         new IndexerHelper(es.client).indexEmbeddedFile("bad_project_name", "/docs/embedded_doc.eml");
 
         BatchDownload bd = createBatchDownload("*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress)).call();
 
         assertThat(new ZipFile(bd.filename.toFile()).size()).isEqualTo(1);
@@ -187,7 +187,7 @@ public class TaskWorkerIntTest {
     @Test
     public void test_to_string_contains_batch_download_uuid() {
         BatchDownload bd = createBatchDownload("*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         BatchDownloadRunner batchDownloadRunner = new BatchDownloadRunner(indexer, createProvider(), taskView, taskView.progress(taskModifier::progress));
 
         assertThat(batchDownloadRunner.toString()).startsWith("BatchDownloadRunner@");
@@ -199,7 +199,7 @@ public class TaskWorkerIntTest {
         new IndexerHelper(es.client).indexFile("mydoc.txt", "content", fs);
         ExecutorService executor = Executors.newFixedThreadPool(1);
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        Task<File> taskView = createTaskView(createBatchDownload("*"));
+         Task<File> taskView = createTaskView(createBatchDownload("*"));
         BatchDownloadRunner batchDownloadRunner = new BatchDownloadRunner(indexer, createProvider(), taskView.progress(taskModifier::progress), taskView, null, countDownLatch);
 
         Future<UriResult> result = executor.submit(batchDownloadRunner);
@@ -214,7 +214,7 @@ public class TaskWorkerIntTest {
     @Test(expected = ElasticSearchAdapterException.class)
     public void test_use_batch_download_scroll_size_value_over_scroll_size_value() throws Exception {
         BatchDownload bd = createBatchDownload("*");
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
             put("downloadFolder", fs.getRoot().toString());
             put(SCROLL_SIZE_OPT, "100");
@@ -230,7 +230,7 @@ public class TaskWorkerIntTest {
             put("downloadFolder", fs.getRoot().toString());
             put(SCROLL_SIZE_OPT, "0");
         }});
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, propertiesProvider, taskView, taskView.progress(taskModifier::progress)).call();
     }
 
@@ -240,7 +240,7 @@ public class TaskWorkerIntTest {
         PropertiesProvider propertiesProvider = new PropertiesProvider(
                 Map.of("downloadFolder", "/unused",
                 BATCH_DOWNLOAD_SCROLL_DURATION_OPT, "10foo"));
-        Task<File> taskView = createTaskView(bd);
+         Task<File> taskView = createTaskView(bd);
         new BatchDownloadRunner(indexer, propertiesProvider, taskView, taskView.progress(taskModifier::progress)).call();
     }
 
@@ -249,7 +249,7 @@ public class TaskWorkerIntTest {
         return new BatchDownload(asList(project(TEST_INDEX)), local(), query, null, fs.getRoot().toPath(), false);
     }
     private Task<File> createTaskView(BatchDownload bd) {
-        return new Task<>(BatchDownloadRunner.class.getName(), bd.user, new HashMap<>() {{
+        return new DatashareTask().task(BatchDownloadRunner.class.getName(), bd.user, new HashMap<>() {{
             put("batchDownload", bd);
         }});
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
@@ -30,11 +30,11 @@ public class TaskWorkerLoopForPipelineTasksTest {
     @Mock Function<Double, Void> updateCallback;
     @Mock ElasticsearchSpewer spewer;
     private final BlockingQueue<Task<?>> taskQueue = new LinkedBlockingQueue<>();
-    private final TaskManagerMemory taskSupplier = new TaskManagerMemory(taskQueue, taskFactory, new PropertiesProvider());
+    private final TaskManagerMemory taskManager = new TaskManagerMemory(taskQueue, taskFactory, new PropertiesProvider());
 
     @Test
     public void test_scan_task() throws Exception {
-        Task<Long> task = new Task<>(ScanTask.class.getName(), User.local(), Map.of("dataDir", "/path/to/files"));
+         Task<Long> task = DatashareTask.task(ScanTask.class.getName(), User.local(), Map.of("dataDir", "/path/to/files"));
         ScanTask taskRunner = new ScanTask(mock(DocumentCollectionFactory.class), task, updateCallback);
         when(taskFactory.createScanTask(any(), any())).thenReturn(taskRunner);
 
@@ -43,7 +43,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
 
     @Test
     public void test_index_task() throws Exception {
-        Task<Long> task = new Task<>(IndexTask.class.getName(), User.local(), new HashMap<>());
+         Task<Long> task = DatashareTask.task(IndexTask.class.getName(), User.local(), new HashMap<>());
         IndexTask taskRunner = new IndexTask(spewer, mock(DocumentCollectionFactory.class), task, updateCallback);
         when(taskFactory.createIndexTask(any(), any())).thenReturn(taskRunner);
 
@@ -52,7 +52,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
 
     @Test
     public void test_extract_nlp_task() throws Exception {
-        Task<Long> task = new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of("nlpPipeline", "EMAIL"));
+         Task<Long> task = DatashareTask.task(ExtractNlpTask.class.getName(), User.local(), Map.of("nlpPipeline", "EMAIL"));
         ExtractNlpTask taskRunner = new ExtractNlpTask(mock(Indexer.class), new PipelineRegistry(new PropertiesProvider()), mock(DocumentCollectionFactory.class), task, updateCallback);
         when(taskFactory.createExtractNlpTask(any(), any())).thenReturn(taskRunner);
 
@@ -61,7 +61,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
 
     @Test
     public void test_scan_index_task() throws Exception {
-        Task<Long> task = new Task<>(ScanIndexTask.class.getName(), User.local(), new HashMap<>());
+         Task<Long> task = DatashareTask.task(ScanIndexTask.class.getName(), User.local(), new HashMap<>());
         ScanIndexTask taskRunner = new ScanIndexTask(mock(DocumentCollectionFactory.class), mock(Indexer.class), task, updateCallback);
         when(taskFactory.createScanIndexTask(any(), any())).thenReturn(taskRunner);
 
@@ -70,7 +70,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
 
     @Test
     public void test_enqueue_from_index_task() throws Exception {
-        Task<Long> task = new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), Map.of("nlpPipeline", "EMAIL"));
+         Task<Long> task = DatashareTask.task(EnqueueFromIndexTask.class.getName(), User.local(), Map.of("nlpPipeline", "EMAIL"));
         EnqueueFromIndexTask taskRunner = new EnqueueFromIndexTask(mock(DocumentCollectionFactory.class), mock(Indexer.class), task, updateCallback);
         when(taskFactory.createEnqueueFromIndexTask(any(), any())).thenReturn(taskRunner);
 
@@ -79,19 +79,19 @@ public class TaskWorkerLoopForPipelineTasksTest {
 
     @Test
     public void test_deduplicate_task() throws Exception {
-        Task<Long> task = new Task<>(DeduplicateTask.class.getName(), User.local(), new HashMap<>());
+         Task<Long> task = DatashareTask.task(DeduplicateTask.class.getName(), User.local(), new HashMap<>());
         DeduplicateTask taskRunner = new DeduplicateTask(mock(DocumentCollectionFactory.class), task, updateCallback);
         when(taskFactory.createDeduplicateTask(any(), any())).thenReturn(taskRunner);
 
         testTaskWithTaskRunner(task);
     }
 
-    private void testTaskWithTaskRunner(Task<Long> task) throws Exception {
-        taskSupplier.startTask(task.name, User.local(), task.args);
-        taskSupplier.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+    private void testTaskWithTaskRunner( Task<Long> task) throws Exception {
+        taskManager.startTask(task.name, task.args);
+        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
 
-        assertThat(taskSupplier.getTasks()).hasSize(1);
-        assertThat(taskSupplier.getTasks().get(0).name).isEqualTo(task.name);
+        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().get(0).name).isEqualTo(task.name);
     }
 
     @Before

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
@@ -32,7 +32,7 @@ public class TaskWorkerLoopIntTest {
         DatashareTaskFactory factory = mock(DatashareTaskFactory.class);
         BatchDownload batchDownload = new BatchDownload(singletonList(project("prj")), User.local(), "foo");
         Map<String, Object> properties = Map.of("batchDownload", batchDownload);
-        Task<File> taskView = new Task<>(BatchDownloadRunner.class.getName(), batchDownload.user, properties);
+         Task<File> taskView = DatashareTask.task(BatchDownloadRunner.class.getName(), batchDownload.user, properties);
         BatchDownloadRunner runner = new BatchDownloadRunner(mock(Indexer.class), new PropertiesProvider(), taskView, taskView.progress(taskSupplier::progress));
         when(factory.createBatchDownloadRunner(any(), any())).thenReturn(runner);
 
@@ -41,7 +41,7 @@ public class TaskWorkerLoopIntTest {
         Thread worker = new Thread(taskWorkerLoop::call);
         worker.start();
         workerStarted.await();
-        taskManager.startTask(BatchDownloadRunner.class.getName(), User.local(), properties);
+        taskManager.startTask(BatchDownloadRunner.class, User.local(), properties);
         Thread.sleep(100); // this is a symptom of a possible flaky test but for now I can't figure out how to be event driven
 
         taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
@@ -51,7 +51,7 @@ public class TaskWorkerLoopIntTest {
         assertThat(taskManager.getTasks().get(0).getError()).isNotNull();
         assertThat(taskManager.getTasks().get(0).getProgress()).isEqualTo(1);
         assertThat(taskManager.getTasks().get(0).args).hasSize(2);
-        assertThat(taskManager.getTasks().get(0).getUser()).isEqualTo(User.local());
+        assertThat(DatashareTask.getUser(taskManager.getTasks().get(0))).isEqualTo(User.local());
     }
 
     @Before

--- a/datashare-app/src/test/java/org/icij/datashare/web/ApiKeyResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ApiKeyResourceTest.java
@@ -4,17 +4,16 @@ package org.icij.datashare.web;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
+import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.tasks.DelApiKeyTask;
 import org.icij.datashare.tasks.GenApiKeyTask;
 import org.icij.datashare.tasks.GetApiKeyTask;
-import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.user.User;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -68,7 +68,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
             protected void configure() {
                 bind(DatashareTaskFactory.class).toInstance(taskFactory);
                 bind(Indexer.class).toInstance(mock(Indexer.class));
-                bind(TaskManager.class).toInstance(taskManager);
+                bind(DatashareTaskManager.class).toInstance(taskManager);
                 bind(TaskSupplier.class).toInstance(taskManager);
                 bind(TaskModifier.class).toInstance(taskManager);
                 bind(PipelineRegistry.class).toInstance(pipelineRegistry);
@@ -189,7 +189,6 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         defaultProperties.put("foo", "baz");
         defaultProperties.put("key", "val");
         defaultProperties.put("user", User.local());
-        defaultProperties.put("group", new Group("Java"));
         defaultProperties.remove(REPORT_NAME_OPT);
 
         assertThat(taskManager.getTasks()).hasSize(2);
@@ -210,7 +209,6 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         defaultProperties.put("key1", "val1");
         defaultProperties.put("key2", "val2");
         defaultProperties.put("user", User.local());
-        defaultProperties.put("group", new Group("Java"));
 
         assertThat(taskManager.getTasks()).hasSize(1);
         assertThat(taskManager.getTasks().get(0).name).isEqualTo("org.icij.datashare.tasks.IndexTask");
@@ -471,6 +469,8 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
             "arguments": {"user":{"@type":"org.icij.datashare.user.User", "id":"local","name":null,"email":null,"provider":"local","details":{"uid":"local","groups_by_applications":{"datashare":["local-datashare"]}}
             }}}""", TaskCreation.class.getName()))
                 .should().respond(201);
+        // Cancel the all tasks to avoid side-effects with other tests
+        put("/api/task/stopAll").should().respond(200);
     }
 
     @NotNull
@@ -507,9 +507,9 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         when(taskFactory.createScanIndexTask(any(), any())).thenReturn(mock(ScanIndexTask.class));
         when(taskFactory.createEnqueueFromIndexTask(any(), any())).thenReturn(mock(EnqueueFromIndexTask.class));
         when(taskFactory.createExtractNlpTask(any(), any())).thenReturn(mock(ExtractNlpTask.class));
-        when(taskFactory.createTestTask(any(Task.class), any(Function.class))).thenReturn(new TestTask(10));
-        when(taskFactory.createTestSleepingTask(any(Task.class), any(Function.class))).thenReturn(new TestSleepingTask(100000));
-        when(taskFactory.createTaskCreation(any(Task.class), any(Function.class))).thenReturn(mock(TaskCreation.class));
+        when(taskFactory.createTestTask(any( Task.class), any(Function.class))).thenReturn(new TestTask(10));
+        when(taskFactory.createTestSleepingTask(any( Task.class), any(Function.class))).thenReturn(new TestSleepingTask(100000));
+        when(taskFactory.createTaskCreation(any( Task.class), any(Function.class))).thenReturn(mock(TaskCreation.class));
     }
 
     public interface DatashareTaskFactoryForTest extends DatashareTaskFactory {

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
@@ -8,7 +8,6 @@ import net.codestory.http.security.SessionIdStore;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.bus.amqp.UriResult;
 import org.icij.datashare.tasks.DatashareTaskFactory;
@@ -199,7 +198,7 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
                 bind(PropertiesProvider.class).toInstance(propertiesProvider);
                 bind(PipelineRegistry.class).toInstance(mock(PipelineRegistry.class));
                 bind(SessionIdStore.class).toInstance(SessionIdStore.inMemory());
-                bind(TaskManager.class).toInstance(taskManager);
+                bind(DatashareTaskManager.class).toInstance(taskManager);
                 bind(TaskModifier.class).toInstance(taskManager);
                 bind(Filter.class).toInstance(new BasicAuthFilter("/", "ds", DatashareUser.users(userLogins)));
                 bind(DatashareTaskFactory.class).toInstance(taskFactory);

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
@@ -10,13 +10,10 @@ import org.icij.datashare.Entity;
 import org.icij.datashare.asynctasks.bus.amqp.Event;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.asynctasks.bus.amqp.UriResult;
-import org.icij.datashare.user.User;
 
-import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -29,12 +26,10 @@ import static java.util.UUID.randomUUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Task<V> extends Event implements Entity {
-    public static final String USER_KEY = "user";
-    public static final String GROUP_KEY = "group";
     @JsonIgnore private StateLatch stateLatch;
     @JsonIgnore private final Object lock = new Object();
 
-    public enum State {CREATED, QUEUED, RUNNING, CANCELLED, ERROR, DONE;}
+    public enum State {CREATED, QUEUED, RUNNING, CANCELLED, ERROR, DONE}
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@type")
     public final Map<String, Object> args;
     public final String id;
@@ -50,20 +45,16 @@ public class Task<V> extends Event implements Entity {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
     private volatile V result;
 
-    public Task(String name, User user, Map<String, Object> args) {
-        this(randomUUID().toString(), name, user, args);
+    public Task(String name, Map<String, Object> args) {
+        this(randomUUID().toString(), name, State.CREATED, 0, null, args);
     }
 
-    public Task(String name, User user, Group group, Map<String, Object> args) {
-        this(randomUUID().toString(), name, State.CREATED, 0, null, addTo(args, user, group));
+    public Task(String id, String name) {
+        this(id, name, new HashMap<>());
     }
 
-    public Task(String id, String name, User user, Group group) {
-        this(id, name, user,addTo(new HashMap<>(), user, group));
-    }
-
-    public Task(String id, String name, User user, Map<String, Object> args) {
-        this(id, name, State.CREATED, 0, null, addTo(args, user));
+    public Task(String id, String name, Map<String, Object> args) {
+        this(id, name, State.CREATED, 0, null, args);
     }
 
     @JsonCreator
@@ -179,16 +170,6 @@ public class Task<V> extends Event implements Entity {
         return id == null;
     }
 
-    @JsonIgnore
-    public User getUser() {
-        return (User) args.get(USER_KEY);
-    }
-
-    @JsonIgnore
-    public Group getGroup() {
-        return (Group) args.get(GROUP_KEY);
-    }
-
     public static <V> String getId(Callable<V> task) {
         return task.toString();
     }
@@ -209,18 +190,5 @@ public class Task<V> extends Event implements Entity {
     private void setState(State state) {
         this.state = state;
         ofNullable(stateLatch).ifPresent(sl -> sl.setTaskState(state));
-    }
-
-    private static Map<String, Object> addTo(Map<String, Object> properties, User user) {
-        LinkedHashMap<String, Object> result = new LinkedHashMap<>(properties);
-        result.put(USER_KEY, user);
-        return result;
-    }
-
-    private static Map<String, Object> addTo(Map<String, Object> properties, User user, Group group) {
-        LinkedHashMap<String, Object> result = new LinkedHashMap<>(properties);
-        result.put(USER_KEY, user);
-        result.put(GROUP_KEY, group);
-        return result;
     }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskAlreadyExists.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskAlreadyExists.java
@@ -1,0 +1,9 @@
+package org.icij.datashare.asynctasks;
+
+public class TaskAlreadyExists extends Exception {
+    final String taskId;
+
+    public TaskAlreadyExists(String taskId) {
+        this.taskId = taskId;
+    }
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.asynctasks;
 
+import java.util.Optional;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpConsumer;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpInterlocutor;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpQueue;
@@ -8,10 +9,8 @@ import org.icij.datashare.asynctasks.bus.amqp.ShutdownEvent;
 import org.icij.datashare.asynctasks.bus.amqp.TaskEvent;
 
 import org.icij.datashare.tasks.RoutingStrategy;
-import org.icij.datashare.user.User;
 
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -22,22 +21,22 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
 public class TaskManagerAmqp implements TaskManager {
-    private final Map<String, Task<?>> tasks;
+    private final Map<String, TaskMetadata<?>> taskMetas;
     private final RoutingStrategy routingStrategy;
     private final AmqpInterlocutor amqp;
     private final AmqpConsumer<TaskEvent, Consumer<TaskEvent>> eventConsumer;
 
-    public TaskManagerAmqp(AmqpInterlocutor amqp, Map<String, Task<?>> tasks) throws IOException {
-        this(amqp, tasks, RoutingStrategy.UNIQUE);
+    public TaskManagerAmqp(AmqpInterlocutor amqp, Map<String, TaskMetadata<?>> taskMetas) throws IOException {
+        this(amqp, taskMetas, RoutingStrategy.UNIQUE);
     }
 
-    public TaskManagerAmqp(AmqpInterlocutor amqp, Map<String, Task<?>> tasks, RoutingStrategy routingStrategy) throws IOException {
-        this(amqp, tasks, routingStrategy, null);
+    public TaskManagerAmqp(AmqpInterlocutor amqp, Map<String, TaskMetadata<?>> taskMetas, RoutingStrategy routingStrategy) throws IOException {
+        this(amqp, taskMetas, routingStrategy, null);
     }
 
-    public TaskManagerAmqp(AmqpInterlocutor amqp, Map<String, Task<?>> tasks, RoutingStrategy routingStrategy, Runnable eventCallback) throws IOException {
+    public TaskManagerAmqp(AmqpInterlocutor amqp, Map<String, TaskMetadata<?>> taskMetas, RoutingStrategy routingStrategy, Runnable eventCallback) throws IOException {
         this.amqp = amqp;
-        this.tasks = tasks;
+        this.taskMetas = taskMetas;
         this.routingStrategy = routingStrategy;
         eventConsumer = new AmqpConsumer<>(amqp, event ->
                 ofNullable(TaskManager.super.handleAck(event)).flatMap(t ->
@@ -46,7 +45,7 @@ public class TaskManagerAmqp implements TaskManager {
 
     @Override
     public boolean stopTask(String taskId) {
-        Task<?> taskView = tasks.get(taskId);
+        Task<?> taskView = this.getTask(taskId);
         if (taskView != null) {
             try {
                 logger.info("sending cancel event for {}", taskId);
@@ -63,11 +62,11 @@ public class TaskManagerAmqp implements TaskManager {
 
     @Override
     public <V> Task<V> clearTask(String taskId) {
-        if (tasks.get(taskId).getState() == Task.State.RUNNING) {
+        if (this.getTask(taskId).getState() == Task.State.RUNNING) {
             throw new IllegalStateException(String.format("task id <%s> is already in RUNNING state", taskId));
         }
         logger.info("deleting task id <{}>", taskId);
-        return (Task<V>) tasks.remove(taskId);
+        return (Task<V>) taskMetas.remove(taskId).task();
     }
 
     @Override
@@ -76,15 +75,29 @@ public class TaskManagerAmqp implements TaskManager {
         return true;
     }
 
-    public boolean save(Task<?> task) {
-        Task<?> oldVal = tasks.put(task.id, task);
-        return oldVal == null;
+    @Override
+    public <V> void saveMetadata(TaskMetadata<V> taskMetadata) throws TaskAlreadyExists {
+        String taskId = taskMetadata.taskId();
+        if (taskMetas.containsKey(taskId)) {
+            throw new TaskAlreadyExists(taskId);
+        }
+        this.taskMetas.put(taskId, taskMetadata);
+    }
+
+    @Override
+    public <V> void persistUpdate(Task<V> task) throws UnknownTask {
+        TaskMetadata<V> updated = (TaskMetadata<V>) taskMetas.get(task.id);
+        if (updated == null) {
+            throw new UnknownTask(task.id);
+        }
+        updated = updated.withTask(task);
+        this.taskMetas.put(task.id, updated);
     }
 
     @Override
     public void enqueue(Task<?> task) throws IOException {
         switch (routingStrategy) {
-            case GROUP -> amqp.publish(AmqpQueue.TASK, task.getGroup().id(), task);
+            case GROUP -> amqp.publish(AmqpQueue.TASK, this.taskMetas.get(task.id).group().id(), task);
             case NAME -> amqp.publish(AmqpQueue.TASK, task.name, task);
             default -> amqp.publish(AmqpQueue.TASK, task);
         }
@@ -92,22 +105,28 @@ public class TaskManagerAmqp implements TaskManager {
 
     @Override
     public <V> Task<V> getTask(String taskId) {
-        return (Task<V>) tasks.get(taskId);
+        return (Task<V>) Optional.ofNullable(taskMetas.get(taskId)).map(TaskMetadata::task).orElse(null);
     }
 
     @Override
     public List<Task<?>> getTasks() {
-        return new LinkedList<>(tasks.values());
+        return taskMetas.values().stream().map(TaskMetadata::task).collect(toList());
     }
 
     @Override
-    public List<Task<?>> getTasks(User user, Pattern pattern) {
-        return TaskManager.getTasks(tasks.values().stream(), user, pattern);
+    public List<Task<?>> getTasks(Pattern pattern) throws IOException {
+        return this.getTasks(taskMetas.values().stream().map(TaskMetadata::task), pattern);
+    }
+
+    @Override
+    public Group getTaskGroup(String taskId) {
+        return taskMetas.get(taskId).group();
     }
 
     @Override
     public List<Task<?>> clearDoneTasks() {
-        return tasks.values().stream().filter(f -> f.getState() != Task.State.RUNNING).map(t -> tasks.remove(t.id)).collect(toList());
+        return taskMetas.values().stream().map(TaskMetadata::task).filter(Task::isFinished)
+            .map(t -> taskMetas.remove(t.id).task()).collect(toList());
     }
 
     public void close() throws IOException {
@@ -117,6 +136,6 @@ public class TaskManagerAmqp implements TaskManager {
 
     @Override
     public void clear() {
-        tasks.clear();
+        taskMetas.clear();
     }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
@@ -1,17 +1,15 @@
 package org.icij.datashare.asynctasks;
 
+import java.util.Optional;
 import org.apache.commons.lang3.NotImplementedException;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.bus.amqp.Event;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
-import org.icij.datashare.asynctasks.bus.amqp.TaskEvent;
-import org.icij.datashare.user.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,13 +20,12 @@ import java.util.stream.IntStream;
 
 import static java.lang.Integer.parseInt;
 import static java.util.stream.Collectors.toList;
-import static org.icij.datashare.asynctasks.Task.State.RUNNING;
 
 
 public class TaskManagerMemory implements TaskManager, TaskSupplier {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ExecutorService executor;
-    private final ConcurrentMap<String, Task<?>> tasks = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, TaskMetadata<?>> taskMetas = new ConcurrentHashMap<>();
     private final BlockingQueue<Task<?>> taskQueue;
     private final List<TaskWorkerLoop> loops;
     private final AtomicInteger executedTasks = new AtomicInteger(0);
@@ -47,22 +44,27 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
     }
 
     public <V> Task<V> getTask(final String taskId) {
-        return (Task<V>) tasks.get(taskId);
+        return (Task<V>) Optional.ofNullable(taskMetas.get(taskId)).map(TaskMetadata::task).orElse(null);
     }
 
     @Override
     public List<Task<?>> getTasks() {
-        return new LinkedList<>(tasks.values());
+        return taskMetas.values().stream().map(TaskMetadata::task).collect(toList());
     }
 
     @Override
-    public List<Task<?>> getTasks(User user, Pattern pattern) {
-        return TaskManager.getTasks(tasks.values().stream(), user, pattern);
+    public List<Task<?>> getTasks(Pattern pattern) throws IOException {
+        return this.getTasks(taskMetas.values().stream().map(TaskMetadata::task), pattern);
+    }
+
+    @Override
+    public Group getTaskGroup(String taskId) {
+        return taskMetas.get(taskId).group();
     }
 
     @Override
     public Void progress(String taskId, double rate) {
-        Task<?> taskView = tasks.get(taskId);
+        Task<?> taskView = getTask(taskId);
         if (taskView != null) {
             taskView.setProgress(rate);
         } else {
@@ -73,7 +75,7 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
 
     @Override
     public <V extends Serializable> void result(String taskId, V result) {
-        Task<V> taskView = (Task<V>) tasks.get(taskId);
+        Task<V> taskView = getTask(taskId);
         if (taskView != null) {
             taskView.setResult(result);
             executedTasks.incrementAndGet();
@@ -84,7 +86,7 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
 
     @Override
     public void canceled(Task<?> task, boolean requeue) {
-        Task<?> taskView = tasks.get(task.id);
+        Task<?> taskView = taskMetas.get(task.id).task();
         if (taskView != null) {
             taskView.cancel();
             if (requeue) {
@@ -95,7 +97,7 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
 
     @Override
     public void error(String taskId, TaskError reason) {
-        Task<?> taskView = tasks.get(taskId);
+        Task<?> taskView = taskMetas.get(taskId).task();
         if (taskView != null) {
             taskView.setError(reason);
             executedTasks.incrementAndGet();
@@ -104,9 +106,23 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
         }
     }
 
-    public boolean save(Task<?> taskView) {
-        Task<?> oldTask = tasks.put(taskView.id, taskView);
-        return oldTask == null;
+    @Override
+    public <V> void saveMetadata(TaskMetadata<V> taskMetadata) throws TaskAlreadyExists {
+        String taskId = taskMetadata.taskId();
+        if (taskMetas.containsKey(taskId)) {
+            throw new TaskAlreadyExists(taskId);
+        }
+        this.taskMetas.put(taskId, taskMetadata);
+    }
+
+    @Override
+    public <V> void persistUpdate(Task<V> task) throws UnknownTask {
+        TaskMetadata<V> updated = (TaskMetadata<V>) taskMetas.get(task.id);
+        if (updated == null) {
+            throw new UnknownTask(task.id);
+        }
+        updated = updated.withTask(task);
+        this.taskMetas.put(task.id, updated);
     }
 
     @Override
@@ -121,30 +137,31 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
     }
 
     public List<Task<?>> waitTasksToBeDone(int timeout, TimeUnit timeUnit) {
-        return tasks.values().stream().peek(taskView -> {
+        return taskMetas.values().stream().peek(m -> {
             try {
-                taskView.getResult(timeout, timeUnit);
+                m.task().getResult(timeout, timeUnit);
             } catch (InterruptedException | CancellationException e) {
                 logger.error("task interrupted while running", e);
             }
-        }).collect(toList());
+        }).map(TaskMetadata::task).collect(toList());
     }
 
     public List<Task<?>> clearDoneTasks() {
-        return tasks.values().stream().filter(taskView -> taskView.getState() != RUNNING).map(t -> tasks.remove(t.id)).collect(toList());
+        return taskMetas.values().stream().map(TaskMetadata::task).filter(Task::isFinished)
+            .map(t -> taskMetas.remove(t.id).task()).collect(toList());
     }
 
     @Override
-    public <V> Task<V> clearTask(String taskName) {
-        if (tasks.get(taskName).getState() == Task.State.RUNNING) {
-            throw new IllegalStateException(String.format("task id <%s> is already in RUNNING state", taskName));
+    public <V> Task<V> clearTask(String taskId) {
+        if (getTask(taskId).getState() == Task.State.RUNNING) {
+            throw new IllegalStateException(String.format("task id <%s> is already in RUNNING state", taskId));
         }
-        logger.info("deleting task id <{}>", taskName);
-        return (Task<V>) tasks.remove(taskName);
+        logger.info("deleting task id <{}>", taskId);
+        return (Task<V>) taskMetas.remove(taskId).task();
     }
 
     public boolean stopTask(String taskId) {
-        Task<?> taskView = tasks.get(taskId);
+        Task<?> taskView = getTask(taskId);
         if (taskView != null) {
             switch (taskView.getState()) {
                 case QUEUED:
@@ -185,7 +202,7 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
     public void clear() {
         executedTasks.set(0);
         taskQueue.clear();
-        tasks.clear();
+        taskMetas.clear();
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
@@ -5,13 +5,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpQueue;
 import org.icij.datashare.asynctasks.bus.amqp.CancelEvent;
 import org.icij.datashare.asynctasks.bus.amqp.ShutdownEvent;
 import org.icij.datashare.asynctasks.bus.amqp.TaskEvent;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.tasks.RoutingStrategy;
-import org.icij.datashare.user.User;
 import org.redisson.Redisson;
 import org.redisson.RedissonBlockingQueue;
 import org.redisson.RedissonMap;
@@ -30,11 +31,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
 
@@ -44,7 +43,7 @@ import static java.util.stream.Collectors.toList;
 public class TaskManagerRedis implements TaskManager {
     private final Runnable eventCallback; // for test
     public static final String EVENT_CHANNEL_NAME = "EVENT";
-    private final RedissonMap<String, Task<?>> tasks;
+    private final RedissonMap<String, TaskMetadata<?>> taskMetas;
     private final RTopic eventTopic;
     private final RedissonClient redissonClient;
     private final RoutingStrategy routingStrategy;
@@ -57,39 +56,44 @@ public class TaskManagerRedis implements TaskManager {
         this.redissonClient = redissonClient;
         this.routingStrategy = routingStrategy;
         CommandSyncService commandSyncService = getCommandSyncService();
-        this.tasks = new RedissonMap<>(new TaskViewCodec(), commandSyncService, taskMapName, redissonClient, null, null);
+        this.taskMetas = new RedissonMap<>(new RedisCodec<>(TaskMetadata.class), commandSyncService, taskMapName, redissonClient, null, null);
         this.eventTopic = redissonClient.getTopic(EVENT_CHANNEL_NAME);
         this.eventCallback = eventCallback;
         eventTopic.addListener(TaskEvent.class, (channelString, message) -> handleEvent(message));
     }
 
-    @Override
-    public <V> Task<V> getTask(String id) {
-        return (Task<V>) tasks.get(id);
+    public <V> Task<V> getTask(final String taskId) {
+        return (Task<V>) Optional.ofNullable(taskMetas.get(taskId)).map(TaskMetadata::task).orElse(null);
     }
 
     @Override
     public List<Task<?>> getTasks() {
-        return new LinkedList<>(tasks.values());
+        return taskMetas.values().stream().map(TaskMetadata::task).collect(Collectors.toList());
     }
 
     @Override
-    public List<Task<?>> getTasks(User user, Pattern pattern) {
-        return TaskManager.getTasks(tasks.values().stream(), user, pattern);
+    public List<Task<?>> getTasks(Pattern pattern) throws IOException {
+        return this.getTasks(taskMetas.values().stream().map(TaskMetadata::task), pattern);
+    }
+
+    @Override
+    public Group getTaskGroup(String taskId) {
+        return taskMetas.get(taskId).group();
     }
 
     @Override
     public List<Task<?>> clearDoneTasks() {
-        return tasks.values().stream().filter(Task::isFinished).map(t -> tasks.remove(t.id)).collect(toList());
+        return taskMetas.values().stream().map(TaskMetadata::task).filter(Task::isFinished)
+            .map(t -> taskMetas.remove(t.id).task()).collect(toList());
     }
 
     @Override
-    public Task<?> clearTask(String taskId) {
-        if (tasks.get(taskId).getState() == Task.State.RUNNING) {
+    public <V> Task<V> clearTask(String taskId) {
+        if (getTask(taskId).getState() == Task.State.RUNNING) {
             throw new IllegalStateException(String.format("task id <%s> is already in RUNNING state", taskId));
         }
         logger.info("deleting task id <{}>", taskId);
-        return tasks.remove(taskId);
+        return (Task<V>) taskMetas.remove(taskId).task();
     }
 
     @Override
@@ -116,13 +120,13 @@ public class TaskManagerRedis implements TaskManager {
     BlockingQueue<Task<?>> taskQueue(Task<?> task) {
         switch (routingStrategy) {
             case GROUP -> {
-                return new RedissonBlockingQueue<>(new TaskViewCodec(), getCommandSyncService(), String.format("%s.%s", AmqpQueue.TASK.name(), task.getGroup().id()), redissonClient);
+                return new RedissonBlockingQueue<>(new RedisCodec<>(Task.class), getCommandSyncService(), String.format("%s.%s", AmqpQueue.TASK.name(), this.taskMetas.get(task.id).group().id()), redissonClient);
             }
             case NAME -> {
-                return new RedissonBlockingQueue<>(new TaskViewCodec(), getCommandSyncService(), String.format("%s.%s", AmqpQueue.TASK.name(), task.name), redissonClient);
+                return new RedissonBlockingQueue<>(new RedisCodec<>(Task.class), getCommandSyncService(), String.format("%s.%s", AmqpQueue.TASK.name(), task.name), redissonClient);
             }
             default -> {
-                return new RedissonBlockingQueue<>(new TaskViewCodec(), getCommandSyncService(), AmqpQueue.TASK.name(), redissonClient);
+                return new RedissonBlockingQueue<>(new RedisCodec<>(Task.class), getCommandSyncService(), AmqpQueue.TASK.name(), redissonClient);
             }
         }
     }
@@ -140,7 +144,7 @@ public class TaskManagerRedis implements TaskManager {
 
     @Override
     public void clear() {
-        tasks.clear();
+        taskMetas.clear();
         clearTaskQueues();
     }
 
@@ -153,9 +157,23 @@ public class TaskManagerRedis implements TaskManager {
                 .forEach(k -> redissonClient.getQueue(k).delete());
     }
 
-    public boolean save(Task<?> task) {
-        Task<?> oldVal = tasks.put(task.id, task);
-        return oldVal == null;
+    @Override
+    public <V> void saveMetadata(TaskMetadata<V> taskMetadata) throws TaskAlreadyExists {
+        String taskId = taskMetadata.taskId();
+        if (taskMetas.containsKey(taskId)) {
+            throw new TaskAlreadyExists(taskId);
+        }
+        this.taskMetas.put(taskId, taskMetadata);
+    }
+
+    @Override
+    public <V> void persistUpdate(Task<V> task) throws UnknownTask {
+        TaskMetadata<V> updated = (TaskMetadata<V>) taskMetas.get(task.id);
+        if (updated == null) {
+            throw new UnknownTask(task.id);
+        }
+        updated = updated.withTask(task);
+        this.taskMetas.put(task.id, updated);
     }
 
     @Override
@@ -163,14 +181,16 @@ public class TaskManagerRedis implements TaskManager {
         taskQueue(task).add(task);
     }
 
-    public static class TaskViewCodec extends BaseCodec {
+    public  static class RedisCodec<T> extends BaseCodec {
+        private final Class<T> clazz;
         private final Encoder keyEncoder;
         private final Decoder<Object> keyDecoder;
         protected final ObjectMapper mapObjectMapper;
 
-        public TaskViewCodec() {
+        public RedisCodec(Class<T> clazz) {
+            // Ugly but this doesn't work with type ref directly
+            this.clazz = clazz;
             this.mapObjectMapper = JsonObjectMapper.MAPPER;
-
             this.keyEncoder = in -> {
                 ByteBuf out = ByteBufAllocator.DEFAULT.buffer();
                 out.writeCharSequence(in.toString(), Charset.defaultCharset());
@@ -203,8 +223,8 @@ public class TaskManagerRedis implements TaskManager {
 
         private final Decoder<Object> decoder = new Decoder<>() {
             @Override
-            public Object decode(ByteBuf buf, State state) throws IOException {
-                return mapObjectMapper.readValue((InputStream) new ByteBufInputStream(buf), Task.class);
+            public T decode(ByteBuf buf, State state) throws IOException {
+                return mapObjectMapper.readValue((InputStream) new ByteBufInputStream(buf), clazz);
             }
         };
 

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskMetadata.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskMetadata.java
@@ -1,0 +1,11 @@
+package org.icij.datashare.asynctasks;
+
+public record TaskMetadata<V>(Task<V> task, Group group) {
+    String taskId() {
+        return task.id;
+    }
+
+    TaskMetadata<V> withTask(Task<V> task) {
+        return new TaskMetadata<>(task, this.group);
+    }
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskSupplier.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskSupplier.java
@@ -2,7 +2,6 @@ package org.icij.datashare.asynctasks;
 
 import org.icij.datashare.asynctasks.bus.amqp.Event;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
-import org.icij.datashare.asynctasks.bus.amqp.TaskEvent;
 
 import java.io.Closeable;
 import java.io.Serializable;

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskSupplierRedis.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskSupplierRedis.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.asynctasks;
 
+import java.util.Optional;
 import org.apache.commons.lang3.NotImplementedException;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpQueue;
 import org.icij.datashare.asynctasks.bus.amqp.CancelledEvent;
@@ -83,8 +84,8 @@ public class TaskSupplierRedis implements TaskSupplier {
 
     private <V extends Serializable> BlockingQueue<Task<V>> taskQueue() {
         return this.taskQueueKey == null ?
-            new RedissonBlockingQueue<>(new TaskManagerRedis.TaskViewCodec(), getCommandSyncService(), AmqpQueue.TASK.name(), redissonClient):
-            new RedissonBlockingQueue<>(new TaskManagerRedis.TaskViewCodec(), getCommandSyncService(), String.format("%s.%s", AmqpQueue.TASK.name(), taskQueueKey), redissonClient);
+            new RedissonBlockingQueue<>(new TaskManagerRedis.RedisCodec<>(Task.class), getCommandSyncService(), AmqpQueue.TASK.name(), redissonClient):
+            new RedissonBlockingQueue<>(new TaskManagerRedis.RedisCodec<>(Task.class), getCommandSyncService(), String.format("%s.%s", AmqpQueue.TASK.name(), taskQueueKey), redissonClient);
     }
 
     private CommandSyncService getCommandSyncService() {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/UnknownTask.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/UnknownTask.java
@@ -1,0 +1,9 @@
+package org.icij.datashare.asynctasks;
+
+public class UnknownTask extends Exception {
+    final String taskId;
+
+    public UnknownTask(String taskId) {
+        this.taskId = taskId;
+    }
+}

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisCodecTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisCodecTest.java
@@ -3,7 +3,6 @@ package org.icij.datashare.asynctasks;
 import io.netty.buffer.Unpooled;
 import org.fest.assertions.Assertions;
 import org.icij.datashare.asynctasks.bus.amqp.UriResult;
-import org.icij.datashare.user.User;
 import org.junit.Test;
 import org.redisson.client.handler.State;
 
@@ -15,14 +14,13 @@ import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
-import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
 
 public class TaskManagerRedisCodecTest {
-    TaskManagerRedis.TaskViewCodec codec = new TaskManagerRedis.TaskViewCodec();
+    TaskManagerRedis.RedisCodec<?> codec = new TaskManagerRedis.RedisCodec<>(Task.class);
 
     @Test
     public void test_json_serialize_deserialize_with_inline_properties_map() throws Exception {
-        Task<?> taskView = new Task<>("name", User.local(), Map.of("key", "value"));
+        Task<?> taskView = new Task<>("name", Map.of("key", "value"));
         String json = codec.getValueEncoder().encode(taskView).toString(Charset.defaultCharset());
 
         assertThat(json).contains("\"key\":\"value\"");
@@ -30,14 +28,13 @@ public class TaskManagerRedisCodecTest {
 
         Task<?> actualTask = (Task<?>) codec.getValueDecoder().decode(Unpooled.wrappedBuffer(json.getBytes()), new State());
         Assertions.assertThat(actualTask.name).isEqualTo("name");
-        Assertions.assertThat(actualTask.args).hasSize(2);
+        Assertions.assertThat(actualTask.args).hasSize(1);
         Assertions.assertThat(actualTask.args).includes(entry("key", "value"));
-        Assertions.assertThat(actualTask.getUser()).isEqualTo(User.local());
     }
 
     @Test
     public void test_uri_result() throws Exception {
-        Task<?> task = new Task<>("name", User.local(), new HashMap<>());
+        Task<?> task = new Task<>("name", new HashMap<>());
         task.setResult(new UriResult(new URI("file://uri"), 123L));
 
         assertThat(encodeDecode(task).getResult()).isInstanceOf(UriResult.class);
@@ -45,7 +42,7 @@ public class TaskManagerRedisCodecTest {
 
     @Test
     public void test_simple_results() throws Exception {
-        Task<?> task = new Task<>("name", User.local(), new HashMap<>());
+        Task<?> task = new Task<>("name", new HashMap<>());
         task.setResult(123L);
         assertThat(encodeDecode(task).getResult()).isInstanceOf(Long.class);
 

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
@@ -58,7 +58,7 @@ public class TaskManagersIntTest {
                 "messageBusAddress", "amqp://admin:admin@rabbitmq"));
         final RedissonClient redissonClient = new RedissonClientFactory().withOptions(
             Options.from(propertiesProvider.getProperties())).create();
-        Map<String, Task<?>> amqpTasks = new RedissonMap<>(new TaskManagerRedis.TaskViewCodec(),
+        Map<String, TaskMetadata<?>> amqpTasks = new RedissonMap<>(new TaskManagerRedis.RedisCodec<>(TaskMetadata.class),
             new CommandSyncService(((Redisson) redissonClient).getConnectionManager(),
                 new RedissonObjectBuilder(redissonClient)),
             "tasks:queue:test",
@@ -97,7 +97,7 @@ public class TaskManagersIntTest {
     @Test(timeout = 10000)
     public void test_stop_running_task() throws Exception {
         eventWaiter.setWaiter(new CountDownLatch(2)); // 1 progress, 1 cancelled
-        String taskViewId = taskManager.startTask(TestFactory.SleepForever.class, User.local(), new HashMap<>());
+        String taskViewId = taskManager.startTask(TestFactory.SleepForever.class, new HashMap<>());
 
         taskInspector.awaitStatus(taskViewId, Task.State.RUNNING, 1, SECONDS);
         taskManager.stopTask(taskViewId);
@@ -112,8 +112,8 @@ public class TaskManagersIntTest {
     public void test_stop_queued_task() throws Exception {
         eventWaiter.setWaiter(new CountDownLatch(3)); // 1 progress, 2 cancelled
 
-        String tv1Id = taskManager.startTask(TestFactory.SleepForever.class, User.local(), new HashMap<>());
-        String tv2Id = taskManager.startTask(TestFactory.SleepForever.class, User.local(), new HashMap<>());
+        String tv1Id = taskManager.startTask(TestFactory.SleepForever.class, new HashMap<>());
+        String tv2Id = taskManager.startTask(TestFactory.SleepForever.class, new HashMap<>());
 
         taskInspector.awaitStatus(tv1Id, Task.State.RUNNING, 1, SECONDS);
         taskManager.stopTask(tv2Id);

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskTest.java
@@ -2,7 +2,6 @@ package org.icij.datashare.asynctasks;
 
 import org.fest.assertions.Assertions;
 import org.icij.datashare.json.JsonObjectMapper;
-import org.icij.datashare.user.User;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -12,14 +11,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
 
 public class TaskTest {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Test
     public void test_get_result_sync_when_task_is_running() throws InterruptedException {
-        Task<String> taskView = new Task<>("name", User.local(), new HashMap<>());
+        Task<String> taskView = new Task<>("name",  new HashMap<>());
         executor.execute(() -> {
             try {
                 taskView.getResult(1, TimeUnit.SECONDS);
@@ -45,14 +43,8 @@ public class TaskTest {
     }
 
     @Test
-    public void test_user_group_parameters() {
-        Task<Object> taskView = new Task<>("foo", User.local(), new Group("bar"), Map.of("baz", "qux"));
-        assertThat(taskView.args).includes(entry("group", new Group("bar")), entry("user", User.local()), entry("baz", "qux"));
-    }
-
-    @Test
     public void test_progress() {
-        Task<Object> taskView = new Task<>("name", User.local(), new HashMap<>());
+        Task<Object> taskView = new Task<>("name", new HashMap<>());
         assertThat(taskView.getProgress()).isEqualTo(0);
         assertThat(taskView.getState()).isEqualTo(Task.State.CREATED);
 
@@ -90,10 +82,9 @@ public class TaskTest {
 
     @Test
     public void test_serialize_deserialize() throws Exception {
-        Task<Object> taskView = new Task<>("name", User.local(), Map.of("key", "value"));
+        Task<Object> taskView = new Task<>("name", Map.of("key", "value"));
         String json = JsonObjectMapper.MAPPER.writeValueAsString(taskView);
         assertThat(json).contains("\"@type\":\"Task\"");
-        assertThat(json).contains("\"user\":{\"@type\":\"org.icij.datashare.user.User\"");
 
         Task<?> taskCreation = JsonObjectMapper.MAPPER.readValue(json, Task.class);
         assertThat(taskCreation).isEqualTo(taskView);

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.asynctasks;
 
-import org.icij.datashare.user.User;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -28,7 +27,7 @@ public class TaskWorkerLoopTest {
     @Test(timeout = 2000)
     public void test_loop() throws Exception {
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
-        Task<Serializable> taskView = new Task<>(TestFactory.HelloWorld.class.getName(), User.local(), Map.of("greeted", "world"));
+        Task<Serializable> taskView = new Task<>(TestFactory.HelloWorld.class.getName(), Map.of("greeted", "world"));
         Mockito.when(supplier.get(ArgumentMatchers.anyInt(), ArgumentMatchers.any())).thenReturn(taskView);
         CountDownLatch taskStarted = whenTaskHasStarted(taskView.id);
 
@@ -42,9 +41,9 @@ public class TaskWorkerLoopTest {
     }
 
     @Test(timeout = 2000)
-    public void test_unknown_task() throws Exception {
+    public void test_unknown_task() {
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
-        Task<Serializable> taskView = new Task<>("unknown_task", User.local(), Map.of());
+        Task<Serializable> taskView = new Task<>("unknown_task", Map.of());
 
         try {
             app.handle(taskView);
@@ -57,7 +56,7 @@ public class TaskWorkerLoopTest {
     @Test(timeout = 2000)
     public void test_cancel_task() throws Exception {
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
-        Task<Serializable> taskView = new Task<>(TestFactory.SleepForever.class.getName(), User.local(), Map.of());
+        Task<Serializable> taskView = new Task<>(TestFactory.SleepForever.class.getName(), Map.of());
         Mockito.when(supplier.get(ArgumentMatchers.anyInt(), ArgumentMatchers.any())).thenReturn(taskView);
         boolean requeue = false;
         CountDownLatch taskStarted = whenTaskHasStarted(taskView.id);
@@ -75,7 +74,7 @@ public class TaskWorkerLoopTest {
     @Test(timeout = 2000)
     public void test_cancel_task_and_requeue() throws Exception {
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
-        Task<Serializable> taskView = new Task<>(TestFactory.SleepForever.class.getName(), User.local(), Map.of());
+        Task<Serializable> taskView = new Task<>(TestFactory.SleepForever.class.getName(), Map.of());
         Mockito.when(supplier.get(ArgumentMatchers.anyInt(), ArgumentMatchers.any())).thenReturn(taskView);
         boolean requeue = true;
         CountDownLatch taskStarted = whenTaskHasStarted(taskView.id);
@@ -93,7 +92,7 @@ public class TaskWorkerLoopTest {
     @Test(timeout = 2000)
     public void test_task_interrupted() throws Exception {
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
-        Task<Serializable> taskView = new Task<>(TestFactory.SleepForever.class.getName(), User.local(), Map.of());
+        Task<Serializable> taskView = new Task<>(TestFactory.SleepForever.class.getName(), Map.of());
         Mockito.when(supplier.get(ArgumentMatchers.anyInt(), ArgumentMatchers.any())).thenReturn(taskView);
         CountDownLatch taskStarted = whenTaskHasStarted(taskView.id);
 


### PR DESCRIPTION
# ⚠️ Requires Redis migrations (I'm keen on learning how to do it)

# Bug description

This PR aims at addressing some of the serialization issues/descrepencies between `datashare.asynctasks` and `icij-worker`.
More precisely, `datashare.asynctasks` systematically includes the task `User` and `Group` inside the `Task.args`.

However inside `icij-worker` all task arguments are forwared to task functions, ending up in python `TypeError` because of extra arguments (namely `user` and `group`).

The bug hides the 2 following issues.

## `datashare-app` `User` concept leakage

`datashare.asynctasks` APIs use the `User` type which is a `datashare-app` concept. While this concept is used in the Datashare app, applications using a TM + workers won't necessarily use a `User` (which is a DS specific concept). In particular `icij-worker` as no knowledge of such concept, because most Python TM + worker applications won't use it. Basically, the `User` concept is leaking from `datashare-app` to all applications (including non Java application) following the `datashare.asynctasks` / `icij-worker` API.

## Leaking the internal `Group` concept to task implementers

`datashare.asynctasks` serializes the group inside task arguments, which implies that task functions must be able to have a `group` argument as input. However task functions dont need the `group` argument to be performed. The Group is a `datashare.asynctasks` / `icij-worker` "internal". Task implementers shouldn't need to include the `group` argument inside their task function to make them work.


## Fix

### Chosen fixes
I chose to remove the `User` concept from `datashare.asynctask` and move it inside `datashare-app`, where task are created with a `user` argument, this only task performs for datashare will need to feature this argument. `datashare-app` uses a `DatashareTaskManager` extends `TaskManager` which includes all User related API (which were removed from `TaskManager`). Additionnaly, the `DatashareTask` helper class was implemented to create task with a `user` arg. I choose no to create a `DatashareTask` class inheriting `Task` because this breaks the task serialization (`"@type": "DatashareTask"`).


I chose to align `datashare.asynctasks` behavior on the `icij-worker` one. Basically, when we create a task for the first time, we can assign a group to this task, hence, the TM has knowledge of the task group. The TM can keep track of task group rather than adding it to the task arguments.

### Discarded fixes

A first solution I thought about was to implement Python fix to this issue by systematically removing the `user` and `group` arguments from the args received from the broker.
However I quickly discard this options because it basically "reserved" the `group` and `user` argument names for task implementers. These names are quite commons, and if we systematically remove them, it means that task implementers can't use them. An alternative solution whould have been to explore the Python task arguments and filter out all misnamed arguments, but I don't really like this approach as it can lead to silent failures.


# Alternative implems
## `datashare-app` `User` concept leakage
To avoid leaking the `User` concept to the Python lib, we could also implement a `UserTask` in `datashare.asynctasks`.
This class would be used by `datashare-app` and Python service which don't use the user won't be forced to use it.

# Changes
## ⚠️ `datashare-tasks`
### Changed
- updated the `TaskManager` API to keep track of the `Group`. Rather than always calling `save` to create and then update tasks, we now use `saveMetadata` to persist a task and it group (and potentially other persistent metadata) for the first time, then we call `persisUpdate(Task<V> task)` to update the task itself, other persistent metadata remain untouched (basically once a task is saved with a group information, there's no reason to update it). This behavior is similar to the `icij-worker` behavior, where the group information is not persisted in task themselve, be it's the TM's responsibility to keep track of it.

### Removed
- remove all `User` related APIs

## ⚠️ `datashare-app`

### Changed
- created a `DatashareTaskManager` and `DatashareTask` to implement user related task APIs
