### PR TITLE
Fix: workers shutdown cli

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -1,6 +1,5 @@
 package org.icij.datashare;
 
-import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.cli.CliExtensionService;
 import org.icij.datashare.cli.spi.CliExtension;
@@ -101,38 +100,31 @@ class CliApp {
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
         if (pipeline.has(Stage.DEDUPLICATE)) {
-            taskManager.startTask(
-                    new Task<>(DeduplicateTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.SCANIDX)) {
-            taskManager.startTask(
-                    new Task<>(ScanIndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.SCAN)) {
-            taskManager.startTask(
-                    new Task<>(ScanTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.INDEX)) {
-            taskManager.startTask(
-                    new Task<>(IndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.ENQUEUEIDX)) {
-            taskManager.startTask(
-                    new Task<>(EnqueueFromIndexTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.NLP)) {
-            taskManager.startTask(
-                    new Task<>(ExtractNlpTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.ARTIFACT)) {
-            taskManager.startTask(
-                    new Task<>(ArtifactTask.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties));
         }
         taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS);
         taskManager.shutdown();

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -134,6 +134,7 @@ class CliApp {
             taskManager.startTask(
                     new Task<>(ArtifactTask.class.getName(), nullUser(), propertiesToMap(properties)));
         }
-        taskManager.shutdownAndAwaitTermination(Integer.MAX_VALUE, SECONDS);
+        taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS);
+        taskManager.shutdown();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -8,6 +8,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import net.codestory.http.Configuration;
 import net.codestory.http.annotations.Get;
@@ -153,14 +154,14 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         }
     }
 
-    @Provides
+    @Provides @Singleton
     RedissonClient provideRedissonClient() {
         CloseableRedissonClient redissonClient = new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).createCloseable();
         addCloseable(redissonClient);
         return redissonClient;
     }
 
-    @Provides
+    @Provides @Singleton
     org.icij.datashare.asynctasks.bus.amqp.AmqpInterlocutor provideAmqpInterlocutor() {
         AmqpInterlocutor amqp = null;
         try {
@@ -173,7 +174,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         return amqp;
     }
 
-    @Provides
+    @Provides @Singleton
     DocumentCollectionFactory<Path> provideScanQueue(final PropertiesProvider propertiesProvider) {
         return switch (getQueueType(propertiesProvider, QUEUE_TYPE_OPT, QueueType.MEMORY)) {
             case MEMORY -> new MemoryDocumentCollectionFactory<>();
@@ -181,7 +182,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         };
     }
 
-    @Provides
+    @Provides @Singleton
     DocumentCollectionFactory<String> provideIndexQueue(final PropertiesProvider propertiesProvider) {
         return switch (getQueueType(propertiesProvider, QUEUE_TYPE_OPT, QueueType.MEMORY)) {
             case MEMORY -> new MemoryDocumentCollectionFactory<>();
@@ -189,19 +190,19 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         };
     }
 
-    @Provides
+    @Provides @Singleton
     Indexer provideIndexer() {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(createESClient(propertiesProvider), propertiesProvider);
         addCloseable(indexer);
         return indexer;
     }
 
-    @Provides
+    @Provides @Singleton
     LanguageGuesser provideLanguageGuesser() throws IOException {
         return new OptimaizeLanguageGuesser();
     }
 
-    @Provides
+    @Provides @Singleton
     org.icij.datashare.extension.PipelineRegistry providePipelineRegistry(final PropertiesProvider propertiesProvider) {
         PipelineRegistry pipelineRegistry = new PipelineRegistry(propertiesProvider);
         pipelineRegistry.register(EmailPipeline.class);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -23,7 +23,9 @@ import java.util.function.Function;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_POLLING_INTERVAL_SEC;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_OPT;
 
 @TaskGroup("Java")
 public class ArtifactTask extends PipelineTask<String> {
@@ -31,35 +33,35 @@ public class ArtifactTask extends PipelineTask<String> {
     private final Indexer indexer;
     private final Project project;
     private final Path artifactDir;
+    private final int pollingInterval;
 
     @Inject
     public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
         super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class);
         this.indexer = indexer;
         project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
+        pollingInterval = Integer.parseInt(propertiesProvider.get(POLLING_INTERVAL_OPT).orElse(DEFAULT_POLLING_INTERVAL_SEC));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
     }
 
     @Override
     public Long call() throws Exception {
         super.call();
-        logger.info("creating artifact cache in {} for project {} from queue {}", artifactDir, project, inputQueue.getName());
+        logger.info("creating artifact cache in {} for project {} from queue {} with polling interval {}s", artifactDir, project, inputQueue.getName(), pollingInterval);
         SourceExtractor extractor = new SourceExtractor(propertiesProvider);
         List<String> sourceExcludes = List.of("content", "content_translated");
         String docId;
         long nbDocs = 0;
-        while (!(STRING_POISON.equals(docId = inputQueue.poll(60, TimeUnit.SECONDS)))) {
+        while ((docId = inputQueue.poll(pollingInterval, TimeUnit.SECONDS)) != null) {
             try {
-                if (docId != null) {
-                    Document doc = indexer.get(project.name, docId, sourceExcludes);
-                    extractor.extractEmbeddedSources(project, doc);
-                    nbDocs++;
-                }
+                Document doc = indexer.get(project.name, docId, sourceExcludes);
+                extractor.extractEmbeddedSources(project, doc);
+                nbDocs++;
             } catch (Throwable e) {
                 logger.error("error in ArtifactTask loop", e);
             }
         }
-        logger.info("exiting ArtifactTask loop after {} document(s).", nbDocs);
+        logger.info("exiting ArtifactTask loop after processing {} document(s).", nbDocs);
         return nbDocs;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
@@ -77,13 +77,11 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
         try (DocumentQueue<String> outputQueue = factory.createQueue(getOutputQueueName(), String.class)) {
             do {
                 docsToProcess.forEach(doc -> outputQueue.add(doc.getId()));
-                docsToProcess = searcher.scroll(scrollDuration).collect(toList());
+                docsToProcess = searcher.scroll(scrollDuration).toList();
             } while (!docsToProcess.isEmpty());
-            outputQueue.add(STRING_POISON);
-            logger.info("enqueued into {} {} files", outputQueue.getName(), totalHits);
             searcher.clearScroll();
         }
-
+        logger.info("enqueued into {} {} files", outputQueue.getName(), totalHits);
         return totalHits;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
@@ -3,31 +3,36 @@ package org.icij.datashare.tasks;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.cli.DatashareCliOptions;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.extract.redis.RedissonClientFactory;
 import org.icij.task.Options;
-import org.jetbrains.annotations.NotNull;
 import org.redisson.api.RedissonClient;
 
 @Singleton
 public class TaskManagerRedis extends org.icij.datashare.asynctasks.TaskManagerRedis {
+    private final int pollingIntervalMs; // for tests
 
     // Convenience class made to ease injection and test
     @Inject
     public TaskManagerRedis(RedissonClient redissonClient, PropertiesProvider propertiesProvider) {
-        this(redissonClient, CommonMode.DS_TASK_MANAGER_MAP_NAME, Utils.getRoutingStrategy(propertiesProvider), null);
+        this(redissonClient, CommonMode.DS_TASK_MANAGER_MAP_NAME, Utils.getRoutingStrategy(propertiesProvider), null, POLLING_INTERVAL);
     }
 
     public TaskManagerRedis(PropertiesProvider propertiesProvider) {
-        this(propertiesProvider, CommonMode.DS_TASK_MANAGER_MAP_NAME, null);
+        this(propertiesProvider, CommonMode.DS_TASK_MANAGER_MAP_NAME, null, POLLING_INTERVAL);
     }
 
-    TaskManagerRedis(PropertiesProvider propertiesProvider, String taskMapName, Runnable eventCallback) {
-        this(new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create(), taskMapName, Utils.getRoutingStrategy(propertiesProvider), eventCallback);
+    TaskManagerRedis(PropertiesProvider propertiesProvider, String taskMapName, Runnable eventCallback, int pollingIntervalMs) {
+        this(new RedissonClientFactory().withOptions(Options.from(propertiesProvider.getProperties())).create(), taskMapName, Utils.getRoutingStrategy(propertiesProvider), eventCallback, pollingIntervalMs);
     }
 
-    TaskManagerRedis(RedissonClient redissonClient, String taskMapName, RoutingStrategy routingStrategy, Runnable eventCallback) {
+    TaskManagerRedis(RedissonClient redissonClient, String taskMapName, RoutingStrategy routingStrategy, Runnable eventCallback, int pollingIntervalMs) {
         super(redissonClient, taskMapName, routingStrategy, eventCallback);
+        this.pollingIntervalMs = pollingIntervalMs;
+    }
+
+    @Override
+    public int getTerminationPollingInterval() {
+        return pollingIntervalMs;
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
@@ -56,7 +56,7 @@ public class CliModeWorkerAcceptanceTest {
         workerApp.start();
         workerStarted.await();
 
-        mode.get(TaskManager.class).shutdownAndAwaitTermination(1, TimeUnit.SECONDS); // to send shutdown
+        mode.get(TaskManager.class).awaitTermination(1, TimeUnit.SECONDS); // to send shutdown
         workerApp.join();
         mode.get(Indexer.class).close();
     }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
@@ -56,7 +56,8 @@ public class CliModeWorkerAcceptanceTest {
         workerApp.start();
         workerStarted.await();
 
-        mode.get(TaskManager.class).awaitTermination(1, TimeUnit.SECONDS); // to send shutdown
+        mode.get(TaskManager.class).shutdown(); // to send shutdown
+        mode.get(TaskManager.class).awaitTermination(1, TimeUnit.SECONDS);
         workerApp.join();
         mode.get(Indexer.class).close();
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -31,17 +32,20 @@ public class ArtifactTaskTest {
         new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void test_create_artifact_cache_one_file() throws Exception {
-        Path path = Path.of(getClass().getResource("/docs/embedded_doc.eml").getPath());
+        Path path = Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).getPath());
         String sha256 = "0f95ef97e4619f7bae2a585c6cf24587cd7a3a81a26599c8774d669e5c175e5e";
         mockIndexer.indexFile("prj", sha256, path, "message/rfc822");
 
         DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
         queue.add(sha256);
-        queue.add("POISON");
 
-        Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of("artifactDir", artifactDir.getRoot().toString(), "defaultProject", "prj")),
+        Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1"
+                )),
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
@@ -41,7 +41,7 @@ public class EnqueueFromIndexTaskTest {
         MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
         EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
         enqueueFromIndex.call();
-        assertThat(factory.queues.get("test:queue:nlp")).hasSize(21); // with poison
+        assertThat(factory.queues.get("test:queue:nlp")).hasSize(20);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class EnqueueFromIndexTaskTest {
         MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
         EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
         enqueueFromIndex.call();
-        assertThat(factory.queues.get("test:queue:nlp")).hasSize(2); // with poison
+        assertThat(factory.queues.get("test:queue:nlp")).hasSize(1);
     }
 
     @Test
@@ -79,6 +79,6 @@ public class EnqueueFromIndexTaskTest {
         MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
         EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer, new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
         enqueueFromIndex.call();
-        assertThat(factory.queues.get("test:queue:nlp")).hasSize(2); // with poison
+        assertThat(factory.queues.get("test:queue:nlp")).hasSize(1);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
@@ -58,13 +58,13 @@ public class TaskManagerMemoryForBatchSearchTest {
     }
 
     @Test(timeout = 2000)
-    public void test_main_loop_exit_with_sigterm_when_empty_batch_queue() throws InterruptedException {
+    public void test_main_loop_exit_with_sigterm_when_empty_batch_queue() throws Exception {
         startLoop.await();
 
         Signal term = new Signal("TERM");
         Signal.raise(term);
 
-        assertThat(taskManager.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(taskManager.awaitTermination(1, TimeUnit.SECONDS)).isFalse();
     }
 
     @Test(timeout = 2000)

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
@@ -51,7 +51,7 @@ public class TaskManagerMemoryForBatchSearchTest {
     public void test_main_loop() throws Exception {
         mockSearch.willReturn(1, createDoc("doc1").build(), createDoc("doc2").build());
         taskManager.startTask(testBatchSearch.uuid, BatchSearchRunner.class, local());
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
 
         verify(repository).setState(testBatchSearch.uuid, BatchSearch.State.RUNNING);
         verify(repository).setState(testBatchSearch.uuid, BatchSearch.State.SUCCESS);
@@ -64,7 +64,7 @@ public class TaskManagerMemoryForBatchSearchTest {
         Signal term = new Signal("TERM");
         Signal.raise(term);
 
-        assertThat(taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(taskManager.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
     }
 
     @Test(timeout = 2000)
@@ -78,7 +78,7 @@ public class TaskManagerMemoryForBatchSearchTest {
 
         countDownLatch.await();
         Signal.raise(new Signal("TERM"));
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
 
         assertThat(DatashareTime.getInstance().now().getTime() - beforeTest.getTime()).isEqualTo(100);
         assertThat(taskManager.getTasks()).hasSize(1);
@@ -91,7 +91,7 @@ public class TaskManagerMemoryForBatchSearchTest {
         mockSearch.willThrow(new IOException("io exception"));
 
         taskManager.startTask(new Task<>(testBatchSearch.uuid, BatchSearchRunner.class.getName(), local(), new Group("TestGroup")));
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
 
         verify(repository).setState(testBatchSearch.uuid, BatchSearch.State.RUNNING);
         verify(repository).setState(eq(testBatchSearch.uuid), any(SearchException.class));
@@ -129,7 +129,7 @@ public class TaskManagerMemoryForBatchSearchTest {
         Signal term = new Signal("TERM");
         Signal.raise(term);
 
-        assertThat(taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(taskManager.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
         assertThat(batchSearchRunner.cancelAsked).isTrue();
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
@@ -108,8 +108,8 @@ public class TaskManagerMemoryForBatchSearchTest {
         when(factory.createBatchSearchRunner(any(), any())).thenReturn(bsr1, bsr2);
         when(repository.get(bs1.uuid)).thenReturn(bs1);
         when(repository.get(bs2.uuid)).thenReturn(bs2);
-        String taskView1Id = taskManager.startTask(bs1.uuid, BatchSearchRunner.class, bs1.user);
-        String taskView2Id = taskManager.startTask(bs2.uuid, BatchSearchRunner.class, bs2.user);
+        taskManager.startTask(bs1.uuid, BatchSearchRunner.class, bs1.user);
+        taskManager.startTask(bs2.uuid, BatchSearchRunner.class, bs2.user);
 
         bs1Started.await();
         Signal.raise(new Signal("TERM"));

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
@@ -88,7 +88,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
 
     private void testTaskWithTaskRunner(Task<Long> task) throws Exception {
         taskSupplier.startTask(task.name, User.local(), task.args);
-        taskSupplier.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskSupplier.awaitTermination(1, TimeUnit.SECONDS);
 
         assertThat(taskSupplier.getTasks()).hasSize(1);
         assertThat(taskSupplier.getTasks().get(0).name).isEqualTo(task.name);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
@@ -44,7 +44,7 @@ public class TaskWorkerLoopIntTest {
         taskManager.startTask(BatchDownloadRunner.class.getName(), User.local(), properties);
         Thread.sleep(100); // this is a symptom of a possible flaky test but for now I can't figure out how to be event driven
 
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
         eventWaiter.await();
 
         assertThat(taskManager.getTasks()).hasSize(1);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
@@ -27,7 +27,7 @@ public class TaskWorkerLoopIntTest {
     TaskManagerRedis taskManager;
     CountDownLatch eventWaiter;
 
-    @Test(timeout = 5000)
+    @Test(timeout = 10000)
     public void test_batch_download_task_view_properties() throws Exception {
         DatashareTaskFactory factory = mock(DatashareTaskFactory.class);
         BatchDownload batchDownload = new BatchDownload(singletonList(project("prj")), User.local(), "foo");
@@ -57,7 +57,7 @@ public class TaskWorkerLoopIntTest {
     @Before
     public void setUp() throws Exception {
         eventWaiter = new CountDownLatch(2); // progress, error
-        taskManager = new TaskManagerRedis(new PropertiesProvider(), "test:task:manager", eventWaiter::countDown);
+        taskManager = new TaskManagerRedis(new PropertiesProvider(), "test:task:manager", eventWaiter::countDown, 100);
     }
 
     @After

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -83,7 +84,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_index_file() {
+    public void test_index_file() throws IOException {
         RestAssert response = post("/api/task/batchUpdate/index/" + getClass().getResource("/docs/doc.txt").getPath().substring(1), "{}");
 
         ShouldChain responseBody = response.should().haveType("application/json");
@@ -107,7 +108,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_index_file_and_filter() {
+    public void test_index_file_and_filter() throws IOException {
         String body = "{\"options\":{\"filter\": true}}";
         RestAssert response = post("/api/task/batchUpdate/index/" + getClass().getResource("/docs/doc.txt").getPath().substring(1), body);
 
@@ -122,7 +123,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_index_file_and_filter_with_custom_report_map() {
+    public void test_index_file_and_filter_with_custom_report_map() throws IOException {
         String body = "{\"options\":{\"filter\": true, \"defaultProject\": \"foo\"}}";
         RestAssert response = post("/api/task/batchUpdate/index/" + getClass().getResource("/docs/doc.txt").getPath().substring(1), body);
 
@@ -137,7 +138,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_index_file_and_filter_with_custom_queue() {
+    public void test_index_file_and_filter_with_custom_queue() throws IOException {
         String body = "{\"options\":{\"filter\": true, \"defaultProject\": \"foo\"}}";
         RestAssert response = post("/api/task/batchUpdate/index/" + getClass().getResource("/docs/doc.txt").getPath().substring(1), body);
 
@@ -149,12 +150,12 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_index_directory() {
+    public void test_index_directory() throws IOException {
         RestAssert response = post("/api/task/batchUpdate/index/file/" + getClass().getResource("/docs/").getPath().substring(1), "{}");
 
         ShouldChain responseBody = response.should().haveType("application/json");
 
-        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).collect(toList());
+        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).toList();
         responseBody.should().contain(taskNames.get(0));
         responseBody.should().contain(taskNames.get(1));
     }
@@ -172,7 +173,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_index_and_scan_directory_with_options() {
-        String path = getClass().getResource("/docs").getPath();
+        String path = Objects.requireNonNull(getClass().getResource("/docs")).getPath();
 
         RestAssert response = post("/api/task/batchUpdate/index/" + path.substring(1),
                 "{\"options\":{\"foo\":\"baz\",\"key\":\"val\"}}");
@@ -212,14 +213,14 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_scan_with_options() {
+    public void test_scan_with_options() throws IOException {
         String path = getClass().getResource("/docs").getPath();
         RestAssert response = post("/api/task/batchUpdate/scan/" + path.substring(1),
                 "{\"options\":{\"key\":\"val\",\"foo\":\"qux\"}}");
 
         ShouldChain responseBody = response.should().haveType("application/json");
 
-        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).collect(toList());
+        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).toList();
         assertThat(taskNames.size()).isEqualTo(1);
         responseBody.should().contain(taskNames.get(0));
         Map<String, Object> defaultProperties = getDefaultProperties();
@@ -231,48 +232,48 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_scan_queue_is_created_correctly() {
+    public void test_scan_queue_is_created_correctly() throws IOException {
         String body = "{\"options\":{\"filter\": true, \"defaultProject\": \"foo\"}}";
-        String path = getClass().getResource("/docs/").getPath();
+        String path = Objects.requireNonNull(getClass().getResource("/docs/")).getPath();
         RestAssert response = post("/api/task/batchUpdate/scan/" + path.substring(1), body);
         response.should().haveType("application/json");
-        taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).collect(toList());
+        taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).toList();
 
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().args).
                 includes(entry("queueName", "extract:queue:foo:1725215461"));
     }
 
     @Test
-    public void test_digest_project_name_is_created_correctly() {
+    public void test_digest_project_name_is_created_correctly() throws IOException {
         String body = "{\"options\":{\"filter\": true, \"defaultProject\": \"foo\"}}";
-        String path = getClass().getResource("/docs/").getPath();
+        String path = Objects.requireNonNull(getClass().getResource("/docs/")).getPath();
         RestAssert response = post("/api/task/batchUpdate/scan/" + path.substring(1), body);
         response.should().haveType("application/json");
-        taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).collect(toList());
+        taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).toList();
 
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().args).
                 includes(entry("digestProjectName", "foo"));
     }
 
     @Test
-    public void test_scan_queue_is_created_correctly_and_options_ignored() {
+    public void test_scan_queue_is_created_correctly_and_options_ignored() throws IOException {
         String body = "{\"options\":{\"filter\": true, \"defaultProject\": \"foo\", \"queueName\": \"bar\"}}";
-        String path = getClass().getResource("/docs/").getPath();
+        String path = Objects.requireNonNull(getClass().getResource("/docs/")).getPath();
         RestAssert response = post("/api/task/batchUpdate/scan/" + path.substring(1), body);
         response.should().haveType("application/json");
-        taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).collect(toList());
+        taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).toList();
 
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().args).
                 includes(entry("queueName", "extract:queue:foo:1725215461"));
     }
 
     @Test
-    public void test_findNames_should_create_resume() {
+    public void test_findNames_should_create_resume() throws IOException {
         RestAssert response = post("/api/task/findNames/EMAIL", "{\"options\":{\"waitForNlpApp\": false}}");
 
         response.should().haveType("application/json");
 
-        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).collect(toList());
+        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).toList();
         assertThat(taskNames.size()).isEqualTo(2);
 
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.EnqueueFromIndexTask")).isNotNull();
@@ -348,9 +349,9 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_clean_tasks() {
+    public void test_clean_tasks() throws IOException {
         post("/api/task/batchUpdate/index/file/" + getClass().getResource("/docs/doc.txt").getPath().substring(1), "{}").response();
-        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).collect(toList());
+        List<String> taskNames = taskManager.waitTasksToBeDone(1, SECONDS).stream().map(t -> t.id).toList();
 
         ShouldChain responseBody = post("/api/task/clean", "{}").should().haveType("application/json");
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
@@ -42,7 +42,7 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
     private TaskManagerMemory taskManager;
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         taskManager.waitTasksToBeDone(1, SECONDS);
         taskManager.clearDoneTasks();
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -190,6 +190,7 @@ public class DatashareCli {
         DatashareCliOptions.searchQuery(parser);
         DatashareCliOptions.taskRoutingStrategy(parser);
         DatashareCliOptions.taskRoutingKey(parser);
+        DatashareCliOptions.pollingInterval(parser);
         return parser;
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -126,6 +126,7 @@ public final class DatashareCliOptions {
     public static final String TASK_ROUTING_STRATEGY_OPT = "taskRoutingStrategy";
     public static final String TASK_ROUTING_KEY_OPT = "taskRoutingKey";
     public static final String OAUTH_USER_PROJECTS_KEY_OPT = "oauthUserProjectsAttribute";
+    public static final String POLLING_INTERVAL_OPT = "pollingInterval";
 
 
     private static final Path DEFAULT_DATASHARE_HOME = Paths.get(System.getProperty("user.home"), ".local/share/datashare");
@@ -174,6 +175,7 @@ public final class DatashareCliOptions {
     public static final int DEFAULT_SESSION_TTL_SECONDS = 43200;
     public static final String DEFAULT_MAX_CONTENT_LENGTH = "20000000";
     public static final RoutingStrategy DEFAULT_TASK_ROUTING_STRATEGY = RoutingStrategy.UNIQUE;
+    public static final String DEFAULT_POLLING_INTERVAL_SEC = "60";
 
     // A list of aliases for retro-compatibility when an option changed
     public static final Map<String, String> OPT_ALIASES = Map.ofEntries(
@@ -826,6 +828,12 @@ public final class DatashareCliOptions {
         parser.acceptsAll(singletonList(SEARCH_QUERY_OPT), "Json query for filtering index matches for EnqueueFromIndex task.")
                 .withRequiredArg()
                 .ofType(String.class);
+    }
+
+    public static void pollingInterval(OptionParser parser) {
+        parser.acceptsAll(singletonList(POLLING_INTERVAL_OPT), "Queue polling interval.")
+                .withRequiredArg()
+                .ofType(String.class).defaultsTo("60");
     }
 
     public static ValueConverter<String> toAbsolute() {

--- a/datashare-index/src/main/java/org/icij/datashare/extract/MemoryDocumentCollectionFactory.java
+++ b/datashare-index/src/main/java/org/icij/datashare/extract/MemoryDocumentCollectionFactory.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.extract;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.icij.extract.queue.DocumentQueue;
 import org.icij.extract.queue.MemoryDocumentQueue;
@@ -22,8 +23,8 @@ public class MemoryDocumentCollectionFactory<T> implements DocumentCollectionFac
 
     @Override
     public DocumentQueue<T> createQueue(String queueName, Class<T> clazz) {
-        if (!queues.containsKey(queueName)) {
-            synchronized (queues) {
+        synchronized (queues) {
+            if (!queues.containsKey(queueName)) {
                 queues.put(queueName, new MemoryDocumentQueue<>(queueName, QUEUE_CAPACITY));
             }
         }
@@ -32,8 +33,8 @@ public class MemoryDocumentCollectionFactory<T> implements DocumentCollectionFac
 
     @Override
     public ReportMap createMap(String mapName) {
-        if (!maps.containsKey(mapName)) {
-            synchronized (maps) {
+        synchronized (maps) {
+            if (!maps.containsKey(mapName)) {
                 maps.putIfAbsent(mapName, new HashMapReportMap());
             }
         }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
@@ -86,6 +86,16 @@ public class Task<V> extends Event implements Entity {
         return result;
     }
 
+    /**
+     * Beware that the lock is working only on a "local" use.
+     * If the task is serialized/deserialized then the lock won't do anything
+     * because the lock instance will change.
+     *
+     * @param timeout
+     * @param unit
+     * @return
+     * @throws InterruptedException
+     */
     public V getResult(int timeout, TimeUnit unit) throws InterruptedException {
         synchronized (lock) {
             if (!isFinished()) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
@@ -195,7 +195,7 @@ public interface TaskManager extends Closeable {
      *
      * @param timeout amount for the timeout
      * @param timeUnit unit of the timeout
-     * @return the list of tasks
+     * @return the list of unfinished/alive tasks
      * @throws IOException if the task list cannot be retrieved because of a network failure.
      */
     default List<Task<?>> waitTasksToBeDone(int timeout, TimeUnit timeUnit) throws IOException {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
@@ -71,18 +71,18 @@ public class TaskManagerAmqp implements TaskManager {
     }
 
     @Override
-    public boolean shutdownAndAwaitTermination(int timeout, TimeUnit timeUnit) throws InterruptedException, IOException {
+    public boolean shutdown() throws IOException {
         amqp.publish(AmqpQueue.WORKER_EVENT, new ShutdownEvent());
         return true;
     }
 
-    public boolean save(Task<?> task) {
+    public <V> boolean save(Task<V> task) {
         Task<?> oldVal = tasks.put(task.id, task);
         return oldVal == null;
     }
 
     @Override
-    public void enqueue(Task<?> task) throws IOException {
+    public <V> void enqueue(Task<V> task) throws IOException {
         switch (routingStrategy) {
             case GROUP -> amqp.publish(AmqpQueue.TASK, task.getGroup().id(), task);
             case NAME -> amqp.publish(AmqpQueue.TASK, task.name, task);

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
@@ -173,6 +173,17 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
         executor.shutdown();
     }
 
+    @Override
+    public List<Task<?>> waitTasksToBeDone(int timeout, TimeUnit timeUnit) throws IOException {
+        return getTasks().stream().peek(taskView -> {
+            try {
+                taskView.getResult(timeout, timeUnit);
+            } catch (InterruptedException e) {
+                logger.error("getResult interrupted while waiting for result", e);
+            }
+        }).toList();
+    }
+
     int numberOfExecutedTasks() {
         return executedTasks.get();
     }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
@@ -103,30 +103,25 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
         }
     }
 
-    public boolean save(Task<?> taskView) {
+    public <V> boolean save(Task<V> taskView) {
         Task<?> oldTask = tasks.put(taskView.id, taskView);
         return oldTask == null;
     }
 
     @Override
-    public void enqueue(Task<?> task) {
+    public <V> void enqueue(Task<V> task) {
         taskQueue.add(task);
     }
 
-    public boolean shutdownAndAwaitTermination(int timeout, TimeUnit timeUnit) throws InterruptedException {
+    public boolean awaitTermination(int timeout, TimeUnit timeUnit) throws IOException, InterruptedException {
         waitTasksToBeDone(timeout, timeUnit);
-        executor.shutdownNow();
         return executor.awaitTermination(timeout, timeUnit);
     }
 
-    public List<Task<?>> waitTasksToBeDone(int timeout, TimeUnit timeUnit) {
-        return tasks.values().stream().peek(taskView -> {
-            try {
-                taskView.getResult(timeout, timeUnit);
-            } catch (InterruptedException | CancellationException e) {
-                logger.error("task interrupted while running", e);
-            }
-        }).collect(toList());
+    @Override
+    public boolean shutdown() throws IOException {
+        executor.shutdown();
+        return true;
     }
 
     public List<Task<?>> clearDoneTasks() {

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.event.Level;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -119,6 +120,12 @@ public class TaskManagerMemoryTest {
             "unknown task id <unknownId> for result=0.5 call");
     }
 
+    @Test
+    public void test_wait_task_to_be_done() throws Exception {
+        taskManager.startTask(TestFactory.Sleep.class, User.local(), Map.of("duration", 100));
+        List<Task<?>> tasks = taskManager.waitTasksToBeDone(200, TimeUnit.MILLISECONDS);
+        assertThat(tasks).hasSize(1);
+    }
 
     @After
     public void tearDown() throws Exception {

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -40,7 +40,7 @@ public class TaskManagerMemoryTest {
         Task<Integer> task = new Task<>(TestFactory.HelloWorld.class.getName(), User.local(), Map.of("greeted", "world"));
 
         String tid = taskManager.startTask(task);
-        taskManager.shutdownAndAwaitTermination(100, TimeUnit.MILLISECONDS);
+        taskManager.awaitTermination(100, TimeUnit.MILLISECONDS);
 
         assertThat(taskManager.getTask(tid).getState()).isEqualTo(Task.State.DONE);
         assertThat(taskManager.getTask(tid).getResult()).isEqualTo("Hello world!");
@@ -54,7 +54,7 @@ public class TaskManagerMemoryTest {
 
         taskInspector.awaitToBeStarted(taskId, 10000);
         taskManager.stopTask(taskId);
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
 
         assertThat(taskManager.getTask(taskId).getState()).isEqualTo(Task.State.CANCELLED);
         assertThat(taskManager.numberOfExecutedTasks()).isEqualTo(0);
@@ -72,7 +72,7 @@ public class TaskManagerMemoryTest {
         taskManager.stopTask(t2.id); // the second is still in the queue
         taskManager.stopTask(t1.id);
 
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
         assertThat(t2.getState()).isEqualTo(Task.State.CANCELLED);
         assertThat(taskManager.numberOfExecutedTasks()).isEqualTo(0);
         assertThat(taskManager.getTasks()).hasSize(2);
@@ -83,7 +83,7 @@ public class TaskManagerMemoryTest {
         Task<Integer> task = new Task<>("sleep", User.local(), Map.of("intParameter", 12));
 
         taskManager.startTask(task);
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
         assertThat(taskManager.getTasks()).hasSize(1);
 
         taskManager.clearTask(task.id);
@@ -96,7 +96,7 @@ public class TaskManagerMemoryTest {
         Task<Integer> task = new Task<>("sleep", User.local(), Map.of("intParameter", 12));
 
         taskManager.startTask(task);
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
         taskManager.progress(task.id, 0.5);
         assertThat(taskManager.getTask(task.id).getState()).isEqualTo(Task.State.RUNNING);
 
@@ -104,16 +104,16 @@ public class TaskManagerMemoryTest {
     }
 
     @Test
-    public void test_progress_on_unknown_task() throws InterruptedException {
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+    public void test_progress_on_unknown_task() throws Exception {
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
         taskManager.progress("unknownId", 0.5);
         assertThat(logbackCapturingRule.logs(Level.WARN)).contains(
             "unknown task id <unknownId> for progress=0.5 call");
     }
 
     @Test
-    public void test_result_on_unknown_task() throws InterruptedException {
-        taskManager.shutdownAndAwaitTermination(1, TimeUnit.SECONDS);
+    public void test_result_on_unknown_task() throws Exception {
+        taskManager.awaitTermination(1, TimeUnit.SECONDS);
         taskManager.result("unknownId", 0.5);
         assertThat(logbackCapturingRule.logs(Level.WARN)).contains(
             "unknown task id <unknownId> for result=0.5 call");

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisTest.java
@@ -91,7 +91,6 @@ public class TaskManagerRedisTest {
         String taskViewId = taskManager.startTask("sleep", User.local(), new HashMap<>());
 
         assertThat(taskManager.getTasks()).hasSize(1);
-        System.out.println(taskManager.getTasks());
 
         taskSupplier.result(taskViewId, 12);
         assertThat(waitForEvent.await(1, TimeUnit.SECONDS)).isTrue();

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
@@ -126,7 +126,7 @@ public class TaskManagersIntTest {
         assertThat(taskManager.getTask(tv2Id).getState()).isEqualTo(Task.State.CANCELLED);
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 10000)
     public void test_await_tasks_termination() throws Exception {
         String tv1Id = taskManager.startTask(TestFactory.Sleep.class, User.local(), Map.of("duration", 100));
         String tv2Id = taskManager.startTask(TestFactory.Sleep.class, User.local(), Map.of("duration", 200));

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TestFactory.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TestFactory.java
@@ -45,7 +45,7 @@ public class TestFactory implements TaskFactory {
     }
 
     @TaskGroup("TestGroup")
-    public static class Sleep implements Callable<Void> {
+    public static class Sleep implements Callable<Integer> {
         private final Function<Double, Void> progress;
         private final int duration;
 
@@ -55,9 +55,9 @@ public class TestFactory implements TaskFactory {
             this.duration = (int) taskView.args.get("duration");
         }
         @Override
-        public Void call() throws Exception {
+        public Integer call() throws Exception {
             Thread.sleep(duration);
-            return null;
+            return duration;
         }
     }
 


### PR DESCRIPTION
This PR fixes several issues:

- task CLI should handle the task `GROUP`
- missing singleton annotations that created several instances of services
- the waitForTasks that used an object instance lock with network access. It doesn't work because instance lock is changing at each network retrieval
- split of `shutdownAndAwaitTermination(timeout)` in two methods `shutdown()` and `awaitTermination(timeout)` 

see #1598 