### PR TITLE
feat: allows to return OpenAPI yaml format

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/OpenApiResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/OpenApiResource.java
@@ -3,24 +3,41 @@ package org.icij.datashare.web;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Singleton;
 import io.swagger.v3.core.util.Json31;
+import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.models.OpenAPI;
 import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Prefix;
+import net.codestory.http.errors.BadRequestException;
 import net.codestory.http.payload.Payload;
 import org.icij.swagger.FluentReader;
 
+import static java.util.Optional.ofNullable;
 import static org.icij.swagger.ClassUtils.findAllClassesUsingClassLoader;
 
 @Singleton
-@Prefix("/api/openapi")
+@Prefix("/api/openapi?format=:format")
 public class OpenApiResource {
-    @Operation(description = "Get the JSON OpenAPI v3 contract specification")
-    @ApiResponse(responseCode = "200", description="returns the JSON file")
+    @Operation(description = "Get the JSON or YAML OpenAPI v3 contract specification",
+            parameters = {
+                @Parameter(name = "format",
+                    description = "format of openapi description. Possible values are \"json\" or \"yaml\". Default=\"json\".",
+                    in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponse(responseCode = "200", description="returns the JSON or YAML file")
     @Get()
-    public Payload get() {
+    public Payload get(String format) {
         final OpenAPI openAPI = new FluentReader().read(findAllClassesUsingClassLoader(getClass().getPackageName()));
-        return new Payload("text/json", Json31.mapper().convertValue(openAPI, ObjectNode.class).toString());
+        if ("json".equals(ofNullable(format).orElse("json"))) {
+            return new Payload("text/json", Json31.mapper().convertValue(openAPI, ObjectNode.class).toString());
+        } else if ("yaml".equals(format)) {
+            return new Payload("text/yaml", Yaml31.pretty(openAPI));
+        } else {
+            throw new BadRequestException();
+        }
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/OpenApiResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/OpenApiResourceTest.java
@@ -12,6 +12,12 @@ public class OpenApiResourceTest extends AbstractProdWebServerTest {
                 haveType("text/json").
                 contain("\"openapi\":\"3.0.1\"");
     }
+    @Test
+    public void test_get_yaml() {
+        get("/api/openapi?format=yaml").should().respond(200).
+                haveType("text/yaml").
+                contain("openapi: 3.0.1");
+    }
 
     @Before
     public void setUp() {


### PR DESCRIPTION
We thought that it would help to use html description texts in the openapi documentation but it didn't :(

As the impact is not that important in the code, we could keep the changes.

what do you think?