### PR TITLE
Fix: openapi html to md documentation

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/ApiKeyResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ApiKeyResource.java
@@ -55,7 +55,7 @@ public class ApiKeyResource {
         }},200);
     }
 
-    @Operation(description = "Deletes an apikey for current user. Only available in SERVER mode.")
+    @Operation(description = "Deletes an apikey for current user. Only available in `SERVER` mode.")
     @ApiResponse(responseCode = "204", description = "when key has been deleted")
     @Delete("/:userId")
     public Payload deleteKey(@Parameter(name = "userId", description = "user identifier", in = ParameterIn.PATH) String userId,Context context) throws Exception {

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -45,8 +45,10 @@ public class BatchSearchResource {
         this.propertiesProvider = propertiesProvider;
     }
 
-    @Operation(description = "Retrieves the batch search list for the user issuing the request filter with the given criteria, and the total of batch searches matching the criteria.<br>" +
-            "If from/size are not given their default values are 0, meaning that all the results are returned. BatchDate must be a list of 2 items (the first one for the starting date and the second one for the ending date) If defined publishState is a string equals to \"0\" or \"1\"",
+    @Operation(description = """
+            Retrieves the batch search list for the user issuing the request filter with the given criteria, and the total of batch searches matching the criteria.
+            
+            If from/size are not given their default values are 0, meaning that all the results are returned. BatchDate must be a list of 2 items (the first one for the starting date and the second one for the ending date) If defined publishState is a string equals to "0" or "1\"""",
             requestBody = @RequestBody(description = "the json webQuery request body", required = true,  content = @Content(schema = @Schema(implementation = BatchSearchRepository.WebQuery.class)))
     )
     @ApiResponse(responseCode = "200", description = "the list of batch searches with the total batch searches for the query", useReturnTypeSchema = true)
@@ -185,8 +187,10 @@ public class BatchSearchResource {
         return notFound();
     }
 
-    @Operation( description = "Retrieves the results of a batch search as JSON with a list of items and a pagination metadata.<br/>" +
-            "If from/size are not given their default values are 0, meaning that all the results are returned.",
+    @Operation( description = """
+            Retrieves the results of a batch search as JSON with a list of items and a pagination metadata.
+            
+            If from/size are not given their default values are 0, meaning that all the results are returned.""",
                 requestBody = @RequestBody(
                         required = true,
                         description = "filter ",

--- a/datashare-app/src/main/java/org/icij/datashare/web/ExtensionResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ExtensionResource.java
@@ -31,9 +31,11 @@ public class ExtensionResource {
     @Inject
     public ExtensionResource(ExtensionService extensionService) {this.extensionService = extensionService;}
 
-    @Operation(description = "Gets the extension set in JSON.<br>" +
-            "If a request parameter \"filter\" is provided, the regular expression will be applied to the list.<br>" +
-            "See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for pattern syntax.",
+    @Operation(description = """
+            Gets the extension set in JSON.
+            If a request parameter "filter" is provided, the regular expression will be applied to the list.
+            
+            See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for pattern syntax.""",
             parameters = {@Parameter(name = "filter", description = "regular expression to apply", in = ParameterIn.QUERY)})
     @ApiResponse(responseCode = "200", description = "returns the extensions set", useReturnTypeSchema = true)
     @Get()

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -66,15 +66,20 @@ public class IndexResource {
         }
     }
 
-    @Operation(description = "The search endpoint is just a proxy in front of Elasticsearch, everything sent is forwarded to Elasticsearch.<br>" +
-            "DELETE method is not allowed.<br>Path can be of the form :<br>" +
-            "- _search/scroll<br>" +
-            "- index_name/_search<br>" +
-            "- index_name1,index_name2/_search<br>" +
-            "- index_name/_count<br>" +
-            "- index_name1,index_name2/_count<br>" +
-            "- index_name/doc/_search<br>" +
-            "- index_name1,index_name2/doc/_search")
+    @Operation(description = """
+            The search endpoint is just a proxy in front of Elasticsearch, everything sent is forwarded to Elasticsearch.
+            
+            DELETE method is not allowed.
+            
+            Path can be of the form :
+            - _search/scroll
+            - index_name/_search
+            - index_name1,index_name2/_search
+            - index_name/_count
+            - index_name1,index_name2/_count
+            - index_name/doc/_search
+            - index_name1,index_name2/doc/_search
+            """)
     @ApiResponse(responseCode = "200", description = "returns 200")
     @ApiResponse(responseCode = "400", description = "returns 400 if there is an error from ElasticSearch")
     @Post("/search/:path:")
@@ -86,9 +91,11 @@ public class IndexResource {
         }
     }
 
-    @Operation(description = "Search GET request to Elasticsearch. As it is a GET method, all paths are accepted.<br>" +
-            "if a body is provided, the body will be sent to ES as source=urlencoded(body)&source_content_type=application%2Fjson<br>" +
-            "In that case, request parameters are not taken into account.")
+    @Operation(description = """
+            Search GET request to Elasticsearch. As it is a GET method, all paths are accepted.
+            
+            if a body is provided, the body will be sent to ES as source=urlencoded(body)&source_content_type=application%2Fjson\
+            In that case, request parameters are not taken into account.""")
     @ApiResponse(responseCode = "200", description = "returns 200")
     @ApiResponse(responseCode = "400", description = "returns 400 if there is an error from ElasticSearch")
     @Get("/search/:path:")

--- a/datashare-app/src/main/java/org/icij/datashare/web/NerResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/NerResource.java
@@ -41,8 +41,10 @@ public class NerResource {
         return pipelineRegistry.getPipelineTypes();
     }
 
-    @Operation(description = "When datashare is launched in NER mode (without index) it exposes a name finding HTTP API.<br>" +
-            "The text is sent with the HTTP body.")
+    @Operation(description = """
+            When datashare is launched in NER mode (without index) it exposes a name finding HTTP API.
+            
+            The text is sent with the HTTP body.""")
     @ApiResponse(responseCode = "200", description = "returns the list of NamedEntities annotations", useReturnTypeSchema = true)
     @Post("/findNames/:pipeline")
     public List<NamedEntity> getAnnotations(@Parameter(name = "pipeline", description = "pipeline to use", in = ParameterIn.PATH) final String pipeline,

--- a/datashare-app/src/main/java/org/icij/datashare/web/NoteResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/NoteResource.java
@@ -26,35 +26,44 @@ public class NoteResource {
     @Inject
     public NoteResource(Repository repository) {this.repository = repository;}
 
-    @Operation(description = "Gets the list of notes for a project and a document path.<br/>" +
-            "if we have on disk:" +
-            "<pre>" +
-            "/a/b/doc1<br/>" +
-            "/a/c/doc2<br/>" +
-            "/d/doc3<br/>" +
-            "</pre>" +
-            "And in database:" +
-            "<pre>" +
-            "projectId | path | note | variant<br/>" +
-            "--- | --- | --- | ---<br/>" +
-            "p1 | a | note A | info<br/>" +
-            "p1 | a/b | note B | danger" +
-            "</pre>" +
-            " then :" +
-            "<pre>" +
-            "- `GET /api/p1/notes/a/b/doc1` will return note A and B<br/>" +
-            "- `GET /api/p1/notes/a/c/doc2` will return note A<br/>" +
-            "- `GET /api/p1/notes/d/doc3` will return an empty list<br/>" +
-            "</pre>" +
-            "<br/>" +
-            "Note the <code>:path:</code> it is a greedy parameter at the end of the url<br/>" +
-            "<code>@Get(\"/start/with/:parameter\")</code>" +
-            "will match <code>/start/with/myparameter</code>" +
-            "but not /start/with/myparameter/with/slashes<br/>" +
-            "<br/>" +
-            "<code>@Get(\"/start/with/:parameter:\")</code>" +
-            " will match <code>/start/with/myparameter/with/slashes</code>" +
-            " and the parameter variable will contain <code>myparameter/with/slashes</code>",
+    @Operation(description = """
+            Gets the list of notes for a project and a document path.
+            
+            if we have on disk:
+            ```
+            /a/b/doc1
+            /a/c/doc2
+            /d/doc3
+            ```
+            
+            And in database:
+            ```
+            projectId | path | note | variant
+            --- | --- | --- | ---
+            p1 | a | note A | info
+            p1 | a/b | note B | danger
+            ```
+            
+            then:
+            
+            - `GET /api/p1/notes/a/b/doc1` will return note A and B
+            - `GET /api/p1/notes/a/c/doc2` will return note A
+            - `GET /api/p1/notes/d/doc3` will return an empty list
+           
+            Note the `:path:` it is a greedy parameter at the end of the url
+            
+            ```
+            @Get("/start/with/:parameter")
+            ```
+            
+            matches `/start/with/myparameter` but not `/start/with/myparameter/with/slashes`
+            
+            ```
+            @Get("/start/with/:parameter:")
+            ```
+            
+            matches `/start/with/myparameter/with/slashes` and the parameter variable will contain `myparameter/with/slashes`
+            """,
             parameters = {
                 @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
                 @Parameter(name = "path", description = "the path of the document.", in = ParameterIn.PATH),

--- a/datashare-app/src/main/java/org/icij/datashare/web/PluginResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/PluginResource.java
@@ -31,9 +31,12 @@ public class PluginResource {
     @Inject
     public PluginResource(PluginService pluginService) { this.pluginService = pluginService; }
 
-    @Operation(description = "Gets the plugins set in JSON.<br>" +
-            "If a request parameter \"filter\" is provided, the regular expression will be applied to the list.<br>" +
-            "See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for pattern syntax.",
+    @Operation(description = """
+            Gets the plugins set in JSON.
+            
+            If a request parameter "filter" is provided, the regular expression will be applied to the list.
+            
+            See [Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html) for pattern syntax.""",
             parameters = {@Parameter(name = "filter", description = "regular expression to apply", in = ParameterIn.QUERY)})
     @ApiResponse(responseCode = "200", description = "returns the plugins set", useReturnTypeSchema = true)
     @Get()

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -133,8 +133,10 @@
             return notFoundIfNull(getUserProject((DatashareUser) context.currentUser(), id));
         }
 
-        @Operation(description = "Returns 200 if the project is allowed with this network route : in Datashare database there is the project table that can specify an IP mask that is allowed per project. If the client IP is not in the range, then the file download will be forbidden. In that project table there is a field called `allow_from_mask` that can have a mask with IP and star wildcard.<br/>" +
-                "Ex : <pre>192.168.*.*</pre> will match all subnetwork 192.168.0.0 IP's and only users with an IP in.",
+        @Operation(description = """
+                Returns 200 if the project is allowed with this network route : in Datashare database there is the project table that can specify an IP mask that is allowed per project. If the client IP is not in the range, then the file download will be forbidden. In that project table there is a field called `allow_from_mask` that can have a mask with IP and star wildcard.
+                
+                Ex : `192.168.*.*` will match all subnetwork `192.168.0.0` IP's and only users with an IP in.""",
                 parameters = {@Parameter(name = "id", description = "project id")}
         )
         @ApiResponse(responseCode = "200", description = "if project download is allowed for this project and IP")

--- a/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/RootResource.java
@@ -59,9 +59,13 @@ public class RootResource {
         return content;
     }
 
-    @Operation(description = "Gets the public (i.e. without user's information) datashare settings parameters.<br>" +
-            "These parameters are used for the client app for the init process.<br>" +
-            "The endpoint is removing all fields that contain Address or Secret or Url or Key")
+    @Operation(description = """
+            Gets the public (i.e. without user's information) datashare settings parameters.
+            
+            These parameters are used for the client app for the init process.
+            
+            The endpoint is removing all fields that contain Address or Secret or Url or Key
+            """)
     @ApiResponse(responseCode = "200", description = "returns the list of public settings", useReturnTypeSchema = true)
     @Get("settings")
     public Map<String, Object> getPublicSettings() {

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -104,10 +104,12 @@ public class TaskResource {
         this.propertiesProvider = propertiesProvider;
         this.batchSearchRepository = batchSearchRepository;
     }
-    @Operation(description = "Gets all the user tasks.<br>" +
-            "Filters can be added with <pre>name=value</pre>. For example if <pre>name=foo</pre> is given in the request url query," +
-            "the tasks containing the term \"foo\" are going to be returned. It can contain also dotted keys. " +
-            "For example if <pre>args.dataDir=bar</pre> is provided, tasks with \"dataDir\" containing \"bar\" are going to be selected.",
+    @Operation(description = """
+            Gets all the user tasks.
+            
+            Filters can be added with `name=value`. For example if `name=foo` is given in the request url query,
+            the tasks containing the term "foo" are going to be returned. It can contain also dotted keys.
+            For example if `args.dataDir=bar` is provided, tasks with "dataDir" containing "bar" are going to be selected.""",
             parameters = {@Parameter(name = "name", description = "pattern contained in the task name", in = ParameterIn.QUERY)})
     @ApiResponse(responseCode = "200", description = "returns the list of tasks", useReturnTypeSchema = true)
     @Get("/all")
@@ -156,38 +158,45 @@ public class TaskResource {
         return result == null ? new Payload(204) : new Payload(result);
     }
 
-    @Operation(description = "Creates a new batch search. This is a multipart form with 9 fields:<br/>" +
-            "name, description, csvFile, published, fileTypes, paths, fuzziness, phrase_matches, query_template<br>" +
-            "<br/>" +
-            "Queries with less than two characters are filtered.<br>" +
-            "<br>" +
-            "To make a request manually, you can create a file like:<br>" +
-            "<pre>"+
-            "--BOUNDARY<br/>\"" +
-            "Content-Disposition: form-data; name=\"name\"<br/>" +
-            "<br/>" +
-            "my batch search<br/>" +
-            " --BOUNDARY<br/>" +
-            "Content-Disposition: form-data; name=\"description\"<br/>" +
-            "<br/>" +
-            "search description<br/>" +
-            " --BOUNDARY<br/>" +
-            "Content-Disposition: form-data; name=\"csvFile\"; filename=\"search.csv\"<br/>" +
-            "Content-Type: text/csv<br/>" +
-            "<br/>" +
-            "Obama<br/>" +
-            "skype<br/>" +
-            "test<br/>" +
-            "query three<br/>" +
-            "--BOUNDARY--<br/>" +
-            "Content-Disposition: form-data; name=\"published\"<br/>" +
-            "<br/>" +
-            "true<br/>" +
-            "--BOUNDARY--<br/>" +
-            "</pre><br/>" +
-            "<br/>Then curl with" +
-            "<pre>curl -i -XPOST localhost:8080/api/batch/search/prj1,prj2 -H 'Content-Type: multipart/form-data; boundary=BOUNDARY' --data-binary @/home/dev/multipart.txt</pre>" +
-            "you'll maybe have to replace \\n with \\n\\r with <pre>sed -i 's/$/^M/g' ~/multipart.txt</pre>",
+    @Operation(description = """
+            Creates a new batch search. This is a multipart form with 9 fields:
+            
+            name, description, csvFile, published, fileTypes, paths, fuzziness, phrase_matches, query_template.
+            
+            Queries with less than two characters are filtered.
+            
+            To make a request manually, you can create a file like:
+            ```
+            --BOUNDARY
+            Content-Disposition: form-data; name="name"
+            
+            my batch search
+             --BOUNDARY
+            Content-Disposition: form-data; name="description"
+            
+            search description
+             --BOUNDARY
+            Content-Disposition: form-data; name="csvFile"; filename="search.csv"
+            Content-Type: text/csv
+            
+            Obama
+            skype
+            test
+            query three
+            --BOUNDARY--
+            Content-Disposition: form-data; name="published"
+            
+            true
+            --BOUNDARY--
+            ```
+            
+            Then curl with
+            
+            ```
+            curl -i -XPOST localhost:8080/api/batch/search/prj1,prj2 -H 'Content-Type: multipart/form-data; boundary=BOUNDARY' --data-binary @/home/dev/multipart.txt
+            ```
+            
+            you'll maybe have to replace \\n with \\n\\r with `sed -i 's/$/^M/g' ~/multipart.txt`""",
             requestBody = @RequestBody(description = "multipart form", required = true,
                     content = @Content(mediaType = "multipart/form-data",
                             schemaProperties = {
@@ -276,10 +285,17 @@ public class TaskResource {
         return ok().withAllowMethods("OPTIONS", "POST").withAllowHeaders("Content-Type");
     }
 
-    @Operation(description = "Download files from a search query.<br>Expected parameters are :<br>" +
-            "- project: string<br>- query: string or elasticsearch JSON query<br>" +
-            "If the query is a string it is taken as an ES query string, else it is a raw JSON query (without the query part)," +
-            "see org.elasticsearch.index.query.WrapperQueryBuilder that is used to wrap the query",
+    @Operation(description = """
+            Download files from a search query.
+            
+             Expected parameters are:
+            
+            - project: string
+            - query: string or elasticsearch JSON query
+            
+            If the query is a string it is taken as an ES query string, else it is a raw JSON query (without the query part),\
+            see org.elasticsearch.index.query.WrapperQueryBuilder that is used to wrap the query
+            """,
             requestBody = @RequestBody(description = "the json used to wrap the query", required = true,  content = @Content(schema = @Schema(implementation = OptionsWrapper.class))))
     @ApiResponse(responseCode = "200", description = "returns 200 and the json task id", useReturnTypeSchema = true)
     @Post("/batchDownload")
@@ -399,8 +415,10 @@ public class TaskResource {
         return ok().withAllowMethods("OPTIONS", "PUT");
     }
 
-    @Operation(description = "Cancels the running tasks. It returns a map with task name/stop statuses.<br>" +
-            "If the status is false, it means that the thread has not been stopped.")
+    @Operation(description = """
+            Cancels the running tasks. It returns a map with task name/stop statuses.
+            
+            If the status is false, it means that the thread has not been stopped.""")
     @ApiResponse(responseCode = "200", description = "returns 200 and the tasks stop result map", useReturnTypeSchema = true)
     @Put("/stopAll")
     public Map<String, Boolean> stopAllTasks(final Context context) throws IOException {
@@ -414,13 +432,17 @@ public class TaskResource {
         return ok().withAllowMethods("OPTIONS", "PUT");
     }
 
-    @Operation(description = "Find names using the given pipeline :<br><br>" +
-            "- OPENNLP<br>" +
-            "- CORENLP<br>" +
-            "- IXAPIPE<br>" +
-            "- GATENLP<br>" +
-            "- MITIE<br><br>" +
-            "This endpoint is going to find all Documents that are not taggued with the given pipeline and extract named entities for all these documents.",
+    @Operation(description = """
+            Find names using the given pipeline:
+            
+            - OPENNLP
+            - CORENLP
+            - IXAPIPE
+            - GATENLP
+            - MITIE
+            
+            This endpoint is going to find all Documents that are not tagged with the given pipeline and extract named entities for all these documents.
+            """,
             requestBody = @RequestBody(description = "wrapper for options json", required = true,  content = @Content(schema = @Schema(implementation = OptionsWrapper.class))))
     @ApiResponse(responseCode = "200", description = "returns 200 and the created task ids", content = @Content(schema = @Schema(implementation = TasksResponse.class)))
     @Post("/findNames/:pipeline")

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -171,11 +171,11 @@ public class TaskResource {
             Content-Disposition: form-data; name="name"
             
             my batch search
-             --BOUNDARY
+            --BOUNDARY
             Content-Disposition: form-data; name="description"
             
             search description
-             --BOUNDARY
+            --BOUNDARY
             Content-Disposition: form-data; name="csvFile"; filename="search.csv"
             Content-Type: text/csv
             
@@ -196,7 +196,7 @@ public class TaskResource {
             curl -i -XPOST localhost:8080/api/batch/search/prj1,prj2 -H 'Content-Type: multipart/form-data; boundary=BOUNDARY' --data-binary @/home/dev/multipart.txt
             ```
             
-            you'll maybe have to replace \\n with \\n\\r with `sed -i 's/$/^M/g' ~/multipart.txt`""",
+            you'll maybe have to replace \\n with \\r\\n with `sed -i 's/$/^M/g' ~/multipart.txt`""",
             requestBody = @RequestBody(description = "multipart form", required = true,
                     content = @Content(mediaType = "multipart/form-data",
                             schemaProperties = {

--- a/datashare-app/src/main/java/org/icij/datashare/web/TreeResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TreeResource.java
@@ -40,8 +40,12 @@ public class TreeResource {
         this.propertiesProvider = propertiesProvider;
     }
 
-    @Operation(description = "Lists all files and directory for the given path. This endpoint returns a JSON using the same specification than the `tree` command on UNIX. It is roughly the equivalent of:<br>" +
-            "<pre>tree -L 1 -spJ --noreport /home/datashare/data</pre>")
+    @Operation(description = """
+            Lists all files and directory for the given path. This endpoint returns a JSON using the same specification than the `tree` command on UNIX. It is roughly the equivalent of:
+            ```
+            tree -L 1 -spJ --noreport /home/datashare/data
+            ```
+            """)
     @ApiResponse(responseCode = "200", description = "returns the list of files and directory", useReturnTypeSchema = true)
     @Get(":dirPath:")
     public DirectoryReport getTree(@Parameter(name="dirPath", description="directory path in the tree", in = ParameterIn.PATH) final String dirPath, Context context) throws IOException {

--- a/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
@@ -104,9 +104,12 @@ public class UserResource {
         return parseBoolean(desc) || getStringValue(desc).isEmpty() || !desc.equalsIgnoreCase("false");
     }
 
-    @Operation(description = "Add or update an event to user's history. The event's type, the project ids and the uri are passed in the request body.<br>" +
-            "To update the event's name, the eventId is required to retrieve the corresponding event." +
-            "The project list related to the event is stored in database but is never queried (no filters on project)")
+    @Operation(description = """
+            Add or update an event to user's history. The event's type, the project ids and the uri are passed in the request body.
+            
+            To update the event's name, the eventId is required to retrieve the corresponding event.
+            The project list related to the event is stored in database but is never queried (no filters on project).
+            """)
     @ApiResponse(responseCode = "200", description = "returns 200 when event is added or updated.")
     @Put("/me/history")
     public Payload addToUserHistory(@Parameter(name = "query", description = "user history query to save", in = ParameterIn.QUERY) UserHistoryQuery query, Context context) {


### PR DESCRIPTION
html was not interpreted by gitbook openapi translation.

So we used markdown:

- for code the triple backquotes are working fine
- for the line breaks you can use `\n\n` (note that a single `\n` will be ignored like in markdown and more `\n` are ignored also)

 