### PR TITLE
Fix: monitoring event

### DIFF
--- a/datashare-api/pom.xml
+++ b/datashare-api/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>datashare-api</artifactId>
-    <version>14.4.1</version>
+    <version>14.4.2</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/datashare-api/pom.xml
+++ b/datashare-api/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>datashare-api</artifactId>
-    <version>14.4.0</version>
+    <version>14.4.1</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
@@ -128,19 +128,6 @@ public class AmqpChannel {
 		rabbitMqChannel.exchangeDeclare(queue.exchange, queue.exchangeType, durable);
 	}
 
-	void initForMonitoring(boolean rabbitMq, int nbMaxMessages) throws IOException {
-		Map<String, Object> queueArguments = new HashMap<>() {{
-			if (rabbitMq) {
-				putAll(queue.arguments);
-			}
-		}};
-		String queueName = queueName(null);
-		rabbitMqChannel.exchangeDeclare(queue.exchange, queue.exchangeType, durable);
-		rabbitMqChannel.queueDeclare(queueName, durable, exclusive, autoDelete, queueArguments);
-		rabbitMqChannel.queueBind(queueName, queue.exchange, ofNullable(key).orElse(queue.routingKey));
-		rabbitMqChannel.basicQos(nbMaxMessages);
-	}
-
 	void initForConsume(boolean rabbitMq, int nbMaxMessages) throws IOException {
 		Map<String, Object> queueArguments = new HashMap<>() {{
 			if (rabbitMq) {

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <datashare-api.version>14.4.0</datashare-api.version>
+        <datashare-api.version>14.4.1</datashare-api.version>
         <datashare-cli.version>13.6.1</datashare-cli.version>
         <datashare-tasks.version>15.2.0</datashare-tasks.version>
         <ftm.version>0.3.1</ftm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <datashare-api.version>14.4.1</datashare-api.version>
+        <datashare-api.version>14.4.2</datashare-api.version>
         <datashare-cli.version>13.6.1</datashare-cli.version>
         <datashare-tasks.version>15.2.0</datashare-tasks.version>
         <ftm.version>0.3.1</ftm.version>


### PR DESCRIPTION
refactor: code duplication for queue creation

fix 500 error. `GetHealth()` returns result of a monitoring event publication if monitoring is set to true. Else it returns if the AMQP connection is open.

see #1638
