### PR TITLE
fix: host specific url 

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/DeliverableHelper.java
+++ b/datashare-app/src/main/java/org/icij/datashare/DeliverableHelper.java
@@ -12,7 +12,7 @@ public class DeliverableHelper {
 
     static URL hostSpecificUrl(OsArchDetector osArchDetector, URL url, String version) {
         String fileName = url.getFile();
-        String fileNameWithOsAndArch = fileName.replace(version, String.format("%s-%s", osArchDetector.osArchSuffix(), version));
+        String fileNameWithOsAndArch = fileName.replace("-" + version, String.format("-%s-%s", osArchDetector.osArchSuffix(), version));
         try {
             return new URL(url.getProtocol(), url.getHost(), fileNameWithOsAndArch);
         } catch (MalformedURLException e) {

--- a/datashare-app/src/test/java/org/icij/datashare/DeliverableHelperTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/DeliverableHelperTest.java
@@ -13,7 +13,7 @@ public class DeliverableHelperTest {
     @Test
     public void test_url() throws MalformedURLException {
         OsArchDetector detector = new OsArchDetector(OS.linux, ARCH.x86_64);
-        assertThat(DeliverableHelper.hostSpecificUrl(detector, new URL("http://foo/bar/baz-1.2.3"), "1.2.3").toString())
-                .isEqualTo("http://foo/bar/baz-linux-x86_64-1.2.3");
+        assertThat(DeliverableHelper.hostSpecificUrl(detector, new URL("http://foo/bar/tag/1.2.3/baz-1.2.3"), "1.2.3").toString())
+                .isEqualTo("http://foo/bar/tag/1.2.3/baz-linux-x86_64-1.2.3");
     }
 }


### PR DESCRIPTION
# Changes

## `datashare-app`

### Fixed
- fix `DeliverableHelper.hostSpecificUrl` when version appears twice in the deliverable URL