### PR TITLE
feat: batch searches proxy

### DIFF
--- a/datashare-api/src/test/java/org/icij/datashare/batch/BatchSearchRecordTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/batch/BatchSearchRecordTest.java
@@ -7,8 +7,8 @@ import org.icij.datashare.json.JsonObjectMapper;
 import org.junit.Test;
 
 import java.util.Date;
+import java.util.List;
 
-import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.Project.project;
 
@@ -17,7 +17,7 @@ public class BatchSearchRecordTest {
     public void test_serialize_deserialize() throws JsonProcessingException {
         ObjectMapper typeInclusionMapper = JsonObjectMapper.MAPPER;
         String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        BatchSearchRecord batchRecord = new BatchSearchRecord(asList(project("project")), "name", "description", 123, new Date(), uri);
+        BatchSearchRecord batchRecord = new BatchSearchRecord(List.of(project("project")), "name", "description", 123, new Date(), uri);
         String json = typeInclusionMapper.writeValueAsString(batchRecord);
         BatchSearchRecord actualBatchRecord = typeInclusionMapper.readValue(json, BatchSearchRecord.class);
         assertThat(batchRecord).isEqualTo(actualBatchRecord);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskFactory.java
@@ -1,7 +1,6 @@
 package org.icij.datashare.tasks;
 
 import java.util.LinkedList;
-import java.util.List;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.user.User;
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -26,9 +26,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
-import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
 import static net.codestory.http.payload.Payload.*;
 import static org.icij.datashare.function.ThrowingFunctions.parseBoolean;

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -143,7 +143,9 @@ public class TaskResource {
                 .stream()
                 .filter(not(paginationFields::contains))
                 .collect(toMap(s -> s, s -> Pattern.compile(String.format(".*%s.*", context.get(s)))));
-        return taskManager.getTasks((User) context.currentUser(), filters, pagination);
+        User user = (User) context.currentUser();
+        List<BatchSearchRecord> batchSearchRecords = batchSearchRepository.getRecords(user, user.getProjectNames());
+        return taskManager.getTasks(user, filters, pagination, batchSearchRecords);
     }
 
     @Operation(description = "Gets one task with its id.")

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -8,6 +8,7 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.bus.amqp.TaskCreation;
+import org.icij.datashare.batch.BatchSearchRepository;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.extension.PipelineRegistry;
 import org.icij.datashare.nlp.EmailPipeline;
@@ -52,6 +53,9 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     public DatashareTimeRule time = new DatashareTimeRule("2021-07-07T12:23:34Z");
     @Mock
     JooqRepository jooqRepository;
+    @Mock
+    BatchSearchRepository batchSearchRepository;
+
     private static final TestTaskUtils.DatashareTaskFactoryForTest taskFactory = mock(TestTaskUtils.DatashareTaskFactoryForTest.class);
     private static final TaskManagerMemory taskManager = new TaskManagerMemory(taskFactory, new TaskRepositoryMemory(), new PropertiesProvider(Map.of(TASK_MANAGER_POLLING_INTERVAL_OPT, "500")));
 
@@ -59,10 +63,11 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     public void setUp() {
         initMocks(this);
         when(jooqRepository.getProjects()).thenReturn(new ArrayList<>());
+        when(batchSearchRepository.getRecords(any(), any())).thenReturn(new ArrayList<>());
         PipelineRegistry pipelineRegistry = new PipelineRegistry(getDefaultPropertiesProvider());
         pipelineRegistry.register(EmailPipeline.class);
         LocalUserFilter localUserFilter = new LocalUserFilter(getDefaultPropertiesProvider(), jooqRepository);
-        configure(routes -> routes.add(new TaskResource(taskFactory, taskManager, getDefaultPropertiesProvider(), null)).filter(localUserFilter));
+        configure(routes -> routes.add(new TaskResource(taskFactory, taskManager, getDefaultPropertiesProvider(), batchSearchRepository)).filter(localUserFilter));
         TestTaskUtils.init(taskFactory);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.web;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.function.Function;
 import net.codestory.http.filters.basic.BasicAuthFilter;
@@ -10,6 +11,7 @@ import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.bus.amqp.UriResult;
+import org.icij.datashare.batch.BatchSearchRepository;
 import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.tasks.*;
@@ -17,7 +19,9 @@ import org.icij.datashare.user.User;
 import org.icij.datashare.user.UserTask;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,9 +36,20 @@ import static org.icij.datashare.user.User.localUser;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class UserTaskResourceTest extends AbstractProdWebServerTest {
     private TaskManagerMemory taskManager;
+
+    @Mock
+    BatchSearchRepository batchSearchRepository;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(batchSearchRepository.getRecords(any(), any())).thenReturn(new ArrayList<>());
+    }
+
 
     @After
     public void tearDown() throws IOException {
@@ -178,15 +193,17 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
         when(taskFactory.createDummyUserTask(any(), any())).thenReturn((DummyUserTask<Serializable>) userTask);
         setupAppWith(taskFactory, userLogins);
     }
+
     private void setupAppWith(SleepingUserTask c1, SleepingUserTask c2, String... userLogins) {
         DatashareTaskFactoryForTest taskFactory = mock(DatashareTaskFactoryForTest.class);
         when(taskFactory.createSleepingUserTask(any(), any())).thenReturn(c1, c2);
         setupAppWith(taskFactory, userLogins);
     }
+
     private void setupAppWith(DatashareTaskFactory taskFactory, String... userLogins) {
         final PropertiesProvider propertiesProvider = new PropertiesProvider(Map.of("mode", "LOCAL"));
         taskManager = new TaskManagerMemory(taskFactory, new TaskRepositoryMemory(), new PropertiesProvider());
-        configure(routes -> routes.add(new TaskResource(taskFactory, taskManager, propertiesProvider, null))
+        configure(routes -> routes.add(new TaskResource(taskFactory, taskManager, propertiesProvider, batchSearchRepository))
                 .filter(new BasicAuthFilter("/", "ds", DatashareUser.users(userLogins))));
     }
 

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
@@ -104,6 +104,11 @@ public class Task<V extends Serializable> extends Event implements Entity, Compa
         }
     }
 
+    public void setState(State state) {
+        this.state = state;
+        ofNullable(stateLatch).ifPresent(sl -> sl.setTaskState(state));
+    }
+
     public void setResult(TaskResult<V> result) {
         synchronized (lock) {
             this.result =  result;
@@ -246,11 +251,6 @@ public class Task<V extends Serializable> extends Event implements Entity, Compa
 
     void setLatch(StateLatch stateLatch) {
         this.stateLatch = stateLatch;
-    }
-
-    private void setState(State state) {
-        this.state = state;
-        ofNullable(stateLatch).ifPresent(sl -> sl.setTaskState(state));
     }
 
     private static Map<String, Object> addTo(Map<String, Object> properties, User user) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
@@ -89,6 +89,10 @@ public interface TaskManager extends Closeable {
         return getFilteredTaskStream(filters, taskStream).skip(pagination.from).limit(pagination.size).collect(toList());
     }
 
+    default List<Task<?>> getTasks(User user, List<BatchSearchRecord> batchSearchRecords) throws IOException {
+        return getTasks(user, Map.of(), new WebQueryPagination(), batchSearchRecords);
+    }
+
 
     default boolean awaitTermination(int timeout, TimeUnit timeUnit) throws InterruptedException, IOException {
         return !waitTasksToBeDone(timeout, timeUnit).isEmpty();

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/Event.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/Event.java
@@ -26,7 +26,7 @@ public class Event implements Serializable {
 	@Serial private static final long serialVersionUID = -2295266944323500399L;
 	public static final int MAX_RETRIES_LEFT = 3;
 	protected int retriesLeft = MAX_RETRIES_LEFT;
-	public final Date createdAt;
+	public Date createdAt;
 
 	public Event() {
 		this(DatashareTime.getNow(), 3);
@@ -48,5 +48,9 @@ public class Event implements Serializable {
 
 	public byte[] serialize() throws IOException {
 		return JsonObjectMapper.MAPPER.writeValueAsBytes(this);
+	}
+
+	public void setCreatedAt(Date createdAt) {
+		this.createdAt = createdAt;
 	}
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -146,7 +146,7 @@ public class TaskManagerMemoryTest {
         List<ProjectProxy> projects = List.of(project("project"));
         BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, Map.of(), new WebQueryPagination(), List.of(batchSearchRecord));
+        List<Task<?>> tasks = taskManager.getTasks(user, List.of(batchSearchRecord));
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
         assertThat(tasks.get(0).getUser()).isEqualTo(user);
@@ -161,10 +161,10 @@ public class TaskManagerMemoryTest {
         Task<String> task = new Task<>("name", User.local(), new HashMap<>());
         taskManager.insert(task, null);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, Map.of(), new WebQueryPagination(), List.of(batchSearchRecord));
+        List<Task<?>> tasks = taskManager.getTasks(user, List.of(batchSearchRecord));
         assertThat(tasks).hasSize(2);
-        assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
-        assertThat(tasks.get(0).getUser()).isEqualTo(user);
+        assertThat(tasks.get(1).id).isEqualTo(batchSearchRecord.uuid);
+        assertThat(tasks.get(1).getUser()).isEqualTo(user);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class TaskManagerMemoryTest {
         BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
         List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, Map.of(), new WebQueryPagination(), batchSearchRecords);
+        List<Task<?>> tasks = taskManager.getTasks(user, batchSearchRecords);
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).name).isEqualTo("org.icij.datashare.tasks.BatchSearchRunnerProxy");
     }
@@ -190,7 +190,7 @@ public class TaskManagerMemoryTest {
         Task<String> task = new Task<>(batchSearchRecord.uuid, "name", User.local());
         taskManager.insert(task, null);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, Map.of(), new WebQueryPagination(), List.of(batchSearchRecord));
+        List<Task<?>> tasks = taskManager.getTasks(user, List.of(batchSearchRecord));
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).name).isEqualTo("name");
     }


### PR DESCRIPTION
This PR add retro-compatibility for listing batch searches without tasks (#1794). To address this problem, the backend create on the fly "BatchSearchRunnerProxy" tasks that are merged with the actual list of tasks.

This also has the benefit to add access control to the batch searches tasks belonging to other user in server mode. Because the list of tasks is built based on the batch searches a user has access to, this create a way for them to see tasks they did not authored.

The frontend was already modified to support this new type of task.