### PR TITLE
feat: add `/api/task` endpoint with pagination

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -100,6 +100,7 @@ import static org.icij.datashare.text.nlp.AbstractModels.syncModels;
 @Singleton
 @Prefix("/api/task")
 public class TaskResource {
+    public static final Set<String> PAGINATION_FIELDS = WebQueryPagination.fields();
     private final DatashareTaskFactory taskFactory;
     private final TaskManager taskManager;
     private final PropertiesProvider propertiesProvider;
@@ -603,23 +604,21 @@ public class TaskResource {
     public record TasksResponse(List<String> taskIds) {}
 
     private WebQueryPagination getPagination(Context context) {
-        Set<String> paginationFields = WebQueryPagination.fields();
         Map<String, Object> paginationMap = context
                 .query()
                 .keys()
                 .stream()
-                .filter(paginationFields::contains)
+                .filter(PAGINATION_FIELDS::contains)
                 .collect(toMap(s -> s, context::get));
         return WebQueryPagination.fromMap(paginationMap);
     }
 
     private Map<String, Pattern> getArbitraryFilters(Context context) {
-        Set<String> paginationFields = WebQueryPagination.fields();
         return context
                 .query()
                 .keys()
                 .stream()
-                .filter(not(paginationFields::contains))
+                .filter(not(PAGINATION_FIELDS::contains))
                 .collect(toMap(s -> s, s -> Pattern.compile(String.format(".*%s.*", context.get(s)))));
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -141,8 +141,12 @@ public class TaskResource {
         // Sort the tasks before applying the filter and the pagination
         Stream<Task<?>> taskStream = tasks.stream().sorted(new Task.Comparator(pagination.sort, pagination.order));
         // Filter the tasks before the pagination
-        List<Task<?>> filteredTasks = taskManager.getFilteredTaskStream(filters, taskStream).toList();
-        // Then finally, use WebResponse to take care of the pagination for us
+        List<Task<?>> filteredTasks = taskManager
+                .getFilteredTaskStream(filters, taskStream)
+                .skip(pagination.from)
+                .limit(pagination.size)
+                .toList();
+        // Then finally, use WebResponse to take display the pagination for us
         WebResponse<Task<?>> tasksWebResponse = new WebResponse<>(filteredTasks, pagination.from, pagination.size, tasks.size());
         return new Payload(tasksWebResponse);
     }

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -603,26 +603,6 @@ public class TaskResource {
     public record TaskResponse(String taskId) {}
     public record TasksResponse(List<String> taskIds) {}
 
-    private WebQueryPagination getPagination(Context context) {
-        Map<String, Object> paginationMap = context
-                .query()
-                .keys()
-                .stream()
-                .filter(PAGINATION_FIELDS::contains)
-                .collect(toMap(s -> s, context::get));
-        return WebQueryPagination.fromMap(paginationMap);
-    }
-
-    private Map<String, Pattern> getArbitraryFilters(Context context) {
-        return context
-                .query()
-                .keys()
-                .stream()
-                .filter(not(PAGINATION_FIELDS::contains))
-                .collect(toMap(s -> s, s -> Pattern.compile(String.format(".*%s.*", context.get(s)))));
-    }
-
-
     private String fieldValue(String field, List<Part> parts) {
         List<String> values = fieldValues(field, parts);
         return values.isEmpty() ? null: values.get(0);
@@ -659,5 +639,24 @@ public class TaskResource {
         } catch (UnknownTask ex) {
             throw new NotFoundException();
         }
+    }
+
+    private static WebQueryPagination getPagination(Context context) {
+        Map<String, Object> paginationMap = context
+                .query()
+                .keys()
+                .stream()
+                .filter(PAGINATION_FIELDS::contains)
+                .collect(toMap(s -> s, context::get));
+        return WebQueryPagination.fromMap(paginationMap);
+    }
+
+    private static Map<String, Pattern> getArbitraryFilters(Context context) {
+        return context
+                .query()
+                .keys()
+                .stream()
+                .filter(not(PAGINATION_FIELDS::contains))
+                .collect(toMap(s -> s, s -> Pattern.compile(String.format(".*%s.*", context.get(s)))));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -129,10 +129,10 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         post("/api/task/batchUpdate/index/" + subpath, body).should().haveType("application/json");
         post("/api/task/batchUpdate/index/" + subpath, body).should().haveType("application/json");
 
-        get("/api/task?size=2&from=1").should().haveType("application/json")
+        get("/api/task?size=2&from=2").should().haveType("application/json")
                 .contain("\"count\":2")
                 .contain("\"total\":4")
-                .contain("\"from\":1")
+                .contain("\"from\":2")
                 .contain("\"size\":2");
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -76,6 +76,22 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_get_tasks_with_correct_id() throws IOException {
+        String dummyTaskId = taskManager.startTask(TestSleepingTask.class, User.local(), new HashMap<>());
+        get("/api/task").should()
+                .respond(200)
+                .contain("\"id\":\"" + dummyTaskId + "\"")
+                .contain("\"state\":\"RUNNING\"");
+        put("/api/task/stop/" + dummyTaskId).should()
+                .respond(200)
+                .contain("true");
+        get("/api/task").should()
+                .respond(200)
+                .contain("\"id\":\"" + dummyTaskId + "\"")
+                .contain("\"state\":\"CANCELLED\"");
+    }
+
+    @Test
     public void test_get_tasks() {
         String subpath = getClass().getResource("/docs/doc.txt").getPath().substring(1);
         String body = "{\"options\":{\"reportName\": \"foo\"}}";

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -89,6 +89,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_tasks_paginated_with_zero_tasks() {
         get("/api/task?size=10").should().haveType("application/json")
+                .contain("\"count\":0")
                 .contain("\"total\":0")
                 .contain("\"from\":0")
                 .contain("\"size\":10");
@@ -101,6 +102,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         post("/api/task/batchUpdate/index/" + subpath, body).should().haveType("application/json");
 
         get("/api/task?size=4").should().haveType("application/json")
+                .contain("\"count\":2")
                 .contain("\"total\":2")
                 .contain("\"from\":0")
                 .contain("\"size\":4");
@@ -114,6 +116,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         post("/api/task/batchUpdate/index/" + subpath, body).should().haveType("application/json");
 
         get("/api/task?size=2").should().haveType("application/json")
+                .contain("\"count\":2")
                 .contain("\"total\":4")
                 .contain("\"from\":0")
                 .contain("\"size\":2");

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -130,6 +130,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         post("/api/task/batchUpdate/index/" + subpath, body).should().haveType("application/json");
 
         get("/api/task?size=2&from=1").should().haveType("application/json")
+                .contain("\"count\":2")
                 .contain("\"total\":4")
                 .contain("\"from\":1")
                 .contain("\"size\":2");


### PR DESCRIPTION
In order to add proper pagination to the task pages (see #1798), we need to know the total number of tasks. This PR adds a new `/api/task` endpoint with pagination metadata, for instance:

```json
{
  "pagination": {
    "count": 3,
    "from": 0,
    "size": 3,
    "total": 5
  },
  "items": [
    {
      "id": "653de5ef-c245-4126-8ce3-8307f360b07d",
      "name": "org.icij.datashare.tasks.IndexTask",
      "state": "RUNNING",
      "progress": 0.0,
      "createdAt": "2025-04-25T16:59:34.368+00:00",
      "retriesLeft": 3,
      "args": { }
    },
    {
      "id": "b5aa4678-3d2b-4c67-892f-ba43b6847df3",
      "name": "org.icij.datashare.tasks.IndexTask",
      "state": "DONE",
      "progress": 1.0,
      "createdAt": "2025-04-25T17:00:46.578+00:00",
      "retriesLeft": 3,
      "completedAt": "2025-04-25T17:00:51.882+00:00",
      "args": {}
    },
    {
      "id": "365f8cc3-560a-4865-856d-232063fde603",
      "name": "org.icij.datashare.tasks.ScanTask",
      "state": "RUNNING",
      "progress": 0.0,
      "createdAt": "2025-04-22T12:21:47.578+00:00",
      "retriesLeft": 3,
      "args": {}
    }
  ]
}

```

The old `/api/task/all` endpoint is now deprecated.