### PR TITLE
chore: refactor task manager to return stream of tasks

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
@@ -136,7 +136,7 @@ public class CreateNlpBatchesFromIndexParametrizedTest {
                 new Task<>(CreateNlpBatchesFromIndex.class.getName(), new User("test"), properties), null);
         // When
         List<String> taskIds = enqueueFromIndex.call();
-        List<List<Language>> queued = taskManager.getTasks().stream()
+        List<List<Language>> queued = taskManager.getTasks()
             .sorted(Comparator.comparing(t -> t.createdAt))
             .map(t -> ((List<CreateNlpBatchesFromIndex.BatchDocument>) t.args.get("docs")).stream().map(
                 CreateNlpBatchesFromIndex.BatchDocument::language).toList())

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
@@ -79,7 +79,7 @@ public class CreateNlpBatchesFromIndexTest {
             new Task<>(CreateNlpBatchesFromIndex.class.getName(), new User("test"), properties), null);
         // When
         enqueueFromIndex.call();
-        List<List<String>> queued = taskManager.getTasks().stream()
+        List<List<String>> queued = taskManager.getTasks()
             .map(t -> ((List<CreateNlpBatchesFromIndex.BatchDocument>) t.args.get("docs")).stream().map(
                 CreateNlpBatchesFromIndex.BatchDocument::id).toList())
             .toList();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskManagerMemoryForBatchSearchTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import java.util.List;
 import org.icij.datashare.CollectionUtils;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.*;
@@ -78,8 +79,9 @@ public class TaskManagerMemoryForBatchSearchTest {
         taskManager.awaitTermination(1, TimeUnit.SECONDS);
 
         assertThat(DatashareTime.getInstance().now().getTime() - beforeTest.getTime()).isEqualTo(100);
-        assertThat(taskManager.getTasks()).hasSize(1);
-        assertThat(taskManager.getTasks().get(0).id).isEqualTo(testBatchSearch.uuid);
+        List<Task<?>> tasks = taskManager.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).id).isEqualTo(testBatchSearch.uuid);
     }
 
     @Test(timeout = 5000)
@@ -112,7 +114,7 @@ public class TaskManagerMemoryForBatchSearchTest {
         Signal.raise(new Signal("TERM"));
         taskManager.waitTasksToBeDone(1, TimeUnit.SECONDS);
 
-        assertThat(taskManager.getTasks()).hasSize(2);
+        assertThat(taskManager.getTasks().toList()).hasSize(2);
     }
 
     @Ignore
@@ -126,7 +128,7 @@ public class TaskManagerMemoryForBatchSearchTest {
 
         verify(repository).setState(testBatchSearch.uuid, BatchSearch.State.RUNNING);
         verify(repository).setState(eq(testBatchSearch.uuid), any(SearchException.class));
-        assertThat(taskManager.getTasks().get(0).getState()).isEqualTo(Task.State.ERROR);
+        assertThat(taskManager.getTasks().toList().get(0).getState()).isEqualTo(Task.State.ERROR);
     }
 
     @Test(timeout = 5000)

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import java.util.List;
 import java.util.function.Function;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
@@ -15,8 +16,6 @@ import org.mockito.Mock;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -90,8 +89,9 @@ public class TaskWorkerLoopForPipelineTasksTest {
         taskSupplier.startTask(task.name, User.local(), task.args);
         taskSupplier.awaitTermination(1, TimeUnit.SECONDS);
 
-        assertThat(taskSupplier.getTasks()).hasSize(1);
-        assertThat(taskSupplier.getTasks().get(0).name).isEqualTo(task.name);
+        List<Task<?>> tasks = taskSupplier.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).name).isEqualTo(task.name);
     }
 
     @Before

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tasks;
 
+import java.util.List;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskWorkerLoop;
@@ -47,11 +48,12 @@ public class TaskWorkerLoopIntTest {
         taskManager.awaitTermination(1, TimeUnit.SECONDS);
         eventWaiter.await();
 
-        assertThat(taskManager.getTasks()).hasSize(1);
-        assertThat(taskManager.getTasks().get(0).getError()).isNotNull();
-        assertThat(taskManager.getTasks().get(0).getProgress()).isEqualTo(1);
-        assertThat(taskManager.getTasks().get(0).args).hasSize(2);
-        assertThat(taskManager.getTasks().get(0).getUser()).isEqualTo(User.local());
+        List<Task<?>> tasks = taskManager.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getError()).isNotNull();
+        assertThat(tasks.get(0).getProgress()).isEqualTo(1);
+        assertThat(tasks.get(0).args).hasSize(2);
+        assertThat(tasks.get(0).getUser()).isEqualTo(User.local());
     }
 
     @Before

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.web;
 
+import java.util.stream.Stream;
 import net.codestory.http.filters.basic.BasicAuthFilter;
 import net.codestory.http.security.Users;
 import org.icij.datashare.PropertiesProvider;

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceBatchSearchTest.java
@@ -2,6 +2,7 @@ package org.icij.datashare.web;
 
 import net.codestory.rest.Response;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.batch.BatchSearch;
 import org.icij.datashare.batch.BatchSearchRecord;
@@ -114,7 +115,7 @@ public class TaskResourceBatchSearchTest extends AbstractProdWebServerTest {
     public void test_upload_batch_search_csv_with_csvFile_with_60K_queries_should_send_request_too_large() throws IOException {
         when(batchSearchRepository.save(any())).thenReturn(true);
         StringBuilder content = new StringBuilder();
-        IntStream.range(0,60000).boxed().collect(Collectors.toList()).forEach(i -> content.append("Test ").append(i).append("\r\n"));
+        IntStream.range(0,60000).boxed().toList().forEach(i -> content.append("Test ").append(i).append("\r\n"));
         Response response = postRaw("/api/task/batchSearch/prj", "multipart/form-data;boundary=AaB03x",
                 new MultipartContentBuilder("AaB03x")
                         .addField("name","nameValue")
@@ -134,8 +135,9 @@ public class TaskResourceBatchSearchTest extends AbstractProdWebServerTest {
                 singletonList(project("prj")), "nameValue", null,
                 asSet("query", "éèàç"), new Date(), BatchSearch.State.QUEUED, User.local());
         verify(batchSearchRepository).save(eq(expected));
-        assertThat(taskManager.getTasks()).hasSize(1);
-        assertThat(taskManager.getTasks().get(0).name).isEqualTo(BatchSearchRunner.class.getName());
+        List<Task<?>> tasks = taskManager.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).name).isEqualTo(BatchSearchRunner.class.getName());
     }
 
     @Test
@@ -190,8 +192,9 @@ public class TaskResourceBatchSearchTest extends AbstractProdWebServerTest {
         assertThat(argument.getValue().queryTemplate).isEqualTo(sourceSearch.queryTemplate);
 
         assertThat(argument.getValue().state).isEqualTo(BatchSearchRecord.State.QUEUED);
-        assertThat(taskManager.getTasks()).hasSize(1);
-        assertThat(taskManager.getTasks().get(0).name).isEqualTo(BatchSearchRunner.class.getName());
+        List<Task<?>> tasks = taskManager.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).name).isEqualTo(BatchSearchRunner.class.getName());
     }
 
     @Test

--- a/datashare-tasks/pom.xml
+++ b/datashare-tasks/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>datashare-tasks</artifactId>
     <name>datashare-tasks</name>
     <packaging>jar</packaging>
-    <version>16.1.4</version>
+    <version>17.0.0</version>
     <description>Datashare asynchronous task execution library</description>
 
     <properties>

--- a/datashare-tasks/pom.xml
+++ b/datashare-tasks/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>datashare-tasks</artifactId>
     <name>datashare-tasks</name>
     <packaging>jar</packaging>
-    <version>17.0.0</version>
+    <version>17.0.1</version>
     <description>Datashare asynchronous task execution library</description>
 
     <properties>

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerAmqpTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerAmqpTest.java
@@ -154,20 +154,20 @@ public class TaskManagerAmqpTest {
         String taskView1Id = taskManager.startTask("taskName1", User.local(), new HashMap<>());
         taskManager.startTask("taskName2", User.local(), new HashMap<>());
 
-        assertThat(taskManager.getTasks()).hasSize(2);
+        assertThat(taskManager.getTasks().toList()).hasSize(2);
 
         Task<?> clearedTask = taskManager.clearTask(taskView1Id);
 
         assertThat(taskView1Id).isEqualTo(clearedTask.id);
         assertThrows(UnknownTask.class, () -> taskManager.getTask(taskView1Id));
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_clear_running_task_should_throw_exception() throws Exception {
         taskManager.startTask("taskName", User.local(), new HashMap<>());
 
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
 
         // in the task runner loop
         Task<Serializable> task = taskQueue.poll(1, TimeUnit.SECONDS); // to sync
@@ -198,7 +198,7 @@ public class TaskManagerAmqpTest {
 
         taskManager.insert(task, null);
 
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
         assertThat(taskManager.getTask(task.id)).isNotNull();
     }
 
@@ -216,7 +216,7 @@ public class TaskManagerAmqpTest {
     }
 
     @Test
-    public void test_health_ok() throws Exception {
+    public void test_health_ok() {
         assertThat(taskManager.getHealth()).isTrue();
     }
 

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -11,13 +11,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 
+import java.util.stream.Stream;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.batch.BatchSearchRecord;
-import org.icij.datashare.batch.WebQueryPagination;
 import org.icij.datashare.test.LogbackCapturingRule;
-import org.icij.datashare.text.Project;
 import org.icij.datashare.text.ProjectProxy;
 import org.icij.datashare.time.DatashareTime;
 import org.icij.datashare.user.User;
@@ -53,7 +51,7 @@ public class TaskManagerMemoryTest {
 
         assertThat(taskManager.getTask(tid).getState()).isEqualTo(Task.State.DONE);
         assertThat(taskManager.getTask(tid).getResult()).isEqualTo(new TaskResult<>("Hello world!"));
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
     }
 
     @Test
@@ -85,7 +83,7 @@ public class TaskManagerMemoryTest {
         taskManager.awaitTermination(1, TimeUnit.SECONDS);
         assertThat(t2.getState()).isEqualTo(Task.State.CANCELLED);
         assertThat(taskManager.numberOfExecutedTasks()).isEqualTo(0);
-        assertThat(taskManager.getTasks()).hasSize(2);
+        assertThat(taskManager.getTasks().toList()).hasSize(2);
     }
 
     @Test
@@ -94,11 +92,11 @@ public class TaskManagerMemoryTest {
 
         taskManager.startTask(task, new Group(TaskGroupType.Test));
         taskManager.awaitTermination(1, TimeUnit.SECONDS);
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
 
         taskManager.clearTask(task.id);
 
-        assertThat(taskManager.getTasks()).hasSize(0);
+        assertThat(taskManager.getTasks().toList()).hasSize(0);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -135,7 +133,7 @@ public class TaskManagerMemoryTest {
 
         taskManager.insert(task, null);
 
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
         assertThat(taskManager.getTask(task.id)).isNotNull();
     }
 
@@ -146,7 +144,7 @@ public class TaskManagerMemoryTest {
         List<ProjectProxy> projects = List.of(project("project"));
         BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, List.of(batchSearchRecord));
+        List<Task<?>> tasks = taskManager.getTasks(user, Stream.of(batchSearchRecord)).toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
         assertThat(tasks.get(0).getUser()).isEqualTo(user);
@@ -161,7 +159,7 @@ public class TaskManagerMemoryTest {
         Task<String> task = new Task<>("name", User.local(), new HashMap<>());
         taskManager.insert(task, null);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, List.of(batchSearchRecord));
+        List<Task<?>> tasks = taskManager.getTasks(user, Stream.of(batchSearchRecord)).toList();
         assertThat(tasks).hasSize(2);
         assertThat(tasks.get(1).id).isEqualTo(batchSearchRecord.uuid);
         assertThat(tasks.get(1).getUser()).isEqualTo(user);
@@ -175,7 +173,7 @@ public class TaskManagerMemoryTest {
         BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
         List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, batchSearchRecords);
+        List<Task<?>> tasks = taskManager.getTasks(user, batchSearchRecords.stream()).toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).name).isEqualTo("org.icij.datashare.tasks.BatchSearchRunnerProxy");
     }
@@ -190,7 +188,7 @@ public class TaskManagerMemoryTest {
         Task<String> task = new Task<>(batchSearchRecord.uuid, "name", User.local());
         taskManager.insert(task, null);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, List.of(batchSearchRecord));
+        List<Task<?>> tasks = taskManager.getTasks(user, Stream.of(batchSearchRecord)).toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).name).isEqualTo("name");
     }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.asynctasks;
 
+import java.util.List;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
@@ -43,7 +44,7 @@ public class TaskManagerRedisTest {
 
         taskManager.insert(task, new Group(TaskGroupType.Test));
 
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
         assertThat(taskManager.getTask(task.id)).isNotNull();
     }
 
@@ -64,8 +65,9 @@ public class TaskManagerRedisTest {
     public void test_start_task() throws IOException {
         assertThat(taskManager.startTask("HelloWorld", User.local(),
             new HashMap<>() {{ put("greeted", "world"); }})).isNotNull();
-        assertThat(taskManager.getTasks()).hasSize(1);
-        assertThat(taskManager.getTasks().get(0).getUser()).isEqualTo(User.local());
+        List<Task<?>> tasks = taskManager.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getUser()).isEqualTo(User.local());
     }
 
     @Test
@@ -103,14 +105,14 @@ public class TaskManagerRedisTest {
     public void test_done_tasks() throws Exception {
         String taskViewId = taskManager.startTask("sleep", User.local(), new HashMap<>());
 
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
 
         taskSupplier.result(taskViewId, new TaskResult<>(12));
         assertThat(waitForEvent.await(1, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(taskManager.getTasks().get(0).getState()).isEqualTo(Task.State.DONE);
+        assertThat(taskManager.getTasks().toList().get(0).getState()).isEqualTo(Task.State.DONE);
         assertThat(taskManager.clearDoneTasks()).hasSize(1);
-        assertThat(taskManager.getTasks()).hasSize(0);
+        assertThat(taskManager.getTasks().toList()).hasSize(0);
     }
 
     @Test
@@ -122,10 +124,10 @@ public class TaskManagerRedisTest {
         taskSupplier.result(taskView1Id, new TaskResult<>(123));
         assertThat(waitForEvent.await(1, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(taskManager.getTasks()).hasSize(2);
+        assertThat(taskManager.getTasks().toList()).hasSize(2);
         Task<?> clearedTask = taskManager.clearTask(taskView1Id);
         assertThat(taskView1Id).isEqualTo(clearedTask.id);
-        assertThat(taskManager.getTasks()).hasSize(1);
+        assertThat(taskManager.getTasks().toList()).hasSize(1);
         assertThat(taskManager.getTask(taskView1Id)).isNull();
         assertThat(taskManager.getTask(taskView2Id)).isNotNull();
     }
@@ -150,8 +152,9 @@ public class TaskManagerRedisTest {
         taskSupplier.result(taskViewId, expectedResult);
         assertThat(waitForEvent.await(100, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(taskManager.getTasks()).hasSize(1);
-        assertThat(taskManager.getTasks().get(0).getResult()).isEqualTo(expectedResult);
+        List<Task<?>> tasks = taskManager.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getResult()).isEqualTo(expectedResult);
     }
 
     @Test

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.asynctasks;
 
 
+import java.util.List;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpInterlocutor;
 import org.icij.datashare.asynctasks.bus.amqp.AmqpQueue;
@@ -89,8 +90,9 @@ public class TaskManagersIntTest {
         taskInspector.awaitStatus(taskViewId, Task.State.CANCELLED, 1, SECONDS);
         eventWaiter.await();
 
-        assertThat(taskManager.getTasks()).hasSize(1);
-        assertThat(taskManager.getTasks().get(0).getState()).isEqualTo(Task.State.CANCELLED);
+        List<Task<?>> tasks = taskManager.getTasks().toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).getState()).isEqualTo(Task.State.CANCELLED);
     }
 
     @Test(timeout = 10000)
@@ -104,7 +106,7 @@ public class TaskManagersIntTest {
         taskInspector.awaitStatus(tv1Id, Task.State.CANCELLED, 1, SECONDS);
         taskInspector.awaitStatus(tv2Id, Task.State.CANCELLED, 1, SECONDS);
 
-        assertThat(taskManager.getTasks()).hasSize(2);
+        assertThat(taskManager.getTasks().toList()).hasSize(2);
         assertThat(taskManager.getTask(tv1Id).getState()).isEqualTo(Task.State.CANCELLED);
         assertThat(taskManager.getTask(tv2Id).getState()).isEqualTo(Task.State.CANCELLED);
     }
@@ -119,7 +121,7 @@ public class TaskManagersIntTest {
         taskInspector.awaitStatus(tv1Id, Task.State.CANCELLED, 1, SECONDS);
         taskInspector.awaitStatus(tv2Id, Task.State.CANCELLED, 1, SECONDS);
 
-        assertThat(taskManager.getTasks()).hasSize(2);
+        assertThat(taskManager.getTasks().toList()).hasSize(2);
         assertThat(taskManager.getTask(tv1Id).getState()).isEqualTo(Task.State.CANCELLED);
         assertThat(taskManager.getTask(tv2Id).getState()).isEqualTo(Task.State.CANCELLED);
     }
@@ -133,7 +135,7 @@ public class TaskManagersIntTest {
         taskManager.stopTasks(User.local(), Map.of("name", Pattern.compile(".*Another.*")));
         taskInspector.awaitStatus(tv1Id, Task.State.CANCELLED, 1, SECONDS);
 
-        assertThat(taskManager.getTasks()).hasSize(2);
+        assertThat(taskManager.getTasks().toList()).hasSize(2);
         assertThat(taskManager.getTask(tv1Id).getState()).isEqualTo(Task.State.CANCELLED);
         assertThat(taskManager.getTask(tv2Id).getState()).isEqualTo(Task.State.RUNNING);
 
@@ -150,13 +152,11 @@ public class TaskManagersIntTest {
         taskInspector.awaitStatus(tv1Id, Task.State.RUNNING, 1, SECONDS);
         taskManager.stopTasks(User.local());
         taskInspector.awaitStatus(tv1Id, Task.State.CANCELLED, 1, SECONDS);
-
-        assertThat(taskManager.getTask(tv1Id).getState()).isEqualTo(Task.State.CANCELLED);
-        assertThat(taskManager.getTask(tv2Id).getState()).isEqualTo(Task.State.CANCELLED);
+        taskInspector.awaitStatus(tv2Id, Task.State.CANCELLED, 1, SECONDS);
 
         taskManager.clearDoneTasks();
 
-        assertThat(taskManager.getTasks()).isEmpty();
+        assertThat(taskManager.getTasks().toList()).isEmpty();
     }
 
     @Test(timeout = 10000)
@@ -172,7 +172,7 @@ public class TaskManagersIntTest {
 
         taskManager.clearDoneTasks();
 
-        assertThat(taskManager.getTasks()).isNotEmpty();
+        assertThat(taskManager.getTasks().toList()).isNotEmpty();
     }
 
     @Test(timeout = 10000)

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
         <datashare-api.version>14.5.0</datashare-api.version>
         <datashare-cli.version>13.6.1</datashare-cli.version>
-        <datashare-tasks.version>16.1.4</datashare-tasks.version>
+        <datashare-tasks.version>17.0.0</datashare-tasks.version>
         <ftm.version>0.3.1</ftm.version>
 
         <datashare-mitie.version>${project.version}</datashare-mitie.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
         <datashare-api.version>14.5.0</datashare-api.version>
         <datashare-cli.version>13.6.1</datashare-cli.version>
-        <datashare-tasks.version>17.0.0</datashare-tasks.version>
+        <datashare-tasks.version>17.0.1</datashare-tasks.version>
         <ftm.version>0.3.1</ftm.version>
 
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
# PR description

Currently each time we filter tasks we always materialize them in a list which contains all tasks. As we run more tasks to Datashare this list can grow very large, using a stream API will help reduce the memory footprint of task search.

# Changes

## `datashare-tasks`

### Changed
- change `TaskManager` APIs to return task streams
