### PR TITLE
chore: unify and optimize task search APIs (`TaskManager.getTasks`)

### DIFF
--- a/datashare-api/pom.xml
+++ b/datashare-api/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>datashare-api</artifactId>
-    <version>15.0.0</version>
+    <version>14.6.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/datashare-api/pom.xml
+++ b/datashare-api/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>datashare-api</artifactId>
-    <version>14.5.0</version>
+    <version>15.0.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/datashare-api/src/main/java/org/icij/datashare/batch/WebQueryPagination.java
+++ b/datashare-api/src/main/java/org/icij/datashare/batch/WebQueryPagination.java
@@ -2,10 +2,13 @@ package org.icij.datashare.batch;
 
 
 import java.lang.reflect.Field;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
@@ -39,6 +42,10 @@ public class WebQueryPagination {
                 (String) paginationMap.get("order"),
                 Integer.parseInt(ofNullable(paginationMap.get("from")).orElse("0").toString()),
                 Integer.parseInt(ofNullable(paginationMap.get("size")).orElse(Integer.MAX_VALUE).toString()));
+    }
+
+    public <T> Stream<T> paginate(Stream<T> stream, Function<WebQueryPagination, Comparator<T>> comparatorFactory) {
+        return stream.sorted(comparatorFactory.apply(this)).skip(from).limit(size);
     }
 
     @Override

--- a/datashare-api/src/main/java/org/icij/datashare/user/User.java
+++ b/datashare-api/src/main/java/org/icij/datashare/user/User.java
@@ -10,7 +10,6 @@ import org.icij.datashare.text.Project;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -221,7 +221,7 @@
             });
             logger.info("Stopping tasks : {}", taskManager.stopTasks(user));
             taskManager.waitTasksToBeDone(TaskManager.POLLING_INTERVAL*2, MILLISECONDS);
-            logger.info("Deleted tasks : {}", !taskManager.clearDoneTasks().isEmpty());
+            logger.info("Deleted tasks : {}", taskManager.clearDoneTasks().findFirst().isPresent());
             return new Payload(204);
         }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -221,7 +221,7 @@
             });
             logger.info("Stopping tasks : {}", taskManager.stopTasks(user));
             taskManager.waitTasksToBeDone(TaskManager.POLLING_INTERVAL*2, MILLISECONDS);
-            logger.info("Deleted tasks : {}", taskManager.clearDoneTasks().findFirst().isPresent());
+            logger.info("Deleted tasks : {}", !taskManager.clearDoneTasks().isEmpty());
             return new Payload(204);
         }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.web;
 
-import java.util.stream.Stream;
 import net.codestory.http.filters.basic.BasicAuthFilter;
 import net.codestory.http.security.Users;
 import org.icij.datashare.PropertiesProvider;
@@ -323,7 +322,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         when(repository.getProjects(any())).thenReturn(asList(foo, bar));
         when(repository.deleteAll("foo")).thenReturn(true).thenReturn(false);
         when(repository.deleteAll("bar")).thenReturn(true).thenReturn(false);
-        when(taskManager.clearDoneTasks()).thenReturn(Stream.of(task)).thenReturn(Stream.of());
+        when(taskManager.clearDoneTasks()).thenReturn(List.of(task)).thenReturn(List.of());
         delete("/api/project/").should().respond(204);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -323,7 +323,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         when(repository.getProjects(any())).thenReturn(asList(foo, bar));
         when(repository.deleteAll("foo")).thenReturn(true).thenReturn(false);
         when(repository.deleteAll("bar")).thenReturn(true).thenReturn(false);
-        when(taskManager.clearDoneTasks()).thenReturn(List.of(task)).thenReturn(List.of());
+        when(taskManager.clearDoneTasks()).thenReturn(Stream.of(task)).thenReturn(Stream.of());
         delete("/api/project/").should().respond(204);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceBatchSearchTest.java
@@ -124,7 +124,8 @@ public class TaskResourceBatchSearchTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_upload_batch_search_csv_with_name_and_csvfile_should_send_OK() throws InterruptedException {
+    public void test_upload_batch_search_csv_with_name_and_csvfile_should_send_OK()
+        throws InterruptedException, IOException {
         when(batchSearchRepository.save(any())).thenReturn(true);
         Response response = postRaw("/api/task/batchSearch/prj", "multipart/form-data;boundary=AaB03x",
                 new MultipartContentBuilder("AaB03x")
@@ -171,7 +172,7 @@ public class TaskResourceBatchSearchTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_rerun_batch_search() {
+    public void test_rerun_batch_search() throws IOException {
         String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
         BatchSearch sourceSearch = new BatchSearch(asList(project("prj1"), project("prj2")), "name", "description1", asSet("query 1", "query 2"), uri, User.local());
         when(batchSearchRepository.get(null, sourceSearch.uuid)).thenReturn(sourceSearch);

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserTaskResourceTest.java
@@ -140,7 +140,7 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_task_list_with_filter() throws IOException {
+    public void test_task_list_by_name() throws IOException {
         setupAppWith(new DummyUserTask<>("bar"), "bar");
         String t2Id = taskManager.startTask(DummyUserTask.class, localUser("bar"), new HashMap<>());
 
@@ -150,7 +150,6 @@ public class UserTaskResourceTest extends AbstractProdWebServerTest {
                 contain("\"uid\":\"bar\"").
                 contain("\"groups_by_applications\":{\"datashare\":[\"bar-datashare\"]}").
                 contain("\"args\":{\"user\":{\"@type\":\"org.icij.datashare.user.User\",\"id\":\"bar\"");
-        get("/api/task/all?filter=foo").withPreemptiveAuthentication("bar", "qux").should().contain("[]");
     }
 
     @Test

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqTaskRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqTaskRepository.java
@@ -3,35 +3,42 @@ package org.icij.datashare.db;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.icij.datashare.asynctasks.Group;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskAlreadyExists;
+import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskGroupType;
-import org.icij.datashare.asynctasks.TaskMetadata;
 import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.TaskResult;
+import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.db.tables.records.TaskRecord;
 import org.icij.datashare.json.JsonObjectMapper;
+import org.jooq.Condition;
 import org.jooq.DSLContext;
-import org.jooq.InsertOnDuplicateSetMoreStep;
 import org.jooq.InsertValuesStep11;
 import org.jooq.SQLDialect;
+import org.jooq.exception.IntegrityConstraintViolationException;
 import org.jooq.impl.DSL;
 
 import javax.sql.DataSource;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.AbstractMap;
-import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.asynctasks.bus.amqp.Event.MAX_RETRIES_LEFT;
 import static org.icij.datashare.db.Tables.TASK;
+import static org.jooq.impl.DSL.selectFrom;
+import static org.jooq.impl.DSL.trueCondition;
 import static org.jooq.impl.DSL.using;
 
 public class JooqTaskRepository implements TaskRepository {
@@ -45,109 +52,129 @@ public class JooqTaskRepository implements TaskRepository {
     }
 
     @Override
-    public int size() {
-        return DSL.using(connectionProvider, dialect).selectCount().from(TASK).fetchOne(0, Integer.class);
+    public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
+        return (Task<V>) createTaskFrom(DSL.using(connectionProvider, dialect).selectFrom(TASK).
+                where(TASK.ID.eq(taskId)).fetchOne());
     }
 
     @Override
-    public boolean containsKey(Object o) {
-        DSLContext ctx = DSL.using(connectionProvider, dialect);
-        return ctx.fetchExists(
-                ctx.selectOne()
-                        .from(TASK)
-                        .where(TASK.ID.eq((String) o))
-        );
-    }
-
-    @Override
-    public boolean containsValue(Object o) {
-        return containsKey(((Task<?>) o).getId());
-    }
-
-    @Override
-    public TaskMetadata<?> get(Object o) {
-        return createTaskFrom(DSL.using(connectionProvider, dialect).selectFrom(TASK).
-                where(TASK.ID.eq((String) o)).fetchOne());
-    }
-
-    @Override
-    public TaskMetadata<?> put(String s, TaskMetadata<?> taskMetadata) {
-        if (taskMetadata == null || s == null || !s.equals(taskMetadata.taskId())) {
-            throw new IllegalArgumentException(String.format("task is null or its id (%s) is different than the key (%s)", ofNullable(taskMetadata).map(TaskMetadata::taskId).orElse(null), s));
-        }
-        return using(connectionProvider, dialect).transactionResult(configuration -> {
+    public <V extends Serializable> void insert(Task<V> task, Group group) throws IOException, TaskAlreadyExists {
+        using(connectionProvider, dialect).transactionResult(configuration -> {
             DSLContext inner = using(configuration);
-            TaskMetadata<?> old = createTaskFrom(inner.selectFrom(TASK).where(TASK.ID.eq(taskMetadata.taskId())).fetchOne());
-            if (old != null && old.equals(taskMetadata)) return null; // no need to go further
-
             InsertValuesStep11<TaskRecord, String, String, String, String, String, Double, LocalDateTime, LocalDateTime, Integer, Integer, String> insertInto = insert(inner);
-            insertValues(taskMetadata, insertInto);
-            InsertOnDuplicateSetMoreStep<TaskRecord> onDuplicate = insertInto.onDuplicateKeyUpdate()
-                    .set(TASK.ERROR, TYPE_INCLUSION_MAPPER.writeValueAsString(taskMetadata.task().getError()))
-                    .set(TASK.RESULT, TYPE_INCLUSION_MAPPER.writeValueAsString(taskMetadata.task().getResult()))
-                    .set(TASK.STATE, taskMetadata.task().getState().name())
-                    .set(TASK.PROGRESS, taskMetadata.task().getProgress())
-                    .set(TASK.COMPLETED_AT, ofNullable(taskMetadata.task().getCompletedAt()).map(d -> new Timestamp(d.getTime()).toLocalDateTime()).orElse(null));
-
-            onDuplicate.execute();
-            return old;
+            insertValues(task, group, insertInto);
+            try {
+                insertInto.execute();
+            } catch (IntegrityConstraintViolationException e) {
+                String cause = e.getCause().getMessage();
+                if (cause.contains("SQLITE_CONSTRAINT_PRIMARYKEY") || cause.contains("task_pkey")) {
+                    throw new TaskAlreadyExists(task.id);
+                }
+                throw e;
+            }
+            return null;
         });
     }
 
     @Override
-    public TaskMetadata<?> remove(Object key) {
-        return createTaskFrom(DSL.using(connectionProvider, dialect).deleteFrom(TASK).where(TASK.ID.eq((String) key)).returning().fetchOne());
+    public <V extends Serializable> void update(Task<V> task) throws IOException, UnknownTask {
+        using(connectionProvider, dialect).transactionResult(configuration -> {
+            TaskRecord r = using(configuration)
+                .update(TASK)
+                .set(TASK.ERROR, TYPE_INCLUSION_MAPPER.writeValueAsString(task.getError()))
+                .set(TASK.RESULT, TYPE_INCLUSION_MAPPER.writeValueAsString(task.getResult()))
+                .set(TASK.STATE, task.getState().name())
+                .set(TASK.PROGRESS, task.getProgress())
+                .set(TASK.COMPLETED_AT, ofNullable(task.getCompletedAt()).map(d -> new Timestamp(d.getTime()).toLocalDateTime()).orElse(null))
+                .where(TASK.ID.eq(task.id))
+                .returning()
+                .fetchOne();
+            if (r == null) {
+                throw new UnknownTask(task.id);
+            }
+            return null;
+        });
+    }
+
+
+    @Override
+    public <V extends Serializable> Task<V> delete(String taskId) throws IOException, UnknownTask {
+        Task<V> task = (Task<V>) createTaskFrom(DSL.using(connectionProvider, dialect)
+            .deleteFrom(TASK).where(TASK.ID.eq(taskId)).returning().fetchOne()
+        );
+        if (task == null) {
+            throw new UnknownTask(taskId);
+        }
+        return task;
     }
 
     @Override
-    public void putAll(Map<? extends String, ? extends TaskMetadata<?>> map) {
-        ofNullable(map).orElseThrow(() -> new IllegalArgumentException("task(s) map is null"));
-        InsertValuesStep11<TaskRecord, String, String, String, String, String, Double, LocalDateTime, LocalDateTime, Integer, Integer, String> insert = insert(using(connectionProvider, dialect));
-        map.values().forEach(t -> insertValues(t, insert));
-        insert.execute();
-    }
-
-    @Override
-    public void clear() {
+    public void deleteAll() {
         DSL.using(connectionProvider, dialect).deleteFrom(TASK).execute();
     }
 
     @Override
-    public Set<String> keySet() {
-        return DSL.using(connectionProvider, dialect).select(TASK.ID).from(TASK)
-                .stream().map(r -> r.field1().getValue(r)).collect(Collectors.toSet());
+    public Group getTaskGroup(String taskId) throws UnknownTask {
+        String groupId = Optional.ofNullable(
+            DSL.using(connectionProvider, dialect)
+                .select(TASK.GROUP_ID)
+                .from(TASK)
+                .where(TASK.ID.eq(taskId))
+                .fetchOne()
+            )
+            .map(r -> r.get(TASK.GROUP_ID))
+            .orElseThrow(() -> new UnknownTask(taskId));
+        return new Group(TaskGroupType.valueOf(groupId));
     }
 
     @Override
-    public Collection<TaskMetadata<?>> values() {
-        return DSL.using(connectionProvider, dialect).selectFrom(TASK).stream()
-                .map(this::createTaskFrom).collect(Collectors.toList());
+    public Stream<Task<? extends Serializable>> getTasks(TaskFilters filters) {
+        if (filters == null) {
+            return selectFrom(TASK).stream().map(this::createTaskFrom);
+        }
+        Stream<Task<? extends Serializable>> tasks = selectTasks(DSL.using(connectionProvider, dialect), filters);
+        if (filters.getArgs() != null && !filters.getArgs().isEmpty()) {
+            tasks = tasks.filter(TaskFilters.empty().withArgs(filters.getArgs())::filter);
+        }
+        return tasks;
     }
 
-    @Override
-    public Set<Entry<String, TaskMetadata<?>>> entrySet() {
-        return DSL.using(connectionProvider, dialect).selectFrom(TASK).stream()
-                .map(t -> new AbstractMap.SimpleEntry<String, TaskMetadata<?>>(t.getId(), createTaskFrom(t)))
-                .collect(Collectors.toSet());
-    }
-
-    private TaskMetadata<?> createTaskFrom(TaskRecord taskRecord) {
+    private Task<?> createTaskFrom(TaskRecord taskRecord) {
         return ofNullable(taskRecord).map(r ->
         {
-            Date createdAt = r.getCreatedAt() == null ? null : Date.from(r.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant());;
-            Date completedAt = r.getCompletedAt() == null ? null :Date.from(r.getCompletedAt().atZone(ZoneId.systemDefault()).toInstant());;
+            Date createdAt = r.getCreatedAt() == null ? null : Date.from(r.getCreatedAt().atZone(ZoneId.systemDefault()).toInstant());
+            Date completedAt = r.getCompletedAt() == null ? null :Date.from(r.getCompletedAt().atZone(ZoneId.systemDefault()).toInstant());
             try {
                 Map<String, Object> args = TYPE_INCLUSION_MAPPER.readValue(r.getArgs(), new TypeReference<>() {});
                 TaskResult<?> result = r.getResult() == null ? null: TYPE_INCLUSION_MAPPER.readValue(r.getResult(), new TypeReference<>() {});
                 TaskError error  = r.getError() == null ? null: TYPE_INCLUSION_MAPPER.readValue(r.getError(), TaskError.class);
                 Task<?> task = new Task<>(r.getId(), r.getName(), Task.State.valueOf(r.getState()),
                         r.getProgress(), createdAt, r.getRetriesLeft(), completedAt, args, result, error);
-                return new TaskMetadata<>(task, new Group(TaskGroupType.valueOf(r.getGroupId())));
+                return task;
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
         }).orElse(null);
     }
+
+    private Stream<Task<? extends Serializable>> selectTasks(DSLContext ctx, TaskFilters filters) {
+        List<Condition> conditions = new ArrayList<>();
+        if (filters.getStates() != null && !filters.getStates().isEmpty()) {
+            Condition hasState = trueCondition();
+            for (Task.State s : filters.getStates()) {
+                hasState.and(TASK.STATE.eq(s.name()));
+            }
+            conditions.add(hasState);
+        }
+        if (filters.getName() != null) {
+            conditions.add(TASK.NAME.likeRegex(filters.getName()));
+        }
+        if (filters.getUser() != null) {
+            conditions.add(TASK.USER_ID.eq(filters.getUser().id));
+        }
+        return ctx.selectFrom(TASK).where(conditions).stream().map(this::createTaskFrom);
+    }
+
 
     private InsertValuesStep11<TaskRecord, String, String, String, String, String, Double, LocalDateTime, LocalDateTime, Integer, Integer, String> insert(DSLContext ctx) {
         return ctx.insertInto(TASK).columns(
@@ -155,18 +182,17 @@ public class JooqTaskRepository implements TaskRepository {
                         TASK.CREATED_AT, TASK.COMPLETED_AT, TASK.RETRIES_LEFT, TASK.MAX_RETRIES, TASK.ARGS);
     }
 
-    private static void insertValues(TaskMetadata<?> taskMetadata, InsertValuesStep11<TaskRecord, String, String, String, String, String, Double, LocalDateTime, LocalDateTime, Integer, Integer, String> insert) {
-        Task<?> t = taskMetadata.task();
+    private static void insertValues(Task<?> task, Group group, InsertValuesStep11<TaskRecord, String, String, String, String, String, Double, LocalDateTime, LocalDateTime, Integer, Integer, String> insert) {
         try {
-            insert.values(t.id, t.name,
-                    t.getState().name(),
-                    ofNullable(t.getUser()).map(u -> u.id).orElse(null),
-                    ofNullable(taskMetadata.group()).map(Group::getId).orElse(null),
-                    t.getProgress(),
-                    new Timestamp(t.createdAt.getTime()).toLocalDateTime(),
-                    ofNullable(t.getCompletedAt()).map(d -> new Timestamp(d.getTime()).toLocalDateTime()).orElse(null),
-                    t.getRetriesLeft(),
-                    MAX_RETRIES_LEFT, TYPE_INCLUSION_MAPPER.writeValueAsString(t.args)); // to force writing @type fields in the hashmap
+            insert.values(task.id, task.name,
+                    task.getState().name(),
+                    ofNullable(task.getUser()).map(u -> u.id).orElse(null),
+                    ofNullable(group).map(Group::getId).orElse(null),
+                    task.getProgress(),
+                    new Timestamp(task.createdAt.getTime()).toLocalDateTime(),
+                    ofNullable(task.getCompletedAt()).map(d -> new Timestamp(d.getTime()).toLocalDateTime()).orElse(null),
+                    task.getRetriesLeft(),
+                    MAX_RETRIES_LEFT, TYPE_INCLUSION_MAPPER.writeValueAsString(task.args)); // to force writing @type fields in the hashmap
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/datashare-tasks/pom.xml
+++ b/datashare-tasks/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>datashare-tasks</artifactId>
     <name>datashare-tasks</name>
     <packaging>jar</packaging>
-    <version>17.0.1</version>
+    <version>18.0.0</version>
     <description>Datashare asynchronous task execution library</description>
 
     <properties>

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
@@ -1,10 +1,13 @@
-package org.icij.datashare.asynctasks;
+    package org.icij.datashare.asynctasks;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.icij.datashare.Entity;
 import org.icij.datashare.asynctasks.bus.amqp.Event;
@@ -35,7 +38,13 @@ public class Task<V extends Serializable> extends Event implements Entity, Compa
     @JsonIgnore private StateLatch stateLatch;
     @JsonIgnore private final Object lock = new Object();
 
-    public enum State {CREATED, QUEUED, RUNNING, CANCELLED, ERROR, DONE}
+    public enum State {
+        CREATED, QUEUED, RUNNING, CANCELLED, ERROR, DONE;
+
+        public static final Set<State> FINAL_STATES = Set.of(CANCELLED, ERROR, DONE);
+        public static final Set<State> NON_FINAL_STATES = Arrays.stream(State.values()).filter(s -> !FINAL_STATES.contains(s))
+            .collect(Collectors.toSet());
+    }
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@type")
     public final Map<String, Object> args;
     public final String id;

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Task.java
@@ -176,7 +176,7 @@ public class Task<V extends Serializable> extends Event implements Entity, Compa
 
     @JsonIgnore
     public boolean isFinished() {
-        return State.DONE.equals(state) || State.CANCELLED.equals(state) || State.ERROR.equals(state);
+        return State.FINAL_STATES.contains(state);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskFilters.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskFilters.java
@@ -1,0 +1,154 @@
+package org.icij.datashare.asynctasks;
+
+import static java.util.stream.Collectors.toMap;
+import static org.icij.datashare.text.StringUtils.getValue;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.icij.datashare.user.User;
+
+public final class TaskFilters {
+    private final List<ArgsFilter> args;
+    private final Set<Task.State> states;
+    private final String name;
+    private final User user;
+    private final Integer regexFlags;
+    private Map<String, Pattern> argsPatterns = null;
+    private Pattern taskNamePattern = null;
+
+    public TaskFilters(List<ArgsFilter> args, Set<Task.State> states, String name, User user, Integer regexFlags) {
+        this.args = args;
+        this.states = states;
+        this.name = name;
+        this.user = user;
+        this.regexFlags = regexFlags;
+    }
+
+    public TaskFilters(List<ArgsFilter> args, Set<Task.State> states, String name, User user) {
+        this(args, states, name, user, null);
+    }
+
+    public static TaskFilters empty() {
+        return new TaskFilters(null, null, null, null);
+    }
+
+    public Set<Task.State> getStates() {
+        return states;
+    }
+
+    public List<ArgsFilter> getArgs() {
+        return args;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public TaskFilters withUser(User taskUser) {
+        return new TaskFilters(args, states, name, taskUser, regexFlags);
+    }
+
+    public TaskFilters withStates(Set<Task.State> taskStates) {
+        return new TaskFilters(args, taskStates, name, user, regexFlags);
+    }
+
+    public TaskFilters withNames(String name) {
+        return new TaskFilters(args, states, name, user, regexFlags);
+    }
+
+    public TaskFilters withArgs(List<ArgsFilter> taskArgs) {
+        return new TaskFilters(taskArgs, states, name, user, regexFlags);
+    }
+
+    public TaskFilters withFlag(Integer flag) {
+        return new TaskFilters(args, states, name, user, flag);
+    }
+
+    public record ArgsFilter(String argLocation, String pattern) {
+    }
+
+    public boolean filter(Task<? extends Serializable> task) {
+        return byName(task.name) && byUser(task.getUser()) && byState(task.getState()) && byArgs(task.args);
+    }
+
+    private boolean byState(Task.State taskState) {
+        return Optional.ofNullable(states).map(expectedStates -> {
+            if (!expectedStates.isEmpty()) {
+                return expectedStates.contains(taskState);
+            }
+            return true;
+        }).orElse(true);
+    }
+
+    private boolean byUser(User taskUser) {
+        return Optional.ofNullable(this.user).map(u -> u.equals(taskUser)).orElse(true);
+    }
+
+    private boolean byName(String taskName) {
+        return Optional.ofNullable(getNamePattern()).map(p -> p.matcher(taskName).find()).orElse(true);
+    }
+
+    private boolean byArgs(Map<String, Object> taskArgs) {
+        return Optional.ofNullable(getArgsPatterns())
+            .map(patterns -> patterns.entrySet()
+                .stream()
+                .allMatch(e -> e.getValue().matcher(String.valueOf(getValue(taskArgs, e.getKey()))).find()
+                ))
+            .orElse(true);
+    }
+
+    private Pattern getNamePattern() {
+        if (name == null) {
+            return null;
+        }
+        if (taskNamePattern == null) {
+            taskNamePattern = regexFlags == null ? Pattern.compile(name) : Pattern.compile(name, regexFlags);
+        }
+        return taskNamePattern;
+    }
+
+    private Map<String, Pattern> getArgsPatterns() {
+        if (args == null || args.isEmpty()) {
+            return null;
+        }
+        if (argsPatterns == null) {
+            argsPatterns = args.stream().collect(toMap(e -> e.argLocation, e -> {
+                if (regexFlags != null) {
+                    return Pattern.compile(e.pattern, regexFlags);
+                }
+                return Pattern.compile(e.pattern);
+            }));
+        }
+        return argsPatterns;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TaskFilters filters = (TaskFilters) o;
+        return Objects.equals(args, filters.args) && Objects.equals(states, filters.states)
+            && Objects.equals(name, filters.name) && Objects.equals(user, filters.user)
+            && Objects.equals(regexFlags, filters.regexFlags) && Objects.equals(argsPatterns,
+            filters.argsPatterns) && Objects.equals(taskNamePattern, filters.taskNamePattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(args, states, name, user, regexFlags, argsPatterns, taskNamePattern);
+    }
+
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
@@ -2,6 +2,7 @@ package org.icij.datashare.asynctasks;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -114,9 +115,8 @@ public class TaskManagerAmqp implements TaskManager {
 
     @Override
     public List<Task<?>> clearDoneTasks(TaskFilters filters) throws IOException {
-        Set<Task.State> stateFilter = new HashSet<>(FINAL_STATES);
-        stateFilter.addAll(Optional.ofNullable(filters.getStates()).orElse(Set.of()));
-        Stream<Task<?>> taskStream = tasks.getTasks(filters.withStates(stateFilter))
+        // Require tasks to be in final state and apply user filters
+        Stream<Task<?>> taskStream = tasks.getTasks(filters.withStates(FINAL_STATES))
             .map(t -> {
                 try {
                     return tasks.delete(t.id);

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
@@ -143,9 +143,8 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
     @Override
     public List<Task<?>> clearDoneTasks(TaskFilters filters) throws IOException {
         synchronized (tasks) {
-            Set<Task.State> stateFilter = new HashSet<>(FINAL_STATES);
-            stateFilter.addAll(Optional.ofNullable(filters.getStates()).orElse(Set.of()));
-            Stream<Task<?>> taskStream = tasks.getTasks(filters.withStates(stateFilter))
+            // Require tasks to be in final state and apply user filters
+            Stream<Task<?>> taskStream = tasks.getTasks(filters.withStates(FINAL_STATES))
                 .map(t -> {
                     try {
                         return tasks.delete(t.id);

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
@@ -85,9 +85,8 @@ public class TaskManagerRedis implements TaskManager {
 
     @Override
     public List<Task<?>> clearDoneTasks(TaskFilters filters) throws IOException {
-        Set<Task.State> stateFilter = new HashSet<>(FINAL_STATES);
-        stateFilter.addAll(Optional.ofNullable(filters.getStates()).orElse(Set.of()));
-        Stream<Task<?>> taskStream = tasks.getTasks(filters.withStates(stateFilter))
+        // Require tasks to be in final state and apply user filters
+        Stream<Task<?>> taskStream = tasks.getTasks(filters.withStates(FINAL_STATES))
             .map(t -> {
                 try {
                     return tasks.delete(t.id);

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepository.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepository.java
@@ -2,26 +2,21 @@ package org.icij.datashare.asynctasks;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Map;
-import java.util.Optional;
+import java.util.stream.Stream;
 
-public interface TaskRepository extends Map<String, TaskMetadata<?>> {
-    default <V extends Serializable> void insert(Task<V> task, Group group) throws IOException, TaskAlreadyExists {
-        if (containsKey(task.id)) {
-            throw new TaskAlreadyExists(task.id);
-        }
-        put(task.id, new TaskMetadata<>(task, group));
-    }
+public interface TaskRepository {
+    <V extends Serializable> void insert(Task<V> task, Group group) throws IOException, TaskAlreadyExists;
 
-    default  <V extends Serializable> void update(Task<V> task) throws IOException, UnknownTask {
-        put(task.id, Optional.ofNullable(get(task.id)).orElseThrow(() -> new UnknownTask(task.id)).withTask(task));
-    }
+    <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask;
 
-    default  <V extends Serializable> Task<V> getTask(String taskId) throws UnknownTask {
-        return (Task<V>) Optional.ofNullable(get(taskId)).orElseThrow(() -> new UnknownTask(taskId)).task();
-    }
+    <V extends Serializable> void update(Task<V> task) throws IOException, UnknownTask;
 
-    default boolean isEmpty() {
-        return size() == 0;
-    }
+    <V extends Serializable> Task<V> delete(String taskId) throws IOException, UnknownTask;
+
+    void deleteAll() throws IOException, UnknownTask;
+
+    Group getTaskGroup(String taskId) throws IOException, UnknownTask;
+
+
+    Stream<Task<? extends Serializable>> getTasks(TaskFilters filters) throws IOException, UnknownTask;
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryMemory.java
@@ -1,5 +1,50 @@
 package org.icij.datashare.asynctasks;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
-public class TaskRepositoryMemory extends ConcurrentHashMap<String, TaskMetadata<?>> implements TaskRepository { }
+public class TaskRepositoryMemory extends ConcurrentHashMap<String, TaskMetadata<?>> implements TaskRepository {
+    @Override
+    public <V extends Serializable> void insert(Task<V> task, Group group) throws IOException {
+        super.put(task.id, new TaskMetadata<>(task, group));
+    }
+
+    @Override
+    public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
+        TaskMetadata<V> taskMetadata = (TaskMetadata<V>) super.get(taskId);
+        if (taskMetadata == null) {
+            throw new UnknownTask(taskId);
+        }
+        return taskMetadata.task();
+    }
+
+    @Override
+    public Stream<Task<? extends Serializable>> getTasks(TaskFilters filters) throws IOException, UnknownTask {
+        return super.values().stream().map(TaskMetadata::task)
+            .filter(filters::filter)
+            .map(t -> (Task<? extends Serializable>)t);
+    }
+
+    @Override
+    public <V extends Serializable> void update(Task<V> task) throws IOException, UnknownTask {
+        put(task.id, super.get(task.id).withTask(task));
+    }
+
+    @Override
+    public <V extends Serializable> Task<V> delete(String taskId) throws IOException, UnknownTask {
+        return (Task<V>) Optional.ofNullable(remove(taskId)).orElseThrow(() -> new UnknownTask(taskId)).task();
+    }
+
+    @Override
+    public void deleteAll() throws IOException, UnknownTask {
+        clear();
+    }
+
+    @Override
+    public Group getTaskGroup(String taskId) throws IOException, UnknownTask {
+        return super.get(taskId).group();
+    }
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryRedis.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryRedis.java
@@ -1,5 +1,9 @@
 package org.icij.datashare.asynctasks;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.redisson.Redisson;
 import org.redisson.RedissonMap;
 import org.redisson.api.RedissonClient;
@@ -14,5 +18,46 @@ public class TaskRepositoryRedis extends RedissonMap<String, TaskMetadata<?>> im
     public TaskRepositoryRedis(RedissonClient redisson, String name) {
         super(new TaskManagerRedis.RedisCodec<>(TaskMetadata.class), new CommandSyncService(((Redisson) redisson).getConnectionManager(), new RedissonObjectBuilder(redisson)),
                 name, redisson, null, null);
+    }
+
+    @Override
+    public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask{
+        TaskMetadata<V> taskMetadata = (TaskMetadata<V>) super.get(taskId);
+        if (taskMetadata == null) {
+            throw new UnknownTask(taskId);
+        }
+        return taskMetadata.task();
+    }
+
+    @Override
+    public Stream<Task<? extends Serializable>> getTasks(TaskFilters filters) throws IOException, UnknownTask {
+        return super.values().stream().map(TaskMetadata::task)
+            .filter(filters::filter)
+            .map(t -> (Task<? extends Serializable>)t);
+    }
+
+    @Override
+    public <V extends Serializable> void insert(Task<V> task, Group group) throws IOException {
+        super.put(task.id, new TaskMetadata<>(task, group));
+    }
+
+    @Override
+    public <V extends Serializable> void update(Task<V> task) throws IOException, UnknownTask {
+        put(task.id, super.get(task.id).withTask(task));
+    }
+
+    @Override
+    public <V extends Serializable> Task<V> delete(String taskId) throws IOException, UnknownTask {
+        return (Task<V>) Optional.ofNullable(remove(taskId)).orElseThrow(() -> new UnknownTask(taskId)).task();
+    }
+
+    @Override
+    public void deleteAll() throws IOException, UnknownTask {
+        clear();
+    }
+
+    @Override
+    public Group getTaskGroup(String taskId) throws IOException, UnknownTask {
+        return super.get(taskId).group();
     }
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskFilterTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskFilterTest.java
@@ -1,0 +1,99 @@
+package org.icij.datashare.asynctasks;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.icij.datashare.user.User;
+import org.junit.Test;
+
+public class TaskFilterTest {
+    static final Task<String> t1 = new Task<>("someTask", User.local(), Map.of());
+    static Task<String> t2 = new Task<>("someOtherTask", null, Map.of("nested", Map.of("attribute","nestedvalue")));
+    static {
+        t2.setState(Task.State.DONE);
+    }
+    static List<Task<?>> tasks = List.of(t1, t2);
+
+    @Test
+    public void test_task_empty_filters() {
+        // Given
+        TaskFilters filters = TaskFilters.empty();
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(tasks);
+    }
+
+    @Test
+    public void test_task_empty_args() {
+        // Given
+        TaskFilters filters = TaskFilters.empty().withArgs(List.of());
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(tasks);
+    }
+
+    @Test
+    public void test_task_empty_states() {
+        // Given
+        TaskFilters filters = TaskFilters.empty().withStates(Set.of());
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(tasks);
+    }
+
+    @Test
+    public void test_task_filters_by_names() {
+        // Given
+        TaskFilters filters = TaskFilters.empty().withNames("someT.*");
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(List.of(t1));
+    }
+
+    @Test
+    public void test_task_filters_by_names_with_regex_pattern() {
+        // Given
+        TaskFilters filters = TaskFilters.empty().withNames(".*some|someOther.*");
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(List.of(t1, t2));
+    }
+
+    @Test
+    public void test_task_filters_by_user() {
+        // Given
+        TaskFilters filters = TaskFilters.empty().withUser(User.local());
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(List.of(t1));
+    }
+
+    @Test
+    public void test_task_filters_by_args() {
+        // Given
+        TaskFilters.ArgsFilter argsFilter = new TaskFilters.ArgsFilter("nested.attribute", "nestedv.*");
+        TaskFilters filters = TaskFilters.empty().withArgs(List.of(argsFilter));
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(List.of(t2));
+    }
+
+    @Test
+    public void test_task_filters_by_state() {
+        // Given
+        TaskFilters filters = TaskFilters.empty().withStates(Set.of(Task.State.DONE));
+        // When
+        List<Task<?>> filtered = tasks.stream().filter(filters::filter).toList();
+        // Then
+        assertThat(filtered).isEqualTo(List.of(t2));
+    }
+}

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerAmqpTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerAmqpTest.java
@@ -193,7 +193,7 @@ public class TaskManagerAmqpTest {
     }
 
     @Test
-    public void test_save_task() throws IOException {
+    public void test_insert_task() throws IOException {
         Task<String> task = new Task<>("name", User.local(), new HashMap<>());
 
         taskManager.insert(task, null);

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -128,7 +128,7 @@ public class TaskManagerMemoryTest {
     }
 
     @Test
-    public void test_persist_task() throws TaskAlreadyExists, IOException, UnknownTask {
+    public void test_insert_task() throws TaskAlreadyExists, IOException, UnknownTask {
         Task<String> task = new Task<>("name", User.local(), new HashMap<>());
 
         taskManager.insert(task, null);
@@ -144,7 +144,7 @@ public class TaskManagerMemoryTest {
         List<ProjectProxy> projects = List.of(project("project"));
         BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, Stream.of(batchSearchRecord)).toList();
+        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
         assertThat(tasks.get(0).getUser()).isEqualTo(user);
@@ -159,7 +159,7 @@ public class TaskManagerMemoryTest {
         Task<String> task = new Task<>("name", User.local(), new HashMap<>());
         taskManager.insert(task, null);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, Stream.of(batchSearchRecord)).toList();
+        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
         assertThat(tasks).hasSize(2);
         assertThat(tasks.get(1).id).isEqualTo(batchSearchRecord.uuid);
         assertThat(tasks.get(1).getUser()).isEqualTo(user);
@@ -173,7 +173,7 @@ public class TaskManagerMemoryTest {
         BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
         List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, batchSearchRecords.stream()).toList();
+        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), batchSearchRecords.stream()).toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).name).isEqualTo("org.icij.datashare.tasks.BatchSearchRunnerProxy");
     }
@@ -188,7 +188,7 @@ public class TaskManagerMemoryTest {
         Task<String> task = new Task<>(batchSearchRecord.uuid, "name", User.local());
         taskManager.insert(task, null);
 
-        List<Task<?>> tasks = taskManager.getTasks(user, Stream.of(batchSearchRecord)).toList();
+        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).name).isEqualTo("name");
     }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerRedisTest.java
@@ -178,11 +178,11 @@ public class TaskManagerRedisTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         taskManager.clear();
     }
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         taskManager.clear();
     }
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagersIntTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -132,7 +131,7 @@ public class TaskManagersIntTest {
         String tv2Id = taskManager.startTask(TestFactory.SleepForever.class, User.local(), new HashMap<>());
 
         taskInspector.awaitStatus(tv1Id, Task.State.RUNNING, 1, SECONDS);
-        taskManager.stopTasks(User.local(), Map.of("name", Pattern.compile(".*Another.*")));
+        taskManager.stopTasks(TaskFilters.empty().withUser(User.local()).withNames(".*Another.*"));
         taskInspector.awaitStatus(tv1Id, Task.State.CANCELLED, 1, SECONDS);
 
         assertThat(taskManager.getTasks().toList()).hasSize(2);

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <datashare-api.version>14.5.0</datashare-api.version>
+        <datashare-api.version>15.0.0</datashare-api.version>
         <datashare-cli.version>13.6.1</datashare-cli.version>
         <datashare-tasks.version>17.0.1</datashare-tasks.version>
         <ftm.version>0.3.1</ftm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <datashare-api.version>15.0.0</datashare-api.version>
+        <datashare-api.version>14.6.0</datashare-api.version>
         <datashare-cli.version>13.6.1</datashare-cli.version>
         <datashare-tasks.version>18.0.0</datashare-tasks.version>
         <ftm.version>0.3.1</ftm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
         <datashare-api.version>15.0.0</datashare-api.version>
         <datashare-cli.version>13.6.1</datashare-cli.version>
-        <datashare-tasks.version>17.0.1</datashare-tasks.version>
+        <datashare-tasks.version>18.0.0</datashare-tasks.version>
         <ftm.version>0.3.1</ftm.version>
 
         <datashare-mitie.version>${project.version}</datashare-mitie.version>


### PR DESCRIPTION
# TODO
- [x] merge #1802 (the branch is based on #1802)

# Description

Fixes #1803 (as a side effect of the refactoring)

Currently the task search APIs support arbitrary filters which in practice are not used arbitrarily.
The frontend only searches by:
- user ID
- arg value
- task name

On the other hand, supporting arbitrary filters negatively impacts task search, indeed to perform this arbitrary search we:
1. fecth **all task records** from the DB
2. convert them to JSON strings
3. apply the filter on the JSON string

This approach won't scale to many task records.

In contrast, this PR refactors the current task search API, unifies it using a common `TaskManager.getTask(TaskFilters filters)` API supporting all current task searchs (+ searching by task state).

In addition, the `TaskManager.getTask(TaskFilters filters)` API is implemented in each underlying `TaskRepository` API using the dedicated search tools offered by the different implements.

In particular when using SQL, we perform plain SQL queries rather than fecthing all records from the DB and then filter them in Java.


# Changes

## `datashare-tasks`

### Added
- created a `TaskFilters`. This class is used for user filter validation and task stream filtering 


### Changed
-  unified all task search APIs using `TaskManager.getTasks(TaskFilters filters)` and `TaskRepository(TaskFilters filters)`. By default `TaskManager.getTasks(TaskFilters filters)` filters the result of `TaskManager.getTasks()` using the `TaskFilters::filter`. However the implementer can decide to override this default logic if the repo DB implementation supports more efficient search.
- remove the inheritance between `TaskRepository` and `Map<String, TaskMetadata>` forcing to implement unused `Map` methods (kept only the ones used for task search)
 

## `datashare-app`
### Added
- created a `taskFiltersFromContext` helper to build task filters from the HTTP query context
