### PR TITLE
fix(datashare-db): Sqlite regex search for JooqTaskRepositoryTest

### DIFF
--- a/datashare-db/src/main/java/org/icij/datashare/db/ExtendedHikariDatasource.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/ExtendedHikariDatasource.java
@@ -1,0 +1,40 @@
+package org.icij.datashare.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.regex.Pattern;
+import org.sqlite.Function;
+import org.sqlite.jdbc4.JDBC4Connection;
+
+public class ExtendedHikariDatasource extends HikariDataSource {
+    public ExtendedHikariDatasource(HikariConfig configuration) {
+        super(configuration);
+    }
+
+    public Connection getConnection() throws SQLException {
+        Connection conn = super.getConnection();
+        if (conn.isWrapperFor(JDBC4Connection.class)) {
+            Connection unwrapped = conn.unwrap(JDBC4Connection.class);
+            addSQLiteMissingFunctions(unwrapped);
+        }
+        return conn;
+    }
+
+    private void addSQLiteMissingFunctions(Connection sqliteConn) throws SQLException {
+        Function.create(sqliteConn, "REGEXP", new Function() {
+            @Override
+            protected void xFunc() throws SQLException {
+                String expression = value_text(0);
+                String value = value_text(1);
+                if (value == null) {
+                    value = "";
+                }
+
+                Pattern pattern = Pattern.compile(expression);
+                result(pattern.matcher(value).find() ? 1 : 0);
+            }
+        });
+    }
+}

--- a/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/RepositoryFactoryImpl.java
@@ -1,7 +1,6 @@
 package org.icij.datashare.db;
 
 import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import liquibase.Scope;
 import liquibase.command.CommandScope;
 import liquibase.command.core.UpdateCommandStep;
@@ -97,7 +96,7 @@ public class RepositoryFactoryImpl implements RepositoryFactory {
         if (dataSourceUrl.contains("sqlite")) {
             config.setDriverClassName("org.sqlite.JDBC");
         }
-        return new HikariDataSource(config);
+        return new ExtendedHikariDatasource(config);
     }
 
     private String getDataSourceUrl() {

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqTaskRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqTaskRepositoryTest.java
@@ -2,9 +2,11 @@ package org.icij.datashare.db;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 import org.icij.datashare.asynctasks.Group;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskAlreadyExists;
+import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskGroupType;
 import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.asynctasks.UnknownTask;
@@ -135,6 +137,34 @@ public class JooqTaskRepositoryTest {
         repository.update(foo);
         assertThat(repository.getTask(foo.getId()).getResult()).isNull();
         assertThat(repository.getTask(foo.getId()).getError().getMessage()).isEqualTo("boom");
+    }
+
+    @Test
+    public void test_get_tasks() throws Exception {
+        Task<String> foo = new Task<>("foo", User.local(), Map.of("user", User.local()));
+        Task<String> bar = new Task<>("bar", User.local(), Map.of("user", User.local()));
+        repository.insert(foo,  new Group(TaskGroupType.Test));
+        repository.insert(bar,  new Group(TaskGroupType.Test));
+        TaskFilters filter = TaskFilters.empty();
+
+        List<Task<? extends Serializable>> tasks = repository.getTasks(filter).toList();
+
+        assertThat(tasks.size()).isEqualTo(2);
+        assertThat(tasks.stream().map(Task::getId).toList()).isEqualTo(List.of(foo.id, bar.id));
+    }
+
+    @Test
+    public void test_get_tasks_with_filter() throws Exception {
+        Task<String> foo = new Task<>("foo", User.local(), Map.of("user", User.local()));
+        Task<String> bar = new Task<>("bar", User.local(), Map.of("user", User.local()));
+        repository.insert(foo,  new Group(TaskGroupType.Test));
+        repository.insert(bar,  new Group(TaskGroupType.Test));
+        TaskFilters filter = TaskFilters.empty().withNames("foo");
+
+        List<Task<? extends Serializable>> tasks = repository.getTasks(filter).toList();
+
+        assertThat(tasks.size()).isEqualTo(1);
+        assertThat(tasks.get(0).id).isEqualTo(foo.id);
     }
 
     @After


### PR DESCRIPTION
# Changes
## `datashare-db`
### Fixed
- missing `REGEX` SQL function for SQLite DB connection