### PR TITLE
feat: adds progress for IndexTask

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import java.util.function.Function;
 
-import org.checkerframework.checker.units.qual.N;
 import org.icij.datashare.HumanReadableSize;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.icij.datashare.PropertiesProvider;

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -2,37 +2,27 @@ package org.icij.datashare.tasks;
 
 import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PipelineHelper;
-import org.icij.datashare.PluginService;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
-import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.Language;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSpewer;
 import org.icij.datashare.user.User;
-import org.icij.datashare.web.PluginResource;
 import org.icij.extract.queue.DocumentQueue;
 import org.icij.spewer.FieldNames;
-import org.icij.spewer.Spewer;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.tasks.PipelineTask.STRING_POISON;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class IndexTaskIntTest {
     @Rule public ElasticsearchRule es = new ElasticsearchRule();


### PR DESCRIPTION
Related to issue [#1724]

Note : Progress is updated for every processed document on the filesystem. Consequently if a document has a lot of embedded docs, progress would be updated after the last embedded document.