### PR TITLE
fix(asynctasks): AMQP exception handling

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/test/LogbackAppenderWrapper.java
+++ b/datashare-api/src/main/java/org/icij/datashare/test/LogbackAppenderWrapper.java
@@ -4,12 +4,13 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.Context;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -57,7 +58,7 @@ public class LogbackAppenderWrapper {
     }
 
     private static class TestAppender extends AppenderBase<ILoggingEvent> {
-        List<ILoggingEvent> events = new ArrayList<>();
+        Queue<ILoggingEvent> events = new ConcurrentLinkedQueue<>();
 
         @Override
         protected void append(ILoggingEvent iLoggingEvent) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
@@ -90,6 +90,12 @@ public class AmqpChannel {
 				} catch (NackException nackEx) {
                     logger.warn("exception while accepting event. Sending nack with requeue={}", nackEx.requeue, nackEx);
 					rabbitMqChannel.basicNack(envelope.getDeliveryTag(), false, nackEx.requeue);
+				} catch (Exception ex) {
+					logger.error(
+						"Consumer ({}) threw an exception while handling message {} for channel {}. Requeuing this message by default",
+						consumerTag, envelope.getDeliveryTag(), rabbitMqChannel
+					);
+					rabbitMqChannel.basicNack(envelope.getDeliveryTag(), false, true);
 				}
 				criteria.newEvent();
 				if (!criteria.isValid()) {


### PR DESCRIPTION
# PR description

This PR fixes a bug where all exception (except from `NackException` and `Deserializer.DeserializeException`) were not acking or nacking messages, leaving the consumer unavailable for subsequent messages.

This PR modifies this behavior by requeing all unhandled exceptions, which means that **developers will have to explicitly throw `NackException(requeue=false)` on codeblocks where they expect errors to end up in a non requeud message**.

This is a debatable choice, but it seems more reasonable than no requeing by default which could end up in losing important information (unless we explicitely care about throwing NackException(requeue=true).

# Changes
## `datashare-tasks`
- fixed a bug where all unhandled  exceptions (except from `NackException` and `Deserializer.DeserializeException`) leave the channel consumer inactive