### PR TITLE
feature(datashare-app): publish progress update with a minimum interval

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/BatchDownloadApp.java
@@ -1,5 +1,9 @@
 package org.icij.datashare;
 
+import static java.util.Optional.ofNullable;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_PROGRESS_INTERVAL_OPT;
+
 import org.icij.datashare.asynctasks.TaskFactory;
 import org.icij.datashare.asynctasks.TaskWorkerLoop;
 import org.icij.datashare.asynctasks.TaskSupplier;
@@ -13,7 +17,9 @@ import java.util.Properties;
 public class BatchDownloadApp {
     public static void start(Properties properties) throws Exception {
         CommonMode commonMode = CommonMode.create(properties);
-        TaskWorkerLoop taskWorkerLoop = new TaskWorkerLoop(commonMode.get(TaskFactory.class), commonMode.get(TaskSupplier.class));
+        double progressMinIntervalS = (double) ofNullable(properties.get(TASK_PROGRESS_INTERVAL_OPT))
+                .orElse(DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS);
+        TaskWorkerLoop taskWorkerLoop = new TaskWorkerLoop(commonMode.get(TaskFactory.class), commonMode.get(TaskSupplier.class), progressMinIntervalS);
         taskWorkerLoop.call();
         commonMode.get(Indexer.class).close();
         commonMode.get(RedissonClient.class).shutdown();

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -6,7 +6,6 @@ import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.ArtifactTask;
 import org.icij.datashare.tasks.CreateNlpBatchesFromIndex;
-import org.icij.datashare.tasks.BatchNlpTask;
 import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;

--- a/datashare-app/src/main/java/org/icij/datashare/TaskWorkerApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/TaskWorkerApp.java
@@ -14,7 +14,9 @@ import java.util.stream.IntStream;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Optional.ofNullable;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_TASK_WORKERS;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_PROGRESS_INTERVAL_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.TASK_WORKERS_OPT;
 
 
@@ -24,7 +26,9 @@ public class TaskWorkerApp {
 
         try (CommonMode mode = CommonMode.create(properties)) {
             ExecutorService executorService = Executors.newFixedThreadPool(taskWorkersNb);
-            List<TaskWorkerLoop> workers = IntStream.range(0, taskWorkersNb).mapToObj(i -> new TaskWorkerLoop(mode.get(DatashareTaskFactory.class), mode.get(TaskSupplier.class))).toList();
+            double progressMinIntervalS = (double) ofNullable(properties.get(TASK_PROGRESS_INTERVAL_OPT))
+                .orElse(DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS);
+            List<TaskWorkerLoop> workers = IntStream.range(0, taskWorkersNb).mapToObj(i -> new TaskWorkerLoop(mode.get(DatashareTaskFactory.class), mode.get(TaskSupplier.class), progressMinIntervalS)).toList();
             workers.forEach(executorService::submit);
             executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS); // to wait consumers, else we are closing them all
         }

--- a/datashare-app/src/main/java/org/icij/datashare/WebApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/WebApp.java
@@ -33,7 +33,9 @@ import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 
 import static java.util.Optional.ofNullable;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_TASK_WORKERS;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_PROGRESS_INTERVAL_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.TASK_WORKERS_OPT;
 
 public class WebApp {
@@ -58,7 +60,9 @@ public class WebApp {
 
         if (isEmbeddedAMQP(properties, taskWorkersNb)) {
             ExecutorService executorService = Executors.newFixedThreadPool(taskWorkersNb);
-            List<TaskWorkerLoop> workers = IntStream.range(0, taskWorkersNb).mapToObj(i -> new TaskWorkerLoop(mode.get(DatashareTaskFactory.class), mode.get(TaskSupplier.class))).toList();
+            double progressMinIntervalS = (double) ofNullable(properties.get(TASK_PROGRESS_INTERVAL_OPT))
+                .orElse(DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS);
+            List<TaskWorkerLoop> workers = IntStream.range(0, taskWorkersNb).mapToObj(i -> new TaskWorkerLoop(mode.get(DatashareTaskFactory.class), mode.get(TaskSupplier.class), progressMinIntervalS)).toList();
             workers.forEach(executorService::submit);
         }
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
@@ -38,7 +38,7 @@ public class TaskWorkerLoopIntTest {
         when(factory.createBatchDownloadRunner(any(), any())).thenReturn(runner);
 
         CountDownLatch workerStarted = new CountDownLatch(1);
-        TaskWorkerLoop taskWorkerLoop = new TaskWorkerLoop(factory, taskSupplier, workerStarted);
+        TaskWorkerLoop taskWorkerLoop = new TaskWorkerLoop(factory, taskSupplier, workerStarted, 10);
         Thread worker = new Thread(taskWorkerLoop::call);
         worker.start();
         workerStarted.await();

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -198,6 +198,7 @@ public class DatashareCli {
         DatashareCliOptions.pollingInterval(parser);
         DatashareCliOptions.taskRepositoryType(parser);
         DatashareCliOptions.taskManagerPollingInterval(parser);
+        DatashareCliOptions.taskProgressUpdateInterval(parser);
         DatashareCliOptions.taskWorkers(parser);
         return parser;
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -127,6 +127,7 @@ public final class DatashareCliOptions {
     public static final String TASK_REPOSITORY_OPT = "taskRepositoryType";
     public static final String TASK_MANAGER_POLLING_INTERVAL_OPT = "taskManagerPollingIntervalMilliseconds";
     public static final String TASK_WORKERS_OPT = "taskWorkers";
+    public static final String TASK_PROGRESS_INTERVAL_OPT = "taskProgressUpdateIntervalSeconds";
 
     private static final Path DEFAULT_DATASHARE_HOME = Paths.get(System.getProperty("user.home"), ".local/share/datashare");
     private static final Integer DEFAULT_NLP_PARALLELISM = 1;
@@ -181,6 +182,7 @@ public final class DatashareCliOptions {
     public static final String DEFAULT_POLLING_INTERVAL_SEC = "60";
     public static final int DEFAULT_TASK_MANAGER_POLLING_INTERVAL = 5000;
     public static final String DEFAULT_TASK_WORKERS = "1";
+    public static final double DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS = 10;
 
     // A list of aliases for retro-compatibility when an option changed
     public static final Map<String, String> OPT_ALIASES = Map.ofEntries(
@@ -896,6 +898,14 @@ public final class DatashareCliOptions {
                 .withRequiredArg()
                 .ofType(Integer.class)
                 .defaultsTo(DEFAULT_TASK_MANAGER_POLLING_INTERVAL);
+    }
+
+    static void taskProgressUpdateInterval(OptionParser parser) {
+        parser.acceptsAll(
+                        singletonList(TASK_PROGRESS_INTERVAL_OPT), "Minimum interval between progress updates for the same task in seconds.")
+                .withRequiredArg()
+                .ofType(Double.class)
+                .defaultsTo(DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS);
     }
 
     static void taskWorkers(OptionParser parser) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/ProgressSmoother.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/ProgressSmoother.java
@@ -1,0 +1,43 @@
+package org.icij.datashare.asynctasks;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import org.icij.datashare.time.DatashareTime;
+
+
+public class ProgressSmoother implements BiFunction<String, Double, Void> {
+
+    private final BiConsumer<String, Double> progressFn;
+    private final ConcurrentHashMap<String, Long> lastPublished = new ConcurrentHashMap<>();
+    private final double minIntervalMS;
+
+    public ProgressSmoother(final BiConsumer<String, Double> progressFn, double minIntervalS) {
+        this.progressFn = progressFn;
+        this.minIntervalMS = minIntervalS * 1000;
+    }
+
+    @Override
+    public Void apply(String taskId, Double progress) {
+        long now = DatashareTime.getInstance().currentTimeMillis();
+        lastPublished.compute(
+            taskId,
+            (tId, lastUpdated) -> this.progressWithRate(tId, lastUpdated, now, progress)
+        );
+        if (progress == 1.0) {
+            // Clear the cache when we hit 1.0
+            lastPublished.remove(taskId);
+        }
+        return null;
+    }
+
+    private Long progressWithRate(final String taskId, final Long lastUpdated, final long now, final double newProgress) {
+        boolean isNew = lastUpdated == null;
+        boolean isComplete = newProgress == 1.0;
+        if (isNew || isComplete || Math.abs(now - lastUpdated) > minIntervalMS) {
+            progressFn.accept(taskId, newProgress);
+            return now;
+        }
+        return lastUpdated;
+    }
+}

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TestProgressSmoother.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TestProgressSmoother.java
@@ -1,0 +1,59 @@
+package org.icij.datashare.asynctasks;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import org.icij.datashare.test.DatashareTimeRule;
+import org.icij.datashare.time.DatashareTime;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestProgressSmoother {
+    @Rule
+    public DatashareTimeRule time = new DatashareTimeRule();
+
+    @Test
+    public void test_should_smooth_progress() {
+        float minIntervalS = 10;
+        ProgressRecorder recorder = new ProgressRecorder();
+        ProgressSmoother smoothedProgress = new ProgressSmoother(recorder, minIntervalS);
+        String t0 = "task0";
+        String t1 = "task1";
+
+        smoothedProgress.apply(t0, 0.10);
+        smoothedProgress.apply(t1, 0.15);
+        DatashareTime.getInstance().addMilliseconds(5 * 1000);
+        smoothedProgress.apply(t0, 0.2);
+        smoothedProgress.apply(t1, 0.25);
+        DatashareTime.getInstance().addMilliseconds(6 * 1000);
+        smoothedProgress.apply(t0, 0.70);
+        smoothedProgress.apply(t1, 0.75);
+        smoothedProgress.apply(t0, 0.95);
+        smoothedProgress.apply(t1, 1.0);
+        DatashareTime.getInstance().addMilliseconds(1);
+        smoothedProgress.apply(t0, 1.0);
+
+        List<Double> expected0 = List.of(0.1, 0.7, 1.);
+        List<Double> expected1 = List.of(0.15, 0.75, 1.);
+        assertThat(recorder.getPublished(t0)).isEqualTo(expected0);
+        assertThat(recorder.getPublished(t1)).isEqualTo(expected1);
+    }
+
+    private static class ProgressRecorder implements BiConsumer<String, Double> {
+        private final Map<String, List<Double>> published = new HashMap<>();
+
+        @Override
+        public void accept(String taskId, Double progress) {
+            published.putIfAbsent(taskId, new ArrayList<>());
+            published.get(taskId).add(progress);
+        }
+
+        public List<Double> getPublished(String taskId) {
+            return published.get(taskId);
+        }
+    }
+}


### PR DESCRIPTION
# Changes
## `datashare-app`
### Added
-  publish progress update with a minimum interval specified by the `taskProgressUpdateIntervalSeconds` parameters (defaults to 10sec)

## `datashare-asynctasks`
### Added
- added a `ProgressSmoother` wrapper to publish progress with a minimum time interval between updates for the same task