### PR TITLE
fix(datashare-asynctasks): don't requeue message when unhandled exception occur and set worker event queues expiration

### DIFF
--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
@@ -93,7 +93,7 @@ public class AmqpChannel {
 				} catch (Exception ex) {
 					logger.error(
 						"Consumer ({}) threw an exception while handling message {} for channel {}. Requeuing this message by default",
-						consumerTag, envelope.getDeliveryTag(), rabbitMqChannel
+						consumerTag, envelope.getDeliveryTag(), rabbitMqChannel, ex
 					);
 					rabbitMqChannel.basicNack(envelope.getDeliveryTag(), false, true);
 				}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpChannel.java
@@ -92,10 +92,10 @@ public class AmqpChannel {
 					rabbitMqChannel.basicNack(envelope.getDeliveryTag(), false, nackEx.requeue);
 				} catch (Exception ex) {
 					logger.error(
-						"Consumer ({}) threw an exception while handling message {} for channel {}. Requeuing this message by default",
+						"consumer ({}) can't process message {} for channel {}, rejecting the message due to unhandled exception",
 						consumerTag, envelope.getDeliveryTag(), rabbitMqChannel, ex
 					);
-					rabbitMqChannel.basicNack(envelope.getDeliveryTag(), false, true);
+					rabbitMqChannel.basicNack(envelope.getDeliveryTag(), false, false);
 				}
 				criteria.newEvent();
 				if (!criteria.isValid()) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpQueue.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpQueue.java
@@ -18,12 +18,18 @@ public enum AmqpQueue {
 			"x-delivery-limit", 10,
 			"x-consumer-timeout", 3600 * 1000), TASK_DLQ),
 	MANAGER_EVENT_DLQ  ("exchangeDLQManagerEvents",  BuiltinExchangeType.DIRECT,"routingKeyDLQManagerEvents"),
-	MANAGER_EVENT  ("exchangeManagerEvents",  BuiltinExchangeType.DIRECT,"routingKeyManagerEvents", Map.of(), MANAGER_EVENT_DLQ),
+	MANAGER_EVENT  (
+		"exchangeManagerEvents",
+		BuiltinExchangeType.DIRECT,
+		"routingKeyManagerEvents",
+		Map.of("x-delivery-limit", 5),
+		MANAGER_EVENT_DLQ
+	),
 	WORKER_EVENT(
 		"exchangeWorkerEvents",
 		BuiltinExchangeType.FANOUT,
 		"routingKeyWorkerEvents",
-		Map.of("x-expires", 10 * 60 * 1000),
+		Map.of("x-expires", 10 * 60 * 1000, "x-delivery-limit", 5),
 		null
 	),
 	MONITORING("exchangeMonitoring", BuiltinExchangeType.DIRECT, "routingKeyMonitoring", Map.of(

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpQueue.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpQueue.java
@@ -18,18 +18,12 @@ public enum AmqpQueue {
 			"x-delivery-limit", 10,
 			"x-consumer-timeout", 3600 * 1000), TASK_DLQ),
 	MANAGER_EVENT_DLQ  ("exchangeDLQManagerEvents",  BuiltinExchangeType.DIRECT,"routingKeyDLQManagerEvents"),
-	MANAGER_EVENT  (
-		"exchangeManagerEvents",
-		BuiltinExchangeType.DIRECT,
-		"routingKeyManagerEvents",
-		Map.of("x-delivery-limit", 5),
-		MANAGER_EVENT_DLQ
-	),
+	MANAGER_EVENT  ("exchangeManagerEvents",  BuiltinExchangeType.DIRECT,"routingKeyManagerEvents", Map.of(), MANAGER_EVENT_DLQ),
 	WORKER_EVENT(
 		"exchangeWorkerEvents",
 		BuiltinExchangeType.FANOUT,
 		"routingKeyWorkerEvents",
-		Map.of("x-expires", 10 * 60 * 1000, "x-delivery-limit", 5),
+		Map.of("x-expires", 10 * 60 * 1000),
 		null
 	),
 	MONITORING("exchangeMonitoring", BuiltinExchangeType.DIRECT, "routingKeyMonitoring", Map.of(

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpQueue.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/bus/amqp/AmqpQueue.java
@@ -18,8 +18,14 @@ public enum AmqpQueue {
 			"x-delivery-limit", 10,
 			"x-consumer-timeout", 3600 * 1000), TASK_DLQ),
 	MANAGER_EVENT_DLQ  ("exchangeDLQManagerEvents",  BuiltinExchangeType.DIRECT,"routingKeyDLQManagerEvents"),
-	MANAGER_EVENT  ("exchangeManagerEvents",  BuiltinExchangeType.DIRECT,"routingKeyManagerEvents", new HashMap<>(), MANAGER_EVENT_DLQ),
-	WORKER_EVENT("exchangeWorkerEvents", BuiltinExchangeType.FANOUT, "routingKeyWorkerEvents"),
+	MANAGER_EVENT  ("exchangeManagerEvents",  BuiltinExchangeType.DIRECT,"routingKeyManagerEvents", Map.of(), MANAGER_EVENT_DLQ),
+	WORKER_EVENT(
+		"exchangeWorkerEvents",
+		BuiltinExchangeType.FANOUT,
+		"routingKeyWorkerEvents",
+		Map.of("x-expires", 10 * 60 * 1000),
+		null
+	),
 	MONITORING("exchangeMonitoring", BuiltinExchangeType.DIRECT, "routingKeyMonitoring", Map.of(
 			"x-message-ttl", 5000), null);
 


### PR DESCRIPTION
# Description

While #1878 improved exception handling, error handling by requeing message when unhandled exception occurred, it contributed to congest the event queue as event message had no delivery limit, hence the same message ended up being requeued over and over.

While setting delivery limit for even queue would be the ideal solution, this would imply using quorum queues for events. Migrating from classical queues to quorum queues is tricky as it requires to delete the queue and recreate it with a different type. To avoid such migration, we just don't requeue messages in case of unhandled exception.

Additionally workers were not expiring their event queue when dying which resulted in a lot of unused hanging queues

# Changes

## `datashare-asynctasks`

### Fixed
- ~set delivery limits on all event message queues~ -> don't requeue message in case of unhandled exception
- expired worker event queues
- improve error handling logs
