### PR TITLE
fix(datashare-dist): allow classpath overrides in datashare docker image

### DIFF
--- a/datashare-dist/src/main/docker/entrypoint.sh
+++ b/datashare-dist/src/main/docker/entrypoint.sh
@@ -7,6 +7,7 @@ datashare_home=${DATASHARE_HOME:-$HOME/.local/share/datashare}
 datashare_jars=$(find $datashare_home/lib/ -name '*.jar' | xargs | sed 's/ /:/g')
 datashare_jna_tmpdir=${DATASHARE_JNA_TMPDIR:-$datashare_home/index/tmp}
 datashare_sync_nlp_models=${DATASHARE_SYNC_NLP_MODELS:-true}
+datashare_class_path="$datashare_home/dist:$datashare_home/extensions/*:$datashare_jars${CLASSPATH:+:$CLASSPATH}"
 
 if [ "$1" = 'sh' ];
 then
@@ -22,6 +23,6 @@ else
       -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \
       -Djna.tmpdir=$datashare_jna_tmpdir \
       -DDS_SYNC_NLP_MODELS=$datashare_sync_nlp_models \
-      -cp $datashare_home/dist:$datashare_jars org.icij.datashare.Main \
+      -cp "$datashare_class_path" org.icij.datashare.Main \
         "$@"
 fi


### PR DESCRIPTION
# Description

A bug reported in #1888 showed that Datashare's CLI was not extended with the neo4j CLI extension arguments.
There were 2 reasons for this:
1. the docker entry point is not allowing passing a `CLASSPATH` argument to the docker image. Indeed its uses the `java` `cp` argument and doesn't includes the user `CLASSPATH` in it
2. the datashare document was outdated pointing to the wrong extension jar location and preventing the CLI service provider to find the neo4j CLI extension

# Changes

## `datashare-dist`

### Fixed
- allow `CLASSPATH` extension in datashare docker image