### PR TITLE
fix(datashare-api,datashare-nlp-corenlp): fix download of all languages when in downloading EN model

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/io/RemoteFiles.java
+++ b/datashare-api/src/main/java/org/icij/datashare/io/RemoteFiles.java
@@ -112,6 +112,9 @@ public class RemoteFiles {
             }
         } else {
             GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucket).key(remoteKey).build();
+            if (!localFile.getParentFile().exists()) {
+                localFile.getParentFile().mkdirs();
+            }
             s3Client.getObject(getObjectRequest, localFile.toPath()).join();
         }
     }

--- a/datashare-nlp-corenlp/src/main/java/org/icij/datashare/text/nlp/corenlp/models/CoreNlpModels.java
+++ b/datashare-nlp-corenlp/src/main/java/org/icij/datashare/text/nlp/corenlp/models/CoreNlpModels.java
@@ -80,6 +80,10 @@ public class CoreNlpModels extends AbstractModels<StanfordCoreNLP> {
         return getModelsBasePath(language).resolve(getJarFileName(language));
     }
 
+    public Path getModelsFilesystemPath(Language language) {
+        return super.getModelsFilesystemPath(language).resolve(getJarFileName(language));
+    }
+
     String getJarFileName(Language language) {
         List<String> filename;
         if (language.equals(ENGLISH)) {


### PR DESCRIPTION
# Bug description

The S3 bucket data tree structure follow the same structure as the StanfordCoreNLP tree strucutre, where the english model is at the top level of the tree, then each language is in its own directory (there might be optionally an `en` directory for english extract assets if used).

```
dist/
├─ models/
│  ├─ corenlp
│  │  ├─ 4-5-10
│  │  │  ├─ stanford-corenlp-4.5.10-models.jar (< this is the english base model)
│  │  │  ├─ ar/stanford-corenlp-models-arabic.jar
         ├─ de/stanford-corenlp-models-german.jar
```

With the previous codebase where we downloaded corenlp models by directory, when downloading the english model, data for all others models was downloaded.

Instead, this PRs downloads `.jar` rather than directories as only jars are needed.

# Changes

## `datashare-nlp-corenlp`

### Fixed
- download corenlp models as JAR files rather than as directories

## `datashare-api`

### Fixed
- fixed the `RemoteFiles.download` method to create parent directories of file downloads
