### PR TITLE
feat: add a new "parts" field to path with a different analyzer

### DIFF
--- a/datashare-index/src/main/resources/datashare_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_index_mappings.json
@@ -30,7 +30,13 @@
       "type": "integer"
     },
     "path": {
-      "type": "keyword"
+      "type": "keyword",
+      "fields": {
+        "parts": {
+          "type": "text",
+          "analyzer": "path_parts_analyzer"
+        }
+      }
     },
     "title": {
       "type": "keyword"

--- a/datashare-index/src/main/resources/datashare_index_settings.json
+++ b/datashare-index/src/main/resources/datashare_index_settings.json
@@ -17,6 +17,7 @@
     "metadata.tika_metadata_resourcename",
     "name",
     "path",
+    "path.parts",
     "tags"
   ],
   "analysis": {
@@ -24,6 +25,11 @@
       "path_analyzer": {
         "type":"custom",
         "tokenizer": "path_tokenizer"
+      },
+      "path_parts_analyzer": {
+        "type":"custom",
+        "tokenizer": "path_parts_tokenizer",
+        "filter": ["lowercase"]
       },
       "folding": {
         "type":"custom",
@@ -39,6 +45,12 @@
         "buffer_size": 1024,
         "reverse": false,
         "skip": 0
+      },
+      "path_parts_tokenizer": {
+        "type": "pattern",
+        "pattern": "[/\\\\. ]+",
+        "flags": "",
+        "group": -1
       }
     },
     "normalizer": {

--- a/datashare-index/src/main/resources/datashare_index_settings_windows.json
+++ b/datashare-index/src/main/resources/datashare_index_settings_windows.json
@@ -17,6 +17,7 @@
     "metadata.tika_metadata_resourcename",
     "name",
     "path",
+    "path.parts",
     "tags"
   ],
   "analysis": {
@@ -24,6 +25,11 @@
       "path_analyzer": {
         "type":"custom",
         "tokenizer": "path_tokenizer"
+      },
+      "path_parts_analyzer": {
+        "type":"custom",
+        "tokenizer": "path_parts_tokenizer",
+        "filter": ["lowercase"]
       },
       "folding": {
         "type":"custom",
@@ -39,6 +45,12 @@
         "buffer_size": 1024,
         "reverse": false,
         "skip": 0
+      },
+      "path_parts_tokenizer": {
+        "type": "pattern",
+        "pattern": "[/\\\\. ]+",
+        "flags": "",
+        "group": -1
       }
     },
     "normalizer": {


### PR DESCRIPTION
This new field will allow to search in paths without using wildcard or regexes #1942. 

It's the backend counterpart of https://github.com/ICIJ/datashare-client/pull/412. 

Because `path.parts` is added to default_field, that changes doesn't require any additional update on the front.