### PR TITLE
chore: remove spacy extension and bump opennlp to `9.0.6`

### DIFF
--- a/datashare-app/src/main/resources/extensions.json
+++ b/datashare-app/src/main/resources/extensions.json
@@ -4,9 +4,9 @@
       "id": "datashare-nlp-opennlp",
       "name": "OPENNLP Pipeline",
       "description": "Extension to extract NER entities with OPENNLP",
-      "url": "https://github.com/ICIJ/datashare-extension-nlp-opennlp/releases/download/9.0.1/datashare-nlp-opennlp-9.0.1-jar-with-dependencies.jar",
+      "url": "https://github.com/ICIJ/datashare-extension-nlp-opennlp/releases/download/9.0.6/datashare-nlp-opennlp-9.0.6-jar-with-dependencies.jar",
       "homepage": "https://github.com/ICIJ/datashare-extension-nlp-opennlp",
-      "version": "9.0.1",
+      "version": "9.0.6",
       "type": "NLP"
     },
     {
@@ -26,14 +26,6 @@
       "homepage": "https://github.com/ICIJ/datashare-extension-neo4j",
       "version": "1.1.1",
       "type": "WEB"
-    },
-    {
-      "id": "datashare-extension-nlp-spacy",
-      "description": "Extension to extract NER entities with Spacy",
-      "url": "https://github.com/ICIJ/datashare-extension-nlp-spacy/releases/download/0.1.5/datashare-extension-nlp-spacy-0.1.5",
-      "homepage": "https://github.com/ICIJ/datashare-extension-nlp-spacy",
-      "version": "0.1.5",
-      "type": "NLP"
     }
   ]
 }


### PR DESCRIPTION
# Changes

## `datashare-app`

### Changed
- removde spacy extension (not working yet) and bump corenlp to `9.0.6` (latest version)
