### PR TITLE
fix(datashare-api): unauthorized `GetObjectAttributesRequest`

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/io/RemoteFiles.java
+++ b/datashare-api/src/main/java/org/icij/datashare/io/RemoteFiles.java
@@ -16,26 +16,21 @@ import java.util.concurrent.CompletionException;
 import java.util.regex.Pattern;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
-import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectAttributesResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
-import software.amazon.awssdk.services.s3.model.ObjectAttributes;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.DirectoryUpload;
@@ -64,15 +59,22 @@ public class RemoteFiles {
         NettyNioAsyncHttpClient.Builder httpClientBuilder = NettyNioAsyncHttpClient.builder()
             .connectionTimeout(Duration.ofMillis(CONNECTION_TIMEOUT_MS))
             .readTimeout(Duration.ofMillis(READ_TIMEOUT_MS));
+
         S3AsyncClientBuilder s3ClientBuilder = S3AsyncClient.builder()
             .credentialsProvider(AnonymousCredentialsProvider.create())
             .httpClientBuilder(httpClientBuilder)
-            .endpointOverride(URI.create(endPoint))
-            .region(Region.of(S3_REGION))
-            .endpointProvider(S3EndpointProvider.defaultProvider());
-        if (pathStyleAccessEnabled) {
-            s3ClientBuilder.forcePathStyle(true);
+            .region(Region.of(S3_REGION));
+
+        if (endPoint != null && !endPoint.isEmpty()) {
+            s3ClientBuilder.endpointOverride(URI.create(endPoint));
         }
+
+        if (pathStyleAccessEnabled) {
+            s3ClientBuilder.serviceConfiguration(S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
+                .build());
+        }
+
         return new RemoteFiles(s3ClientBuilder.build(), bucketName);
     }
 
@@ -143,10 +145,12 @@ public class RemoteFiles {
             }
             return equals;
         } else {
-            GetObjectAttributesRequest getObjectAttributesRequest = GetObjectAttributesRequest.builder()
-                .bucket(bucket).key(remoteKey).objectAttributes(ObjectAttributes.OBJECT_SIZE).build();
-            GetObjectAttributesResponse response = s3Client.getObjectAttributes(getObjectAttributesRequest).join();;
-            return response.objectSize() == localFile.length();
+            HeadObjectRequest getObjectAttributesRequest = HeadObjectRequest.builder()
+                .bucket(bucket)
+                .key(remoteKey)
+                .build();
+            HeadObjectResponse response = s3Client.headObject(getObjectAttributesRequest).join();
+            return response.contentLength() == localFile.length();
         }
     }
 


### PR DESCRIPTION
# Changes

## `datashare-api`

### Fixed
- unauthorized call to GetObjectAttributesRequest which requires both `GetObject` and `GetObjectAttributes` permissions. Error introduced by: #1929. Not detected by manual unit test as they seem to use local creds
