### PR TITLE
refactor: remove batchSearchRecord specificy APIs from `datashare-tasks`

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -1,12 +1,12 @@
 package org.icij.datashare;
 
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.cli.CliExtensionService;
 import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.ArtifactTask;
 import org.icij.datashare.tasks.CreateNlpBatchesFromIndex;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
@@ -64,7 +64,7 @@ class CliApp {
     }
 
     private static void runTaskWorker(CommonMode mode, Properties properties) throws Exception {
-        TaskManager taskManager = mode.get(TaskManager.class);
+        DatashareTaskManager taskManager = mode.get(DatashareTaskManager.class);
         DatashareTaskFactory taskFactory = mode.get(DatashareTaskFactory.class);
         Indexer indexer = mode.get(Indexer.class);
 

--- a/datashare-app/src/main/java/org/icij/datashare/WebApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/WebApp.java
@@ -8,12 +8,12 @@ import java.io.IOException;
 import java.util.Map;
 import net.codestory.http.WebServer;
 import org.icij.datashare.asynctasks.TaskAlreadyExists;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.batch.BatchSearch;
 import org.icij.datashare.batch.BatchSearchRecord;
 import org.icij.datashare.batch.BatchSearchRepository;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tasks.BatchSearchRunner;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.utils.WebBrowserUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +37,10 @@ public class WebApp {
         boolean shouldOpenBrowser = parseBoolean(mode.properties().getProperty(BROWSER_OPEN_LINK_OPT));
         WebBrowserUtils.openBrowser(port, shouldOpenBrowser);
 
-        requeueDatabaseBatchSearches(mode.get(BatchSearchRepository.class), mode.get(TaskManager.class));
+        requeueDatabaseBatchSearches(mode.get(BatchSearchRepository.class), mode.get(DatashareTaskManager.class));
     }
 
-    private static void requeueDatabaseBatchSearches(BatchSearchRepository repository, TaskManager taskManager) throws IOException {
+    private static void requeueDatabaseBatchSearches(BatchSearchRepository repository, DatashareTaskManager taskManager) throws IOException {
         for (String batchSearchUuid: repository.getQueued()) {
             BatchSearch batchSearch = repository.get(batchSearchUuid);
             try {

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -19,7 +19,6 @@ import net.codestory.http.misc.Env;
 import net.codestory.http.routes.Routes;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.TaskSupplier;
@@ -43,6 +42,7 @@ import org.icij.datashare.session.Policy;
 import org.icij.datashare.session.UsersInDb;
 import org.icij.datashare.session.UsersWritable;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.tasks.TaskManagerAmqp;
 import org.icij.datashare.tasks.TaskManagerMemory;
 import org.icij.datashare.tasks.TaskManagerRedis;
@@ -188,17 +188,17 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         QueueType batchQueueType = getQueueType(propertiesProvider, BATCH_QUEUE_TYPE_OPT, DEFAULT_BATCH_QUEUE_TYPE);
         switch ( batchQueueType ) {
             case REDIS:
-                bind(TaskManager.class).to(TaskManagerRedis.class);
+                bind(DatashareTaskManager.class).to(TaskManagerRedis.class);
                 bind(TaskModifier.class).to(TaskSupplierRedis.class);
                 bind(TaskSupplier.class).to(TaskSupplierRedis.class);
                 break;
             case AMQP:
-                bind(TaskManager.class).to(TaskManagerAmqp.class);
+                bind(DatashareTaskManager.class).to(TaskManagerAmqp.class);
                 bind(TaskSupplier.class).to(TaskSupplierAmqp.class);
                 bind(TaskModifier.class).to(TaskSupplierAmqp.class);
                 break;
             default:
-                bind(TaskManager.class).to(TaskManagerMemory.class);
+                bind(DatashareTaskManager.class).to(TaskManagerMemory.class);
                 bind(TaskModifier.class).to(TaskManagerMemory.class);
                 bind(TaskSupplier.class).to(TaskManagerMemory.class);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndex.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndex.java
@@ -52,7 +52,7 @@ public class CreateNlpBatchesFromIndex extends DefaultTask<List<String>> impleme
 
     private final User user;
     private volatile Thread taskThread;
-    private final TaskManager taskManager;
+    private final DatashareTaskManager taskManager;
     private final String searchQuery;
     private final Map<String, Object> batchTaskArgs;
     private final Pipeline.Type nlpPipeline;
@@ -72,7 +72,7 @@ public class CreateNlpBatchesFromIndex extends DefaultTask<List<String>> impleme
 
     @Inject
     public CreateNlpBatchesFromIndex(
-        final TaskManager taskManager, final Indexer indexer, @Assisted Task<LinkedList<String>> taskView,
+        final DatashareTaskManager taskManager, final Indexer indexer, @Assisted Task<LinkedList<String>> taskView,
         @Assisted final Function<Double, Void> ignored
     ) {
         this.user = taskView.getUser();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskManager.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DatashareTaskManager.java
@@ -1,0 +1,59 @@
+package org.icij.datashare.tasks;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.icij.datashare.Entity;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskFilters;
+import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.asynctasks.TaskResult;
+import org.icij.datashare.batch.BatchSearchRecord;
+
+public interface DatashareTaskManager extends TaskManager {
+    default Stream<Task<?>> getTasks(TaskFilters filters, Stream<BatchSearchRecord> batchSearchRecords) throws
+        IOException {
+        Stream<Task<?>> userTasks = getTasks(filters);
+        // Remove any filter on task's user. This allows to display batch search records from other users.
+        TaskFilters filtersWithoutUser = filters.withUser(null);
+        // The list of batch search records must be converted to a list of task which allow us to apply the same task filters.
+        Stream<Task<Integer>> batchSearchTasks =
+            batchSearchRecords.map(DatashareTaskManager::taskify).filter(filtersWithoutUser::filter);
+        // Merge the list of tasks and deduplicate them by id
+        return Stream.concat(userTasks, batchSearchTasks)
+            .collect(toMap(
+                // We deduplicate tasks by id
+                Entity::getId,
+                task -> task,
+                // Get the first in priority
+                (first, second) -> first,
+                LinkedHashMap::new
+            ))
+            .values()
+            .stream()
+            .map(t -> (Task<?>) t);
+    }
+
+    static Task<Integer> taskify(BatchSearchRecord batchSearchRecord) {
+        String name = "org.icij.datashare.tasks.BatchSearchRunnerProxy";
+        Map<String, Object> batchRecord = Map.of("batchRecord", batchSearchRecord);
+        Task<Integer> task =
+            new Task<>(batchSearchRecord.uuid, name, batchSearchRecord.date, batchSearchRecord.user, batchRecord);
+        // Build a state map between task and batch search record
+        Map<BatchSearchRecord.State, Task.State> stateMap = new EnumMap<>(BatchSearchRecord.State.class);
+        stateMap.put(BatchSearchRecord.State.QUEUED, Task.State.QUEUED);
+        stateMap.put(BatchSearchRecord.State.RUNNING, Task.State.RUNNING);
+        stateMap.put(BatchSearchRecord.State.SUCCESS, Task.State.DONE);
+        stateMap.put(BatchSearchRecord.State.FAILURE, Task.State.ERROR);
+        // Set the task state to the same state as the batch search record
+        task.setState(stateMap.get(batchSearchRecord.state));
+        // Set the task result
+        TaskResult<Integer> result = new TaskResult<>(batchSearchRecord.nbResults);
+        task.setResult(result);
+        return task;
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerAmqp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerAmqp.java
@@ -10,7 +10,7 @@ import org.icij.datashare.asynctasks.bus.amqp.AmqpInterlocutor;
 import static org.icij.datashare.cli.DatashareCliOptions.TASK_MANAGER_POLLING_INTERVAL_OPT;
 
 @Singleton
-public class TaskManagerAmqp extends org.icij.datashare.asynctasks.TaskManagerAmqp {
+public class TaskManagerAmqp extends org.icij.datashare.asynctasks.TaskManagerAmqp implements DatashareTaskManager {
     @Inject
     public TaskManagerAmqp(AmqpInterlocutor amqp, TaskRepository taskRepository, PropertiesProvider propertiesProvider)
         throws IOException {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerMemory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerMemory.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CountDownLatch;
 
 
 @Singleton
-public class TaskManagerMemory extends org.icij.datashare.asynctasks.TaskManagerMemory {
+public class TaskManagerMemory extends org.icij.datashare.asynctasks.TaskManagerMemory implements DatashareTaskManager {
 
     @Inject
     public TaskManagerMemory(DatashareTaskFactory taskFactory, TaskRepository taskRepository, PropertiesProvider propertiesProvider) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerRedis.java
@@ -12,7 +12,7 @@ import org.redisson.api.RedissonClient;
 import static org.icij.datashare.cli.DatashareCliOptions.TASK_MANAGER_POLLING_INTERVAL_OPT;
 
 @Singleton
-public class TaskManagerRedis extends org.icij.datashare.asynctasks.TaskManagerRedis {
+public class TaskManagerRedis extends org.icij.datashare.asynctasks.TaskManagerRedis implements DatashareTaskManager {
 
     // Convenience class made to ease injection and test
     @Inject

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -26,6 +26,7 @@
     import org.icij.datashare.cli.Mode;
     import org.icij.datashare.extract.DocumentCollectionFactory;
     import org.icij.datashare.session.DatashareUser;
+    import org.icij.datashare.tasks.DatashareTaskManager;
     import org.icij.datashare.text.Project;
     import org.icij.datashare.text.indexing.Indexer;
     import org.icij.datashare.utils.DataDirVerifier;
@@ -59,14 +60,14 @@
     public class ProjectResource {
         private final Repository repository;
         private final Indexer indexer;
-        private final TaskManager taskManager;
+        private final DatashareTaskManager taskManager;
         private final DataDirVerifier dataDirVerifier;
         private final ModeVerifier modeVerifier;
         private final DocumentCollectionFactory<Path> documentCollectionFactory;
         private final PropertiesProvider propertiesProvider;
 
         @Inject
-        public ProjectResource(Repository repository, Indexer indexer, TaskManager taskManager,PropertiesProvider propertiesProvider, DocumentCollectionFactory<Path> documentCollectionFactory) {
+        public ProjectResource(Repository repository, Indexer indexer, DatashareTaskManager taskManager, PropertiesProvider propertiesProvider, DocumentCollectionFactory<Path> documentCollectionFactory) {
             this.repository = repository;
             this.indexer = indexer;
             this.taskManager = taskManager;

--- a/datashare-app/src/main/java/org/icij/datashare/web/StatusResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/StatusResource.java
@@ -14,8 +14,8 @@ import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.openmetrics.StatusMapper;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.text.indexing.Indexer;
 
 import java.io.IOException;
@@ -26,10 +26,10 @@ public class StatusResource {
     private final PropertiesProvider propertiesProvider;
     private final Repository repository;
     private final Indexer indexer;
-    private final TaskManager taskManager;
+    private final DatashareTaskManager taskManager;
 
     @Inject
-    public StatusResource(PropertiesProvider propertiesProvider, Repository repository, Indexer indexer, TaskManager taskManager) {
+    public StatusResource(PropertiesProvider propertiesProvider, Repository repository, Indexer indexer, DatashareTaskManager taskManager) {
         this.propertiesProvider = propertiesProvider;
         this.repository = repository;
         this.indexer = indexer;

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -31,7 +31,6 @@ import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskAlreadyExists;
 import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskGroupType;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.asynctasks.bus.amqp.UriResult;
@@ -46,6 +45,7 @@ import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.tasks.BatchDownloadRunner;
 import org.icij.datashare.tasks.BatchSearchRunner;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
 import org.icij.datashare.tasks.IndexTask;
@@ -111,7 +111,7 @@ public class TaskResource {
     public static final Set<String> PAGINATION_FIELDS = WebQueryPagination.fields();
     public static final Set<String> TASK_FILTER_FIELDS = Set.of("args", "name", "state", "user");
     private final DatashareTaskFactory taskFactory;
-    private final TaskManager taskManager;
+    private final DatashareTaskManager taskManager;
     private final PropertiesProvider propertiesProvider;
     private final BatchSearchRepository batchSearchRepository;;
     private final ModeVerifier modeVerifier;
@@ -121,7 +121,7 @@ public class TaskResource {
 
 
     @Inject
-    public TaskResource(final DatashareTaskFactory taskFactory, final TaskManager taskManager,
+    public TaskResource(final DatashareTaskFactory taskFactory, final DatashareTaskManager taskManager,
                         final PropertiesProvider propertiesProvider, final BatchSearchRepository batchSearchRepository) {
         this.taskFactory = taskFactory;
         this.taskManager = taskManager;
@@ -198,7 +198,7 @@ public class TaskResource {
                     .getRecords(user, user.getProjectNames())
                     .stream()
                         .filter(r -> r.uuid.equals(id))
-                        .findFirst().map(TaskManager::taskify)
+                        .findFirst().map(DatashareTaskManager::taskify)
                         .orElseThrow(NotFoundException::new);
         }
     }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CliModeWorkerAcceptanceTest.java
@@ -6,6 +6,7 @@ import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.asynctasks.TaskWorkerLoop;
 import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.text.indexing.Indexer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,8 +59,8 @@ public class CliModeWorkerAcceptanceTest {
         workerApp.start();
         workerStarted.await();
 
-        mode.get(TaskManager.class).shutdown(); // to send shutdown
-        mode.get(TaskManager.class).awaitTermination(1, TimeUnit.SECONDS);
+        mode.get(DatashareTaskManager.class).shutdown(); // to send shutdown
+        mode.get(DatashareTaskManager.class).awaitTermination(1, TimeUnit.SECONDS);
         workerApp.join();
         mode.get(Indexer.class).close();
     }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -3,14 +3,13 @@ package org.icij.datashare.mode;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.cli.Mode;
 import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.session.UsersInDb;
-import org.icij.datashare.session.UsersInRedis;
 import org.icij.datashare.session.UsersWritable;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -43,8 +42,8 @@ public class CommonModeTest {
             put("mode", Mode.LOCAL.name());
             put("queueType", QueueType.MEMORY.name());
         }}));
-        assertThat(injector.getInstance(TaskManager.class)).isSameAs(injector.getInstance(TaskModifier.class));
-        assertThat(injector.getInstance(TaskManager.class)).isSameAs(injector.getInstance(TaskSupplier.class));
+        assertThat(injector.getInstance(DatashareTaskManager.class)).isSameAs(injector.getInstance(TaskModifier.class));
+        assertThat(injector.getInstance(DatashareTaskManager.class)).isSameAs(injector.getInstance(TaskSupplier.class));
     }
     @Test
     public void test_check_queue_type_with_default_value() {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexParametrizedTest.java
@@ -46,7 +46,7 @@ public class CreateNlpBatchesFromIndexParametrizedTest {
 
     static class TestableCreateNlpBatchesFromIndex extends CreateNlpBatchesFromIndex {
         public TestableCreateNlpBatchesFromIndex(
-                TaskManager taskManager, Indexer indexer, Task<LinkedList<String>> taskView, Function<Double, Void> ignored) {
+                DatashareTaskManager taskManager, Indexer indexer, Task<LinkedList<String>> taskView, Function<Double, Void> ignored) {
             super(taskManager, indexer, taskView, ignored);
         }
 
@@ -60,7 +60,7 @@ public class CreateNlpBatchesFromIndexParametrizedTest {
     public static ElasticsearchRule es = new ElasticsearchRule();
     private static final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider())
         .withRefresh(Refresh.True);
-    private static TaskManager taskManager;
+    private static DatashareTaskManager taskManager;
 
     @Before
     public void setUp() {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
@@ -34,7 +34,7 @@ public class CreateNlpBatchesFromIndexTest {
     public static ElasticsearchRule es = new ElasticsearchRule();
     private static final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider())
         .withRefresh(Refresh.True);
-    private static TaskManager taskManager;
+    private static DatashareTaskManager taskManager;
 
     @Before
     public void setUp() {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DatashareTaskManagerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DatashareTaskManagerTest.java
@@ -1,0 +1,158 @@
+package org.icij.datashare.tasks;
+
+import static java.util.Arrays.asList;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.text.Project.project;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Stream;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskFilters;
+import org.icij.datashare.batch.BatchSearchRecord;
+import org.icij.datashare.test.LogbackCapturingRule;
+import org.icij.datashare.text.ProjectProxy;
+import org.icij.datashare.user.User;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class DatashareTaskManagerTest {
+    @Rule
+    public LogbackCapturingRule logbackCapturingRule = new LogbackCapturingRule();
+
+    @Mock
+    DatashareTaskFactory taskFactory;
+
+    DatashareTaskManager taskManager;
+    private final CountDownLatch waitForLoop = new CountDownLatch(1);
+
+    @Before
+    public void setUp() throws Exception {
+        PropertiesProvider propertiesProvider = new PropertiesProvider(Map.of(
+            "taskManagerPollingIntervalMilliseconds", "1000"
+        ));
+        taskManager = new TaskManagerMemory(taskFactory, new TaskRepositoryMemory(), propertiesProvider, waitForLoop);
+        waitForLoop.await();
+    }
+
+    @Test
+    public void test_get_one_proxy_task() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User user = User.local();
+        List<ProjectProxy> projects = List.of(project("project"));
+        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
+
+        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
+        assertThat(tasks.get(0).getUser()).isEqualTo(user);
+    }
+
+    @Test
+    public void test_get_tasks_and_proxy_task() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User user = User.local();
+        List<ProjectProxy> projects = List.of(project("project"));
+        BatchSearchRecord batchSearchRecord =
+            new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
+        Task<String> task = new Task<>("name", User.local(), new HashMap<>());
+        taskManager.insert(task, null);
+
+        List<Task<?>> tasks =
+            taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(1).id).isEqualTo(batchSearchRecord.uuid);
+        assertThat(tasks.get(1).getUser()).isEqualTo(user);
+    }
+
+    @Test
+    public void test_get_tasks_and_proxy_task_from_other_user() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User userLocal = User.local();
+        User userOtherLocal = User.localUser("jdoe");
+        List<ProjectProxy> projects = List.of(project("project"));
+        BatchSearchRecord batchSearchRecord =
+            new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
+        Task<String> task = new Task<>("name", User.local(), new HashMap<>());
+        taskManager.insert(task, null);
+
+        TaskFilters filters = TaskFilters.empty().withUser(userOtherLocal);
+        List<Task<?>> tasks = taskManager.getTasks(filters, Stream.of(batchSearchRecord)).toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
+        assertThat(tasks.get(0).getUser()).isEqualTo(userLocal);
+    }
+
+    @Test
+    public void test_get_unique_proxy_task() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User user = User.local();
+        List<ProjectProxy> projects = List.of(project("project"));
+        BatchSearchRecord batchSearchRecord =
+            new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
+        List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
+
+        List<Task<?>> tasks =
+            taskManager.getTasks(TaskFilters.empty().withUser(user), batchSearchRecords.stream()).toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).name).isEqualTo("org.icij.datashare.tasks.BatchSearchRunnerProxy");
+    }
+
+    @Test
+    public void test_skip_proxy_task_when_filter_by_name_is_given() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User user = User.local();
+        List<ProjectProxy> projects = List.of(project("project"));
+        BatchSearchRecord batchSearchRecord =
+            new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
+        List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
+
+        List<Task<?>> tasks =
+            taskManager.getTasks(TaskFilters.empty().withUser(user).withNames("org.icij.datashare.tasks.IndexTask"),
+                batchSearchRecords.stream()).toList();
+        assertThat(tasks).hasSize(0);
+    }
+
+    @Test
+    public void test_not_skip_proxy_task_when_filter_by_name_is_given_with_correct_value() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User user = User.local();
+        List<ProjectProxy> projects = List.of(project("project"));
+        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
+        List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
+
+        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user).withNames("org.icij.datashare.tasks.BatchSearchRunnerProxy"), batchSearchRecords.stream()).toList();
+        assertThat(tasks).hasSize(1);
+    }
+
+    @Test
+    public void test_get_unique_proxy_task_not_in_priority() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User user = User.local();
+        List<ProjectProxy> projects = List.of(project("project"));
+        BatchSearchRecord batchSearchRecord =
+            new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
+
+        Task<String> task = new Task<>(batchSearchRecord.uuid, "name", User.local());
+        taskManager.insert(task, null);
+
+        List<Task<?>> tasks =
+            taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).name).isEqualTo("name");
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        taskManager.close();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -5,13 +5,13 @@ import net.codestory.http.security.Users;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
 import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.cli.Mode;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.session.YesBasicAuthFilter;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.user.User;
@@ -40,7 +40,8 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     @Mock Repository repository;
     @Mock JooqRepository jooqRepository;
     @Mock Indexer indexer;
-    @Mock TaskManager taskManager;
+    @Mock
+    DatashareTaskManager taskManager;
     @Rule public TemporaryFolder artifactDir = new TemporaryFolder();
     MemoryDocumentCollectionFactory<Path> documentCollectionFactory;
     PropertiesProvider propertiesProvider;

--- a/datashare-app/src/test/java/org/icij/datashare/web/StatusResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/StatusResourceTest.java
@@ -2,7 +2,7 @@ package org.icij.datashare.web;
 
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
-import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.tasks.DatashareTaskManager;
 import org.icij.datashare.test.DatashareTimeRule;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
@@ -22,7 +22,8 @@ public class StatusResourceTest extends AbstractProdWebServerTest {
     @Rule public DatashareTimeRule time = new DatashareTimeRule("2020-06-30T15:31:00Z");
     @Mock Repository repository;
     @Mock Indexer indexer;
-    @Mock TaskManager taskManager;
+    @Mock
+    DatashareTaskManager taskManager;
 
     @Before
     public void setUp() {

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -901,7 +901,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         return taskManager.getTasks().filter(t -> expectedName.equals(t.name)).findFirst();
     }
 
-    private void assertHasState(String taskId, Task.State expectedState, TaskManager taskManager, int timeoutMs, int pollIntervalMs)
+    private void assertHasState(String taskId, Task.State expectedState, DatashareTaskManager taskManager, int timeoutMs, int pollIntervalMs)
         throws IOException, InterruptedException {
         long start = System.currentTimeMillis();
         while (System.currentTimeMillis() - start < timeoutMs) {

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -1,22 +1,16 @@
 package org.icij.datashare.asynctasks;
 
-import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.text.Project.project;
 
 import java.io.IOException;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import java.util.stream.Stream;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.batch.BatchSearchRecord;
 import org.icij.datashare.test.LogbackCapturingRule;
-import org.icij.datashare.text.ProjectProxy;
 import org.icij.datashare.time.DatashareTime;
 import org.icij.datashare.user.User;
 import org.junit.After;
@@ -167,103 +161,6 @@ public class TaskManagerMemoryTest {
 
         assertThat(taskManager.getTasks().toList()).hasSize(1);
         assertThat(taskManager.getTask(task.id)).isNotNull();
-    }
-
-    @Test
-    public void test_get_one_proxy_task() throws IOException {
-        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        User user = User.local();
-        List<ProjectProxy> projects = List.of(project("project"));
-        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
-
-        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
-        assertThat(tasks.get(0).getUser()).isEqualTo(user);
-    }
-
-    @Test
-    public void test_get_tasks_and_proxy_task() throws IOException {
-        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        User user = User.local();
-        List<ProjectProxy> projects = List.of(project("project"));
-        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
-        Task<String> task = new Task<>("name", User.local(), new HashMap<>());
-        taskManager.insert(task, null);
-
-        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
-        assertThat(tasks).hasSize(2);
-        assertThat(tasks.get(1).id).isEqualTo(batchSearchRecord.uuid);
-        assertThat(tasks.get(1).getUser()).isEqualTo(user);
-    }
-
-    @Test
-    public void test_get_tasks_and_proxy_task_from_other_user() throws IOException {
-        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        User userLocal = User.local();
-        User userOtherLocal = User.localUser("jdoe");
-        List<ProjectProxy> projects = List.of(project("project"));
-        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
-        Task<String> task = new Task<>("name", User.local(), new HashMap<>());
-        taskManager.insert(task, null);
-
-        TaskFilters filters = TaskFilters.empty().withUser(userOtherLocal);
-        List<Task<?>> tasks = taskManager.getTasks(filters, Stream.of(batchSearchRecord)).toList();
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).id).isEqualTo(batchSearchRecord.uuid);
-        assertThat(tasks.get(0).getUser()).isEqualTo(userLocal);
-    }
-
-    @Test
-    public void test_get_unique_proxy_task() throws IOException {
-        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        User user = User.local();
-        List<ProjectProxy> projects = List.of(project("project"));
-        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
-        List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
-
-        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), batchSearchRecords.stream()).toList();
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).name).isEqualTo("org.icij.datashare.tasks.BatchSearchRunnerProxy");
-    }
-
-    @Test
-    public void test_skip_proxy_task_when_filter_by_name_is_given() throws IOException {
-        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        User user = User.local();
-        List<ProjectProxy> projects = List.of(project("project"));
-        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
-        List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
-
-        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user).withNames("org.icij.datashare.tasks.IndexTask"), batchSearchRecords.stream()).toList();
-        assertThat(tasks).hasSize(0);
-    }
-
-    @Test
-    public void test_not_skip_proxy_task_when_filter_by_name_is_given_with_correct_value() throws IOException {
-        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        User user = User.local();
-        List<ProjectProxy> projects = List.of(project("project"));
-        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
-        List<BatchSearchRecord> batchSearchRecords = asList(batchSearchRecord, batchSearchRecord);
-
-        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user).withNames("org.icij.datashare.tasks.BatchSearchRunnerProxy"), batchSearchRecords.stream()).toList();
-        assertThat(tasks).hasSize(1);
-    }
-
-    @Test
-    public void test_get_unique_proxy_task_not_in_priority() throws IOException {
-        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
-        User user = User.local();
-        List<ProjectProxy> projects = List.of(project("project"));
-        BatchSearchRecord batchSearchRecord = new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
-
-        Task<String> task = new Task<>(batchSearchRecord.uuid, "name", User.local());
-        taskManager.insert(task, null);
-
-        List<Task<?>> tasks = taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
-        assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).name).isEqualTo("name");
     }
 
     @Test


### PR DESCRIPTION
# Description

First step towards: https://github.com/ICIJ/datashare/issues/2002

Remove `datashare-app` specific logic from `datashare-tasks` to prepare the `TaskManager` API refacto.


# Changes
## `datashare-tasks`
### Removed
- removed the `Stream<Task<?>> getTasks(TaskFilters filters, Stream<BatchSearchRecord> batchSearchRecords)` API from `TaskManager`


## `datashare-app`
### Changed
- added a `DatashareTaskManager extends TaskManager` interface which implements the `Stream<Task<?>> getTasks(TaskFilters filters, Stream<BatchSearchRecord> batchSearchRecords)` API 