### PR TITLE
refactor: `TaskManagerInterface` to allow integration of externally managed task managers

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -221,7 +221,7 @@
                 }
             });
             logger.info("Stopping tasks : {}", taskManager.stopTasks(user));
-            taskManager.waitTasksToBeDone(TaskManager.POLLING_INTERVAL*2, MILLISECONDS);
+            taskManager.waitTasksToBeDone(taskManager.getTerminationPollingInterval()*2, MILLISECONDS);
             logger.info("Deleted tasks : {}", !taskManager.clearDoneTasks().isEmpty());
             return new Payload(204);
         }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DatashareTaskManagerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DatashareTaskManagerTest.java
@@ -64,7 +64,7 @@ public class DatashareTaskManagerTest {
         BatchSearchRecord batchSearchRecord =
             new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
         Task<String> task = new Task<>("name", User.local(), new HashMap<>());
-        taskManager.insert(task, null);
+        taskManager.startTask(task, null);
 
         List<Task<?>> tasks =
             taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();
@@ -82,7 +82,7 @@ public class DatashareTaskManagerTest {
         BatchSearchRecord batchSearchRecord =
             new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
         Task<String> task = new Task<>("name", User.local(), new HashMap<>());
-        taskManager.insert(task, null);
+        taskManager.startTask(task, null);
 
         TaskFilters filters = TaskFilters.empty().withUser(userOtherLocal);
         List<Task<?>> tasks = taskManager.getTasks(filters, Stream.of(batchSearchRecord)).toList();
@@ -142,7 +142,7 @@ public class DatashareTaskManagerTest {
             new BatchSearchRecord(projects, "name", "description", 123, new Date(), uri);
 
         Task<String> task = new Task<>(batchSearchRecord.uuid, "name", User.local());
-        taskManager.insert(task, null);
+        taskManager.startTask(task, null);
 
         List<Task<?>> tasks =
             taskManager.getTasks(TaskFilters.empty().withUser(user), Stream.of(batchSearchRecord)).toList();

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManager.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManager.java
@@ -1,0 +1,29 @@
+package org.icij.datashare.asynctasks;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Task manager back by a queueing system and a persistent storay
+ */
+interface StoreAndQueueTaskManager extends TaskManager {
+    /**
+     * This is a "inner method" that is used in the template method for start(task).
+     * It saves the method in the inner persistent state of TaskManagers implementations.
+     *
+     * @param task to be saved in persistent state
+     * @throws IOException if a network error occurs
+     */
+    <V extends Serializable> void insert(Task<V> task, Group group) throws IOException, TaskAlreadyExists;
+
+    <V extends Serializable> void update(Task<V> task) throws IOException, UnknownTask;
+
+    /**
+     * This is a "inner method" that is used in the template method for start(task).
+     * It put the task in the task queue for workers.
+     *
+     * @param task task to be queued
+     * @throws IOException if a network error occurs
+     */
+    <V extends Serializable> void enqueue(Task<V> task) throws IOException;
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManagerImpl.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManagerImpl.java
@@ -1,0 +1,121 @@
+package org.icij.datashare.asynctasks;
+
+import java.io.IOException;
+import java.io.Serializable;
+import org.icij.datashare.asynctasks.bus.amqp.CancelledEvent;
+import org.icij.datashare.asynctasks.bus.amqp.ErrorEvent;
+import org.icij.datashare.asynctasks.bus.amqp.ProgressEvent;
+import org.icij.datashare.asynctasks.bus.amqp.ResultEvent;
+import org.icij.datashare.asynctasks.bus.amqp.TaskEvent;
+
+/**
+ * Task manager back by a queueing system and a persistent storay
+ */
+abstract class StoreAndQueueTaskManagerImpl implements StoreAndQueueTaskManager {
+
+     // For test
+    abstract protected Group getTaskGroup(String taskId) throws IOException;
+
+    /**
+     * Main start task function. it saves the task in the persistent storage. If the task is new it will enqueue
+     * it in the memory/redis/AMQP queue and return the id. Else it will not enqueue the task and return null.
+     *
+     * @param taskView: the task description.
+     * @param group:    task group
+     * @return task id if it was new and has been saved else null
+     * @throws IOException       in case of communication failure with Redis or AMQP broker
+     * @throws TaskAlreadyExists when the task has already been started
+     */
+    @Override
+    public <V extends Serializable> String startTask(Task<V> taskView, Group group)
+        throws IOException, TaskAlreadyExists {
+        insert(taskView, group);
+        taskView.queue();
+        enqueue(taskView);
+        return taskView.id;
+    }
+
+    private <V extends Serializable> Task<V> setResult(ResultEvent<V> e) throws IOException, UnknownTask {
+        Task<V> taskView = getTask(e.taskId);
+        if (taskView != null) {
+            logger.info("result event for {}", e.taskId);
+            taskView.setResult(e.result);
+            update(taskView);
+        } else {
+            logger.warn("no task found for result event {}", e.taskId);
+        }
+        return taskView;
+    }
+
+    private <V extends Serializable> Task<V> setError(ErrorEvent e) throws IOException, UnknownTask {
+        Task<V> taskView = getTask(e.taskId);
+        if (taskView != null) {
+            logger.info("error event for {}", e.taskId);
+            taskView.setError(e.error);
+            update(taskView);
+        } else {
+            logger.warn("no task found for error event {}", e.taskId);
+        }
+        return taskView;
+    }
+
+    private <V extends Serializable> Task<V> setCanceled(CancelledEvent e) throws IOException, UnknownTask {
+        Task<V> taskView = getTask(e.taskId);
+        if (taskView != null) {
+            logger.info("canceled event for {}", e.taskId);
+            taskView.cancel();
+            update(taskView);
+            if (e.requeue) {
+                try {
+                    enqueue(taskView);
+                } catch (IOException ex) {
+                    logger.error("error while reposting canceled event", ex);
+                }
+            }
+        } else {
+            logger.warn("no task found for canceled event {}", e.taskId);
+        }
+        return taskView;
+    }
+
+    private <V extends Serializable> Task<V> setProgress(ProgressEvent e) throws IOException, UnknownTask {
+        logger.debug("progress event for {}", e.taskId);
+        try {
+            Task<V> taskView = getTask(e.taskId);
+            if (taskView != null) {
+                taskView.setProgress(e.progress);
+                update(taskView);
+            }
+            return taskView;
+        } catch (UnknownTask ex) {
+            throw new NackException(ex, false);
+        }
+    }
+
+    protected final <V extends Serializable> Task<V> handleAck(TaskEvent e) {
+        try {
+            if (e instanceof CancelledEvent ce) {
+                return setCanceled(ce);
+            }
+            if (e instanceof ResultEvent) {
+                return setResult((ResultEvent<V>) e);
+            }
+            if (e instanceof ErrorEvent ee) {
+                return setError(ee);
+            }
+            if (e instanceof ProgressEvent pe) {
+                return setProgress(pe);
+            }
+            logger.warn("received event not handled {}", e);
+            return null;
+        } catch (IOException | UnknownTask ioe) {
+            throw new TaskEventHandlingException(ioe);
+        }
+    }
+
+    protected static class TaskEventHandlingException extends RuntimeException {
+        public TaskEventHandlingException(Exception cause) {
+            super(cause);
+        }
+    }
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.asynctasks.Task.State.FINAL_STATES;
 
-public class TaskManagerAmqp implements TaskManager {
+public class TaskManagerAmqp extends StoreAndQueueTaskManagerImpl {
     protected static final int DEFAULT_TASK_POLLING_INTERVAL_MS = 5000;
     private final TaskRepository tasks;
     private final RoutingStrategy routingStrategy;
@@ -38,9 +38,7 @@ public class TaskManagerAmqp implements TaskManager {
         this.tasks = tasks;
         this.routingStrategy = routingStrategy;
         this.taskPollingIntervalMs = taskPollingIntervalMs;
-        eventConsumer = new AmqpConsumer<>(amqp, event ->
-                ofNullable(TaskManager.super.handleAck(event)).flatMap(t ->
-                        ofNullable(eventCallback)).ifPresent(Runnable::run), AmqpQueue.MANAGER_EVENT, TaskEvent.class).consumeEvents();
+        eventConsumer = new AmqpConsumer<>(amqp, event -> ofNullable(this.handleAck(event)).flatMap(t -> ofNullable(eventCallback)).ifPresent(Runnable::run), AmqpQueue.MANAGER_EVENT, TaskEvent.class).consumeEvents();
     }
 
     @Override
@@ -105,7 +103,7 @@ public class TaskManagerAmqp implements TaskManager {
     }
 
     @Override
-    public Group getTaskGroup(String taskId) throws IOException {
+    protected Group getTaskGroup(String taskId) throws IOException {
         return tasks.getTaskGroup(taskId);
     }
 

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
@@ -21,7 +21,7 @@ import static java.lang.Integer.parseInt;
 import static org.icij.datashare.asynctasks.Task.State.FINAL_STATES;
 
 
-public class TaskManagerMemory implements TaskManager, TaskSupplier {
+public class TaskManagerMemory extends StoreAndQueueTaskManagerImpl implements TaskSupplier {
     protected static final int DEFAULT_TASK_POLLING_INTERVAL_MS = 5000;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ExecutorService executor;
@@ -117,7 +117,7 @@ public class TaskManagerMemory implements TaskManager, TaskSupplier {
     }
 
     @Override
-    public Group getTaskGroup(String taskId) throws IOException {
+    protected Group getTaskGroup(String taskId) throws IOException {
         return tasks.getTaskGroup(taskId);
     }
 

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
@@ -38,7 +38,7 @@ import java.util.stream.StreamSupport;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.asynctasks.Task.State.FINAL_STATES;
 
-public class TaskManagerRedis implements TaskManager {
+public class TaskManagerRedis extends StoreAndQueueTaskManagerImpl {
     private final Runnable eventCallback; // for test
     public static final String EVENT_CHANNEL_NAME = "EVENT";
     protected static final int DEFAULT_TASK_POLLING_INTERVAL_MS = 5000;
@@ -116,7 +116,7 @@ public class TaskManagerRedis implements TaskManager {
     }
 
     public void handleEvent(TaskEvent e) {
-        ofNullable(TaskManager.super.handleAck(e)).flatMap(t -> ofNullable(eventCallback)).ifPresent(Runnable::run);
+        ofNullable(this.handleAck(e)).flatMap(t -> ofNullable(eventCallback)).ifPresent(Runnable::run);
     }
 
     @Override

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerAmqpTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerAmqpTest.java
@@ -5,9 +5,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import org.icij.datashare.EnvUtils;
 import org.icij.datashare.PropertiesProvider;
@@ -64,7 +61,7 @@ public class TaskManagerAmqpTest {
         TaskGroupType key = TaskGroupType.Test;
         try (TaskManagerAmqp groupTaskManager = new TaskManagerAmqp(AMQP, new TaskRepositoryMemory(), RoutingStrategy.GROUP, () -> nextMessage.countDown());
              TaskSupplierAmqp groupTaskSupplier = new TaskSupplierAmqp(AMQP, key.name())) {
-            groupTaskSupplier.consumeTasks(t -> taskQueue.add(t));
+            groupTaskSupplier.consumeTasks(taskQueue::add);
             String expectedTaskViewId = groupTaskManager.startTask("taskName", User.local(), new Group(key), Map.of());
 
             assertThat(groupTaskManager.getTask(expectedTaskViewId)).isNotNull();
@@ -78,7 +75,7 @@ public class TaskManagerAmqpTest {
     public void test_new_task_with_name_routing() throws Exception {
         try (TaskManagerAmqp groupTaskManager = new TaskManagerAmqp(AMQP, new TaskRepositoryMemory(), RoutingStrategy.NAME, () -> nextMessage.countDown());
              TaskSupplierAmqp groupTaskSupplier = new TaskSupplierAmqp(AMQP, "TaskName")) {
-            groupTaskSupplier.consumeTasks(t -> taskQueue.add(t));
+            groupTaskSupplier.consumeTasks(taskQueue::add);
             String expectedTaskViewId = groupTaskManager.startTask("TaskName", User.local(), Map.of());
 
             assertThat(groupTaskManager.getTask(expectedTaskViewId)).isNotNull();


### PR DESCRIPTION
# TODO
- [x] merge https://github.com/ICIJ/datashare/pull/2008

# Description

Second step towards: https://github.com/ICIJ/datashare/issues/2002

Refactors the `TaskManager` interface to allow integration of externally deployed task managers.

The current `TaskManager` interface actually mixes contracts and implementation details.

It makes the asumption that we have access to the task manager storage as well as the task manager queue.

Storage and queues are more implementation details than contracts.


# Changes
## `datashare-tasks`
### Changed
- removed all queue and storage relative APIs from `TaskManager`
- added a `StoreAndQueueTaskManager` interface to define contract of TMs with accessible queues and storages
- added a `StoreAndQueueTaskManagerImpl` abstract class to hold implementation logics for such TMs
