### PR TITLE
feat: ES settings routes in LOCAL/EMBEDDED mode

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -202,6 +202,14 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_close_index_forwards_query_params() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));
+        post("/api/index/%s/_close?ignore_unavailable=true".formatted(es.getIndexName())).should().respond(200);
+        post("/api/index/%s/_open?ignore_unavailable=true".formatted(es.getIndexName())).should().respond(200);
+    }
+
+    @Test
     public void test_close_index_forbidden_in_server_mode() {
         configure(routes -> routes.add(new IndexResource(indexer, serverModeProvider))
                 .filter(new LocalUserFilter(serverModeProvider, jooqRepository, es.getIndexNames())));


### PR DESCRIPTION
Add Elasticsearch administration routes for LOCAL and EMBEDDED modes to enable snapshot management, cluster operations, and index lifecycle control. Applications running in SERVER mode will receive 403 Forbidden responses for these administrative operations. This is part of #2013.                                                                                                                             
                                                                                                                                                                                                                                                                                   
## Changes 

- **`/api/index`**
  - GET - Retrieve Elasticsearch cluster information

- **`/api/index/:index/_close`**
  - POST - Close index with query parameter forwarding

- **`/api/index/:index/_open`**
  - POST - Open index with query parameter forwarding

- **`/api/index/_snapshot/:repository`**
  - GET - Retrieve snapshot repository
  - PUT - Create/update snapshot repository
  - DELETE - Delete snapshot repository

- **`/api/index/_snapshot/:repository/:snapshot`**
  - GET - Retrieve snapshot
  - PUT - Create snapshot
  - DELETE - Delete snapshot

- **`/api/index/_snapshot/:repository/:snapshot/_restore`**
  - POST - Restore snapshot

- **`/api/index/_nodes`**
  - GET - Retrieve nodes information

- **`/api/index/_nodes/settings`**
  - GET - Retrieve nodes settings

- **`/api/index/_cluster/settings`**
  - GET - Retrieve cluster settings