### PR TITLE
refactor(datashare-tasks): rename `TaskManager.getTaskStates` into `TaskManager.getTaskIds`

### DIFF
--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqTaskRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqTaskRepositoryTest.java
@@ -17,7 +17,6 @@ import org.icij.datashare.asynctasks.TaskAlreadyExists;
 import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskGroupType;
 import org.icij.datashare.asynctasks.TaskResult;
-import org.icij.datashare.asynctasks.TaskStateMetadata;
 import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.asynctasks.bus.amqp.UriResult;
@@ -196,36 +195,34 @@ public class JooqTaskRepositoryTest {
     }
 
     @Test
-    public void test_get_task_states() throws Exception {
+    public void test_get_task_ids() throws Exception {
         Task<String> foo = new Task<>("foo", User.local(), Map.of("user", User.local()));
         Task<String> bar = new Task<>("bar", User.local(), Map.of("user", User.local()));
         repository.insert(foo, new Group(TaskGroupType.Test));
         repository.insert(bar, new Group(TaskGroupType.Test));
         TaskFilters filter = TaskFilters.empty();
 
-        List<TaskStateMetadata> tasks = repository.getTaskStates(filter).toList();
+        List<String> taskIds = repository.getTaskIds(filter).toList();
 
-        assertThat(tasks.size()).isEqualTo(2);
-        assertThat(tasks.stream().map(TaskStateMetadata::taskId).toList()).isEqualTo(List.of(foo.id, bar.id));
+        assertThat(taskIds).isEqualTo(List.of(foo.id, bar.id));
     }
 
 
     @Test
-    public void test_get_task_states_with_names_filter() throws Exception {
+    public void test_get_task_ids_with_names_filter() throws Exception {
         Task<String> foo = new Task<>("foo", User.local(), Map.of("user", User.local()));
         Task<String> bar = new Task<>("bar", User.local(), Map.of("user", User.local()));
         repository.insert(foo, new Group(TaskGroupType.Test));
         repository.insert(bar, new Group(TaskGroupType.Test));
         TaskFilters filter = TaskFilters.empty().withNames("foo");
 
-        List<TaskStateMetadata> tasks = repository.getTaskStates(filter).toList();
+        List<String> taskIds = repository.getTaskIds(filter).toList();
 
-        assertThat(tasks.size()).isEqualTo(1);
-        assertThat(tasks.get(0).taskId()).isEqualTo(foo.id);
+        assertThat(taskIds).isEqualTo(List.of(foo.id));
     }
 
     @Test
-    public void test_get_task_states_with_status_filter() throws Exception {
+    public void test_get_task_ids_with_status_filter() throws Exception {
         Task<String> foo = new Task<>("foo", User.local(), Map.of("user", User.local()));
         Task<String> bar = new Task<>("bar", User.local(), Map.of("user", User.local()));
         // Bar must have a result to be considered as "DONE"
@@ -234,14 +231,13 @@ public class JooqTaskRepositoryTest {
         repository.insert(bar, new Group(TaskGroupType.Test));
         TaskFilters filter = TaskFilters.empty().withStates(Task.State.FINAL_STATES);
 
-        List<TaskStateMetadata> tasks = repository.getTaskStates(filter).toList();
+        List<String> taskIds = repository.getTaskIds(filter).toList();
 
-        assertThat(tasks.size()).isEqualTo(1);
-        assertThat(tasks.get(0).taskId()).isEqualTo(bar.id);
+        assertThat(taskIds).isEqualTo(List.of(bar.id));
     }
 
     @Test
-    public void test_get_task_states_with_args_filter() throws Exception {
+    public void test_get_task_ids_with_args_filter() throws Exception {
         Task<String> foo = new Task<>("foo", User.local(), Map.of("someArg", "fooValue"));
         Task<String> bar = new Task<>("bar", User.local(), Map.of("someArg", "barValue"));
 
@@ -251,10 +247,9 @@ public class JooqTaskRepositoryTest {
         TaskFilters filter = TaskFilters.empty()
             .withArgs(new TaskFilters.ArgsFilter("someArg", "bar.*"));
 
-        List<TaskStateMetadata> tasks = repository.getTaskStates(filter).toList();
+        List<String> taskIds = repository.getTaskIds(filter).toList();
 
-        assertThat(tasks.size()).isEqualTo(1);
-        assertThat(tasks.get(0).taskId()).isEqualTo(bar.id);
+        assertThat(taskIds).isEqualTo(List.of(bar.id));
     }
 
     @After

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskFilters.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskFilters.java
@@ -37,6 +37,10 @@ public final class TaskFilters {
         return new TaskFilters(null, null, null, null);
     }
 
+    public boolean isEmpty() {
+        return args == null && states == null && name == null && user == null;
+    }
+
     public Set<Task.State> getStates() {
         return states;
     }
@@ -88,7 +92,11 @@ public final class TaskFilters {
         return byArgs(args);
     }
 
-    private boolean byState(Task.State taskState) {
+    public boolean hasStates() {
+        return states != null && !states.isEmpty();
+    }
+
+    boolean byState(Task.State taskState) {
         return Optional.ofNullable(states).map(expectedStates -> {
             if (!expectedStates.isEmpty()) {
                 return expectedStates.contains(taskState);
@@ -101,11 +109,11 @@ public final class TaskFilters {
         return Optional.ofNullable(this.user).map(u -> u.equals(taskUser)).orElse(true);
     }
 
-    private boolean byName(String taskName) {
+    boolean byName(String taskName) {
         return Optional.ofNullable(getNamePattern()).map(p -> p.matcher(taskName).find()).orElse(true);
     }
 
-    private boolean byArgs(Map<String, Object> taskArgs) {
+    boolean byArgs(Map<String, Object> taskArgs) {
         return Optional.ofNullable(getArgsPatterns())
             .map(patterns -> patterns.entrySet()
                             .stream()

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
@@ -103,8 +103,8 @@ public class TaskManagerAmqp extends StoreAndQueueTaskManagerImpl {
     }
 
     @Override
-    public Stream<TaskStateMetadata> getTaskStates(TaskFilters filters) throws IOException {
-        return tasks.getTaskStates(filters);
+    public Stream<String> getTaskIds(TaskFilters filters) throws IOException {
+        return tasks.getTaskIds(filters);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerMemory.java
@@ -58,8 +58,8 @@ public class TaskManagerMemory extends StoreAndQueueTaskManagerImpl implements T
     }
 
     @Override
-    public Stream<TaskStateMetadata> getTaskStates(TaskFilters filters) throws IOException {
-        return tasks.getTaskStates(filters);
+    public Stream<String> getTaskIds(TaskFilters filters) throws IOException {
+        return tasks.getTaskIds(filters);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerRedis.java
@@ -76,8 +76,8 @@ public class TaskManagerRedis extends StoreAndQueueTaskManagerImpl {
     }
 
     @Override
-    public Stream<TaskStateMetadata> getTaskStates(TaskFilters filters) throws IOException {
-        return tasks.getTaskStates(filters);
+    public Stream<String> getTaskIds(TaskFilters filters) throws IOException {
+        return tasks.getTaskIds(filters);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepository.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepository.java
@@ -19,5 +19,5 @@ public interface TaskRepository {
 
 
     Stream<Task<? extends Serializable>> getTasks(TaskFilters filters) throws IOException, UnknownTask;
-    Stream<TaskStateMetadata> getTaskStates(TaskFilters filters) throws IOException;
+    Stream<String> getTaskIds(TaskFilters filters) throws IOException;
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryMemory.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryMemory.java
@@ -29,9 +29,9 @@ public class TaskRepositoryMemory extends ConcurrentHashMap<String, TaskGroupMet
     }
 
     @Override
-    public Stream<TaskStateMetadata> getTaskStates(TaskFilters filters) throws IOException, UnknownTask {
+    public Stream<String> getTaskIds(TaskFilters filters) throws IOException, UnknownTask {
         // Inefficient implementation of get task state but that's fine for in-memory usage
-        return getTasks(filters).map(t -> new TaskStateMetadata(t.id, t.getState()));
+        return getTasks(filters).map(Task::getId);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryRedis.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskRepositoryRedis.java
@@ -39,9 +39,9 @@ public class TaskRepositoryRedis extends RedissonMap<String, TaskGroupMetadata<?
     }
 
     @Override
-    public Stream<TaskStateMetadata> getTaskStates(TaskFilters filters) throws IOException, UnknownTask {
+    public Stream<String> getTaskIds(TaskFilters filters) throws IOException, UnknownTask {
         // Inefficient implementation of get task state but redis is not used any longer
-        return getTasks(filters).map(t -> new TaskStateMetadata(t.id, t.getState()));
+        return getTasks(filters).map(Task::getId);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskStateMetadata.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskStateMetadata.java
@@ -1,4 +1,0 @@
-package org.icij.datashare.asynctasks;
-
-public record TaskStateMetadata(String taskId, Task.State state) {
-}


### PR DESCRIPTION
# Description

Simplification of #2012


# Changes
## `datashare-tasks`
### Changed
- changed `Stream<TaskStateMetadata> getTaskStates(TaskFilters filters) throws IOException;` into `Stream<String> getTaskIds(TaskFilters filters) throws IOException;`
