### PR TITLE
fix(datashare-tasks): `TaskManagerTemporal.getTaskIds()` consistency

### DIFF
--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskFilters.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskFilters.java
@@ -100,7 +100,7 @@ public final class TaskFilters {
         return states != null && !states.isEmpty();
     }
 
-    boolean byState(Task.State taskState) {
+    public boolean byState(Task.State taskState) {
         return Optional.ofNullable(states).map(expectedStates -> {
             if (!expectedStates.isEmpty()) {
                 return expectedStates.contains(taskState);
@@ -109,11 +109,11 @@ public final class TaskFilters {
         }).orElse(true);
     }
 
-    private boolean byUser(User taskUser) {
+    public boolean byUser(User taskUser) {
         return Optional.ofNullable(this.user).map(u -> u.equals(taskUser)).orElse(true);
     }
 
-    boolean byName(String taskName) {
+    public boolean byName(String taskName) {
         return Optional.ofNullable(getNamePattern()).map(p -> p.matcher(taskName).find()).orElse(true);
     }
 


### PR DESCRIPTION
# Bug description

As describe in [this discussion](https://temporalio.slack.com/archives/CTT84KXK9/p1770118324845739) with temporal maintainers, some temporal actions are async and in particular temporal search **is only eventually consistent** (`listWorkflowExecutions`).

While this is not an issue for front-end search `TaskManagerTemporal.getTaskIds()`, this is more problematic for internal search.
This PRs makes `TaskManagerTemporal.getTaskIds()` immediately consistent by keeping track of tasks  started by the task manager and adding the relevant tasks to the search output of (`listWorkflowExecutions`).

**Known limitation**: known task IDs are recorded in memory, if the task manager crashes or is replaced by a newer pod, `getTaskIds` has a slight chance not to be immediately consistent. This could be improved by using a persistent taskIds repository instead of in-memory map. The goal of this PR was avoid flaky test, a more robust will be implemented if consistency issues arise while stress testing

# Changes
## `datashare-tasks`
### Changed
- makes `TaskManagerTemporal.getTaskIds()` immediately consistent by keeping track of started tasks