### PR TITLE
feature(datashare-tasks): support arbitrary task group

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -212,7 +212,7 @@ public class TaskResource {
     @ApiResponse(responseCode = "404", description = "returns 404 if the task doesn't exist")
     @Put("/:id")
     public <V extends Serializable> Payload createTask(@Parameter(name = "id", description = "task id", required = true, in = ParameterIn.PATH) String id,  Context context, Task<V> taskView) throws IOException {
-        Group taskGroup = Optional.ofNullable(context.get("group")).map(g -> new Group(TaskGroupType.valueOf(g))).orElse(null);
+        Group taskGroup = Optional.ofNullable(context.get("group")).map(Group::new).orElse(null);
         if (taskView == null || id == null || !Objects.equals(taskView.id, id)) {
             return new JsonPayload(400, new ErrorResponse("body should contain a taskView, URL id should be present and equal to body id"));
         }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqTaskRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqTaskRepository.java
@@ -12,7 +12,6 @@ import org.icij.datashare.asynctasks.Group;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskAlreadyExists;
 import org.icij.datashare.asynctasks.TaskFilters;
-import org.icij.datashare.asynctasks.TaskGroupType;
 import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.asynctasks.UnknownTask;
@@ -124,7 +123,7 @@ public class JooqTaskRepository implements TaskRepository {
             )
             .map(r -> r.get(TASK.GROUP_ID))
             .orElseThrow(() -> new UnknownTask(taskId));
-        return new Group(TaskGroupType.valueOf(groupId));
+        return new Group(groupId);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Group.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/Group.java
@@ -2,9 +2,13 @@ package org.icij.datashare.asynctasks;
 
 import org.icij.datashare.Entity;
 
-public record Group(TaskGroupType id) implements Entity {
+public record Group(String id) implements Entity {
     @Override
     public String getId() {
-        return id().name();
+        return id();
+    }
+
+    public Group(TaskGroupType taskGroupId) {
+        this(taskGroupId.name());
     }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerAmqp.java
@@ -86,7 +86,7 @@ public class TaskManagerAmqp extends StoreAndQueueTaskManagerImpl {
     @Override
     public <V extends Serializable> void enqueue(Task<V> task) throws IOException {
         switch (routingStrategy) {
-            case GROUP -> amqp.publish(AmqpQueue.TASK, this.tasks.getTaskGroup(task.id).id().name(), task);
+            case GROUP -> amqp.publish(AmqpQueue.TASK, this.tasks.getTaskGroup(task.id).id(), task);
             case NAME -> amqp.publish(AmqpQueue.TASK, task.name, task);
             default -> amqp.publish(AmqpQueue.TASK, task);
         }


### PR DESCRIPTION
# Feature description

With [datashare-python](https://github.com/ICIJ/datashare-python) its possible to define tasks which are unknown from DS backend. Devs might implement their own tasks with the own task group.

For now creating a task with an unknown task group results in errors since we expect `TaskGroupType`.

This PR allows to use arbitrary task group for tasks, the `TaskGroupType` was initially introduced to normalize task group names and avoid typos (no to restrict task groups).

# Changes
## `datashare-tasks`
### Changed
- allow arbitrary task group IDs when creating tasks