### PR TITLE
refactor(datashare-tasks): create namespace and custom search attributes at app startup

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -20,7 +20,6 @@ import net.codestory.http.extensions.Extensions;
 import net.codestory.http.injection.GuiceAdapter;
 import net.codestory.http.misc.Env;
 import net.codestory.http.routes.Routes;
-import org.icij.datashare.EnvUtils;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
 import org.icij.datashare.asynctasks.Group;
@@ -30,6 +29,7 @@ import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.asynctasks.TaskWorkerLoop;
 import org.icij.datashare.asynctasks.temporal.TemporalHelper;
+import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.batch.BatchSearchRepository;
 import org.icij.datashare.cli.Mode;
 import org.icij.datashare.cli.QueueType;
@@ -99,9 +99,16 @@ import static java.lang.Integer.parseInt;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.PluginService.PLUGINS_BASE_URL;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.DEFAULT_NAMESPACE;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.buildClient;
-import static org.icij.datashare.cli.DatashareCliOptions.*;
+import static org.icij.datashare.cli.DatashareCliOptions.BATCH_QUEUE_TYPE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_BATCH_QUEUE_TYPE;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_QUEUE_TYPE;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_TASK_WORKERS;
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.QUEUE_TYPE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_PROGRESS_INTERVAL_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_REPOSITORY_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_WORKERS_OPT;
 import static org.icij.datashare.cli.QueueType.TEMPORAL;
 import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration.createESClient;
 
@@ -238,12 +245,8 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
     }
 
     @Provides @Singleton
-    WorkflowClient provideTemporalClient(final PropertiesProvider propertiesProvider) {
-        String target = propertiesProvider.get(MESSAGE_BUS_OPT)
-            .orElse(EnvUtils.resolveUri("temporalTarget", "temporal:7233"));
-        String namespace = propertiesProvider.get(TEMPORAL_NAMESPACE_OPT)
-            .orElse(DEFAULT_NAMESPACE);
-        return buildClient(target, namespace);
+    TemporalInterlocutor provideTemporal(final PropertiesProvider propertiesProvider) throws InterruptedException {
+        return new TemporalInterlocutor(propertiesProvider);
     }
 
     @Provides @Singleton
@@ -382,7 +385,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
 
     private ExecutorService runTemporalWorkers() {
         if (getTaskWorkersNb() > 0) {
-            WorkflowClient client = get(WorkflowClient.class);
+            TemporalInterlocutor temporal = get(TemporalInterlocutor.class);
             WorkerOptions workerOptions = WorkerOptions.newBuilder()
                 .setMaxConcurrentWorkflowTaskExecutionSize(getTaskWorkersNb())
                 .setMaxConcurrentActivityExecutionSize(getTaskWorkersNb())
@@ -392,14 +395,14 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
                 workflows = TemporalHelper.discoverWorkflows(
                     "org.icij.datashare.tasks",
                     get(DatashareTaskFactory.class),
-                    client,
+                    temporal.client,
                     Utils.getRoutingStrategy(propertiesProvider),
                     new Group(TaskGroupType.Java)
                 );
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
-            WorkerFactory workerFactory = TemporalHelper.createTemporalWorkerFactory(workflows, client, workerOptions);
+            WorkerFactory workerFactory = TemporalHelper.createTemporalWorkerFactory(workflows, temporal.client, workerOptions);
             executorService.submit(() -> {
                 // Start and add to closable
                 closeables.add(new TemporalHelper.CloseableWorkerFactoryHandle(workerFactory));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerTemporal.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskManagerTemporal.java
@@ -2,8 +2,8 @@ package org.icij.datashare.tasks;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import io.temporal.client.WorkflowClient;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 
 
 @Singleton
@@ -11,7 +11,7 @@ public class TaskManagerTemporal extends org.icij.datashare.asynctasks.TaskManag
     implements DatashareTaskManager {
 
     @Inject
-    public TaskManagerTemporal(WorkflowClient client, PropertiesProvider propertiesProvider) {
-        super(client, Utils.getRoutingStrategy(propertiesProvider));
+    public TaskManagerTemporal(TemporalInterlocutor temporal, PropertiesProvider propertiesProvider) {
+        super(temporal, Utils.getRoutingStrategy(propertiesProvider));
     }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -9,32 +9,25 @@ import static org.icij.datashare.asynctasks.Task.USER_KEY;
 import static org.icij.datashare.asynctasks.bus.amqp.Event.MAX_RETRIES_LEFT;
 import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asExecInfoFilter;
 import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asTaskState;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE_POLL_INTERVAL;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.MAX_PROGRESS_CUSTOM_ATTRIBUTE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.PROGRESS_CUSTOM_ATTRIBUTE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.USER_CUSTOM_ATTRIBUTE;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Durations;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.api.enums.v1.IndexedValueType;
-import io.temporal.api.enums.v1.NamespaceState;
 import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
 import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
-import io.temporal.api.namespace.v1.NamespaceConfig;
-import io.temporal.api.operatorservice.v1.AddSearchAttributesRequest;
-import io.temporal.api.operatorservice.v1.DeleteNamespaceRequest;
-import io.temporal.api.operatorservice.v1.ListSearchAttributesRequest;
-import io.temporal.api.operatorservice.v1.OperatorServiceGrpc;
 import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
 import io.temporal.api.workflowservice.v1.DeleteWorkflowExecutionRequest;
-import io.temporal.api.workflowservice.v1.DescribeNamespaceRequest;
 import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsRequest;
 import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse;
-import io.temporal.api.workflowservice.v1.RegisterNamespaceRequest;
 import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
 import io.temporal.client.WorkflowClient;
-import io.temporal.client.WorkflowClientOptions;
 import io.temporal.client.WorkflowExecutionAlreadyStarted;
 import io.temporal.client.WorkflowExecutionDescription;
 import io.temporal.client.WorkflowExecutionMetadata;
@@ -42,17 +35,11 @@ import io.temporal.client.WorkflowFailedException;
 import io.temporal.client.WorkflowNotFoundException;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
-import io.temporal.common.SearchAttributeKey;
 import io.temporal.common.SearchAttributes;
 import io.temporal.common.converter.DefaultDataConverter;
-import io.temporal.serviceclient.OperatorServiceStubs;
-import io.temporal.serviceclient.OperatorServiceStubsOptions;
-import io.temporal.serviceclient.WorkflowServiceStubs;
-import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
@@ -74,6 +61,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.asynctasks.temporal.TemporalInputPayload;
+import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.asynctasks.temporal.TemporalQueryBuilder;
 import org.icij.datashare.function.Pair;
 import org.icij.datashare.tasks.RoutingStrategy;
@@ -85,25 +73,11 @@ public class TaskManagerTemporal implements TaskManager {
 
     public static final String DEFAULT_NAMESPACE = "datashare-default";
 
-    // See https://docs.temporal.io/list-filter#supported-operators
-    public static final SearchAttributeKey<String> WORKFLOW_TYPE_ATTRIBUTE =
-        SearchAttributeKey.forKeyword("WorkflowType");
-    public static final SearchAttributeKey<String> EXECUTION_STATUS_ATTRIBUTE =
-        SearchAttributeKey.forKeyword("ExecutionStatus");
-    public static final SearchAttributeKey<String> USER_CUSTOM_ATTRIBUTE = SearchAttributeKey.forKeyword("UserId");
-    public static final SearchAttributeKey<Double> MAX_PROGRESS_CUSTOM_ATTRIBUTE =
-        SearchAttributeKey.forDouble("MaxProgress");
-    public static final SearchAttributeKey<Double> PROGRESS_CUSTOM_ATTRIBUTE = SearchAttributeKey.forDouble("Progress");
-
     private final WorkflowClient client;
     private final String namespace;
     private final RoutingStrategy routingStrategy;
 
-
-    private static final NamespaceConfig DEFAULT_NAMESPACE_CONFIG =
-        NamespaceConfig.newBuilder().setWorkflowExecutionRetentionTtl(Durations.fromDays(365)).build();
     private static final Duration DEFAULT_WORKFLOW_TASK_TIMEOUT = Duration.ofDays(7);
-    private static final Duration DEFAULT_NAMESPACE_POLL_INTERVAL = Duration.of(50, ChronoUnit.MILLIS);
     private static final int DEFAULT_PAGE_SIZE = 100;
 
     // TODO: add support for continue-as-new https://docs.temporal.io/develop/java/continue-as-new
@@ -116,20 +90,19 @@ public class TaskManagerTemporal implements TaskManager {
 
     private final WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub;
 
-    public static final Map<String, IndexedValueType> CUSTOM_SEARCH_ATTRIBUTES = Map.of(
-        MAX_PROGRESS_CUSTOM_ATTRIBUTE.getName(), IndexedValueType.INDEXED_VALUE_TYPE_DOUBLE,
-        PROGRESS_CUSTOM_ATTRIBUTE.getName(), IndexedValueType.INDEXED_VALUE_TYPE_DOUBLE,
-        USER_CUSTOM_ATTRIBUTE.getName(), IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
-    );
+    public TaskManagerTemporal(TemporalInterlocutor temporal, RoutingStrategy routingStrategy) {
+        this(temporal.client, temporal.client.getWorkflowServiceStubs().blockingStub(), routingStrategy);
+    }
 
-    private static final Set<Status.Code> NAMESPACE_EXISTS = Set.of(Status.ALREADY_EXISTS.getCode());
-
-
-    public TaskManagerTemporal(WorkflowClient client, RoutingStrategy routingStrategy) {
+    protected TaskManagerTemporal(WorkflowClient client, RoutingStrategy routingStrategy) {
         this(client, client.getWorkflowServiceStubs().blockingStub(), routingStrategy);
     }
 
-    protected TaskManagerTemporal(WorkflowClient client,  WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceStubs, RoutingStrategy routingStrategy) {
+    protected TaskManagerTemporal(
+        WorkflowClient client,
+        WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceStubs,
+        RoutingStrategy routingStrategy
+    ) {
         this.client = client;
         this.namespace = client.getOptions().getNamespace();
         this.workflowServiceBlockingStub = workflowServiceStubs;
@@ -176,7 +149,8 @@ public class TaskManagerTemporal implements TaskManager {
     @Override
     public Stream<String> getTaskIds(TaskFilters filters) throws IOException {
         Stream<WorkflowExecutionInfo> execs = eventuallyConsistentListExecutions(filters);
-        Iterator<WorkflowExecutionInfo> iterator = new StronglyConsistentExecutionIterator(execs, executions, this::fetchExecByIdsIfExist, filters);
+        Iterator<WorkflowExecutionInfo> iterator =
+            new StronglyConsistentExecutionIterator(execs, executions, this::fetchExecByIdsIfExist, filters);
         execs = StreamSupport.stream(
             Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
             false // not parallel
@@ -265,15 +239,6 @@ public class TaskManagerTemporal implements TaskManager {
     public void close() throws IOException {
     }
 
-    public static WorkflowClient buildClient(String target, String namespace) {
-        WorkflowClientOptions clientOptions = WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
-        WorkflowServiceStubsOptions serviceStubsOptions = WorkflowServiceStubsOptions.newBuilder()
-            .setTarget(target)
-            .build();
-        WorkflowServiceStubs serviceStub = WorkflowServiceStubs.newServiceStubs(serviceStubsOptions);
-        return buildClient(serviceStub, clientOptions);
-    }
-
     public static String resolveWfTaskQueue(RoutingStrategy routingStrategy, String queueKey, Group group) {
         switch (routingStrategy) {
             case UNIQUE -> {
@@ -289,109 +254,11 @@ public class TaskManagerTemporal implements TaskManager {
         }
     }
 
-    private static WorkflowClient buildClient(WorkflowServiceStubs serviceStub, WorkflowClientOptions clientOptions) {
-        return WorkflowClient.newInstance(serviceStub, clientOptions);
-    }
-
-
-    protected static void setupNamespace(WorkflowClient client, Duration timeout) throws InterruptedException {
-        long start = System.currentTimeMillis();
-        long timeoutMillis = timeout.toMillis();
-        String namespace = client.getOptions().getNamespace();
-        WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub =
-            client.getWorkflowServiceStubs().blockingStub();
-        OperatorServiceGrpc.OperatorServiceBlockingStub operatorServiceBlockingStub =
-            OperatorServiceStubs.newServiceStubs(
-                OperatorServiceStubsOptions.newBuilder()
-                    .setChannel(client.getWorkflowServiceStubs().getRawChannel())
-                    .validateAndBuildWithDefaults()).blockingStub();
-        synchronized (TaskManagerTemporal.class) {
-            boolean createNamespace = !hasNamespace(workflowServiceBlockingStub, client.getOptions().getNamespace());
-            if (createNamespace) {
-                try {
-                    RegisterNamespaceRequest registerNamespaceRequest = RegisterNamespaceRequest.newBuilder()
-                        .setWorkflowExecutionRetentionPeriod(
-                            DEFAULT_NAMESPACE_CONFIG.getWorkflowExecutionRetentionTtl())
-                        .setNamespace(namespace).build();
-                    workflowServiceBlockingStub.registerNamespace(registerNamespaceRequest);
-                } catch (StatusRuntimeException ex) {
-                    if (!NAMESPACE_EXISTS.contains(ex.getStatus().getCode())) {
-                        throw ex;
-                    }
-                }
-            }
-            if (createNamespace) {
-                while (true) {
-                    if ((System.currentTimeMillis() - start >= timeoutMillis)) {
-                        throw new RuntimeException(
-                            "failed to setup namespace search attribute in less than " + timeout);
-                    }
-                    try {
-                        operatorServiceBlockingStub.addSearchAttributes(
-                            AddSearchAttributesRequest.newBuilder().setNamespace(namespace)
-                                .putAllSearchAttributes(CUSTOM_SEARCH_ATTRIBUTES).build()
-                        );
-                        break;
-                    } catch (StatusRuntimeException ex) {
-                        if (ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                            continue;
-                        }
-                        if (ex.getStatus().getCode().equals(Status.Code.FAILED_PRECONDITION)
-                            && ex.getMessage().contains("Namespace has invalid state")) {
-                            continue;
-                        }
-                        Thread.sleep(DEFAULT_NAMESPACE_POLL_INTERVAL.toMillis());
-                    }
-                }
-            }
-            while (!namespaceIsReady(operatorServiceBlockingStub, namespace)) {
-                if ((System.currentTimeMillis() - start >= timeoutMillis)) {
-                    throw new RuntimeException("failed to read namespace search attribute in less than " + timeout);
-                }
-            }
-        }
-    }
-
-    protected static void deleteNamespace(WorkflowClient client, Duration timeout) {
-        String namespace = client.getOptions().getNamespace();
-        OperatorServiceStubs.newServiceStubs(
-                OperatorServiceStubsOptions.newBuilder()
-                    .setChannel(client.getWorkflowServiceStubs().getRawChannel())
-                    .validateAndBuildWithDefaults())
-            .blockingStub()
-            .deleteNamespace(DeleteNamespaceRequest.newBuilder().setNamespace(namespace).build());
-        awaitNamespaceDeleted(client.getWorkflowServiceStubs().blockingStub(), namespace, timeout);
-    }
-
-    private static boolean hasNamespace(WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub,
-                                        String namespace) {
-        NamespaceState namespaceState;
-        try {
-            namespaceState = workflowServiceBlockingStub.describeNamespace(
-                DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build()
-            ).getNamespaceInfo().getState();
-        } catch (StatusRuntimeException ex) {
-            if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                throw ex;
-            }
-            return false;
-        }
-        return namespaceState.equals(NamespaceState.NAMESPACE_STATE_REGISTERED);
-    }
-
-    private static boolean namespaceIsReady(OperatorServiceGrpc.OperatorServiceBlockingStub operatorServiceBlockingStub,
-                                            String namespace) {
-        Set<String> searchAttributes = operatorServiceBlockingStub
-            .listSearchAttributes(ListSearchAttributesRequest.newBuilder().setNamespace(namespace).build())
-            .getCustomAttributesMap()
-            .keySet();
-        return searchAttributes.containsAll(CUSTOM_SEARCH_ATTRIBUTES.keySet());
-    }
-
-
     private Stream<WorkflowExecutionInfo> eventuallyConsistentListExecutions(TaskFilters filters) {
-        PageFetcher<WorkflowExecutionInfo> fetcher = getWorkflowExecutionFetcher(TemporalQueryBuilder.buildFromFilters(filters));
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new TemporalPageIterator<>(fetcher), Spliterator.ORDERED), false);
+        PageFetcher<WorkflowExecutionInfo> fetcher =
+            getWorkflowExecutionFetcher(TemporalQueryBuilder.buildFromFilters(filters));
+        return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(new TemporalPageIterator<>(fetcher), Spliterator.ORDERED), false);
     }
 
     private <V extends Serializable> Task<V> parseTask(WorkflowExecutionMetadata response) {
@@ -536,7 +403,9 @@ public class TaskManagerTemporal implements TaskManager {
 
         private Iterator<WorkflowExecutionInfo> missingItems = null;
 
-        StronglyConsistentExecutionIterator(Stream<WorkflowExecutionInfo> listWorkflowsResults, Set<String> knownIds, Function<Set<String>, Stream<WorkflowExecutionInfo>> fetchKnownExecInfoFn, TaskFilters filters) {
+        StronglyConsistentExecutionIterator(Stream<WorkflowExecutionInfo> listWorkflowsResults, Set<String> knownIds,
+                                            Function<Set<String>, Stream<WorkflowExecutionInfo>> fetchKnownExecInfoFn,
+                                            TaskFilters filters) {
             this.listWorkflowsResults = listWorkflowsResults.iterator();
             this.remainingIds = new HashSet<>(knownIds);
             this.fetchKnownExecInfoFn = fetchKnownExecInfoFn;
@@ -631,25 +500,6 @@ public class TaskManagerTemporal implements TaskManager {
             }
         }
         throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
-    }
-
-    private static void awaitNamespaceDeleted(
-        WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub, String namespace, Duration timeout)
-        throws RuntimeException {
-        long startTime = System.currentTimeMillis();
-        long maxDuration = timeout.toMillis();
-        while ((System.currentTimeMillis() - startTime < maxDuration)) {
-            try {
-                workflowServiceBlockingStub.describeNamespace(
-                    DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build());
-            } catch (StatusRuntimeException e) {
-                if (!e.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                    throw e;
-                }
-                return;
-            }
-        }
-        throw new RuntimeException("failed to delete namespace in " + timeout);
     }
 
     protected void awaitExecutionDeletion(Set<String> taskIds) throws InterruptedException {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
@@ -9,7 +9,7 @@ import static io.temporal.api.enums.v1.WorkflowExecutionStatus.WORKFLOW_EXECUTIO
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowFunction;
 import static org.icij.datashare.asynctasks.TaskManagerTemporal.resolveWfTaskQueue;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.USER_CUSTOM_ATTRIBUTE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.USER_CUSTOM_ATTRIBUTE;
 
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.client.WorkflowClient;

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -1,0 +1,194 @@
+package org.icij.datashare.asynctasks.temporal;
+
+import static org.icij.datashare.asynctasks.TaskManagerTemporal.DEFAULT_NAMESPACE;
+
+import com.google.protobuf.util.Durations;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.temporal.api.enums.v1.IndexedValueType;
+import io.temporal.api.enums.v1.NamespaceState;
+import io.temporal.api.namespace.v1.NamespaceConfig;
+import io.temporal.api.operatorservice.v1.AddSearchAttributesRequest;
+import io.temporal.api.operatorservice.v1.DeleteNamespaceRequest;
+import io.temporal.api.operatorservice.v1.ListSearchAttributesRequest;
+import io.temporal.api.operatorservice.v1.OperatorServiceGrpc;
+import io.temporal.api.workflowservice.v1.DescribeNamespaceRequest;
+import io.temporal.api.workflowservice.v1.RegisterNamespaceRequest;
+import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.common.SearchAttributeKey;
+import io.temporal.serviceclient.OperatorServiceStubs;
+import io.temporal.serviceclient.OperatorServiceStubsOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Set;
+import org.icij.datashare.EnvUtils;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asynctasks.TaskManagerTemporal;
+
+public class TemporalInterlocutor {
+    public final WorkflowClient client;
+
+    // See https://docs.temporal.io/list-filter#supported-operators
+    public static final SearchAttributeKey<String> WORKFLOW_TYPE_ATTRIBUTE =
+        SearchAttributeKey.forKeyword("WorkflowType");
+    public static final SearchAttributeKey<String> EXECUTION_STATUS_ATTRIBUTE =
+        SearchAttributeKey.forKeyword("ExecutionStatus");
+    public static final SearchAttributeKey<String> USER_CUSTOM_ATTRIBUTE = SearchAttributeKey.forKeyword("UserId");
+    public static final SearchAttributeKey<Double> MAX_PROGRESS_CUSTOM_ATTRIBUTE =
+        SearchAttributeKey.forDouble("MaxProgress");
+    public static final SearchAttributeKey<Double> PROGRESS_CUSTOM_ATTRIBUTE = SearchAttributeKey.forDouble("Progress");
+
+    public static final Map<String, IndexedValueType> CUSTOM_SEARCH_ATTRIBUTES = Map.of(
+        MAX_PROGRESS_CUSTOM_ATTRIBUTE.getName(), IndexedValueType.INDEXED_VALUE_TYPE_DOUBLE,
+        PROGRESS_CUSTOM_ATTRIBUTE.getName(), IndexedValueType.INDEXED_VALUE_TYPE_DOUBLE,
+        USER_CUSTOM_ATTRIBUTE.getName(), IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD
+    );
+    public static final Duration DEFAULT_NAMESPACE_POLL_INTERVAL = Duration.of(50, ChronoUnit.MILLIS);
+
+    private static final Set<Status.Code> NAMESPACE_EXISTS = Set.of(Status.ALREADY_EXISTS.getCode());
+    private static final NamespaceConfig DEFAULT_NAMESPACE_CONFIG =
+        NamespaceConfig.newBuilder().setWorkflowExecutionRetentionTtl(Durations.fromDays(365)).build();
+
+
+    public TemporalInterlocutor(String target, String namespace) throws InterruptedException {
+        this.client = buildClient(target, namespace);
+        setupNamespace(Duration.ofSeconds(30));
+    }
+
+    public TemporalInterlocutor(PropertiesProvider propertiesProvider) throws InterruptedException {
+        this(propertiesProvider.get("messageBusAddress").orElse(EnvUtils.resolveUri("temporalTarget", "temporal:7233")),
+            propertiesProvider.get("temporalNamespace").orElse(DEFAULT_NAMESPACE));
+    }
+
+    private static WorkflowClient buildClient(WorkflowServiceStubs serviceStub, WorkflowClientOptions clientOptions) {
+        return WorkflowClient.newInstance(serviceStub, clientOptions);
+    }
+
+    public void setupNamespace(Duration timeout) throws InterruptedException {
+        long start = System.currentTimeMillis();
+        long timeoutMillis = timeout.toMillis();
+        String namespace = client.getOptions().getNamespace();
+        WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub =
+            client.getWorkflowServiceStubs().blockingStub();
+        OperatorServiceGrpc.OperatorServiceBlockingStub operatorServiceBlockingStub =
+            OperatorServiceStubs.newServiceStubs(
+                OperatorServiceStubsOptions.newBuilder()
+                    .setChannel(client.getWorkflowServiceStubs().getRawChannel())
+                    .validateAndBuildWithDefaults()).blockingStub();
+        synchronized (TaskManagerTemporal.class) {
+            boolean createNamespace = !hasNamespace(workflowServiceBlockingStub, client.getOptions().getNamespace());
+            if (createNamespace) {
+                try {
+                    RegisterNamespaceRequest registerNamespaceRequest = RegisterNamespaceRequest.newBuilder()
+                        .setWorkflowExecutionRetentionPeriod(
+                            DEFAULT_NAMESPACE_CONFIG.getWorkflowExecutionRetentionTtl())
+                        .setNamespace(namespace).build();
+                    workflowServiceBlockingStub.registerNamespace(registerNamespaceRequest);
+                } catch (StatusRuntimeException ex) {
+                    if (!NAMESPACE_EXISTS.contains(ex.getStatus().getCode())) {
+                        throw ex;
+                    }
+                }
+            }
+            if (createNamespace) {
+                while (true) {
+                    if ((System.currentTimeMillis() - start >= timeoutMillis)) {
+                        throw new RuntimeException(
+                            "failed to setup namespace search attribute in less than " + timeout);
+                    }
+                    try {
+                        operatorServiceBlockingStub.addSearchAttributes(
+                            AddSearchAttributesRequest.newBuilder().setNamespace(namespace)
+                                .putAllSearchAttributes(CUSTOM_SEARCH_ATTRIBUTES).build()
+                        );
+                        break;
+                    } catch (StatusRuntimeException ex) {
+                        if (ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                            continue;
+                        }
+                        if (ex.getStatus().getCode().equals(Status.Code.FAILED_PRECONDITION)
+                            && ex.getMessage().contains("Namespace has invalid state")) {
+                            continue;
+                        }
+                        Thread.sleep(DEFAULT_NAMESPACE_POLL_INTERVAL.toMillis());
+                    }
+                }
+            }
+            while (!namespaceIsReady(operatorServiceBlockingStub, namespace)) {
+                if ((System.currentTimeMillis() - start >= timeoutMillis)) {
+                    throw new RuntimeException("failed to read namespace search attribute in less than " + timeout);
+                }
+            }
+        }
+    }
+
+    public void deleteNamespace(Duration timeout) {
+        String namespace = client.getOptions().getNamespace();
+        OperatorServiceStubs.newServiceStubs(
+                OperatorServiceStubsOptions.newBuilder()
+                    .setChannel(client.getWorkflowServiceStubs().getRawChannel())
+                    .validateAndBuildWithDefaults())
+            .blockingStub()
+            .deleteNamespace(DeleteNamespaceRequest.newBuilder().setNamespace(namespace).build());
+        awaitNamespaceDeleted(client.getWorkflowServiceStubs().blockingStub(), namespace, timeout);
+    }
+
+    private static WorkflowClient buildClient(String target, String namespace) {
+        WorkflowClientOptions clientOptions = WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
+        WorkflowServiceStubsOptions serviceStubsOptions = WorkflowServiceStubsOptions.newBuilder()
+            .setTarget(target)
+            .build();
+        WorkflowServiceStubs serviceStub = WorkflowServiceStubs.newServiceStubs(serviceStubsOptions);
+        return buildClient(serviceStub, clientOptions);
+    }
+
+    private static boolean hasNamespace(WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub,
+                                        String namespace) {
+        NamespaceState namespaceState;
+        try {
+            namespaceState = workflowServiceBlockingStub.describeNamespace(
+                DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build()
+            ).getNamespaceInfo().getState();
+        } catch (StatusRuntimeException ex) {
+            if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                throw ex;
+            }
+            return false;
+        }
+        return namespaceState.equals(NamespaceState.NAMESPACE_STATE_REGISTERED);
+    }
+
+    private static boolean namespaceIsReady(OperatorServiceGrpc.OperatorServiceBlockingStub operatorServiceBlockingStub,
+                                            String namespace) {
+        Set<String> searchAttributes = operatorServiceBlockingStub
+            .listSearchAttributes(ListSearchAttributesRequest.newBuilder().setNamespace(namespace).build())
+            .getCustomAttributesMap()
+            .keySet();
+        return searchAttributes.containsAll(CUSTOM_SEARCH_ATTRIBUTES.keySet());
+    }
+
+    private static void awaitNamespaceDeleted(
+        WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub, String namespace, Duration timeout)
+        throws RuntimeException {
+        long startTime = System.currentTimeMillis();
+        long maxDuration = timeout.toMillis();
+        while ((System.currentTimeMillis() - startTime < maxDuration)) {
+            try {
+                workflowServiceBlockingStub.describeNamespace(
+                    DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build());
+            } catch (StatusRuntimeException e) {
+                if (!e.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                    throw e;
+                }
+                return;
+            }
+        }
+        throw new RuntimeException("failed to delete namespace in " + timeout);
+    }
+
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalQueryBuilder.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalQueryBuilder.java
@@ -3,9 +3,9 @@ package org.icij.datashare.asynctasks.temporal;
 import static java.lang.Character.toUpperCase;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.EXECUTION_STATUS_ATTRIBUTE;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.USER_CUSTOM_ATTRIBUTE;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.WORKFLOW_TYPE_ATTRIBUTE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.EXECUTION_STATUS_ATTRIBUTE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.USER_CUSTOM_ATTRIBUTE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.WORKFLOW_TYPE_ATTRIBUTE;
 
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import java.util.ArrayList;

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -8,9 +8,6 @@ import static org.icij.datashare.asynctasks.Task.State.ERROR;
 import static org.icij.datashare.asynctasks.Task.State.RUNNING;
 import static org.icij.datashare.asynctasks.TaskManagerTemporal.DEFAULT_NAMESPACE;
 import static org.icij.datashare.asynctasks.TaskManagerTemporal.WORKFLOWS_DEFAULT;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.buildClient;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.deleteNamespace;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.setupNamespace;
 import static org.icij.datashare.asynctasks.temporal.TemporalHelper.activityFactory;
 import static org.icij.datashare.asynctasks.temporal.TemporalHelper.createTemporalWorkerFactory;
 import static org.junit.Assert.assertThrows;
@@ -38,6 +35,7 @@ import org.icij.datashare.asynctasks.temporal.FailingWorkflowImpl;
 import org.icij.datashare.asynctasks.temporal.HelloWorldActivityImpl;
 import org.icij.datashare.asynctasks.temporal.HelloWorldWorkflowImpl;
 import org.icij.datashare.asynctasks.temporal.TemporalHelper;
+import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
 import org.junit.Before;
@@ -52,7 +50,7 @@ public class TaskManagerTemporalIntTest {
     @Mock
     private TaskFactory taskFactory;
 
-    private static WorkflowClient client;
+    private static TemporalInterlocutor temporal;
 
     private static TaskManagerTemporal taskManager;
 
@@ -60,16 +58,16 @@ public class TaskManagerTemporalIntTest {
 
 
     @BeforeClass
-    public static void setUpClass() {
-        client = buildClient(EnvUtils.resolve("temporalTarget", "temporal:7233"), DEFAULT_NAMESPACE);
-        taskManager = new TaskManagerTemporal(client, RoutingStrategy.UNIQUE);
+    public static void setUpClass() throws InterruptedException {
+        temporal = new TemporalInterlocutor(EnvUtils.resolve("temporalTarget", "temporal:7233"), DEFAULT_NAMESPACE);
+        taskManager = new TaskManagerTemporal(temporal, RoutingStrategy.UNIQUE);
     }
 
     @Before
     public void setUp() throws IOException, InterruptedException {
         mocks = openMocks(this);
         try {
-            deleteNamespace(client, Duration.ofSeconds(5));
+            temporal.deleteNamespace(Duration.ofSeconds(5));
         } catch (StatusRuntimeException ex) {
             if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
                 throw ex;
@@ -79,14 +77,14 @@ public class TaskManagerTemporalIntTest {
             new TemporalHelper.RegisteredWorkflow(
                 HelloWorldWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalHelper.RegisteredActivity(activityFactory(HelloWorldActivityImpl.class, taskFactory, client, 1.0d), WORKFLOWS_DEFAULT))),
+                List.of(new TemporalHelper.RegisteredActivity(activityFactory(HelloWorldActivityImpl.class, taskFactory, temporal.client, 1.0d), WORKFLOWS_DEFAULT))),
             new TemporalHelper.RegisteredWorkflow(
                 FailingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalHelper.RegisteredActivity(activityFactory(FailingActivityImpl.class, taskFactory, client, 1.0d), WORKFLOWS_DEFAULT)))
+                List.of(new TemporalHelper.RegisteredActivity(activityFactory(FailingActivityImpl.class, taskFactory, temporal.client, 1.0d), WORKFLOWS_DEFAULT)))
         );
 
-        setupNamespace(client, Duration.ofSeconds(5));
+        temporal.setupNamespace(Duration.ofSeconds(5));
         taskManager.clear();
         Thread.sleep(2000); // Sleep to allow custom attribute creation propagation refresh rate is 0.1s
     }
@@ -199,7 +197,7 @@ public class TaskManagerTemporalIntTest {
 
     @Test(timeout = 10000)
     public void test_get_task_result() throws IOException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
             Task<String> task = new Task<>("hello-world", User.local(), Map.of("name", "world"));
 
             taskManager.startTask(task);
@@ -213,7 +211,7 @@ public class TaskManagerTemporalIntTest {
 
     @Test(timeout = 20000)
     public void test_task_error() throws IOException, InterruptedException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
             Task<String> task = new Task<>("failing", User.local(), Map.of());
 
             taskManager.startTask(task);
@@ -251,7 +249,7 @@ public class TaskManagerTemporalIntTest {
     @Ignore("keeping this one for manual test as it can take very long to complete")
     @Test
     public void test_clear_done_tasks() throws Exception {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
             Task<String> task = new Task<>("hello-world", User.local(), Map.of("key", "value"));
             taskManager.startTask(task);
             assertThat(taskManager.awaitTermination(2, TimeUnit.SECONDS));
@@ -266,7 +264,7 @@ public class TaskManagerTemporalIntTest {
     @Ignore("keeping this one for manual test as it can take very long to complete")
     @Test
     public void test_clear_done_tasks_with_args_filter() throws IOException, InterruptedException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
             Task<String> first = new Task<>("hello-world", User.local(), Map.of("key", "value"));
             Task<String> second = new Task<>("hello-world", User.local(), Map.of("otherKey", "otherValue"));
             taskManager.startTask(first);


### PR DESCRIPTION
## `datashare-task`
### Changed
- removed namespace related logic from `TaskManagerTemporal` and create a  `TemporalInterlocutor` mirroring the `AmqpInterlocutor` logic (but for temporal). The interlocutor, creates and sets up the temporal DS namespace

## `datashare-app`
### Changed
- set up temporal namespace at app startup