### PR TITLE
Download and install elasticsearch in a separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,10 +430,11 @@ jobs:
           command: java -jar datashare-dist/target/datashare-dist-${CIRCLE_TAG}-all.jar --dataSourceUrl 'jdbc:sqlite:file:memorydb.db?mode=memory&cache=shared' --elasticsearchPath /tmp/datashare/elasticsearch -m EMBEDDED
           background: true
       - run:
+          name: Wait for datashare to be started
+          command: curl --retry 20 --retry-delay 5 --retry-all-errors 'http://localhost:8080/api/status'
+      - run:
           name: Generate openAPI json file
-          command: |
-            curl --retry 20 --retry-delay 5 --retry-all-errors 'http://localhost:8080/api/status'
-            curl -s http://localhost:8080/api/openapi | jq > datashare_openapi.json
+          command: curl -s http://localhost:8080/api/openapi | jq > datashare_openapi.json
       - persist_to_workspace:
           root: /tmp/datashare
           paths:


### PR DESCRIPTION
Download and install elasticsearch in a separate job

Cache elasticsearch/ folder to avoid redownloading it at every build.

Uses the checksum of the installation script in the key of the cache to redownload if the script changes, in particular, if the version of ES used changes