### PR TITLE
Replace timer by event-driven approach to avoid random failure

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -69,7 +69,8 @@ public class BatchDownloadRunner implements Callable<UriResult>, Monitorable, Us
     private final PropertiesProvider propertiesProvider;
     private final Function<Double, Void> progressCallback;
     private final Function<URI, MailSender> mailSenderSupplier;
-    private final CountDownLatch callWaiterLatch;
+    // This Latch will decrement when this runner starts to process a Task
+    private final CountDownLatch callWaiterLatchForTests;
     protected volatile boolean cancelAsked = false;
     protected volatile boolean requeueCancel;
     protected volatile Thread callThread;
@@ -87,7 +88,7 @@ public class BatchDownloadRunner implements Callable<UriResult>, Monitorable, Us
         this.progressCallback = progressCallback;
         this.mailSenderSupplier = mailSenderSupplier;
         this.documentVerifier = new DocumentVerifier(indexer, propertiesProvider);
-        this.callWaiterLatch = latch;
+        this.callWaiterLatchForTests = latch;
     }
 
     @Override
@@ -102,7 +103,7 @@ public class BatchDownloadRunner implements Callable<UriResult>, Monitorable, Us
         long maxZipSizeBytes = HumanReadableSize.parse(propertiesProvider.get(BATCH_DOWNLOAD_MAX_SIZE_OPT).orElse(DEFAULT_BATCH_DOWNLOAD_MAX_SIZE));
         long zippedFilesSize = 0;
         callThread = Thread.currentThread();
-        callWaiterLatch.countDown(); // for tests
+        callWaiterLatchForTests.countDown(); // for tests
         BatchDownload batchDownload = getBatchDownload();
 
         logger.info("running batch download for user {} on project {} with {} scroll with throttle {}ms and scroll size of {}",
@@ -178,6 +179,11 @@ public class BatchDownloadRunner implements Callable<UriResult>, Monitorable, Us
 
     private BatchDownload getBatchDownload() {
         return (BatchDownload) task.args.get("batchDownload");
+    }
+
+    // For tests purposes
+    protected CountDownLatch getCallWaiterLatchForTests() {
+        return this.callWaiterLatchForTests;
     }
 
     @Override

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopIntTest.java
@@ -32,11 +32,13 @@ public class TaskWorkerLoopIntTest {
 
     @Test(timeout = 20000)
     public void test_batch_download_task_view_properties() throws Exception {
+        // GIVEN
         DatashareTaskFactory factory = mock(DatashareTaskFactory.class);
         BatchDownload batchDownload = new BatchDownload(singletonList(project("prj")), User.local(), "foo");
         Map<String, Object> properties = Map.of("batchDownload", batchDownload);
         Task<File> taskView = new Task<>(BatchDownloadRunner.class.getName(), batchDownload.user, properties);
         BatchDownloadRunner runner = new BatchDownloadRunner(mock(Indexer.class), new PropertiesProvider(), taskView, taskView.progress(taskSupplier::progress));
+
         when(factory.createBatchDownloadRunner(any(), any())).thenReturn(runner);
 
         CountDownLatch workerStarted = new CountDownLatch(1);
@@ -44,12 +46,16 @@ public class TaskWorkerLoopIntTest {
         Thread worker = new Thread(taskWorkerLoop::call);
         worker.start();
         workerStarted.await();
+
+        // WHEN
         taskManager.startTask(BatchDownloadRunner.class.getName(), User.local(), properties);
-        Thread.sleep(100); // this is a symptom of a possible flaky test but for now I can't figure out how to be event driven
+
+        runner.getCallWaiterLatchForTests().await();
 
         taskManager.awaitTermination(1, TimeUnit.SECONDS);
         eventWaiter.await();
 
+        // THEN
         List<Task<?>> tasks = taskManager.getTasks().toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).getError()).isNotNull();


### PR DESCRIPTION
The test was flaky because based on a timer.
It now relies on events to ensure the conditions of the tests are always met