### PR TITLE
fix: flaky test TaskWorkerLoopTest#test_loop()

### DIFF
--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
@@ -29,7 +29,8 @@ public class TaskWorkerLoopTest {
     public void test_loop() throws Exception {
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
         Task<Serializable> taskView = new Task<>(TestFactory.HelloWorld.class.getName(), User.local(), Map.of("greeted", "world"));
-        Mockito.when(supplier.get(ArgumentMatchers.anyInt(), ArgumentMatchers.any())).thenReturn(taskView);
+        //Return a task once, then return null to avoid the WorkerLoop processing multiple Tasks
+        Mockito.when(supplier.get(ArgumentMatchers.anyInt(), ArgumentMatchers.any())).thenReturn(taskView).thenReturn(null);
         CountDownLatch taskStarted = whenTaskHasStarted(taskView.id);
 
         Thread appThread = new Thread(app::call);


### PR DESCRIPTION
The goal is to avoid to have the TaskWorkerLoop to be able to process multiple Tasks within the time the tests takes to execute.

Without the changes in the PR, If the Thread of the test takes too long to execute, the TaskWorker can process multiple Tasks and  `Mockito.verify(supplier).result(eq(taskView.id), eq(new TaskResult<>("Hello world!")));` will throw an error because it wasn't called only once.
