### PR TITLE
Fix the flaky tests in TaskResourceTest

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -688,7 +688,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_cannot_clean_running_task() throws Exception {
         String dummyTaskId = taskManager.startTask(TestSleepingTask.class, User.local(), new HashMap<>());
-        assertHasState(dummyTaskId, RUNNING, 5000, 100);
+        assertEventuallyHaveState(dummyTaskId, RUNNING, 5000, 100);
         delete("/api/task/clean/" + dummyTaskId).should().respond(403);
         assertThat(taskManager.getTasks().toList()).hasSize(1);
     }
@@ -698,7 +698,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         String dummyTaskId = taskManager.startTask(TestSleepingTask.class, User.local(), new HashMap<>());
         put("/api/task/stop/" + dummyTaskId).should().respond(200).contain("true");
 
-        assertHasState(dummyTaskId, Task.State.CANCELLED, 1000, 100);
+        assertEventuallyHaveState(dummyTaskId, Task.State.CANCELLED, 1000, 100);
         get("/api/task/all").should().respond(200).contain("\"state\":\"CANCELLED\"");
     }
 
@@ -715,8 +715,8 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
                 contain(t1Id + "\":true").
                 contain(t2Id + "\":true");
 
-        assertHasState(t1Id, Task.State.CANCELLED, 1000, 200);
-        assertHasState(t2Id, Task.State.CANCELLED, 1000, 200);
+        assertEventuallyHaveState(t1Id, Task.State.CANCELLED, 1000, 200);
+        assertEventuallyHaveState(t2Id, Task.State.CANCELLED, 1000, 200);
     }
 
     @Test
@@ -725,11 +725,11 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         String t2Id = taskManager.startTask(TestAnotherSleepingTask.class, User.local(), new HashMap<>());
         put("/api/task/stop?name=Another").should().respond(200).contain(t2Id + "\":true");
 
-        assertHasState(t1Id, RUNNING, 1000, 50);
-        assertHasState(t2Id, Task.State.CANCELLED, 1000, 50);
+        assertEventuallyHaveState(t1Id, RUNNING, 1000, 50);
+        assertEventuallyHaveState(t2Id, Task.State.CANCELLED, 1000, 50);
 
         put("/api/task/stop?name=Sleeping").should().respond(200).contain(t1Id + "\":true");
-        assertHasState(t1Id, Task.State.CANCELLED, 1000, 50);
+        assertEventuallyHaveState(t1Id, Task.State.CANCELLED, 1000, 50);
     }
 
     @Test
@@ -901,7 +901,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         return taskManager.getTasks().filter(t -> expectedName.equals(t.name)).findFirst();
     }
 
-    private void assertHasState(String taskId, Task.State expectedState, int timeoutMs, int pollIntervalMs)
+    private void assertEventuallyHaveState(String taskId, Task.State expectedState, int timeoutMs, int pollIntervalMs)
         throws IOException, InterruptedException {
         long start = System.currentTimeMillis();
         while (System.currentTimeMillis() - start < timeoutMs) {


### PR DESCRIPTION
A method to wait for the status to reach a given value already existed in the class, so I used it.
Contains minor changes to that method