### PR TITLE
fix: override commons-csv transitive dependency by fixing it to 1.14.0 

### DIFF
--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/DatashareExtractIntegrationTest.java
@@ -67,6 +67,18 @@ public class DatashareExtractIntegrationTest {
     }
 
     @Test
+    public void test_spew_and_read_csv() throws Exception {
+        Path path = get(Objects.requireNonNull(getClass().getResource("/docs/sample.csv")).getPath());
+        TikaDocument tikaDocument = createExtractor().extract(path);
+
+        spewer.write(tikaDocument);
+        Document doc = indexer.get(es.getIndexName(), tikaDocument.getId());
+
+        assertThat(doc).isNotNull();
+        assertThat(doc.getContent()).contains("Alice").contains("Bob").contains("Paris").contains("London");
+    }
+
+    @Test
     public void test_spew_and_read_embedded_doc() throws Exception {
         Path path = get(getClass().getResource("/docs/embedded_doc.eml").getPath());
         TikaDocument tikaDocument = createExtractor().extract(path);

--- a/datashare-index/src/test/resources/docs/sample.csv
+++ b/datashare-index/src/test/resources/docs/sample.csv
@@ -1,0 +1,3 @@
+name,age,city
+Alice,30,Paris
+Bob,25,London

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!-- Force commons-csv to 1.14.0 to override jcasbin's 1.12.0 transitive dependency.
+                 Tika 3.x requires CSVParser.builder() which was added in 1.14.0. -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-csv</artifactId>
+                <version>1.14.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
fix: CSV parsing broken by Casbin's commons-csv:1.12.0 transitive dependency

After #2052 (Casbin RBAC), indexing CSV file fails with:
```
Caused by: java.lang.NoSuchMethodError: CSVParser.builder()
```

`jcasbin:1.96.0` pulls in `commons-csv:1.12.0`, but Tika 3.x requires `CSVParser.builder()` which was added in 1.14.0. Because `datashare-nlp-corenlp` has no path to `extract-lib`, it bundles 1.12.0 in its fat JAR — and since the assembly plugin processes it first, the old `CSVParser` class wins.

### Fix

Pin `commons-csv` to `1.14.0` in root `dependencyManagement`, forcing all modules to use the version Tika requires.

Added `test_spew_and_read_csv` in `DatashareExtractIntegrationTest` to catch regressions.