### PR TITLE
Add endpoint to group contentTypes by their contentTypeCategory

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
@@ -52,6 +52,7 @@ public class LocalMode extends CommonMode {
                 add(FtmResource.class).
                 add(NoteResource.class).
                 add(NerResource.class).
+                add(ContentTypeResource.class).
                 filter(IndexWaiterFilter.class).
                 filter(CsrfFilter.class).
                 filter(LocalUserFilter.class);

--- a/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
@@ -95,6 +95,7 @@ public class ServerMode extends CommonMode {
                 add(NerResource.class).
                 add(ApiKeyResource.class).
                 add(ProjectResource.class).
+                add(ContentTypeResource.class).
                 filter(CsrfFilter.class).
                 filter(ApiKeyFilter.class).
                 filter(Filter.class);

--- a/datashare-app/src/main/java/org/icij/datashare/web/ContentTypeResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ContentTypeResource.java
@@ -1,0 +1,31 @@
+package org.icij.datashare.web;
+
+import com.google.inject.Singleton;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import net.codestory.http.annotations.Post;
+import net.codestory.http.annotations.Prefix;
+import org.icij.datashare.text.ContentTypeCategory;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@Singleton
+@Prefix("/api/contentType")
+public class ContentTypeResource {
+
+    @Operation(description = "Returns the list of contentTypes in parameter grouped by contentTypeCategories",
+            parameters = {
+                    @Parameter(name = "contentTypes", description = "The list of contentTypes to group", in = ParameterIn.QUERY),
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "The list of contentTypes was successfully grouped", useReturnTypeSchema = true)
+    @Post("/categories")
+    public Map<ContentTypeCategory, List<String>> groupByCategories(List<String> contentTypes) {
+        return contentTypes.stream().collect(groupingBy(ContentTypeCategory::fromContentType));
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/web/ContentTypeResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ContentTypeResourceTest.java
@@ -1,0 +1,68 @@
+package org.icij.datashare.web;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.text.ContentTypeCategory;
+import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ContentTypeResourceTest extends AbstractProdWebServerTest {
+
+    @Before
+    public void setUp() {
+        configure(routes -> routes.add(new ContentTypeResource()));
+    }
+
+    @Test
+    public void test_group_by_categories_with_audio_and_video() throws Exception {
+        String content = post("/api/contentType/categories", "[\"audio/mp3\", \"video/mp4\"]").response().content();
+        Map<ContentTypeCategory, List<String>> result = JsonObjectMapper.readValue(content, new TypeReference<>() {});
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(ContentTypeCategory.AUDIO)).containsExactly("audio/mp3");
+        assertThat(result.get(ContentTypeCategory.VIDEO)).containsExactly("video/mp4");
+    }
+
+    @Test
+    public void test_group_by_categories_with_unknown_content_type() throws Exception {
+        String content = post("/api/contentType/categories", "[\"application/unknown\"]").response().content();
+        Map<ContentTypeCategory, List<String>> result = JsonObjectMapper.readValue(content, new TypeReference<>() {});
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(ContentTypeCategory.OTHER)).containsExactly("application/unknown");
+    }
+
+    @Test
+    public void test_group_by_categories_with_empty_list() throws Exception {
+        String content = post("/api/contentType/categories", "[]").response().content();
+        Map<ContentTypeCategory, List<String>> result = JsonObjectMapper.readValue(content, new TypeReference<>() {});
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void test_group_by_categories_with_image() throws Exception {
+        String content = post("/api/contentType/categories", "[\"image/png\"]").response().content();
+        Map<ContentTypeCategory, List<String>> result = JsonObjectMapper.readValue(content, new TypeReference<>() {});
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(ContentTypeCategory.IMAGE)).containsExactly("image/png");
+    }
+
+    @Test
+    public void test_group_by_categories_mixed() throws Exception {
+        String content = post("/api/contentType/categories", "[\"audio/mp3\", \"application/unknown\", \"image/jpeg\"]").response().content();
+        Map<ContentTypeCategory, List<String>> result = JsonObjectMapper.readValue(content, new TypeReference<>() {});
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(ContentTypeCategory.AUDIO)).containsExactly("audio/mp3");
+        assertThat(result.get(ContentTypeCategory.OTHER)).containsExactly("application/unknown");
+        assertThat(result.get(ContentTypeCategory.IMAGE)).containsExactly("image/jpeg");
+    }
+}


### PR DESCRIPTION
Since the contentType categories are not fixed, the frontend needs and endpoint to retrieve the category of a given contentType. To avoid multiple requests, I added an endpoint that accepts a List of contentTypes and returns them grouped by contentTypeCategory 