### PR TITLE
UsersInDb should return null user when trying to find a user that does not exist in DB

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/session/UsersInDb.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/UsersInDb.java
@@ -17,7 +17,11 @@ public class UsersInDb implements UsersWritable {
 
     @Override
     public User find(String login) {
-        return new DatashareUser(userRepository.getUser(login));
+        org.icij.datashare.user.User userInDb = userRepository.getUser(login);
+        if(userInDb == null) {
+            return null;
+        }
+        return new DatashareUser(userInDb);
     }
 
     @Override

--- a/datashare-app/src/test/java/org/icij/datashare/session/UsersInDbTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/session/UsersInDbTest.java
@@ -49,6 +49,11 @@ public class UsersInDbTest {
     }
 
     @Test
+    public void find_user_returns_null_when_user_does_not_exist(){
+        assertThat(new UsersInDb(mock(Repository.class)).find("NotExistingUser")).isNull();
+    }
+
+    @Test
     public void find_user_in_db_with_bad_password() {
         Repository repository = mock(Repository.class);
         User expected = new User("foo", "bar", "mail", "icij", new HashMap<String, Object>() {{


### PR DESCRIPTION
This ticket is a similar correction to #2037 but when requesting users from SQL DB instead of Redis

 Before this PR, if the user does not exist in the DB, `UserInDB` would return a non-null value, which could result in a scenario with the front-end where the user can keep using a session cookie, even if the user was removed in the DB (minor issue) 