### PR TITLE
refactor: new CLI with picocli

### DIFF
--- a/datashare-app/pom.xml
+++ b/datashare-app/pom.xml
@@ -31,6 +31,12 @@
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>
+                <!-- fluent-http ships slf4j-simple which conflicts with logback-classic at runtime,
+                     causing "SLF4J: Found provider" warnings and non-deterministic logger selection -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -124,19 +124,17 @@ public class Main {
     }
 
     /**
-     * Returns true (use legacy jopt-simple path) when: no args are given, the first arg is
-     * blank, the first arg starts with - (flag-style), or the first arg is not a recognized
-     * subcommand name. Returns false (use picocli path) only when the first arg exactly
-     * matches a known subcommand.
+     * Returns true (use legacy jopt-simple path) when no argument matches a recognized
+     * subcommand name. Returns false (use picocli path) when any argument exactly matches
+     * a known subcommand. This allows parent-command options (e.g. --elasticsearchPath)
+     * to appear before the subcommand name in the args array.
      */
     static boolean isLegacyInvocation(String[] args) {
-        if (args.length == 0) {
-            return true;
+        for (String arg : args) {
+            if (SUBCOMMAND_NAMES.contains(arg.trim())) {
+                return false;
+            }
         }
-        String first = args[0].trim();
-        if (first.isEmpty() || first.startsWith("-")) {
-            return true;
-        }
-        return !SUBCOMMAND_NAMES.contains(first);
+        return true;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -71,9 +71,9 @@ public class Main {
     }
 
     private static void applyColorScheme(CommandLine commandLine, String[] args) {
-        boolean noColor = System.getenv("NO_COLOR") != null
+        boolean isColorDisabled = System.getenv("NO_COLOR") != null
                 || java.util.Arrays.asList(args).contains("--no-color");
-        if (noColor) {
+        if (isColorDisabled) {
             commandLine.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
         }
     }

--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -35,53 +35,68 @@ public class Main {
      * parser based on isLegacyInvocation(), then starts the appropriate mode.
      */
     public static void main(String[] args) throws Exception {
-        Properties properties;
+        Properties properties = resolveProperties(args);
+        startApplication(properties);
+    }
 
+    private static Properties resolveProperties(String[] args) throws Exception {
         if (isLegacyInvocation(args)) {
             DatashareCli cli = new DatashareCli().parseArguments(args);
-            properties = cli.properties;
-        } else {
-            DatashareCommand cmd = new DatashareCommand();
-            CommandLine commandLine = DatashareHelpFactory.configure(new CommandLine(cmd));
-            commandLine.setOverwrittenOptionsAllowed(true);
-            commandLine.setAbbreviatedOptionsAllowed(false);
-            commandLine.setAbbreviatedSubcommandsAllowed(false);
-            commandLine.setCaseInsensitiveEnumValuesAllowed(true);
-            boolean noColor = System.getenv("NO_COLOR") != null
-                    || java.util.Arrays.asList(args).contains("--no-color");
-            if (noColor) {
-                commandLine.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
-            }
-            // The execution strategy works in two phases:
-            // 1. It scans the parse-result hierarchy for any --help or --version request and
-            //    delegates to RunLast if found, so the correct subcommand-level help page is shown.
-            // 2. It walks down to the deepest executed subcommand in the hierarchy (mirroring
-            //    picocli's RunLast behavior) and registers it on DatashareCommand so its
-            //    properties can be collected after execution.
-            commandLine.setExecutionStrategy(parseResult -> {
-                // Walk the parse-result hierarchy to the deepest subcommand, short-circuiting
-                // immediately if any level has requested help/version so RunLast shows the
-                // right help page.
-                CommandLine.ParseResult current = parseResult;
-                while (current != null) {
-                    if (current.isUsageHelpRequested() || current.isVersionHelpRequested()) {
-                        return new CommandLine.RunLast().execute(parseResult);
-                    }
-                    if (!current.hasSubcommand()) break;
-                    current = current.subcommand();
-                }
-                Object userObject = current.commandSpec().userObject();
-                if (userObject instanceof DatashareSubcommand) {
-                    cmd.setExecutedSubcommand((DatashareSubcommand) userObject);
-                }
-                return new CommandLine.RunLast().execute(parseResult);
-            });
-            int exitCode = commandLine.execute(args);
-            if (exitCode != 0) System.exit(exitCode);
-            if (cmd.getExecutedSubcommand() == null) System.exit(0);
-            properties = cmd.collectProperties();
+            return cli.properties;
         }
+        return runPicocli(args);
+    }
 
+    private static Properties runPicocli(String[] args) {
+        DatashareCommand cmd = new DatashareCommand();
+        CommandLine commandLine = DatashareHelpFactory.configure(new CommandLine(cmd));
+        commandLine.setOverwrittenOptionsAllowed(true);
+        commandLine.setAbbreviatedOptionsAllowed(false);
+        commandLine.setAbbreviatedSubcommandsAllowed(false);
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        applyColorScheme(commandLine, args);
+        // The execution strategy walks the parse-result hierarchy to the deepest subcommand,
+        // short-circuiting to RunLast if --help or --version is requested at any level so the
+        // right help page is shown. Otherwise it registers the executed subcommand on
+        // DatashareCommand so its properties can be collected after execution.
+        commandLine.setExecutionStrategy(parseResult -> resolveSubcommand(parseResult, cmd));
+        int exitCode = commandLine.execute(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+        if (cmd.getExecutedSubcommand() == null) {
+            System.exit(0);
+        }
+        return cmd.collectProperties();
+    }
+
+    private static void applyColorScheme(CommandLine commandLine, String[] args) {
+        boolean noColor = System.getenv("NO_COLOR") != null
+                || java.util.Arrays.asList(args).contains("--no-color");
+        if (noColor) {
+            commandLine.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
+        }
+    }
+
+    private static int resolveSubcommand(CommandLine.ParseResult parseResult, DatashareCommand cmd) {
+        CommandLine.ParseResult current = parseResult;
+        while (current != null) {
+            if (current.isUsageHelpRequested() || current.isVersionHelpRequested()) {
+                return new CommandLine.RunLast().execute(parseResult);
+            }
+            if (!current.hasSubcommand()) {
+                break;
+            }
+            current = current.subcommand();
+        }
+        Object userObject = current.commandSpec().userObject();
+        if (userObject instanceof DatashareSubcommand) {
+            cmd.setExecutedSubcommand((DatashareSubcommand) userObject);
+        }
+        return new CommandLine.RunLast().execute(parseResult);
+    }
+
+    private static void startApplication(Properties properties) throws Exception {
         Mode mode = Mode.valueOf(properties.getProperty("mode", "LOCAL"));
         LOGGER.info("Running datashare {}", mode.isWebServer() ? "web server" : "");
         LOGGER.info("JVM version {}", System.getProperty("java.version"));
@@ -96,8 +111,9 @@ public class Main {
         Runtime.getRuntime().addShutdownHook(commonMode.closeThread());
 
         if (mode.isWebServer()) {
-            ofNullable(DatashareSystemTray.create(commonMode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT_OPT))).
-                    ifPresent(commonMode::addCloseable);
+            String port = commonMode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT_OPT);
+            Closeable tray = DatashareSystemTray.create(port);
+            ofNullable(tray).ifPresent(commonMode::addCloseable);
             WebApp.start(commonMode);
         } else if (mode == Mode.TASK_WORKER) {
             TaskWorkerApp.start(commonMode);
@@ -114,9 +130,13 @@ public class Main {
      * matches a known subcommand.
      */
     static boolean isLegacyInvocation(String[] args) {
-        if (args.length == 0) return true;
+        if (args.length == 0) {
+            return true;
+        }
         String first = args[0].trim();
-        if (first.isEmpty() || first.startsWith("-")) return true;
+        if (first.isEmpty() || first.startsWith("-")) {
+            return true;
+        }
         return !SUBCOMMAND_NAMES.contains(first);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -28,7 +28,7 @@ import static java.util.Optional.ofNullable;
  */
 public class Main {
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
-    private static final Set<String> SUBCOMMAND_NAMES = Set.of("app", "worker", "stage", "plugin", "extension", "api-key", "help");
+    private static final Set<String> SUBCOMMAND_NAMES = new CommandLine(new DatashareCommand()).getSubcommands().keySet();
 
     /**
      * Application entry point. Routes to the legacy jopt-simple parser or the picocli subcommand

--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -2,42 +2,121 @@ package org.icij.datashare;
 
 import org.icij.datashare.cli.DatashareCli;
 import org.icij.datashare.cli.Mode;
+import org.icij.datashare.cli.command.DatashareCommand;
+import org.icij.datashare.cli.command.DatashareHelpFactory;
+import org.icij.datashare.cli.command.DatashareSubcommand;
 import org.icij.datashare.mode.CommonMode;
 import org.icij.datashare.tray.DatashareSystemTray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Level;
+import picocli.CommandLine;
 
 import java.io.Closeable;
 import java.nio.charset.Charset;
+import java.util.Properties;
+import java.util.Set;
 
 import static java.util.Optional.ofNullable;
 
+/**
+ * Datashare supports two CLI invocation styles: legacy (jopt-simple) and new picocli subcommands.
+ * The legacy path is used when: no args are provided, the first arg starts with -, or the
+ * first arg is an unknown word (i.e. not a recognized subcommand).
+ * The new picocli path is used when the first arg is a known subcommand: app, worker,
+ * stage, plugin, extension, api-key, or help.
+ */
 public class Main {
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
+    private static final Set<String> SUBCOMMAND_NAMES = Set.of("app", "worker", "stage", "plugin", "extension", "api-key", "help");
+
+    /**
+     * Application entry point. Routes to the legacy jopt-simple parser or the picocli subcommand
+     * parser based on isLegacyInvocation(), then starts the appropriate mode.
+     */
     public static void main(String[] args) throws Exception {
-        DatashareCli cli = new DatashareCli().parseArguments(args);
-        LOGGER.info("Running datashare {}", cli.isWebServer() ? "web server" : "");
+        Properties properties;
+
+        if (isLegacyInvocation(args)) {
+            DatashareCli cli = new DatashareCli().parseArguments(args);
+            properties = cli.properties;
+        } else {
+            DatashareCommand cmd = new DatashareCommand();
+            CommandLine commandLine = DatashareHelpFactory.configure(new CommandLine(cmd));
+            commandLine.setOverwrittenOptionsAllowed(true);
+            commandLine.setAbbreviatedOptionsAllowed(false);
+            commandLine.setAbbreviatedSubcommandsAllowed(false);
+            commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+            boolean noColor = System.getenv("NO_COLOR") != null
+                    || java.util.Arrays.asList(args).contains("--no-color");
+            if (noColor) {
+                commandLine.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
+            }
+            // The execution strategy works in two phases:
+            // 1. It scans the parse-result hierarchy for any --help or --version request and
+            //    delegates to RunLast if found, so the correct subcommand-level help page is shown.
+            // 2. It walks down to the deepest executed subcommand in the hierarchy (mirroring
+            //    picocli's RunLast behavior) and registers it on DatashareCommand so its
+            //    properties can be collected after execution.
+            commandLine.setExecutionStrategy(parseResult -> {
+                // Walk the parse-result hierarchy to the deepest subcommand, short-circuiting
+                // immediately if any level has requested help/version so RunLast shows the
+                // right help page.
+                CommandLine.ParseResult current = parseResult;
+                while (current != null) {
+                    if (current.isUsageHelpRequested() || current.isVersionHelpRequested()) {
+                        return new CommandLine.RunLast().execute(parseResult);
+                    }
+                    if (!current.hasSubcommand()) break;
+                    current = current.subcommand();
+                }
+                Object userObject = current.commandSpec().userObject();
+                if (userObject instanceof DatashareSubcommand) {
+                    cmd.setExecutedSubcommand((DatashareSubcommand) userObject);
+                }
+                return new CommandLine.RunLast().execute(parseResult);
+            });
+            int exitCode = commandLine.execute(args);
+            if (exitCode != 0) System.exit(exitCode);
+            if (cmd.getExecutedSubcommand() == null) System.exit(0);
+            properties = cmd.collectProperties();
+        }
+
+        Mode mode = Mode.valueOf(properties.getProperty("mode", "LOCAL"));
+        LOGGER.info("Running datashare {}", mode.isWebServer() ? "web server" : "");
         LOGGER.info("JVM version {}", System.getProperty("java.version"));
         LOGGER.info("JVM charset encoding {}", Charset.defaultCharset());
-        Level logLevel = Level.toLevel(cli.properties.getProperty("logLevel"));
+        Level logLevel = Level.toLevel(properties.getProperty("logLevel"));
         LOGGER.info("Log level set to {}", logLevel);
 
         ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(logLevel);
 
-        CommonMode mode = CommonMode.create(cli.properties);
-        Runtime.getRuntime().addShutdownHook(mode.closeThread());
+        CommonMode commonMode = CommonMode.create(properties);
+        Runtime.getRuntime().addShutdownHook(commonMode.closeThread());
 
-        if (cli.isWebServer()) {
-            ofNullable(DatashareSystemTray.create(mode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT_OPT))).
-                    ifPresent(mode::addCloseable);
-            WebApp.start(mode);
-        } else if (cli.mode() == Mode.TASK_WORKER) {
-            TaskWorkerApp.start(mode);
+        if (mode.isWebServer()) {
+            ofNullable(DatashareSystemTray.create(commonMode.properties().getProperty(PropertiesProvider.TCP_LISTEN_PORT_OPT))).
+                    ifPresent(commonMode::addCloseable);
+            WebApp.start(commonMode);
+        } else if (mode == Mode.TASK_WORKER) {
+            TaskWorkerApp.start(commonMode);
         } else {
-            CliApp.start(cli.properties);
+            CliApp.start(properties);
         }
         LOGGER.info("exiting main");
+    }
+
+    /**
+     * Returns true (use legacy jopt-simple path) when: no args are given, the first arg is
+     * blank, the first arg starts with - (flag-style), or the first arg is not a recognized
+     * subcommand name. Returns false (use picocli path) only when the first arg exactly
+     * matches a known subcommand.
+     */
+    static boolean isLegacyInvocation(String[] args) {
+        if (args.length == 0) return true;
+        String first = args[0].trim();
+        if (first.isEmpty() || first.startsWith("-")) return true;
+        return !SUBCOMMAND_NAMES.contains(first);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/EmbeddedMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/EmbeddedMode.java
@@ -113,7 +113,12 @@ public class EmbeddedMode extends LocalMode {
                     String[] parts = line.split(":", 2);
                     String key = parts[0].trim();
                     String value = parts[1].trim().replaceAll("^\\s*\"|\\s*\"$", "");
-                    args.add(format("-E%s=%s", key, value));
+                    // Skip empty values: older settings files wrote path.repo as a YAML list
+                    // ("path.repo:\n  - /path") which produces an empty value here. Passing
+                    // -Epath.repo= to elasticsearch causes a startup error.
+                    if (!value.isEmpty()) {
+                        args.add(format("-E%s=%s", key, value));
+                    }
                 }
             }
             logger.info("loaded {} elasticsearch settings from {}", args.size(), settingsFile);

--- a/datashare-app/src/test/java/org/icij/datashare/MainTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/MainTest.java
@@ -131,4 +131,15 @@ public class MainTest {
     public void test_new_help_subcommand() {
         assertThat(Main.isLegacyInvocation(new String[]{"help"})).isFalse();
     }
+
+    @Test
+    public void test_new_subcommand_after_options() {
+        // Shell script injects --elasticsearch* options before the subcommand
+        assertThat(Main.isLegacyInvocation(new String[]{"--elasticsearchPath", "/path", "help"})).isFalse();
+    }
+
+    @Test
+    public void test_new_app_after_options() {
+        assertThat(Main.isLegacyInvocation(new String[]{"--elasticsearchPath", "/path", "app", "serve"})).isFalse();
+    }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/MainTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/MainTest.java
@@ -1,0 +1,134 @@
+package org.icij.datashare;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class MainTest {
+
+    @Test
+    public void test_legacy_no_args() {
+        assertThat(Main.isLegacyInvocation(new String[]{})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_empty_arg() {
+        assertThat(Main.isLegacyInvocation(new String[]{""})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_whitespace_arg() {
+        assertThat(Main.isLegacyInvocation(new String[]{"  "})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_long_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"--mode=SERVER"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_short_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"-m", "CLI"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_help_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"--help"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_version_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"-v"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_settings_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"-s", "/path/to/settings"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_stages_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"--stages=SCAN,INDEX"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_plugin_list_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"--pluginList"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_api_key_flag() {
+        assertThat(Main.isLegacyInvocation(new String[]{"-k", "alice"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_unknown_word() {
+        // Unknown first words should go to legacy path (backward compat)
+        assertThat(Main.isLegacyInvocation(new String[]{"unknown"})).isTrue();
+    }
+
+    @Test
+    public void test_legacy_random_text() {
+        assertThat(Main.isLegacyInvocation(new String[]{"foo", "bar"})).isTrue();
+    }
+
+    @Test
+    public void test_new_app() {
+        assertThat(Main.isLegacyInvocation(new String[]{"app", "serve"})).isFalse();
+    }
+
+    @Test
+    public void test_new_app_with_options() {
+        assertThat(Main.isLegacyInvocation(new String[]{"app", "serve", "server"})).isFalse();
+    }
+
+    @Test
+    public void test_new_worker() {
+        assertThat(Main.isLegacyInvocation(new String[]{"worker", "run"})).isFalse();
+    }
+
+    @Test
+    public void test_new_stage() {
+        assertThat(Main.isLegacyInvocation(new String[]{"stage", "run", "SCAN"})).isFalse();
+    }
+
+    @Test
+    public void test_new_plugin() {
+        assertThat(Main.isLegacyInvocation(new String[]{"plugin", "list"})).isFalse();
+    }
+
+    @Test
+    public void test_new_plugin_install() {
+        assertThat(Main.isLegacyInvocation(new String[]{"plugin", "install", "foo"})).isFalse();
+    }
+
+    @Test
+    public void test_new_extension() {
+        assertThat(Main.isLegacyInvocation(new String[]{"extension", "install", "foo"})).isFalse();
+    }
+
+    @Test
+    public void test_new_extension_list() {
+        assertThat(Main.isLegacyInvocation(new String[]{"extension", "list"})).isFalse();
+    }
+
+    @Test
+    public void test_new_api_key() {
+        assertThat(Main.isLegacyInvocation(new String[]{"api-key", "create", "alice"})).isFalse();
+    }
+
+    @Test
+    public void test_new_api_key_get() {
+        assertThat(Main.isLegacyInvocation(new String[]{"api-key", "get", "alice"})).isFalse();
+    }
+
+    @Test
+    public void test_new_api_key_delete() {
+        assertThat(Main.isLegacyInvocation(new String[]{"api-key", "delete", "alice"})).isFalse();
+    }
+
+    @Test
+    public void test_new_help_subcommand() {
+        assertThat(Main.isLegacyInvocation(new String[]{"help"})).isFalse();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/MainTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/MainTest.java
@@ -74,12 +74,12 @@ public class MainTest {
 
     @Test
     public void test_new_app() {
-        assertThat(Main.isLegacyInvocation(new String[]{"app", "serve"})).isFalse();
+        assertThat(Main.isLegacyInvocation(new String[]{"app", "start"})).isFalse();
     }
 
     @Test
     public void test_new_app_with_options() {
-        assertThat(Main.isLegacyInvocation(new String[]{"app", "serve", "server"})).isFalse();
+        assertThat(Main.isLegacyInvocation(new String[]{"app", "start", "--mode", "SERVER"})).isFalse();
     }
 
     @Test
@@ -140,6 +140,6 @@ public class MainTest {
 
     @Test
     public void test_new_app_after_options() {
-        assertThat(Main.isLegacyInvocation(new String[]{"--elasticsearchPath", "/path", "app", "serve"})).isFalse();
+        assertThat(Main.isLegacyInvocation(new String[]{"--elasticsearchPath", "/path", "app", "start"})).isFalse();
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/EmbeddedModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/EmbeddedModeTest.java
@@ -54,6 +54,26 @@ public class EmbeddedModeTest {
     }
 
     @Test
+    public void test_buildElasticsearchArgs_skips_empty_values() throws Exception {
+        Path settingsFile = temporaryFolder.newFile("elasticsearch.yml").toPath();
+        // Older Datashare versions wrote path.repo as a YAML list, producing an empty value
+        // when the key line is parsed alone. Passing -Epath.repo= to elasticsearch causes a
+        // startup error; the empty value must be silently skipped.
+        String content = """
+                path.data: "/some/path"
+                path.repo:
+                  - "/some/path/backups"
+                xpack.security.enabled: false
+                """;
+        Files.writeString(settingsFile, content);
+
+        List<String> args = EmbeddedMode.buildElasticsearchArgs(settingsFile);
+
+        assertThat(args).containsOnly("-Epath.data=/some/path", "-Expack.security.enabled=false");
+        assertThat(args).excludes("-Epath.repo=");
+    }
+
+    @Test
     public void test_buildElasticsearchArgs_with_quoted_values() throws Exception {
         Path settingsFile = temporaryFolder.newFile("elasticsearch.yml").toPath();
         String content = """

--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -24,6 +24,12 @@
         </dependency>
 
         <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.7</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.7</version>
@@ -95,6 +101,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -92,6 +92,7 @@ public final class DatashareCliOptions {
     public static final String OAUTH_API_URL_OPT = "oauthApiUrl";
     public static final String OAUTH_AUTHORIZE_URL_OPT = "oauthAuthorizeUrl";
     public static final String OAUTH_CALLBACK_PATH_OPT = "oauthCallbackPath";
+    public static final String OAUTH_CLAIM_ID_ATTRIBUTE_OPT = "oauthClaimIdAttribute";
     public static final String OAUTH_CLIENT_ID_OPT = "oauthClientId";
     public static final String OAUTH_CLIENT_SECRET_OPT = "oauthClientSecret";
     public static final String OAUTH_DEFAULT_PROJECT_OPT = "oauthDefaultProject";

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/OcrType.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/OcrType.java
@@ -1,0 +1,5 @@
+package org.icij.datashare.cli;
+
+public enum OcrType {
+    TESSERACT, TESS4J
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyCommand.java
@@ -1,0 +1,20 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Spec;
+
+@Command(name = "api-key", mixinStandardHelpOptions = true,
+        description = "Manage API keys for programmatic access.",
+        subcommands = {ApiKeyCreateCommand.class, ApiKeyGetCommand.class, ApiKeyDeleteCommand.class})
+public class ApiKeyCommand implements Runnable {
+
+    @Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public void run() {
+        // No subcommand specified: print usage and exit 0 so the user knows what subcommands are available.
+        spec.commandLine().usage(System.out);
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyCreateCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyCreateCommand.java
@@ -28,8 +28,8 @@ public class ApiKeyCreateCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(CRE_API_KEY_OPT, user);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, CRE_API_KEY_OPT, user);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyCreateCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyCreateCommand.java
@@ -1,0 +1,35 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.CRE_API_KEY_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "create", mixinStandardHelpOptions = true, description = {
+        "Generate and store a new API key for a user.",
+        "",
+        "Examples:",
+        "  datashare api-key create alice",
+        "  datashare -s /etc/datashare/settings.properties api-key create alice"
+})
+public class ApiKeyCreateCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Username")
+    String user;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(CRE_API_KEY_OPT, user);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyDeleteCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyDeleteCommand.java
@@ -1,0 +1,34 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.DEL_API_KEY_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "delete", mixinStandardHelpOptions = true, description = {
+        "Revoke and remove the API key for a user.",
+        "",
+        "Examples:",
+        "  datashare api-key delete alice"
+})
+public class ApiKeyDeleteCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Username")
+    String user;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(DEL_API_KEY_OPT, user);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyDeleteCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyDeleteCommand.java
@@ -27,8 +27,8 @@ public class ApiKeyDeleteCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(DEL_API_KEY_OPT, user);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, DEL_API_KEY_OPT, user);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyGetCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyGetCommand.java
@@ -27,8 +27,8 @@ public class ApiKeyGetCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(GET_API_KEY_OPT, user);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, GET_API_KEY_OPT, user);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyGetCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ApiKeyGetCommand.java
@@ -1,0 +1,34 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.GET_API_KEY_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "get", mixinStandardHelpOptions = true, description = {
+        "Print the existing API key for a user.",
+        "",
+        "Examples:",
+        "  datashare api-key get alice"
+})
+public class ApiKeyGetCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Username")
+    String user;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(GET_API_KEY_OPT, user);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/AppCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/AppCommand.java
@@ -1,0 +1,20 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Spec;
+
+@Command(name = "app", mixinStandardHelpOptions = true,
+        description = "Manage and run the Datashare web application.",
+        subcommands = {AppServeCommand.class})
+public class AppCommand implements Runnable {
+
+    @Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public void run() {
+        // No subcommand specified: print usage and exit 0 so the user knows what subcommands are available.
+        spec.commandLine().usage(System.out);
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/AppServeCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/AppServeCommand.java
@@ -36,7 +36,7 @@ public class AppServeCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = serverOptions.toProperties();
-        props.setProperty(MODE_OPT, mode.name());
+        DatashareOptions.putIfNotNull(props, MODE_OPT, mode);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/AppServeCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/AppServeCommand.java
@@ -1,0 +1,42 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "start", mixinStandardHelpOptions = true, description = {
+        "Start the Datashare web application server.",
+        "",
+        "Examples:",
+        "  datashare app start",
+        "  datashare app start --mode SERVER --port 9090",
+        "  datashare app start --mode SERVER --oauthClientId myapp",
+        "  datashare --dataDir /data/docs --elasticsearchAddress http://elastic:9200 app start"
+})
+public class AppServeCommand implements Runnable, DatashareSubcommand {
+
+    @Option(names = {"--mode"}, defaultValue = "LOCAL",
+            paramLabel = "LOCAL|SERVER|EMBEDDED|NER",
+            description = "Server run mode (default: LOCAL)")
+    Mode mode;
+
+    @Mixin
+    ServerOptions serverOptions = new ServerOptions();
+
+    @Override
+    public void run() {
+        // Properties will be collected by DatashareCommand
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = serverOptions.toProperties();
+        props.setProperty(MODE_OPT, mode.name());
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -1,0 +1,54 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+import java.util.Properties;
+
+@Command(name = "datashare",
+        mixinStandardHelpOptions = true,
+        versionProvider = DatashareVersionProvider.class,
+        subcommands = {
+                AppCommand.class,
+                WorkerCommand.class,
+                StageCommand.class,
+                PluginCommand.class,
+                ExtensionCommand.class,
+                ApiKeyCommand.class,
+                CommandLine.HelpCommand.class
+        },
+        description = "Datashare - Index and search your documents")
+public class DatashareCommand implements Runnable {
+
+    @Mixin
+    GlobalOptions globalOptions = new GlobalOptions();
+
+    private DatashareSubcommand executedSubcommand;
+
+    @Override
+    public void run() {
+        // No subcommand specified: legacy invocations are handled by the old parser.
+    }
+
+    public void setExecutedSubcommand(DatashareSubcommand subcommand) {
+        this.executedSubcommand = subcommand;
+    }
+
+    public DatashareSubcommand getExecutedSubcommand() {
+        return executedSubcommand;
+    }
+
+    /**
+     * Collect properties from global options and the executed subcommand.
+     * Subcommand properties override global options on conflict.
+     */
+    public Properties collectProperties() {
+        Properties props = globalOptions.toProperties();
+        if (executedSubcommand != null) {
+            props.putAll(executedSubcommand.getSubcommandProperties());
+        }
+        DatashareOptions.postProcess(props);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -45,9 +45,7 @@ public class DatashareCommand implements Runnable {
      */
     public Properties collectProperties() {
         Properties props = globalOptions.toProperties();
-        if (executedSubcommand != null) {
-            props.putAll(executedSubcommand.getSubcommandProperties());
-        }
+        DatashareOptions.putAll(props, executedSubcommand);
         DatashareOptions.postProcess(props);
         return props;
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareHelpFactory.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareHelpFactory.java
@@ -24,7 +24,7 @@ public final class DatashareHelpFactory {
 
     static final int HELP_WIDTH = 120;
     private static final int INDENT = 2;
-    private static final int COL_GAP = 2;
+    private static final int COLUMN_GAP = 2;
 
     private DatashareHelpFactory() {}
 
@@ -293,7 +293,7 @@ public final class DatashareHelpFactory {
     /** Renders rows as a two-column table with an explicit first-column width. */
     private static String twoColumns(List<String[]> rows, int firstColWidth) {
         String prefix = " ".repeat(INDENT);
-        String fmt = prefix + "%-" + firstColWidth + "s" + " ".repeat(COL_GAP) + "%s%n";
+        String fmt = prefix + "%-" + firstColWidth + "s" + " ".repeat(COLUMN_GAP) + "%s%n";
         StringBuilder sb = new StringBuilder();
         for (String[] row : rows) {
             sb.append(String.format(fmt, row[0], row[1]));

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareHelpFactory.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareHelpFactory.java
@@ -1,0 +1,275 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.Model.PositionalParamSpec;
+import picocli.CommandLine.Model.UsageMessageSpec;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static picocli.CommandLine.Model.UsageMessageSpec.*;
+
+/**
+ * Configures picocli's help output with a yarn-inspired style:
+ * two-column layout where the first column is sized to the widest option name,
+ * so descriptions always appear on the same line.
+ */
+public final class DatashareHelpFactory {
+
+    static final int HELP_WIDTH = 120;
+    private static final int INDENT = 2;
+    private static final int COL_GAP = 2;
+
+    private DatashareHelpFactory() {}
+
+    /**
+     * Applies help styling to cmd and all its subcommands recursively.
+     * Returns cmd for fluent chaining.
+     */
+    public static CommandLine configure(CommandLine cmd) {
+        apply(cmd, true);
+        for (CommandLine sub : cmd.getSubcommands().values()) {
+            configureSubtree(sub);
+        }
+        return cmd;
+    }
+
+    private static void configureSubtree(CommandLine cmd) {
+        apply(cmd, false);
+        for (CommandLine sub : cmd.getSubcommands().values()) {
+            configureSubtree(sub);
+        }
+    }
+
+    private static void apply(CommandLine cmd, boolean isRoot) {
+        UsageMessageSpec usage = cmd.getCommandSpec().usageMessage();
+        usage.abbreviateSynopsis(true);
+        usage.sortOptions(false);
+        usage.width(HELP_WIDTH);
+
+        if (isRoot) {
+            usage.footer(
+                    "",
+                    "  Run '@|italic datashare COMMAND --help|@' for more information on a command.",
+                    "  Documentation and support: https://github.com/ICIJ/datashare"
+            );
+        }
+
+        Map<String, CommandLine.IHelpSectionRenderer> sections = cmd.getHelpSectionMap();
+        // Headings are suppressed here and emitted by the list renderers only when non-empty.
+        // Bold markup (@|bold ...|@) is processed by picocli's ANSI pass at print time,
+        // respecting --no-color / NO_COLOR automatically.
+        sections.put(SECTION_KEY_OPTION_LIST_HEADING,    help -> "");
+        sections.put(SECTION_KEY_COMMAND_LIST_HEADING,   help -> "");
+        sections.put(SECTION_KEY_PARAMETER_LIST_HEADING, help -> "");
+        sections.put(SECTION_KEY_DESCRIPTION_HEADING,    help -> "");
+
+        sections.put(SECTION_KEY_DESCRIPTION,    DatashareHelpFactory::renderDescription);
+        sections.put(SECTION_KEY_OPTION_LIST, h -> {
+            if (!h.commandSpec().subcommands().isEmpty()) return "";
+            List<String[]> rows = optionRows(h.commandSpec().options());
+            if (rows.isEmpty()) return "";
+            return "\n" + bold(h, "Options:") + "\n\n" + twoColumns(rows, sharedFirstColWidth(h));
+        });
+        sections.put(SECTION_KEY_COMMAND_LIST,   h -> { String s = renderCommandList(h);   return s.isEmpty() ? "" : "\n" + bold(h, "Commands:")   + "\n\n" + s; });
+        sections.put(SECTION_KEY_PARAMETER_LIST, h -> { String s = renderParameterList(h); return s.isEmpty() ? "" : "\n" + bold(h, "Arguments:") + "\n\n" + s; });
+
+        sections.put("globalOptionList", h -> {
+            if (h.commandSpec().parent() == null || !h.commandSpec().subcommands().isEmpty()) return "";
+            List<String[]> rows = optionRows(h.commandSpec().root().options());
+            if (rows.isEmpty()) return "";
+            return "\n" + bold(h, "Global Options:") + "\n\n" + twoColumns(rows, sharedFirstColWidth(h));
+        });
+
+        List<String> keys = new ArrayList<>(usage.sectionKeys());
+        int idx = keys.indexOf(SECTION_KEY_OPTION_LIST);
+        if (idx >= 0 && !keys.contains("globalOptionList")) {
+            keys.add(idx + 1, "globalOptionList");
+            usage.sectionKeys(keys);
+        }
+    }
+
+    static String renderOptionList(CommandLine.Help help) {
+        // Parent commands (with subcommands) show only the command list, not inherited options
+        if (!help.commandSpec().subcommands().isEmpty()) return "";
+        // Exclude scope=INHERIT options: they are already shown by renderGlobalOptionList
+        List<OptionSpec> ownOptions = help.commandSpec().options().stream()
+                .filter(o -> !o.inherited())
+                .collect(Collectors.toList());
+        List<String[]> rows = optionRows(ownOptions);
+        return rows.isEmpty() ? "" : twoColumns(rows);
+    }
+
+    static String renderGlobalOptionList(CommandLine.Help help) {
+        // Only show on leaf subcommands (not root, not intermediate commands with subcommands)
+        if (help.commandSpec().parent() == null) return "";
+        if (!help.commandSpec().subcommands().isEmpty()) return "";
+        List<String[]> rows = optionRows(help.commandSpec().root().options());
+        return rows.isEmpty() ? "" : twoColumns(rows);
+    }
+
+    /** Filters, sorts, and maps a list of option specs to two-column row pairs. */
+    private static List<String[]> optionRows(List<OptionSpec> options) {
+        return options.stream()
+                .filter(o -> !o.hidden())
+                .sorted(Comparator.comparing(DatashareHelpFactory::optionSortKey))
+                .map(o -> new String[]{ optionLabel(o), firstLine(o.description()) })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the first-column width sized to the widest option label across both the
+     * command's own options and the root's global options, so both sections align.
+     */
+    private static int sharedFirstColWidth(CommandLine.Help help) {
+        return Stream.concat(
+                help.commandSpec().options().stream().filter(o -> !o.inherited()),
+                help.commandSpec().root().options().stream()
+        ).filter(o -> !o.hidden())
+         .mapToInt(o -> optionLabel(o).length())
+         .max()
+         .orElse(0);
+    }
+
+    static String renderCommandList(CommandLine.Help help) {
+        Map<String, CommandLine> subs = help.commandSpec().subcommands();
+        if (subs.isEmpty()) return "";
+
+        List<String[]> rows = subs.entrySet().stream()
+                .map(e -> new String[]{ e.getKey(),
+                        firstLine(e.getValue().getCommandSpec().usageMessage().description()) })
+                .collect(Collectors.toList());
+        return twoColumns(rows);
+    }
+
+    static String renderParameterList(CommandLine.Help help) {
+        List<PositionalParamSpec> params = help.commandSpec().positionalParameters().stream()
+                .filter(p -> !p.hidden())
+                .collect(Collectors.toList());
+        if (params.isEmpty()) return "";
+
+        List<String[]> rows = params.stream()
+                .map(p -> new String[]{ p.paramLabel(), firstLine(p.description()) })
+                .collect(Collectors.toList());
+        return twoColumns(rows);
+    }
+
+    /**
+     * Renders the command description, automatically bolding lines that look like section
+     * headings (no leading whitespace, ends with :), e.g. "Examples:".
+     * Uses the command's color scheme so bold is stripped when ANSI is disabled.
+     */
+    static String renderDescription(CommandLine.Help help) {
+        String[] desc = help.commandSpec().usageMessage().description();
+        if (desc == null || desc.length == 0) return "";
+        StringBuilder sb = new StringBuilder("\n");
+        for (String line : desc) {
+            if (!line.isEmpty() && !Character.isWhitespace(line.charAt(0)) && line.endsWith(":")) {
+                sb.append(bold(help, line)).append("\n");
+            } else {
+                sb.append(line).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Renders text in bold using the command's color scheme. */
+    private static String bold(CommandLine.Help help, String text) {
+        return help.colorScheme().ansi().string("@|bold " + text + "|@");
+    }
+
+    /** Returns the sort key for an option: the long name (or first name) stripped of leading dashes, lowercased. */
+    static String optionSortKey(OptionSpec option) {
+        return Arrays.stream(option.names())
+                .filter(n -> n.startsWith("--"))
+                .findFirst()
+                .orElse(option.names()[0])
+                .replaceFirst("^-+", "")
+                .toLowerCase();
+    }
+
+    /** Formats option names + param label: e.g. -b, --bind=<host> */
+    static String optionLabel(OptionSpec option) {
+        StringBuilder sb = new StringBuilder();
+        String[] names = option.names();
+        for (int i = 0; i < names.length; i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(names[i]);
+        }
+        if (option.arity().max() > 0) {
+            sb.append("=").append(semanticLabel(option));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns a human-readable type label for the option value,
+     * derived from the option name and its Java type.
+     */
+    private static String semanticLabel(OptionSpec option) {
+        // Use explicitly-set paramLabels (not the picocli-generated <fieldName> default or
+        // the programmatic-builder default "PARAM")
+        String configured = option.paramLabel();
+        if (!configured.equals("PARAM") && !(configured.startsWith("<") && configured.endsWith(">"))) {
+            return configured;
+        }
+
+        Class<?> type = option.type();
+
+        // Numeric Java types
+        if (type == int.class || type == Integer.class
+                || type == long.class || type == Long.class
+                || type == double.class || type == Double.class
+                || type == float.class || type == Float.class) {
+            return "<number>";
+        }
+
+        // File type
+        if (type == java.io.File.class) {
+            return "<path>";
+        }
+
+        // Name-based hints for String options: use the longest --name, lowercased
+        String name = Arrays.stream(option.names())
+                .filter(n -> n.startsWith("--"))
+                .findFirst()
+                .orElse(option.names()[option.names().length - 1])
+                .replaceFirst("^-+", "")
+                .toLowerCase();
+
+        if (name.endsWith("url") || name.endsWith("address") || name.endsWith("uri")) return "<url>";
+        if (name.endsWith("dir") || name.endsWith("path") || name.endsWith("settings")) return "<path>";
+        if (name.endsWith("host") || name.equals("bind")) return "<host>";
+        if (name.endsWith("provider") || name.endsWith("filter")) return "<class>";
+
+        return "<value>";
+    }
+
+    /** Returns the first non-blank description line, or empty string. */
+    private static String firstLine(String[] lines) {
+        if (lines == null || lines.length == 0) return "";
+        return lines[0];
+    }
+
+    /** Renders rows as a two-column table, left column sized to the widest entry. */
+    private static String twoColumns(List<String[]> rows) {
+        return twoColumns(rows, rows.stream().mapToInt(r -> r[0].length()).max().orElse(0));
+    }
+
+    /** Renders rows as a two-column table with an explicit first-column width. */
+    private static String twoColumns(List<String[]> rows, int firstColWidth) {
+        String prefix = " ".repeat(INDENT);
+        String fmt = prefix + "%-" + firstColWidth + "s" + " ".repeat(COL_GAP) + "%s%n";
+        StringBuilder sb = new StringBuilder();
+        for (String[] row : rows) {
+            sb.append(String.format(fmt, row[0], row[1]));
+        }
+        return sb.toString();
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareHelpFactory.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareHelpFactory.java
@@ -54,38 +54,25 @@ public final class DatashareHelpFactory {
         usage.width(HELP_WIDTH);
 
         if (isRoot) {
-            usage.footer(
-                    "",
+            usage.footer("",
                     "  Run '@|italic datashare COMMAND --help|@' for more information on a command.",
-                    "  Documentation and support: https://github.com/ICIJ/datashare"
-            );
+                    "  Documentation and support: https://github.com/ICIJ/datashare");
         }
 
         Map<String, CommandLine.IHelpSectionRenderer> sections = cmd.getHelpSectionMap();
-        // Headings are suppressed here and emitted by the list renderers only when non-empty.
+        // Headings are suppressed; they are emitted by the list renderers only when non-empty.
         // Bold markup (@|bold ...|@) is processed by picocli's ANSI pass at print time,
         // respecting --no-color / NO_COLOR automatically.
-        sections.put(SECTION_KEY_OPTION_LIST_HEADING,    help -> "");
-        sections.put(SECTION_KEY_COMMAND_LIST_HEADING,   help -> "");
-        sections.put(SECTION_KEY_PARAMETER_LIST_HEADING, help -> "");
-        sections.put(SECTION_KEY_DESCRIPTION_HEADING,    help -> "");
+        for (String key : List.of(SECTION_KEY_OPTION_LIST_HEADING, SECTION_KEY_COMMAND_LIST_HEADING,
+                                   SECTION_KEY_PARAMETER_LIST_HEADING, SECTION_KEY_DESCRIPTION_HEADING)) {
+            sections.put(key, h -> "");
+        }
 
         sections.put(SECTION_KEY_DESCRIPTION,    DatashareHelpFactory::renderDescription);
-        sections.put(SECTION_KEY_OPTION_LIST, h -> {
-            if (!h.commandSpec().subcommands().isEmpty()) return "";
-            List<String[]> rows = optionRows(h.commandSpec().options());
-            if (rows.isEmpty()) return "";
-            return "\n" + bold(h, "Options:") + "\n\n" + twoColumns(rows, sharedFirstColWidth(h));
-        });
-        sections.put(SECTION_KEY_COMMAND_LIST,   h -> { String s = renderCommandList(h);   return s.isEmpty() ? "" : "\n" + bold(h, "Commands:")   + "\n\n" + s; });
-        sections.put(SECTION_KEY_PARAMETER_LIST, h -> { String s = renderParameterList(h); return s.isEmpty() ? "" : "\n" + bold(h, "Arguments:") + "\n\n" + s; });
-
-        sections.put("globalOptionList", h -> {
-            if (h.commandSpec().parent() == null || !h.commandSpec().subcommands().isEmpty()) return "";
-            List<String[]> rows = optionRows(h.commandSpec().root().options());
-            if (rows.isEmpty()) return "";
-            return "\n" + bold(h, "Global Options:") + "\n\n" + twoColumns(rows, sharedFirstColWidth(h));
-        });
+        sections.put(SECTION_KEY_OPTION_LIST,    h -> headedSection(h, "Options:",        ownOptionRows(h),    sharedFirstColWidth(h)));
+        sections.put(SECTION_KEY_COMMAND_LIST,   h -> headedSection(h, "Commands:",       renderCommandList(h)));
+        sections.put(SECTION_KEY_PARAMETER_LIST, h -> headedSection(h, "Arguments:",      renderParameterList(h)));
+        sections.put("globalOptionList",         h -> headedSection(h, "Global Options:", globalOptionRows(h), sharedFirstColWidth(h)));
 
         List<String> keys = new ArrayList<>(usage.sectionKeys());
         int idx = keys.indexOf(SECTION_KEY_OPTION_LIST);
@@ -96,22 +83,49 @@ public final class DatashareHelpFactory {
     }
 
     static String renderOptionList(CommandLine.Help help) {
-        // Parent commands (with subcommands) show only the command list, not inherited options
-        if (!help.commandSpec().subcommands().isEmpty()) return "";
-        // Exclude scope=INHERIT options: they are already shown by renderGlobalOptionList
-        List<OptionSpec> ownOptions = help.commandSpec().options().stream()
-                .filter(o -> !o.inherited())
-                .collect(Collectors.toList());
-        List<String[]> rows = optionRows(ownOptions);
-        return rows.isEmpty() ? "" : twoColumns(rows);
+        List<String[]> rows = ownOptionRows(help);
+        if (rows.isEmpty()) {
+            return "";
+        }
+        return twoColumns(rows);
     }
 
     static String renderGlobalOptionList(CommandLine.Help help) {
-        // Only show on leaf subcommands (not root, not intermediate commands with subcommands)
-        if (help.commandSpec().parent() == null) return "";
-        if (!help.commandSpec().subcommands().isEmpty()) return "";
-        List<String[]> rows = optionRows(help.commandSpec().root().options());
-        return rows.isEmpty() ? "" : twoColumns(rows);
+        List<String[]> rows = globalOptionRows(help);
+        if (rows.isEmpty()) {
+            return "";
+        }
+        return twoColumns(rows);
+    }
+
+    private static List<String[]> ownOptionRows(CommandLine.Help help) {
+        if (!help.commandSpec().subcommands().isEmpty()) {
+            return List.of();
+        }
+        return optionRows(help.commandSpec().options().stream()
+                .filter(o -> !o.inherited())
+                .collect(Collectors.toList()));
+    }
+
+    private static List<String[]> globalOptionRows(CommandLine.Help help) {
+        if (help.commandSpec().parent() == null || !help.commandSpec().subcommands().isEmpty()) {
+            return List.of();
+        }
+        return optionRows(help.commandSpec().root().options());
+    }
+
+    private static String headedSection(CommandLine.Help h, String heading, String body) {
+        if (body.isEmpty()) {
+            return "";
+        }
+        return String.format("%n%s%n%n%s", bold(h, heading), body);
+    }
+
+    private static String headedSection(CommandLine.Help h, String heading, List<String[]> rows, int firstColWidth) {
+        if (rows.isEmpty()) {
+            return "";
+        }
+        return String.format("%n%s%n%n%s", bold(h, heading), twoColumns(rows, firstColWidth));
     }
 
     /** Filters, sorts, and maps a list of option specs to two-column row pairs. */
@@ -139,8 +153,9 @@ public final class DatashareHelpFactory {
 
     static String renderCommandList(CommandLine.Help help) {
         Map<String, CommandLine> subs = help.commandSpec().subcommands();
-        if (subs.isEmpty()) return "";
-
+        if (subs.isEmpty()) {
+            return "";
+        }
         List<String[]> rows = subs.entrySet().stream()
                 .map(e -> new String[]{ e.getKey(),
                         firstLine(e.getValue().getCommandSpec().usageMessage().description()) })
@@ -152,8 +167,9 @@ public final class DatashareHelpFactory {
         List<PositionalParamSpec> params = help.commandSpec().positionalParameters().stream()
                 .filter(p -> !p.hidden())
                 .collect(Collectors.toList());
-        if (params.isEmpty()) return "";
-
+        if (params.isEmpty()) {
+            return "";
+        }
         List<String[]> rows = params.stream()
                 .map(p -> new String[]{ p.paramLabel(), firstLine(p.description()) })
                 .collect(Collectors.toList());
@@ -167,7 +183,9 @@ public final class DatashareHelpFactory {
      */
     static String renderDescription(CommandLine.Help help) {
         String[] desc = help.commandSpec().usageMessage().description();
-        if (desc == null || desc.length == 0) return "";
+        if (desc == null || desc.length == 0) {
+            return "";
+        }
         StringBuilder sb = new StringBuilder("\n");
         for (String line : desc) {
             if (!line.isEmpty() && !Character.isWhitespace(line.charAt(0)) && line.endsWith(":")) {
@@ -243,17 +261,27 @@ public final class DatashareHelpFactory {
                 .replaceFirst("^-+", "")
                 .toLowerCase();
 
-        if (name.endsWith("url") || name.endsWith("address") || name.endsWith("uri")) return "<url>";
-        if (name.endsWith("dir") || name.endsWith("path") || name.endsWith("settings")) return "<path>";
-        if (name.endsWith("host") || name.equals("bind")) return "<host>";
-        if (name.endsWith("provider") || name.endsWith("filter")) return "<class>";
+        if (name.endsWith("url") || name.endsWith("address") || name.endsWith("uri")) {
+            return "<url>";
+        }
+        if (name.endsWith("dir") || name.endsWith("path") || name.endsWith("settings")) {
+            return "<path>";
+        }
+        if (name.endsWith("host") || name.equals("bind")) {
+            return "<host>";
+        }
+        if (name.endsWith("provider") || name.endsWith("filter")) {
+            return "<class>";
+        }
 
         return "<value>";
     }
 
     /** Returns the first non-blank description line, or empty string. */
     private static String firstLine(String[] lines) {
-        if (lines == null || lines.length == 0) return "";
+        if (lines == null || lines.length == 0) {
+            return "";
+        }
         return lines[0];
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
@@ -71,4 +71,38 @@ public final class DatashareOptions {
             props.setProperty(key, value);
         }
     }
+
+    static <E extends Enum<E>> void putIfNotNull(Properties props, String key, E value) {
+        if (value != null) {
+            props.setProperty(key, value.name());
+        }
+    }
+
+    static void putIfNotNull(Properties props, String key, Object value) {
+        if (value != null) {
+            props.setProperty(key, String.valueOf(value));
+        }
+    }
+
+    static void put(Properties props, String key, Object value) {
+        props.setProperty(key, String.valueOf(value));
+    }
+
+    static void putAll(Properties props, Properties source) {
+        if (source != null) {
+            props.putAll(source);
+        }
+    }
+
+    static void putIfTrue(Properties props, String key, boolean value) {
+        if (value) {
+            props.setProperty(key, "true");
+        }
+    }
+
+    static void putAll(Properties props, DatashareSubcommand subcommand) {
+        if (subcommand != null) {
+            props.putAll(subcommand.getSubcommandProperties());
+        }
+    }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
@@ -1,0 +1,51 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.user.User;
+
+import java.util.Properties;
+
+import static java.util.Optional.ofNullable;
+import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.PropertiesProvider.DIGEST_PROJECT_NAME_OPT;
+
+/**
+ * Static utility for post-processing picocli-collected properties.
+ * Handles digest project name defaulting, OAuth system property, and option alias resolution.
+ */
+public final class DatashareOptions {
+
+    private DatashareOptions() {}
+
+    /**
+     * Post-process properties to apply digest project name defaulting,
+     * alias mapping, and system property settings.
+     */
+    public static void postProcess(Properties props) {
+        // digestProjectName defaulting (same logic as DatashareCli.parseArguments)
+        if (!Boolean.parseBoolean(props.getProperty("noDigestProject"))
+                && props.getProperty(DIGEST_PROJECT_NAME_OPT) == null) {
+            String defaultDigestProjectName = ofNullable(props.getProperty(DEFAULT_PROJECT_OPT))
+                    .filter(s -> !s.isEmpty())
+                    .orElse("local-datashare");
+            props.setProperty(DIGEST_PROJECT_NAME_OPT, defaultDigestProjectName);
+        }
+
+        // oauthUserProjectsAttribute system property
+        String projectsAttr = props.getProperty("oauthUserProjectsAttribute");
+        if (projectsAttr != null && !User.DEFAULT_PROJECTS_KEY.equals(projectsAttr)) {
+            System.setProperty(User.JVM_PROJECT_KEY, projectsAttr);
+        }
+
+        // Alias mapping (port -> tcpListenPort)
+        if (props.containsKey("port")) {
+            props.setProperty("tcpListenPort", props.getProperty("port"));
+            props.remove("port");
+        }
+    }
+
+    static void putIfNotNull(Properties props, String key, String value) {
+        if (value != null) {
+            props.setProperty(key, value);
+        }
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
@@ -57,8 +57,10 @@ public final class DatashareOptions {
             props.setProperty(DIGEST_PROJECT_NAME_OPT, digestProjectName);
         }
 
-        // Propagate a custom OAuth projects attribute to a JVM system property
-        // so the User class can read it at runtime without accessing properties.
+        // The User class reads the projects key from a JVM system property
+        // (System.getProperty) rather than from the Properties map. This bridges
+        // the two: without it, User.getDefaultProjectsKey() would always fall
+        // back to the hardcoded default "groups_by_applications.datashare".
         String projectsAttribute = props.getProperty(OAUTH_USER_PROJECTS_KEY_OPT);
         boolean hasCustomProjectsAttribute = projectsAttribute != null
                 && !User.DEFAULT_PROJECTS_KEY.equals(projectsAttribute);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
@@ -7,6 +7,10 @@ import java.util.Properties;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.PropertiesProvider.DIGEST_PROJECT_NAME_OPT;
+import static org.icij.datashare.PropertiesProvider.TCP_LISTEN_PORT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.NO_DIGEST_PROJECT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.OAUTH_USER_PROJECTS_KEY_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.PORT_OPT;
 
 /**
  * Static utility for post-processing picocli-collected properties.
@@ -22,7 +26,7 @@ public final class DatashareOptions {
      */
     public static void postProcess(Properties props) {
         // digestProjectName defaulting (same logic as DatashareCli.parseArguments)
-        if (!Boolean.parseBoolean(props.getProperty("noDigestProject"))
+        if (!Boolean.parseBoolean(props.getProperty(NO_DIGEST_PROJECT_OPT))
                 && props.getProperty(DIGEST_PROJECT_NAME_OPT) == null) {
             String defaultDigestProjectName = ofNullable(props.getProperty(DEFAULT_PROJECT_OPT))
                     .filter(s -> !s.isEmpty())
@@ -31,15 +35,15 @@ public final class DatashareOptions {
         }
 
         // oauthUserProjectsAttribute system property
-        String projectsAttr = props.getProperty("oauthUserProjectsAttribute");
+        String projectsAttr = props.getProperty(OAUTH_USER_PROJECTS_KEY_OPT);
         if (projectsAttr != null && !User.DEFAULT_PROJECTS_KEY.equals(projectsAttr)) {
             System.setProperty(User.JVM_PROJECT_KEY, projectsAttr);
         }
 
         // Alias mapping (port -> tcpListenPort)
-        if (props.containsKey("port")) {
-            props.setProperty("tcpListenPort", props.getProperty("port"));
-            props.remove("port");
+        if (props.containsKey(PORT_OPT)) {
+            props.setProperty(TCP_LISTEN_PORT_OPT, props.getProperty(PORT_OPT));
+            props.remove(PORT_OPT);
         }
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
@@ -13,19 +13,40 @@ import static org.icij.datashare.cli.DatashareCliOptions.OAUTH_USER_PROJECTS_KEY
 import static org.icij.datashare.cli.DatashareCliOptions.PORT_OPT;
 
 /**
- * Static utility for post-processing picocli-collected properties.
- * Handles digest project name defaulting, OAuth system property, and option alias resolution.
+ * Applies transformations to the properties collected by picocli before they
+ * reach the application layer. This mirrors the equivalent logic in the legacy
+ * DatashareCli.parseArguments path so that both invocation styles produce
+ * identical properties for downstream consumers.
+ *
+ * Called once by DatashareCommand.collectProperties() after merging global
+ * and subcommand properties.
  */
 public final class DatashareOptions {
 
     private DatashareOptions() {}
 
     /**
-     * Post-process properties to apply digest project name defaulting,
-     * alias mapping, and system property settings.
+     * Normalizes the raw picocli properties so the application layer receives
+     * a consistent set of key/value pairs regardless of which CLI path was used.
+     *
+     * Three transformations are applied in order:
+     *
+     * 1. Digest project name defaulting — when the user has not explicitly
+     *    disabled digest-project (--noDigestProject) and has not set a custom
+     *    digest project name, the default project name is copied into
+     *    digestProjectName. This ensures document hashes are project-scoped
+     *    by default.
+     *
+     * 2. OAuth system property propagation — if the user overrides
+     *    --oauthUserProjectsAttribute, the value is also set as the JVM
+     *    system property so that the User class can read it at runtime
+     *    without accessing the properties directly.
+     *
+     * 3. Port alias resolution — the legacy CLI accepted --port which the
+     *    application layer expects as tcpListenPort. This renames the key
+     *    so downstream code does not need to know about the alias.
      */
     public static void postProcess(Properties props) {
-        // digestProjectName defaulting (same logic as DatashareCli.parseArguments)
         if (!Boolean.parseBoolean(props.getProperty(NO_DIGEST_PROJECT_OPT))
                 && props.getProperty(DIGEST_PROJECT_NAME_OPT) == null) {
             String defaultDigestProjectName = ofNullable(props.getProperty(DEFAULT_PROJECT_OPT))
@@ -34,13 +55,11 @@ public final class DatashareOptions {
             props.setProperty(DIGEST_PROJECT_NAME_OPT, defaultDigestProjectName);
         }
 
-        // oauthUserProjectsAttribute system property
         String projectsAttr = props.getProperty(OAUTH_USER_PROJECTS_KEY_OPT);
         if (projectsAttr != null && !User.DEFAULT_PROJECTS_KEY.equals(projectsAttr)) {
             System.setProperty(User.JVM_PROJECT_KEY, projectsAttr);
         }
 
-        // Alias mapping (port -> tcpListenPort)
         if (props.containsKey(PORT_OPT)) {
             props.setProperty(TCP_LISTEN_PORT_OPT, props.getProperty(PORT_OPT));
             props.remove(PORT_OPT);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareOptions.java
@@ -4,7 +4,6 @@ import org.icij.datashare.user.User;
 
 import java.util.Properties;
 
-import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.PropertiesProvider.DIGEST_PROJECT_NAME_OPT;
 import static org.icij.datashare.PropertiesProvider.TCP_LISTEN_PORT_OPT;
@@ -47,19 +46,28 @@ public final class DatashareOptions {
      *    so downstream code does not need to know about the alias.
      */
     public static void postProcess(Properties props) {
-        if (!Boolean.parseBoolean(props.getProperty(NO_DIGEST_PROJECT_OPT))
-                && props.getProperty(DIGEST_PROJECT_NAME_OPT) == null) {
-            String defaultDigestProjectName = ofNullable(props.getProperty(DEFAULT_PROJECT_OPT))
-                    .filter(s -> !s.isEmpty())
-                    .orElse("local-datashare");
-            props.setProperty(DIGEST_PROJECT_NAME_OPT, defaultDigestProjectName);
+        // Default the digest project name to the current project so document
+        // hashes are project-scoped, unless the user explicitly disabled it.
+        boolean isDigestProjectDisabled = Boolean.parseBoolean(props.getProperty(NO_DIGEST_PROJECT_OPT));
+        boolean hasDigestProjectName = props.getProperty(DIGEST_PROJECT_NAME_OPT) != null;
+        if (!isDigestProjectDisabled && !hasDigestProjectName) {
+            String projectName = props.getProperty(DEFAULT_PROJECT_OPT);
+            boolean hasProjectName = projectName != null && !projectName.isEmpty();
+            String digestProjectName = hasProjectName ? projectName : "local-datashare";
+            props.setProperty(DIGEST_PROJECT_NAME_OPT, digestProjectName);
         }
 
-        String projectsAttr = props.getProperty(OAUTH_USER_PROJECTS_KEY_OPT);
-        if (projectsAttr != null && !User.DEFAULT_PROJECTS_KEY.equals(projectsAttr)) {
-            System.setProperty(User.JVM_PROJECT_KEY, projectsAttr);
+        // Propagate a custom OAuth projects attribute to a JVM system property
+        // so the User class can read it at runtime without accessing properties.
+        String projectsAttribute = props.getProperty(OAUTH_USER_PROJECTS_KEY_OPT);
+        boolean hasCustomProjectsAttribute = projectsAttribute != null
+                && !User.DEFAULT_PROJECTS_KEY.equals(projectsAttribute);
+        if (hasCustomProjectsAttribute) {
+            System.setProperty(User.JVM_PROJECT_KEY, projectsAttribute);
         }
 
+        // Resolve the legacy --port alias to the canonical tcpListenPort key
+        // so downstream code only needs to look up one property name.
         if (props.containsKey(PORT_OPT)) {
             props.setProperty(TCP_LISTEN_PORT_OPT, props.getProperty(PORT_OPT));
             props.remove(PORT_OPT);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareSubcommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareSubcommand.java
@@ -1,0 +1,12 @@
+package org.icij.datashare.cli.command;
+
+import java.util.Properties;
+
+/**
+ * Interface for picocli subcommands that produce properties
+ * to be consumed by the rest of the Datashare application.
+ */
+public interface DatashareSubcommand {
+    /** Returns the properties contributed by this subcommand to be merged into the global properties. */
+    Properties getSubcommandProperties();
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareVersionProvider.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareVersionProvider.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 public class DatashareVersionProvider implements CommandLine.IVersionProvider {
-    /** Returns a single-element array containing {@code "datashare <version>"}, read from {@code /git.properties}. */
+    /** Returns a single-element array containing "datashare <version>", read from /git.properties. */
     @Override
     public String[] getVersion() throws Exception {
         Properties versions = new Properties();

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareVersionProvider.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareVersionProvider.java
@@ -1,0 +1,21 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+public class DatashareVersionProvider implements CommandLine.IVersionProvider {
+    /** Returns a single-element array containing {@code "datashare <version>"}, read from {@code /git.properties}. */
+    @Override
+    public String[] getVersion() throws Exception {
+        Properties versions = new Properties();
+        try (InputStream gitProperties = getClass().getResourceAsStream("/git.properties")) {
+            if (gitProperties != null) {
+                versions.load(gitProperties);
+            }
+        }
+        String version = versions.getProperty("git.build.version", "unknown");
+        return new String[]{"datashare " + version};
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionCommand.java
@@ -1,0 +1,20 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Spec;
+
+@Command(name = "extension", mixinStandardHelpOptions = true,
+        description = "Manage Datashare extensions.",
+        subcommands = {ExtensionListCommand.class, ExtensionInstallCommand.class, ExtensionDeleteCommand.class})
+public class ExtensionCommand implements Runnable {
+
+    @Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public void run() {
+        // No subcommand specified: print usage and exit 0 so the user knows what subcommands are available.
+        spec.commandLine().usage(System.out);
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionDeleteCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionDeleteCommand.java
@@ -1,0 +1,35 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.EXTENSION_DELETE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "delete", mixinStandardHelpOptions = true, description = {
+        "Delete an installed extension by id or directory path.",
+        "",
+        "Examples:",
+        "  datashare extension delete datashare-extension-neo4j",
+        "  datashare --extensionsDir /opt/datashare/extensions extension delete datashare-extension-neo4j"
+})
+public class ExtensionDeleteCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Extension id or base directory")
+    String extensionId;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(EXTENSION_DELETE_OPT, extensionId);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionDeleteCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionDeleteCommand.java
@@ -28,8 +28,8 @@ public class ExtensionDeleteCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(EXTENSION_DELETE_OPT, extensionId);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, EXTENSION_DELETE_OPT, extensionId);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionInstallCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionInstallCommand.java
@@ -29,8 +29,8 @@ public class ExtensionInstallCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(EXTENSION_INSTALL_OPT, extensionId);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, EXTENSION_INSTALL_OPT, extensionId);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionInstallCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionInstallCommand.java
@@ -1,0 +1,36 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.EXTENSION_INSTALL_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "install", mixinStandardHelpOptions = true, description = {
+        "Install an extension by id, URL, or local file path.",
+        "",
+        "Examples:",
+        "  datashare extension install datashare-extension-neo4j",
+        "  datashare extension install https://example.com/myext.jar",
+        "  datashare --extensionsDir /opt/datashare/extensions extension install datashare-extension-neo4j"
+})
+public class ExtensionInstallCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Extension id, URL, or file path")
+    String extensionId;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(EXTENSION_INSTALL_OPT, extensionId);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionListCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionListCommand.java
@@ -29,8 +29,8 @@ public class ExtensionListCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(EXTENSION_LIST_OPT, filter);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, EXTENSION_LIST_OPT, filter);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionListCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ExtensionListCommand.java
@@ -1,0 +1,36 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.EXTENSION_LIST_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "list", mixinStandardHelpOptions = true, description = {
+        "List available extensions from the registry.",
+        "",
+        "Examples:",
+        "  datashare extension list",
+        "  datashare extension list nlp"
+})
+public class ExtensionListCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", arity = "0..1", defaultValue = "true",
+            description = "Optional filter pattern")
+    String filter;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(EXTENSION_LIST_OPT, filter);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
@@ -1,0 +1,151 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.EnvUtils;
+import picocli.CommandLine.Option;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import static org.icij.datashare.PropertiesProvider.DATA_DIR_OPT;
+import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.PropertiesProvider.DIGEST_PROJECT_NAME_OPT;
+import static org.icij.datashare.PropertiesProvider.EXTENSIONS_DIR_OPT;
+import static org.icij.datashare.PropertiesProvider.PLUGINS_DIR_OPT;
+import static org.icij.datashare.PropertiesProvider.QUEUE_NAME_OPT;
+import static org.icij.datashare.PropertiesProvider.SETTINGS_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.*;
+
+/**
+ * Global options defined on the root command.
+ * They must be specified before the subcommand name, e.g.:
+ *   datashare --elasticsearchAddress http://... app start
+ *
+ * They are NOT inherited into subcommands so that subcommand help pages
+ * only show options that are relevant to that specific command.
+ */
+public class GlobalOptions {
+
+    private static String home() { return System.getProperty("user.home", ""); }
+
+    @Option(names = {"-s", "--settings"}, description = "Property settings file")
+    String settings;
+
+    @Option(names = {"--logLevel"}, description = "Log level", defaultValue = "INFO")
+    String logLevel;
+
+    @Option(names = {"--charset"}, description = "Datashare default charset")
+    String charset = Charset.defaultCharset().toString();
+
+    @Option(names = {"-P", "--defaultProject"}, description = "Default project name", defaultValue = "local-datashare")
+    String defaultProject;
+
+    @Option(names = {"--digestAlgorithm"}, description = "Digest algorithm", defaultValue = "SHA_384")
+    String digestAlgorithm;
+
+    @Option(names = {"--digestProjectName"}, description = "Include project name in document hash")
+    String digestProjectName;
+
+    @Option(names = {"--noDigestProject"}, description = "Disable project name in document hash", defaultValue = "false")
+    boolean noDigestProject;
+
+    @Option(names = {"--elasticsearchAddress"}, description = "Elasticsearch host address")
+    String elasticsearchAddress = EnvUtils.resolveUri("elasticsearch", "http://elasticsearch:9200");
+
+    @Option(names = {"--elasticsearchPath"}, description = "Path for launching Elasticsearch")
+    String elasticsearchPath = Paths.get(home(), ".local/share/datashare", "elasticsearch").toString();
+
+    @Option(names = {"--elasticsearchDataPath"}, description = "Data path for embedded Elasticsearch")
+    String elasticsearchDataPath = Paths.get(home(), ".local/share/datashare", "es").toString();
+
+    @Option(names = {"--elasticsearchSettings"}, description = "Path to elasticsearch.yml settings")
+    String elasticsearchSettings = Paths.get(home(), ".local/share/datashare", "elasticsearch.yml").toString();
+
+    @Option(names = {"--redisAddress"}, description = "Redis address")
+    String redisAddress = EnvUtils.resolveUri("redis", "redis://redis:6379");
+
+    @Option(names = {"--redisPoolSize"}, description = "Redis pool size", defaultValue = "5")
+    int redisPoolSize;
+
+    @Option(names = {"--messageBusAddress"}, description = "Message bus address")
+    String messageBusAddress = EnvUtils.resolveUri("redis", "redis://redis:6379");
+
+    @Option(names = {"--busType"}, description = "Backend data bus type", defaultValue = "MEMORY")
+    String busType;
+
+    @Option(names = {"--queueName"}, description = "Extract queue name", defaultValue = "extract:queue")
+    String queueName;
+
+    @Option(names = {"--queueType"}, description = "Backend queues type", defaultValue = "MEMORY")
+    String queueType;
+
+    @Option(names = {"--queueCapacity"}, description = "Queue capacity", defaultValue = "1000000")
+    int queueCapacity;
+
+    @Option(names = {"--dataSourceUrl"}, description = "Datasource URL")
+    String dataSourceUrl = "jdbc:sqlite:file:" + Paths.get(home(), ".local/share/datashare", "dist/datashare.db");
+
+    @Option(names = {"--clusterName"}, description = "Cluster name", defaultValue = "datashare")
+    String clusterName;
+
+    @Option(names = {"--pluginsDir"}, description = "Plugins directory")
+    String pluginsDir = Paths.get(home(), ".local/share/datashare", "plugins").toString();
+
+    @Option(names = {"--extensionsDir"}, description = "Extensions directory")
+    String extensionsDir = Paths.get(home(), ".local/share/datashare", "extensions").toString();
+
+    @Option(names = {"-u", "--defaultUserName"}, description = "Default local user name", defaultValue = "local")
+    String defaultUserName;
+
+    @Option(names = {"--oauthUserProjectsAttribute"}, description = "OAuth user projects key", defaultValue = "groups_by_applications.datashare")
+    String oauthUserProjectsAttribute;
+
+    @Option(names = {"--ext"}, description = "Run CLI extension")
+    String ext;
+
+    @Option(names = {"-d", "--dataDir"}, description = "Document source files directory")
+    File dataDir = new File(Paths.get(home(), "Datashare").toString());
+
+    @Option(names = {"-l", "--language"}, description = "Indexing language")
+    String language;
+
+    @Option(names = {"--no-color"}, description = "Disable ANSI color output", defaultValue = "false")
+    boolean noColor;
+
+    /** Converts the parsed global option fields into a Properties map for the rest of the application. */
+    public Properties toProperties() {
+        Properties props = new Properties();
+
+        DatashareOptions.putIfNotNull(props, SETTINGS_OPT, settings);
+        DatashareOptions.putIfNotNull(props, LOG_LEVEL_OPT, logLevel);
+        DatashareOptions.putIfNotNull(props, CHARSET_OPT, charset);
+        DatashareOptions.putIfNotNull(props, DEFAULT_PROJECT_OPT, defaultProject);
+        DatashareOptions.putIfNotNull(props, DIGEST_ALGORITHM_OPT, digestAlgorithm);
+        DatashareOptions.putIfNotNull(props, DIGEST_PROJECT_NAME_OPT, digestProjectName);
+        props.setProperty(NO_DIGEST_PROJECT_OPT, String.valueOf(noDigestProject));
+        DatashareOptions.putIfNotNull(props, ELASTICSEARCH_ADDRESS_OPT, elasticsearchAddress);
+        DatashareOptions.putIfNotNull(props, ELASTICSEARCH_PATH_OPT, elasticsearchPath);
+        DatashareOptions.putIfNotNull(props, ELASTICSEARCH_DATA_PATH_OPT, elasticsearchDataPath);
+        DatashareOptions.putIfNotNull(props, ELASTICSEARCH_SETTINGS_OPT, elasticsearchSettings);
+        DatashareOptions.putIfNotNull(props, REDIS_ADDRESS_OPT, redisAddress);
+        props.setProperty(REDIS_POOL_SIZE_OPT, String.valueOf(redisPoolSize));
+        DatashareOptions.putIfNotNull(props, MESSAGE_BUS_OPT, messageBusAddress);
+        DatashareOptions.putIfNotNull(props, BUS_TYPE_OPT, busType);
+        DatashareOptions.putIfNotNull(props, QUEUE_NAME_OPT, queueName);
+        DatashareOptions.putIfNotNull(props, QUEUE_TYPE_OPT, queueType);
+        props.setProperty(QUEUE_CAPACITY_OPT, String.valueOf(queueCapacity));
+        DatashareOptions.putIfNotNull(props, DATA_SOURCE_URL_OPT, dataSourceUrl);
+        DatashareOptions.putIfNotNull(props, CLUSTER_NAME_OPT, clusterName);
+        DatashareOptions.putIfNotNull(props, PLUGINS_DIR_OPT, pluginsDir);
+        DatashareOptions.putIfNotNull(props, EXTENSIONS_DIR_OPT, extensionsDir);
+        DatashareOptions.putIfNotNull(props, DEFAULT_USER_NAME_OPT, defaultUserName);
+        DatashareOptions.putIfNotNull(props, OAUTH_USER_PROJECTS_KEY_OPT, oauthUserProjectsAttribute);
+        DatashareOptions.putIfNotNull(props, EXT_OPT, ext);
+        if (dataDir != null) props.setProperty(DATA_DIR_OPT, dataDir.toString());
+        DatashareOptions.putIfNotNull(props, LANGUAGE_OPT, language);
+
+        return props;
+    }
+
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
@@ -19,12 +19,13 @@ import static org.icij.datashare.PropertiesProvider.SETTINGS_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
 
 /**
- * Global options defined on the root command.
- * They must be specified before the subcommand name, e.g.:
+ * Global options available on all commands. Thanks to scope = ScopeType.INHERIT they can
+ * appear anywhere on the command line, before or after the subcommand name, e.g.:
  *   datashare --elasticsearchAddress http://... app start
+ *   datashare app start --elasticsearchAddress http://...
  *
- * They are NOT inherited into subcommands so that subcommand help pages
- * only show options that are relevant to that specific command.
+ * They are shown on the root command help page and in a dedicated "global options" section
+ * on each leaf subcommand help page, separate from the subcommand-specific options.
  */
 public class GlobalOptions {
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
@@ -31,7 +31,9 @@ import static org.icij.datashare.cli.DatashareCliOptions.*;
  */
 public class GlobalOptions {
 
-    private static String home() { return System.getProperty("user.home", ""); }
+    private static String userHome() {
+        return System.getProperty("user.home", "");
+    }
 
     @Option(names = {"-s", "--settings"}, description = "Property settings file", scope = ScopeType.INHERIT)
     String settings;
@@ -58,13 +60,13 @@ public class GlobalOptions {
     String elasticsearchAddress = EnvUtils.resolveUri("elasticsearch", "http://elasticsearch:9200");
 
     @Option(names = {"--elasticsearchPath"}, description = "Path for launching Elasticsearch", scope = ScopeType.INHERIT)
-    String elasticsearchPath = Paths.get(home(), ".local/share/datashare", "elasticsearch").toString();
+    String elasticsearchPath = Paths.get(userHome(), ".local/share/datashare", "elasticsearch").toString();
 
     @Option(names = {"--elasticsearchDataPath"}, description = "Data path for embedded Elasticsearch", scope = ScopeType.INHERIT)
-    String elasticsearchDataPath = Paths.get(home(), ".local/share/datashare", "es").toString();
+    String elasticsearchDataPath = Paths.get(userHome(), ".local/share/datashare", "es").toString();
 
     @Option(names = {"--elasticsearchSettings"}, description = "Path to elasticsearch.yml settings", scope = ScopeType.INHERIT)
-    String elasticsearchSettings = Paths.get(home(), ".local/share/datashare", "elasticsearch.yml").toString();
+    String elasticsearchSettings = Paths.get(userHome(), ".local/share/datashare", "elasticsearch.yml").toString();
 
     @Option(names = {"--redisAddress"}, description = "Redis address", scope = ScopeType.INHERIT)
     String redisAddress = EnvUtils.resolveUri("redis", "redis://redis:6379");
@@ -88,16 +90,16 @@ public class GlobalOptions {
     int queueCapacity;
 
     @Option(names = {"--dataSourceUrl"}, description = "Datasource URL", scope = ScopeType.INHERIT)
-    String dataSourceUrl = "jdbc:sqlite:file:" + Paths.get(home(), ".local/share/datashare", "dist/datashare.db");
+    String dataSourceUrl = "jdbc:sqlite:file:" + Paths.get(userHome(), ".local/share/datashare", "dist/datashare.db");
 
     @Option(names = {"--clusterName"}, description = "Cluster name", defaultValue = "datashare", scope = ScopeType.INHERIT)
     String clusterName;
 
     @Option(names = {"--pluginsDir"}, description = "Plugins directory", scope = ScopeType.INHERIT)
-    String pluginsDir = Paths.get(home(), ".local/share/datashare", "plugins").toString();
+    String pluginsDir = Paths.get(userHome(), ".local/share/datashare", "plugins").toString();
 
     @Option(names = {"--extensionsDir"}, description = "Extensions directory", scope = ScopeType.INHERIT)
-    String extensionsDir = Paths.get(home(), ".local/share/datashare", "extensions").toString();
+    String extensionsDir = Paths.get(userHome(), ".local/share/datashare", "extensions").toString();
 
     @Option(names = {"-u", "--defaultUserName"}, description = "Default local user name", defaultValue = "local", scope = ScopeType.INHERIT)
     String defaultUserName;
@@ -109,7 +111,7 @@ public class GlobalOptions {
     String ext;
 
     @Option(names = {"-d", "--dataDir"}, description = "Document source files directory", scope = ScopeType.INHERIT)
-    File dataDir = new File(Paths.get(home(), "Datashare").toString());
+    File dataDir = new File(Paths.get(userHome(), "Datashare").toString());
 
     @Option(names = {"-l", "--language"}, description = "Indexing language", scope = ScopeType.INHERIT)
     String language;

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.cli.command;
 
 import org.icij.datashare.EnvUtils;
+import org.icij.datashare.cli.DigestAlgorithm;
+import org.icij.datashare.cli.QueueType;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ScopeType;
 
@@ -44,7 +46,7 @@ public class GlobalOptions {
     String defaultProject;
 
     @Option(names = {"--digestAlgorithm"}, description = "Digest algorithm", defaultValue = "SHA_384", scope = ScopeType.INHERIT)
-    String digestAlgorithm;
+    DigestAlgorithm digestAlgorithm;
 
     @Option(names = {"--digestProjectName"}, description = "Include project name in document hash", scope = ScopeType.INHERIT)
     String digestProjectName;
@@ -74,13 +76,13 @@ public class GlobalOptions {
     String messageBusAddress = EnvUtils.resolveUri("redis", "redis://redis:6379");
 
     @Option(names = {"--busType"}, description = "Backend data bus type", defaultValue = "MEMORY", scope = ScopeType.INHERIT)
-    String busType;
+    QueueType busType;
 
     @Option(names = {"--queueName"}, description = "Extract queue name", defaultValue = "extract:queue", scope = ScopeType.INHERIT)
     String queueName;
 
     @Option(names = {"--queueType"}, description = "Backend queues type", defaultValue = "MEMORY", scope = ScopeType.INHERIT)
-    String queueType;
+    QueueType queueType;
 
     @Option(names = {"--queueCapacity"}, description = "Queue capacity", defaultValue = "1000000", scope = ScopeType.INHERIT)
     int queueCapacity;
@@ -125,18 +127,18 @@ public class GlobalOptions {
         DatashareOptions.putIfNotNull(props, DEFAULT_PROJECT_OPT, defaultProject);
         DatashareOptions.putIfNotNull(props, DIGEST_ALGORITHM_OPT, digestAlgorithm);
         DatashareOptions.putIfNotNull(props, DIGEST_PROJECT_NAME_OPT, digestProjectName);
-        props.setProperty(NO_DIGEST_PROJECT_OPT, String.valueOf(noDigestProject));
+        DatashareOptions.put(props, NO_DIGEST_PROJECT_OPT, noDigestProject);
         DatashareOptions.putIfNotNull(props, ELASTICSEARCH_ADDRESS_OPT, elasticsearchAddress);
         DatashareOptions.putIfNotNull(props, ELASTICSEARCH_PATH_OPT, elasticsearchPath);
         DatashareOptions.putIfNotNull(props, ELASTICSEARCH_DATA_PATH_OPT, elasticsearchDataPath);
         DatashareOptions.putIfNotNull(props, ELASTICSEARCH_SETTINGS_OPT, elasticsearchSettings);
         DatashareOptions.putIfNotNull(props, REDIS_ADDRESS_OPT, redisAddress);
-        props.setProperty(REDIS_POOL_SIZE_OPT, String.valueOf(redisPoolSize));
+        DatashareOptions.put(props, REDIS_POOL_SIZE_OPT, redisPoolSize);
         DatashareOptions.putIfNotNull(props, MESSAGE_BUS_OPT, messageBusAddress);
         DatashareOptions.putIfNotNull(props, BUS_TYPE_OPT, busType);
         DatashareOptions.putIfNotNull(props, QUEUE_NAME_OPT, queueName);
         DatashareOptions.putIfNotNull(props, QUEUE_TYPE_OPT, queueType);
-        props.setProperty(QUEUE_CAPACITY_OPT, String.valueOf(queueCapacity));
+        DatashareOptions.put(props, QUEUE_CAPACITY_OPT, queueCapacity);
         DatashareOptions.putIfNotNull(props, DATA_SOURCE_URL_OPT, dataSourceUrl);
         DatashareOptions.putIfNotNull(props, CLUSTER_NAME_OPT, clusterName);
         DatashareOptions.putIfNotNull(props, PLUGINS_DIR_OPT, pluginsDir);
@@ -144,7 +146,7 @@ public class GlobalOptions {
         DatashareOptions.putIfNotNull(props, DEFAULT_USER_NAME_OPT, defaultUserName);
         DatashareOptions.putIfNotNull(props, OAUTH_USER_PROJECTS_KEY_OPT, oauthUserProjectsAttribute);
         DatashareOptions.putIfNotNull(props, EXT_OPT, ext);
-        if (dataDir != null) props.setProperty(DATA_DIR_OPT, dataDir.toString());
+        DatashareOptions.putIfNotNull(props, DATA_DIR_OPT, dataDir);
         DatashareOptions.putIfNotNull(props, LANGUAGE_OPT, language);
 
         return props;

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
@@ -2,6 +2,7 @@ package org.icij.datashare.cli.command;
 
 import org.icij.datashare.EnvUtils;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.ScopeType;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -29,88 +30,88 @@ public class GlobalOptions {
 
     private static String home() { return System.getProperty("user.home", ""); }
 
-    @Option(names = {"-s", "--settings"}, description = "Property settings file")
+    @Option(names = {"-s", "--settings"}, description = "Property settings file", scope = ScopeType.INHERIT)
     String settings;
 
-    @Option(names = {"--logLevel"}, description = "Log level", defaultValue = "INFO")
+    @Option(names = {"--logLevel"}, description = "Log level", defaultValue = "INFO", scope = ScopeType.INHERIT)
     String logLevel;
 
-    @Option(names = {"--charset"}, description = "Datashare default charset")
+    @Option(names = {"--charset"}, description = "Datashare default charset", scope = ScopeType.INHERIT)
     String charset = Charset.defaultCharset().toString();
 
-    @Option(names = {"-P", "--defaultProject"}, description = "Default project name", defaultValue = "local-datashare")
+    @Option(names = {"-P", "--defaultProject"}, description = "Default project name", defaultValue = "local-datashare", scope = ScopeType.INHERIT)
     String defaultProject;
 
-    @Option(names = {"--digestAlgorithm"}, description = "Digest algorithm", defaultValue = "SHA_384")
+    @Option(names = {"--digestAlgorithm"}, description = "Digest algorithm", defaultValue = "SHA_384", scope = ScopeType.INHERIT)
     String digestAlgorithm;
 
-    @Option(names = {"--digestProjectName"}, description = "Include project name in document hash")
+    @Option(names = {"--digestProjectName"}, description = "Include project name in document hash", scope = ScopeType.INHERIT)
     String digestProjectName;
 
-    @Option(names = {"--noDigestProject"}, description = "Disable project name in document hash", defaultValue = "false")
+    @Option(names = {"--noDigestProject"}, description = "Disable project name in document hash", defaultValue = "false", scope = ScopeType.INHERIT)
     boolean noDigestProject;
 
-    @Option(names = {"--elasticsearchAddress"}, description = "Elasticsearch host address")
+    @Option(names = {"--elasticsearchAddress"}, description = "Elasticsearch host address", scope = ScopeType.INHERIT)
     String elasticsearchAddress = EnvUtils.resolveUri("elasticsearch", "http://elasticsearch:9200");
 
-    @Option(names = {"--elasticsearchPath"}, description = "Path for launching Elasticsearch")
+    @Option(names = {"--elasticsearchPath"}, description = "Path for launching Elasticsearch", scope = ScopeType.INHERIT)
     String elasticsearchPath = Paths.get(home(), ".local/share/datashare", "elasticsearch").toString();
 
-    @Option(names = {"--elasticsearchDataPath"}, description = "Data path for embedded Elasticsearch")
+    @Option(names = {"--elasticsearchDataPath"}, description = "Data path for embedded Elasticsearch", scope = ScopeType.INHERIT)
     String elasticsearchDataPath = Paths.get(home(), ".local/share/datashare", "es").toString();
 
-    @Option(names = {"--elasticsearchSettings"}, description = "Path to elasticsearch.yml settings")
+    @Option(names = {"--elasticsearchSettings"}, description = "Path to elasticsearch.yml settings", scope = ScopeType.INHERIT)
     String elasticsearchSettings = Paths.get(home(), ".local/share/datashare", "elasticsearch.yml").toString();
 
-    @Option(names = {"--redisAddress"}, description = "Redis address")
+    @Option(names = {"--redisAddress"}, description = "Redis address", scope = ScopeType.INHERIT)
     String redisAddress = EnvUtils.resolveUri("redis", "redis://redis:6379");
 
-    @Option(names = {"--redisPoolSize"}, description = "Redis pool size", defaultValue = "5")
+    @Option(names = {"--redisPoolSize"}, description = "Redis pool size", defaultValue = "5", scope = ScopeType.INHERIT)
     int redisPoolSize;
 
-    @Option(names = {"--messageBusAddress"}, description = "Message bus address")
+    @Option(names = {"--messageBusAddress"}, description = "Message bus address", scope = ScopeType.INHERIT)
     String messageBusAddress = EnvUtils.resolveUri("redis", "redis://redis:6379");
 
-    @Option(names = {"--busType"}, description = "Backend data bus type", defaultValue = "MEMORY")
+    @Option(names = {"--busType"}, description = "Backend data bus type", defaultValue = "MEMORY", scope = ScopeType.INHERIT)
     String busType;
 
-    @Option(names = {"--queueName"}, description = "Extract queue name", defaultValue = "extract:queue")
+    @Option(names = {"--queueName"}, description = "Extract queue name", defaultValue = "extract:queue", scope = ScopeType.INHERIT)
     String queueName;
 
-    @Option(names = {"--queueType"}, description = "Backend queues type", defaultValue = "MEMORY")
+    @Option(names = {"--queueType"}, description = "Backend queues type", defaultValue = "MEMORY", scope = ScopeType.INHERIT)
     String queueType;
 
-    @Option(names = {"--queueCapacity"}, description = "Queue capacity", defaultValue = "1000000")
+    @Option(names = {"--queueCapacity"}, description = "Queue capacity", defaultValue = "1000000", scope = ScopeType.INHERIT)
     int queueCapacity;
 
-    @Option(names = {"--dataSourceUrl"}, description = "Datasource URL")
+    @Option(names = {"--dataSourceUrl"}, description = "Datasource URL", scope = ScopeType.INHERIT)
     String dataSourceUrl = "jdbc:sqlite:file:" + Paths.get(home(), ".local/share/datashare", "dist/datashare.db");
 
-    @Option(names = {"--clusterName"}, description = "Cluster name", defaultValue = "datashare")
+    @Option(names = {"--clusterName"}, description = "Cluster name", defaultValue = "datashare", scope = ScopeType.INHERIT)
     String clusterName;
 
-    @Option(names = {"--pluginsDir"}, description = "Plugins directory")
+    @Option(names = {"--pluginsDir"}, description = "Plugins directory", scope = ScopeType.INHERIT)
     String pluginsDir = Paths.get(home(), ".local/share/datashare", "plugins").toString();
 
-    @Option(names = {"--extensionsDir"}, description = "Extensions directory")
+    @Option(names = {"--extensionsDir"}, description = "Extensions directory", scope = ScopeType.INHERIT)
     String extensionsDir = Paths.get(home(), ".local/share/datashare", "extensions").toString();
 
-    @Option(names = {"-u", "--defaultUserName"}, description = "Default local user name", defaultValue = "local")
+    @Option(names = {"-u", "--defaultUserName"}, description = "Default local user name", defaultValue = "local", scope = ScopeType.INHERIT)
     String defaultUserName;
 
-    @Option(names = {"--oauthUserProjectsAttribute"}, description = "OAuth user projects key", defaultValue = "groups_by_applications.datashare")
+    @Option(names = {"--oauthUserProjectsAttribute"}, description = "OAuth user projects key", defaultValue = "groups_by_applications.datashare", scope = ScopeType.INHERIT)
     String oauthUserProjectsAttribute;
 
-    @Option(names = {"--ext"}, description = "Run CLI extension")
+    @Option(names = {"--ext"}, description = "Run CLI extension", scope = ScopeType.INHERIT)
     String ext;
 
-    @Option(names = {"-d", "--dataDir"}, description = "Document source files directory")
+    @Option(names = {"-d", "--dataDir"}, description = "Document source files directory", scope = ScopeType.INHERIT)
     File dataDir = new File(Paths.get(home(), "Datashare").toString());
 
-    @Option(names = {"-l", "--language"}, description = "Indexing language")
+    @Option(names = {"-l", "--language"}, description = "Indexing language", scope = ScopeType.INHERIT)
     String language;
 
-    @Option(names = {"--no-color"}, description = "Disable ANSI color output", defaultValue = "false")
+    @Option(names = {"--no-color"}, description = "Disable ANSI color output", defaultValue = "false", scope = ScopeType.INHERIT)
     boolean noColor;
 
     /** Converts the parsed global option fields into a Properties map for the rest of the application. */

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.cli.command;
 
 import org.icij.datashare.PipelineHelper;
+import org.icij.datashare.cli.OcrType;
 import org.icij.datashare.text.nlp.Pipeline;
 import picocli.CommandLine.Option;
 
@@ -33,7 +34,7 @@ public class PipelineOptions {
     boolean ocr;
 
     @Option(names = {"--ocrType"}, description = "OCR implementation: TESSERACT or TESS4J", defaultValue = "TESSERACT")
-    String ocrType;
+    OcrType ocrType;
 
     @Option(names = {"--ocrLanguage"}, description = "OCR languages for tesseract")
     String ocrLanguage;
@@ -63,19 +64,19 @@ public class PipelineOptions {
     public Properties toProperties() {
         Properties props = new Properties();
         DatashareOptions.putIfNotNull(props, ARTIFACT_DIR_OPT, artifactDir);
-        if (nlpPipeline != null) props.setProperty(NLP_PIPELINE_OPT, nlpPipeline.name());
-        props.setProperty(NLP_PARALLELISM_OPT, String.valueOf(nlpParallelism));
-        props.setProperty(NLP_BATCH_SIZE_OPT, String.valueOf(batchSize));
-        props.setProperty(NLP_MAX_TEXT_LENGTH_OPT, String.valueOf(maxTextLength));
-        props.setProperty(OCR_OPT, String.valueOf(ocr));
+        DatashareOptions.putIfNotNull(props, NLP_PIPELINE_OPT, nlpPipeline);
+        DatashareOptions.put(props, NLP_PARALLELISM_OPT, nlpParallelism);
+        DatashareOptions.put(props, NLP_BATCH_SIZE_OPT, batchSize);
+        DatashareOptions.put(props, NLP_MAX_TEXT_LENGTH_OPT, maxTextLength);
+        DatashareOptions.put(props, OCR_OPT, ocr);
         DatashareOptions.putIfNotNull(props, OCR_TYPE_OPT, ocrType);
         DatashareOptions.putIfNotNull(props, OCR_LANGUAGE_OPT, ocrLanguage);
-        if (parallelism != null) props.setProperty(PARALLELISM_OPT, String.valueOf(parallelism));
-        props.setProperty(PARSER_PARALLELISM_OPT, String.valueOf(parserParallelism));
-        if (resume) props.setProperty(RESUME_OPT, "true");
-        props.setProperty(FOLLOW_SYMLINKS_OPT, String.valueOf(followSymlinks));
+        DatashareOptions.putIfNotNull(props, PARALLELISM_OPT, parallelism);
+        DatashareOptions.put(props, PARSER_PARALLELISM_OPT, parserParallelism);
+        DatashareOptions.putIfTrue(props, RESUME_OPT, resume);
+        DatashareOptions.put(props, FOLLOW_SYMLINKS_OPT, followSymlinks);
         DatashareOptions.putIfNotNull(props, CREATE_INDEX_OPT, createIndex);
-        props.setProperty(INDEX_TIMEOUT_OPT, String.valueOf(indexTimeout));
+        DatashareOptions.put(props, INDEX_TIMEOUT_OPT, indexTimeout);
         DatashareOptions.putIfNotNull(props, SEARCH_QUERY_OPT, searchQuery);
         return props;
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -1,0 +1,83 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.PipelineHelper;
+import org.icij.datashare.text.nlp.Pipeline;
+import picocli.CommandLine.Option;
+
+import java.util.Properties;
+
+import static org.icij.datashare.PropertiesProvider.RESUME_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.*;
+
+/**
+ * Options specific to the stage run subcommand.
+ */
+public class PipelineOptions {
+
+    @Option(names = {"--artifactDir"}, description = "Artifact directory for embedded caching")
+    String artifactDir;
+
+    @Option(names = {"--nlpPipeline"}, description = "NLP pipeline to be run", defaultValue = "CORENLP")
+    Pipeline.Type nlpPipeline;
+
+    @Option(names = {"--nlpParallelism"}, description = "NLP extraction threads per pipeline", defaultValue = "1")
+    int nlpParallelism;
+
+    @Option(names = {"--batchSize"}, description = "Batch size of NLP extraction task", defaultValue = "1024")
+    int batchSize;
+
+    @Option(names = {"--maxTextLength"}, description = "Max text length for NLP", defaultValue = "1024")
+    int maxTextLength;
+
+    @Option(names = {"-o", "--ocr"}, description = "Enable OCR at file parsing time", defaultValue = "true")
+    boolean ocr;
+
+    @Option(names = {"--ocrType"}, description = "OCR implementation: TESSERACT or TESS4J", defaultValue = "TESSERACT")
+    String ocrType;
+
+    @Option(names = {"--ocrLanguage"}, description = "OCR languages for tesseract")
+    String ocrLanguage;
+
+    @Option(names = {"--parallelism"}, description = "Number of task management threads")
+    Integer parallelism;
+
+    @Option(names = {"--parserParallelism"}, description = "Number of file parser threads", defaultValue = "1")
+    int parserParallelism;
+
+    @Option(names = {"-r", "--resume"}, description = "Resume pending operations")
+    boolean resume;
+
+    @Option(names = {"--followSymlinks"}, description = "Follow symlinks while scanning", defaultValue = "true")
+    boolean followSymlinks;
+
+    @Option(names = {"--createIndex"}, description = "Create an index with the given name")
+    String createIndex;
+
+    @Option(names = {"--indexTimeout"}, description = "Index timeout in minutes", defaultValue = "30")
+    int indexTimeout;
+
+    @Option(names = {"--searchQuery"}, description = "JSON query for EnqueueFromIndex task")
+    String searchQuery;
+
+    /** Converts the parsed pipeline option fields into a Properties map for the rest of the application. */
+    public Properties toProperties() {
+        Properties props = new Properties();
+        DatashareOptions.putIfNotNull(props, ARTIFACT_DIR_OPT, artifactDir);
+        if (nlpPipeline != null) props.setProperty(NLP_PIPELINE_OPT, nlpPipeline.name());
+        props.setProperty(NLP_PARALLELISM_OPT, String.valueOf(nlpParallelism));
+        props.setProperty(NLP_BATCH_SIZE_OPT, String.valueOf(batchSize));
+        props.setProperty(NLP_MAX_TEXT_LENGTH_OPT, String.valueOf(maxTextLength));
+        props.setProperty(OCR_OPT, String.valueOf(ocr));
+        DatashareOptions.putIfNotNull(props, OCR_TYPE_OPT, ocrType);
+        DatashareOptions.putIfNotNull(props, OCR_LANGUAGE_OPT, ocrLanguage);
+        if (parallelism != null) props.setProperty(PARALLELISM_OPT, String.valueOf(parallelism));
+        props.setProperty(PARSER_PARALLELISM_OPT, String.valueOf(parserParallelism));
+        if (resume) props.setProperty(RESUME_OPT, "true");
+        props.setProperty(FOLLOW_SYMLINKS_OPT, String.valueOf(followSymlinks));
+        DatashareOptions.putIfNotNull(props, CREATE_INDEX_OPT, createIndex);
+        props.setProperty(INDEX_TIMEOUT_OPT, String.valueOf(indexTimeout));
+        DatashareOptions.putIfNotNull(props, SEARCH_QUERY_OPT, searchQuery);
+        return props;
+    }
+
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginCommand.java
@@ -1,0 +1,20 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Spec;
+
+@Command(name = "plugin", mixinStandardHelpOptions = true,
+        description = "Manage Datashare plugins.",
+        subcommands = {PluginListCommand.class, PluginInstallCommand.class, PluginDeleteCommand.class})
+public class PluginCommand implements Runnable {
+
+    @Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public void run() {
+        // No subcommand specified: print usage and exit 0 so the user knows what subcommands are available.
+        spec.commandLine().usage(System.out);
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginDeleteCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginDeleteCommand.java
@@ -1,0 +1,35 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.PLUGIN_DELETE_OPT;
+
+@Command(name = "delete", mixinStandardHelpOptions = true, description = {
+        "Delete an installed plugin by id or directory path.",
+        "",
+        "Examples:",
+        "  datashare plugin delete datashare-plugin-ner-corenlp",
+        "  datashare --pluginsDir /opt/datashare/plugins plugin delete datashare-plugin-ner-corenlp"
+})
+public class PluginDeleteCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Plugin id or base directory")
+    String pluginId;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(PLUGIN_DELETE_OPT, pluginId);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginDeleteCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginDeleteCommand.java
@@ -28,8 +28,8 @@ public class PluginDeleteCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(PLUGIN_DELETE_OPT, pluginId);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, PLUGIN_DELETE_OPT, pluginId);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginInstallCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginInstallCommand.java
@@ -1,0 +1,36 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.PLUGIN_INSTALL_OPT;
+
+@Command(name = "install", mixinStandardHelpOptions = true, description = {
+        "Install a plugin by id, URL, or local file path.",
+        "",
+        "Examples:",
+        "  datashare plugin install datashare-plugin-ner-corenlp",
+        "  datashare plugin install https://example.com/myplugin.jar",
+        "  datashare --pluginsDir /opt/datashare/plugins plugin install datashare-plugin-ner-corenlp"
+})
+public class PluginInstallCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Plugin id, URL, or file path")
+    String pluginId;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(PLUGIN_INSTALL_OPT, pluginId);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginInstallCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginInstallCommand.java
@@ -29,8 +29,8 @@ public class PluginInstallCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(PLUGIN_INSTALL_OPT, pluginId);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, PLUGIN_INSTALL_OPT, pluginId);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginListCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginListCommand.java
@@ -29,8 +29,8 @@ public class PluginListCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = new Properties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(PLUGIN_LIST_OPT, filter);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, PLUGIN_LIST_OPT, filter);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginListCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PluginListCommand.java
@@ -1,0 +1,36 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.PLUGIN_LIST_OPT;
+
+@Command(name = "list", mixinStandardHelpOptions = true, description = {
+        "List available plugins from the registry.",
+        "",
+        "Examples:",
+        "  datashare plugin list",
+        "  datashare plugin list ocr"
+})
+public class PluginListCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", arity = "0..1", defaultValue = "true",
+            description = "Optional filter pattern")
+    String filter;
+
+    @Override
+    public void run() {
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = new Properties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(PLUGIN_LIST_OPT, filter);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
@@ -1,0 +1,215 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import static org.icij.datashare.PropertiesProvider.REPORT_NAME_OPT;
+import static org.icij.datashare.PropertiesProvider.TCP_LISTEN_PORT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.*;
+
+/**
+ * Options specific to the app start subcommand.
+ */
+public class ServerOptions {
+
+    private static String home() { return System.getProperty("user.home", ""); }
+
+    // HTTP server binding
+    @Option(names = {"-b", "--bind"}, description = "Host/IP to bind the HTTP server to")
+    String bind;
+
+    @Option(names = {"--port", "--tcpListenPort"}, description = "HTTP server port", defaultValue = "8080")
+    int tcpListenPort;
+
+    @Option(names = {"--cors"}, description = "CORS headers", defaultValue = "no-cors")
+    String cors;
+
+    @Option(names = {"--rootHost"}, description = "Datashare host for urls")
+    String rootHost;
+
+    @Option(names = {"--maxContentLength"}, description = "Maximum content length", defaultValue = "20000000")
+    String maxContentLength;
+
+    @Option(names = {"--browserOpenLink"}, description = "Open link in default browser", defaultValue = "false")
+    boolean browserOpenLink;
+
+    @Option(names = {"--protectedUriPrefix"}, description = "Protected URI prefix", defaultValue = "/api/")
+    String protectedUriPrefix;
+
+    @Option(names = {"--statusAllowedNets"}, description = "CIDR list for unauthenticated /api/status", defaultValue = "127.0.0.0/8,::1/128")
+    String statusAllowedNets;
+
+    // OAuth / Authentication
+    @Option(names = {"--oauthClientId"}, description = "OAuth2 client id")
+    String oauthClientId;
+
+    @Option(names = {"--oauthClientSecret"}, description = "OAuth2 client secret key. Prefer passing via a settings file to avoid leaking into shell history.")
+    String oauthClientSecret;
+
+    @Option(names = {"--oauthAuthorizeUrl"}, description = "OAuth2 authorize url")
+    String oauthAuthorizeUrl;
+
+    @Option(names = {"--oauthTokenUrl"}, description = "OAuth2 token url")
+    String oauthTokenUrl;
+
+    @Option(names = {"--oauthApiUrl"}, description = "OAuth2 api url")
+    String oauthApiUrl;
+
+    @Option(names = {"--oauthCallbackPath"}, description = "OAuth2 callback path")
+    String oauthCallbackPath;
+
+    @Option(names = {"--oauthDefaultProject"}, description = "Default project for OAuth2 users")
+    String oauthDefaultProject;
+
+    @Option(names = {"--oauthScope"}, description = "OAuth2 scope")
+    String oauthScope;
+
+    @Option(names = {"--oauthClaimIdAttribute"}, description = "OAuth claim id attribute")
+    String oauthClaimIdAttribute;
+
+    @Option(names = {"--authUsersProvider"}, description = "Auth users provider class")
+    String authUsersProvider;
+
+    @Option(names = {"--authFilter"}, description = "Auth filter class")
+    String authFilter;
+
+    @Option(names = {"--sessionSigningKey"}, description = "HMAC key for session signing. Prefer passing via a settings file to avoid leaking into shell history.")
+    String sessionSigningKey;
+
+    @Option(names = {"--sessionTtlSeconds"}, description = "Session TTL in seconds", defaultValue = "43200")
+    int sessionTtlSeconds;
+
+    @Option(names = {"--sessionStoreType"}, description = "Session store type", defaultValue = "MEMORY")
+    String sessionStoreType;
+
+    // Batch / Download
+    @Option(names = {"--batchQueueType"}, description = "Batch queue type", defaultValue = "MEMORY")
+    String batchQueueType;
+
+    @Option(names = {"--batchSearchMaxTimeSeconds"}, description = "Max batch search time in seconds")
+    Integer batchSearchMaxTimeSeconds;
+
+    @Option(names = {"--batchThrottleMilliseconds"}, description = "Batch throttle in milliseconds")
+    Integer batchThrottleMilliseconds;
+
+    @Option(names = {"--batchDownloadDir"}, description = "Batch download directory")
+    String batchDownloadDir = Paths.get(home(), ".local/share/datashare/tmp").toString();
+
+    @Option(names = {"--batchDownloadMaxSize"}, description = "Max batch download size", defaultValue = "100M")
+    String batchDownloadMaxSize;
+
+    @Option(names = {"--batchDownloadMaxNbFiles"}, description = "Max batch download files", defaultValue = "10000")
+    int batchDownloadMaxNbFiles;
+
+    @Option(names = {"--batchDownloadEncrypt"}, description = "Encrypt batch download zips")
+    Boolean batchDownloadEncrypt;
+
+    @Option(names = {"--batchDownloadTimeToLive"}, description = "Batch download TTL in hours", defaultValue = "24")
+    int batchDownloadTimeToLive;
+
+    @Option(names = {"--embeddedDocumentDownloadMaxSize"}, description = "Max embedded document download size", defaultValue = "1G")
+    String embeddedDocumentDownloadMaxSize;
+
+    // Scroll
+    @Option(names = {"--scroll"}, description = "Scroll duration for ES", defaultValue = "60000ms")
+    String scroll;
+
+    @Option(names = {"--scrollSize"}, description = "Scroll size for ES", defaultValue = "1000")
+    int scrollSize;
+
+    @Option(names = {"--scrollSlices"}, description = "Scroll slices for ES", defaultValue = "1")
+    int scrollSlices;
+
+    @Option(names = {"--batchSearchScroll"}, description = "Batch search scroll duration", defaultValue = "60000ms")
+    String batchSearchScroll;
+
+    @Option(names = {"--batchSearchScrollSize"}, description = "Batch search scroll size", defaultValue = "1000")
+    int batchSearchScrollSize;
+
+    @Option(names = {"--batchDownloadScroll"}, description = "Batch download scroll duration", defaultValue = "60000ms")
+    String batchDownloadScroll;
+
+    @Option(names = {"--batchDownloadScrollSize"}, description = "Batch download scroll size", defaultValue = "1000")
+    int batchDownloadScrollSize;
+
+    // Misc server
+    @Option(names = {"--reportName"}, description = "Report map name")
+    String reportName;
+
+    @Option(names = {"--smtpUrl"}, description = "SMTP URL for sending emails")
+    String smtpUrl;
+
+    @Option(names = {"--temporalNamespace"}, description = "Temporal namespace", defaultValue = "datashare-default")
+    String temporalNamespace;
+
+    // Task management and document processing options — shared with WorkerRunCommand and StageRunCommand
+    @Mixin
+    WorkerOptions workerOptions = new WorkerOptions();
+
+    @Mixin
+    PipelineOptions pipelineOptions = new PipelineOptions();
+
+    /** Converts the parsed server option fields into a Properties map for the rest of the application. */
+    public Properties toProperties() {
+        Properties props = new Properties();
+
+        DatashareOptions.putIfNotNull(props, BIND_HOST_OPT, bind);
+        props.setProperty(TCP_LISTEN_PORT_OPT, String.valueOf(tcpListenPort));
+        DatashareOptions.putIfNotNull(props, CORS_OPT, cors);
+        DatashareOptions.putIfNotNull(props, ROOT_HOST_OPT, rootHost);
+        DatashareOptions.putIfNotNull(props, MAX_CONTENT_LENGTH_OPT, maxContentLength);
+        props.setProperty(BROWSER_OPEN_LINK_OPT, String.valueOf(browserOpenLink));
+        DatashareOptions.putIfNotNull(props, PROTECTED_URI_PREFIX_OPT, protectedUriPrefix);
+        DatashareOptions.putIfNotNull(props, STATUS_ALLOWED_NETS_OPT, statusAllowedNets);
+
+        DatashareOptions.putIfNotNull(props, OAUTH_CLIENT_ID_OPT, oauthClientId);
+        DatashareOptions.putIfNotNull(props, OAUTH_CLIENT_SECRET_OPT, oauthClientSecret);
+        DatashareOptions.putIfNotNull(props, OAUTH_AUTHORIZE_URL_OPT, oauthAuthorizeUrl);
+        DatashareOptions.putIfNotNull(props, OAUTH_TOKEN_URL_OPT, oauthTokenUrl);
+        DatashareOptions.putIfNotNull(props, OAUTH_API_URL_OPT, oauthApiUrl);
+        DatashareOptions.putIfNotNull(props, OAUTH_CALLBACK_PATH_OPT, oauthCallbackPath);
+        DatashareOptions.putIfNotNull(props, OAUTH_DEFAULT_PROJECT_OPT, oauthDefaultProject);
+        DatashareOptions.putIfNotNull(props, OAUTH_SCOPE_OPT, oauthScope);
+        DatashareOptions.putIfNotNull(props, OAUTH_CLAIM_ID_ATTRIBUTE_OPT, oauthClaimIdAttribute);
+        DatashareOptions.putIfNotNull(props, AUTH_USERS_PROVIDER_OPT, authUsersProvider);
+        DatashareOptions.putIfNotNull(props, AUTH_FILTER_OPT, authFilter);
+        DatashareOptions.putIfNotNull(props, SESSION_SIGNING_KEY_OPT, sessionSigningKey);
+        props.setProperty(SESSION_TTL_SECONDS_OPT, String.valueOf(sessionTtlSeconds));
+        DatashareOptions.putIfNotNull(props, SESSION_STORE_TYPE_OPT, sessionStoreType);
+
+        DatashareOptions.putIfNotNull(props, BATCH_QUEUE_TYPE_OPT, batchQueueType);
+        if (batchSearchMaxTimeSeconds != null) props.setProperty(BATCH_SEARCH_MAX_TIME_OPT, String.valueOf(batchSearchMaxTimeSeconds));
+        if (batchThrottleMilliseconds != null) props.setProperty(BATCH_THROTTLE_OPT, String.valueOf(batchThrottleMilliseconds));
+        DatashareOptions.putIfNotNull(props, BATCH_DOWNLOAD_DIR_OPT, resolveAbsolutePath(batchDownloadDir));
+        DatashareOptions.putIfNotNull(props, BATCH_DOWNLOAD_MAX_SIZE_OPT, batchDownloadMaxSize);
+        props.setProperty(BATCH_DOWNLOAD_MAX_NB_FILES_OPT, String.valueOf(batchDownloadMaxNbFiles));
+        if (batchDownloadEncrypt != null) props.setProperty(BATCH_DOWNLOAD_ENCRYPT_OPT, String.valueOf(batchDownloadEncrypt));
+        props.setProperty(BATCH_DOWNLOAD_ZIP_TTL_OPT, String.valueOf(batchDownloadTimeToLive));
+        DatashareOptions.putIfNotNull(props, EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT, embeddedDocumentDownloadMaxSize);
+
+        DatashareOptions.putIfNotNull(props, SCROLL_DURATION_OPT, scroll);
+        props.setProperty(SCROLL_SIZE_OPT, String.valueOf(scrollSize));
+        props.setProperty(SCROLL_SLICES_OPT, String.valueOf(scrollSlices));
+        DatashareOptions.putIfNotNull(props, BATCH_SEARCH_SCROLL_DURATION_OPT, batchSearchScroll);
+        props.setProperty(BATCH_SEARCH_SCROLL_SIZE_OPT, String.valueOf(batchSearchScrollSize));
+        DatashareOptions.putIfNotNull(props, BATCH_DOWNLOAD_SCROLL_DURATION_OPT, batchDownloadScroll);
+        props.setProperty(BATCH_DOWNLOAD_SCROLL_SIZE_OPT, String.valueOf(batchDownloadScrollSize));
+
+        DatashareOptions.putIfNotNull(props, REPORT_NAME_OPT, reportName);
+        DatashareOptions.putIfNotNull(props, SMTP_URL_OPT, smtpUrl);
+        DatashareOptions.putIfNotNull(props, TEMPORAL_NAMESPACE_OPT, temporalNamespace);
+
+        props.putAll(workerOptions.toProperties());
+        props.putAll(pipelineOptions.toProperties());
+
+        return props;
+    }
+
+    private static String resolveAbsolutePath(String value) {
+        if (value == null) return null;
+        return Paths.get(value).toAbsolutePath().normalize().toString();
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.cli.command;
 
+import org.icij.datashare.cli.QueueType;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
@@ -83,11 +84,11 @@ public class ServerOptions {
     int sessionTtlSeconds;
 
     @Option(names = {"--sessionStoreType"}, description = "Session store type", defaultValue = "MEMORY")
-    String sessionStoreType;
+    QueueType sessionStoreType;
 
     // Batch / Download
     @Option(names = {"--batchQueueType"}, description = "Batch queue type", defaultValue = "MEMORY")
-    String batchQueueType;
+    QueueType batchQueueType;
 
     @Option(names = {"--batchSearchMaxTimeSeconds"}, description = "Max batch search time in seconds")
     Integer batchSearchMaxTimeSeconds;
@@ -157,11 +158,11 @@ public class ServerOptions {
         Properties props = new Properties();
 
         DatashareOptions.putIfNotNull(props, BIND_HOST_OPT, bind);
-        props.setProperty(TCP_LISTEN_PORT_OPT, String.valueOf(tcpListenPort));
+        DatashareOptions.put(props, TCP_LISTEN_PORT_OPT, tcpListenPort);
         DatashareOptions.putIfNotNull(props, CORS_OPT, cors);
         DatashareOptions.putIfNotNull(props, ROOT_HOST_OPT, rootHost);
         DatashareOptions.putIfNotNull(props, MAX_CONTENT_LENGTH_OPT, maxContentLength);
-        props.setProperty(BROWSER_OPEN_LINK_OPT, String.valueOf(browserOpenLink));
+        DatashareOptions.put(props, BROWSER_OPEN_LINK_OPT, browserOpenLink);
         DatashareOptions.putIfNotNull(props, PROTECTED_URI_PREFIX_OPT, protectedUriPrefix);
         DatashareOptions.putIfNotNull(props, STATUS_ALLOWED_NETS_OPT, statusAllowedNets);
 
@@ -177,33 +178,33 @@ public class ServerOptions {
         DatashareOptions.putIfNotNull(props, AUTH_USERS_PROVIDER_OPT, authUsersProvider);
         DatashareOptions.putIfNotNull(props, AUTH_FILTER_OPT, authFilter);
         DatashareOptions.putIfNotNull(props, SESSION_SIGNING_KEY_OPT, sessionSigningKey);
-        props.setProperty(SESSION_TTL_SECONDS_OPT, String.valueOf(sessionTtlSeconds));
+        DatashareOptions.put(props, SESSION_TTL_SECONDS_OPT, sessionTtlSeconds);
         DatashareOptions.putIfNotNull(props, SESSION_STORE_TYPE_OPT, sessionStoreType);
 
         DatashareOptions.putIfNotNull(props, BATCH_QUEUE_TYPE_OPT, batchQueueType);
-        if (batchSearchMaxTimeSeconds != null) props.setProperty(BATCH_SEARCH_MAX_TIME_OPT, String.valueOf(batchSearchMaxTimeSeconds));
-        if (batchThrottleMilliseconds != null) props.setProperty(BATCH_THROTTLE_OPT, String.valueOf(batchThrottleMilliseconds));
+        DatashareOptions.putIfNotNull(props, BATCH_SEARCH_MAX_TIME_OPT, batchSearchMaxTimeSeconds);
+        DatashareOptions.putIfNotNull(props, BATCH_THROTTLE_OPT, batchThrottleMilliseconds);
         DatashareOptions.putIfNotNull(props, BATCH_DOWNLOAD_DIR_OPT, resolveAbsolutePath(batchDownloadDir));
         DatashareOptions.putIfNotNull(props, BATCH_DOWNLOAD_MAX_SIZE_OPT, batchDownloadMaxSize);
-        props.setProperty(BATCH_DOWNLOAD_MAX_NB_FILES_OPT, String.valueOf(batchDownloadMaxNbFiles));
-        if (batchDownloadEncrypt != null) props.setProperty(BATCH_DOWNLOAD_ENCRYPT_OPT, String.valueOf(batchDownloadEncrypt));
-        props.setProperty(BATCH_DOWNLOAD_ZIP_TTL_OPT, String.valueOf(batchDownloadTimeToLive));
+        DatashareOptions.put(props, BATCH_DOWNLOAD_MAX_NB_FILES_OPT, batchDownloadMaxNbFiles);
+        DatashareOptions.putIfNotNull(props, BATCH_DOWNLOAD_ENCRYPT_OPT, batchDownloadEncrypt);
+        DatashareOptions.put(props, BATCH_DOWNLOAD_ZIP_TTL_OPT, batchDownloadTimeToLive);
         DatashareOptions.putIfNotNull(props, EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT, embeddedDocumentDownloadMaxSize);
 
         DatashareOptions.putIfNotNull(props, SCROLL_DURATION_OPT, scroll);
-        props.setProperty(SCROLL_SIZE_OPT, String.valueOf(scrollSize));
-        props.setProperty(SCROLL_SLICES_OPT, String.valueOf(scrollSlices));
+        DatashareOptions.put(props, SCROLL_SIZE_OPT, scrollSize);
+        DatashareOptions.put(props, SCROLL_SLICES_OPT, scrollSlices);
         DatashareOptions.putIfNotNull(props, BATCH_SEARCH_SCROLL_DURATION_OPT, batchSearchScroll);
-        props.setProperty(BATCH_SEARCH_SCROLL_SIZE_OPT, String.valueOf(batchSearchScrollSize));
+        DatashareOptions.put(props, BATCH_SEARCH_SCROLL_SIZE_OPT, batchSearchScrollSize);
         DatashareOptions.putIfNotNull(props, BATCH_DOWNLOAD_SCROLL_DURATION_OPT, batchDownloadScroll);
-        props.setProperty(BATCH_DOWNLOAD_SCROLL_SIZE_OPT, String.valueOf(batchDownloadScrollSize));
+        DatashareOptions.put(props, BATCH_DOWNLOAD_SCROLL_SIZE_OPT, batchDownloadScrollSize);
 
         DatashareOptions.putIfNotNull(props, REPORT_NAME_OPT, reportName);
         DatashareOptions.putIfNotNull(props, SMTP_URL_OPT, smtpUrl);
         DatashareOptions.putIfNotNull(props, TEMPORAL_NAMESPACE_OPT, temporalNamespace);
 
-        props.putAll(workerOptions.toProperties());
-        props.putAll(pipelineOptions.toProperties());
+        DatashareOptions.putAll(props, workerOptions.toProperties());
+        DatashareOptions.putAll(props, pipelineOptions.toProperties());
 
         return props;
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
@@ -16,7 +16,9 @@ import static org.icij.datashare.cli.DatashareCliOptions.*;
  */
 public class ServerOptions {
 
-    private static String home() { return System.getProperty("user.home", ""); }
+    private static String userHome() {
+        return System.getProperty("user.home", "");
+    }
 
     // HTTP server binding
     @Option(names = {"-b", "--bind"}, description = "Host/IP to bind the HTTP server to")
@@ -97,7 +99,7 @@ public class ServerOptions {
     Integer batchThrottleMilliseconds;
 
     @Option(names = {"--batchDownloadDir"}, description = "Batch download directory")
-    String batchDownloadDir = Paths.get(home(), ".local/share/datashare/tmp").toString();
+    String batchDownloadDir = Paths.get(userHome(), ".local/share/datashare/tmp").toString();
 
     @Option(names = {"--batchDownloadMaxSize"}, description = "Max batch download size", defaultValue = "100M")
     String batchDownloadMaxSize;

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageCommand.java
@@ -1,0 +1,20 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Spec;
+
+@Command(name = "stage", mixinStandardHelpOptions = true,
+        description = "Run document processing pipeline stages.",
+        subcommands = {StageRunCommand.class})
+public class StageCommand implements Runnable {
+
+    @Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public void run() {
+        // No subcommand specified: print usage and exit 0 so the user knows what subcommands are available.
+        spec.commandLine().usage(System.out);
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageRunCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageRunCommand.java
@@ -1,0 +1,42 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.PipelineHelper;
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "run", mixinStandardHelpOptions = true, description = {
+        "Run one or more document processing pipeline stages.",
+        "",
+        "Examples:",
+        "  datashare stage run SCAN,INDEX",
+        "  datashare stage run SCAN,INDEX,NLP --nlpPipeline OPENNLP",
+        "  datashare stage run INDEX --resume",
+        "  datashare --dataDir /data/docs -P my-project stage run SCAN,INDEX,NLP"
+})
+public class StageRunCommand implements Runnable, DatashareSubcommand {
+
+    @Parameters(index = "0", description = "Comma-separated list of stages to run (e.g. SCAN,INDEX,NLP)")
+    String stages;
+
+    @Mixin
+    PipelineOptions pipelineOptions = new PipelineOptions();
+
+    @Override
+    public void run() {
+        // Properties will be collected by DatashareCommand
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = pipelineOptions.toProperties();
+        props.setProperty(MODE_OPT, Mode.CLI.name());
+        props.setProperty(PipelineHelper.STAGES_OPT, stages);
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageRunCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageRunCommand.java
@@ -4,7 +4,7 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.cli.Mode;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
-import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Option;
 
 import java.util.Properties;
 
@@ -14,14 +14,14 @@ import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
         "Run one or more document processing pipeline stages.",
         "",
         "Examples:",
-        "  datashare stage run SCAN,INDEX",
-        "  datashare stage run SCAN,INDEX,NLP --nlpPipeline OPENNLP",
-        "  datashare stage run INDEX --resume",
-        "  datashare --dataDir /data/docs -P my-project stage run SCAN,INDEX,NLP"
+        "  datashare stage run --stages SCAN,INDEX",
+        "  datashare stage run --stages SCAN,INDEX,NLP --nlpPipeline OPENNLP",
+        "  datashare stage run --stages INDEX --resume",
+        "  datashare --dataDir /data/docs -P my-project stage run --stages SCAN,INDEX,NLP"
 })
 public class StageRunCommand implements Runnable, DatashareSubcommand {
 
-    @Parameters(index = "0", description = "Comma-separated list of stages to run (e.g. SCAN,INDEX,NLP)")
+    @Option(names = {"--stages"}, required = true, description = "Comma-separated list of stages to run (e.g. SCAN,INDEX,NLP)")
     String stages;
 
     @Mixin

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageRunCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/StageRunCommand.java
@@ -35,8 +35,8 @@ public class StageRunCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = pipelineOptions.toProperties();
-        props.setProperty(MODE_OPT, Mode.CLI.name());
-        props.setProperty(PipelineHelper.STAGES_OPT, stages);
+        DatashareOptions.put(props, MODE_OPT, Mode.CLI);
+        DatashareOptions.put(props, PipelineHelper.STAGES_OPT, stages);
         return props;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerCommand.java
@@ -1,0 +1,20 @@
+package org.icij.datashare.cli.command;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Spec;
+
+@Command(name = "worker", mixinStandardHelpOptions = true,
+        description = "Manage task workers for background processing.",
+        subcommands = {WorkerRunCommand.class})
+public class WorkerCommand implements Runnable {
+
+    @Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public void run() {
+        // No subcommand specified: print usage and exit 0 so the user knows what subcommands are available.
+        spec.commandLine().usage(System.out);
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.cli.command;
 
+import org.icij.datashare.cli.TaskRepositoryType;
 import org.icij.datashare.tasks.RoutingStrategy;
 import picocli.CommandLine.Option;
 
@@ -25,7 +26,7 @@ public class WorkerOptions {
     String pollingInterval;
 
     @Option(names = {"--taskRepositoryType"}, description = "Task repository type", defaultValue = "DATABASE")
-    String taskRepositoryType;
+    TaskRepositoryType taskRepositoryType;
 
     @Option(names = {"--taskManagerPollingIntervalMilliseconds"}, description = "Task manager polling interval ms", defaultValue = "5000")
     int taskManagerPollingIntervalMilliseconds;
@@ -37,12 +38,12 @@ public class WorkerOptions {
     public Properties toProperties() {
         Properties props = new Properties();
         DatashareOptions.putIfNotNull(props, TASK_WORKERS_OPT, taskWorkers);
-        if (taskRoutingStrategy != null) props.setProperty(TASK_ROUTING_STRATEGY_OPT, taskRoutingStrategy.name());
+        DatashareOptions.putIfNotNull(props, TASK_ROUTING_STRATEGY_OPT, taskRoutingStrategy);
         DatashareOptions.putIfNotNull(props, TASK_ROUTING_KEY_OPT, taskRoutingKey);
         DatashareOptions.putIfNotNull(props, POLLING_INTERVAL_SECONDS_OPT, pollingInterval);
         DatashareOptions.putIfNotNull(props, TASK_REPOSITORY_OPT, taskRepositoryType);
-        props.setProperty(TASK_MANAGER_POLLING_INTERVAL_OPT, String.valueOf(taskManagerPollingIntervalMilliseconds));
-        props.setProperty(TASK_PROGRESS_INTERVAL_OPT, String.valueOf(taskProgressUpdateIntervalSeconds));
+        DatashareOptions.put(props, TASK_MANAGER_POLLING_INTERVAL_OPT, taskManagerPollingIntervalMilliseconds);
+        DatashareOptions.put(props, TASK_PROGRESS_INTERVAL_OPT, taskProgressUpdateIntervalSeconds);
         return props;
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
@@ -1,0 +1,49 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.tasks.RoutingStrategy;
+import picocli.CommandLine.Option;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.*;
+
+/**
+ * Options specific to the worker run subcommand.
+ */
+public class WorkerOptions {
+
+    @Option(names = {"--taskWorkers"}, description = "Number of task workers", defaultValue = "1")
+    String taskWorkers;
+
+    @Option(names = {"--taskRoutingStrategy"}, description = "Task routing strategy", defaultValue = "UNIQUE")
+    RoutingStrategy taskRoutingStrategy;
+
+    @Option(names = {"--taskRoutingKey"}, description = "Task routing key")
+    String taskRoutingKey;
+
+    @Option(names = {"--pollingInterval"}, description = "Queue polling interval", defaultValue = "60")
+    String pollingInterval;
+
+    @Option(names = {"--taskRepositoryType"}, description = "Task repository type", defaultValue = "DATABASE")
+    String taskRepositoryType;
+
+    @Option(names = {"--taskManagerPollingIntervalMilliseconds"}, description = "Task manager polling interval ms", defaultValue = "5000")
+    int taskManagerPollingIntervalMilliseconds;
+
+    @Option(names = {"--taskProgressUpdateIntervalSeconds"}, description = "Task progress update interval seconds", defaultValue = "10.0")
+    double taskProgressUpdateIntervalSeconds;
+
+    /** Converts the parsed worker option fields into a Properties map for the rest of the application. */
+    public Properties toProperties() {
+        Properties props = new Properties();
+        DatashareOptions.putIfNotNull(props, TASK_WORKERS_OPT, taskWorkers);
+        if (taskRoutingStrategy != null) props.setProperty(TASK_ROUTING_STRATEGY_OPT, taskRoutingStrategy.name());
+        DatashareOptions.putIfNotNull(props, TASK_ROUTING_KEY_OPT, taskRoutingKey);
+        DatashareOptions.putIfNotNull(props, POLLING_INTERVAL_SECONDS_OPT, pollingInterval);
+        DatashareOptions.putIfNotNull(props, TASK_REPOSITORY_OPT, taskRepositoryType);
+        props.setProperty(TASK_MANAGER_POLLING_INTERVAL_OPT, String.valueOf(taskManagerPollingIntervalMilliseconds));
+        props.setProperty(TASK_PROGRESS_INTERVAL_OPT, String.valueOf(taskProgressUpdateIntervalSeconds));
+        return props;
+    }
+
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerRunCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerRunCommand.java
@@ -1,0 +1,36 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.Mode;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.MODE_OPT;
+
+@Command(name = "run", mixinStandardHelpOptions = true, description = {
+        "Start a task worker that processes background jobs from the queue.",
+        "",
+        "Examples:",
+        "  datashare worker run",
+        "  datashare worker run --taskWorkers 4",
+        "  datashare worker run --taskWorkers 4 --taskRoutingStrategy GROUP",
+        "  datashare --elasticsearchAddress http://elastic:9200 --redisAddress redis://redis:6379 worker run --taskWorkers 4"
+})
+public class WorkerRunCommand implements Runnable, DatashareSubcommand {
+
+    @Mixin
+    WorkerOptions workerOptions = new WorkerOptions();
+
+    @Override
+    public void run() {
+        // Properties will be collected by DatashareCommand
+    }
+
+    @Override
+    public Properties getSubcommandProperties() {
+        Properties props = workerOptions.toProperties();
+        props.setProperty(MODE_OPT, Mode.TASK_WORKER.name());
+        return props;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerRunCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerRunCommand.java
@@ -30,7 +30,7 @@ public class WorkerRunCommand implements Runnable, DatashareSubcommand {
     @Override
     public Properties getSubcommandProperties() {
         Properties props = workerOptions.toProperties();
-        props.setProperty(MODE_OPT, Mode.TASK_WORKER.name());
+        DatashareOptions.put(props, MODE_OPT, Mode.TASK_WORKER);
         return props;
     }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/LegacyInvocationTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/LegacyInvocationTest.java
@@ -1,0 +1,567 @@
+package org.icij.datashare.cli;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
+/**
+ * Regression tests for the legacy (jopt-simple) CLI invocation path.
+ *
+ * These tests exercise DatashareCli directly and must pass both
+ * before and after any CLI refactoring. They document the contract of the
+ * legacy path: given a set of --option arguments, the resulting
+ * Properties must contain specific key/value pairs consumed by the
+ * application (CommonMode, WebApp, CliApp, TaskWorkerApp, etc.).
+ */
+public class LegacyInvocationTest {
+
+    private Properties parse(String... args) {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(args);
+        return cli.properties;
+    }
+
+    @Before
+    public void setUp() {
+        System.setProperty("user.home", "/home/datashare");
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("user.home");
+    }
+
+    @Test
+    public void test_default_mode_is_local() {
+        assertThat(parse("")).includes(entry("mode", "LOCAL"));
+    }
+
+    @Test
+    public void test_no_args_defaults_to_local() {
+        assertThat(parse()).includes(entry("mode", "LOCAL"));
+    }
+
+    @Test
+    public void test_mode_local_explicit() {
+        assertThat(parse("--mode=LOCAL")).includes(entry("mode", "LOCAL"));
+    }
+
+    @Test
+    public void test_mode_server() {
+        assertThat(parse("--mode=SERVER")).includes(entry("mode", "SERVER"));
+    }
+
+    @Test
+    public void test_mode_embedded() {
+        assertThat(parse("--mode=EMBEDDED")).includes(entry("mode", "EMBEDDED"));
+    }
+
+    @Test
+    public void test_mode_ner() {
+        assertThat(parse("--mode=NER")).includes(entry("mode", "NER"));
+    }
+
+    @Test
+    public void test_mode_task_worker() {
+        assertThat(parse("--mode=TASK_WORKER")).includes(entry("mode", "TASK_WORKER"));
+    }
+
+    @Test
+    public void test_mode_cli() {
+        assertThat(parse("--mode=CLI")).includes(entry("mode", "CLI"));
+    }
+
+    @Test
+    public void test_last_mode_wins() {
+        assertThat(parse("--mode=SERVER", "--mode=LOCAL")).includes(entry("mode", "LOCAL"));
+    }
+
+    @Test
+    public void test_is_web_server_for_local_mode() {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(new String[]{"--mode=LOCAL"});
+        assertThat(cli.isWebServer()).isTrue();
+    }
+
+    @Test
+    public void test_is_web_server_for_server_mode() {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(new String[]{"--mode=SERVER"});
+        assertThat(cli.isWebServer()).isTrue();
+    }
+
+    @Test
+    public void test_is_web_server_for_embedded_mode() {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(new String[]{"--mode=EMBEDDED"});
+        assertThat(cli.isWebServer()).isTrue();
+    }
+
+    @Test
+    public void test_is_web_server_for_ner_mode() {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(new String[]{"--mode=NER"});
+        assertThat(cli.isWebServer()).isTrue();
+    }
+
+    @Test
+    public void test_is_not_web_server_for_task_worker_mode() {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(new String[]{"--mode=TASK_WORKER"});
+        assertThat(cli.isWebServer()).isFalse();
+    }
+
+    @Test
+    public void test_is_not_web_server_for_cli_mode() {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(new String[]{"--mode=CLI"});
+        assertThat(cli.isWebServer()).isFalse();
+    }
+
+    @Test
+    public void test_stages_scan_index() {
+        assertThat(parse("--mode=CLI", "--stages=SCAN,INDEX"))
+                .includes(entry("mode", "CLI"))
+                .includes(entry("stages", "SCAN,INDEX"));
+    }
+
+    @Test
+    public void test_stages_all_main() {
+        assertThat(parse("--stages=SCAN,INDEX,NLP")).includes(entry("stages", "SCAN,INDEX,NLP"));
+    }
+
+    @Test
+    public void test_stages_full_pipeline() {
+        assertThat(parse("--stages=SCAN,INDEX,CATEGORIZE,NLP"))
+                .includes(entry("stages", "SCAN,INDEX,CATEGORIZE,NLP"));
+    }
+
+    @Test
+    public void test_stages_single_scan() {
+        assertThat(parse("--stages=SCAN")).includes(entry("stages", "SCAN"));
+    }
+
+    @Test
+    public void test_plugin_list_no_filter() {
+        assertThat(parse("--pluginList")).includes(entry("pluginList", "true"));
+    }
+
+    @Test
+    public void test_plugin_list_with_filter() {
+        assertThat(parse("--pluginList=.*")).includes(entry("pluginList", ".*"));
+    }
+
+    @Test
+    public void test_plugin_install() {
+        assertThat(parse("--pluginInstall", "my-plugin")).includes(entry("pluginInstall", "my-plugin"));
+    }
+
+    @Test
+    public void test_plugin_install_from_url() {
+        assertThat(parse("--pluginInstall", "https://example.com/plugin.jar"))
+                .includes(entry("pluginInstall", "https://example.com/plugin.jar"));
+    }
+
+    @Test
+    public void test_plugin_delete() {
+        assertThat(parse("--pluginDelete", "my-plugin")).includes(entry("pluginDelete", "my-plugin"));
+    }
+
+    @Test
+    public void test_plugin_not_set_by_default() {
+        Properties props = parse("");
+        assertThat(props.getProperty("pluginList")).isNull();
+        assertThat(props.getProperty("pluginInstall")).isNull();
+        assertThat(props.getProperty("pluginDelete")).isNull();
+    }
+
+    @Test
+    public void test_extension_list_no_filter() {
+        assertThat(parse("--extensionList")).includes(entry("extensionList", "true"));
+    }
+
+    @Test
+    public void test_extension_list_with_filter() {
+        assertThat(parse("--extensionList=.*nlp.*")).includes(entry("extensionList", ".*nlp.*"));
+    }
+
+    @Test
+    public void test_extension_install() {
+        assertThat(parse("--extensionInstall", "my-ext")).includes(entry("extensionInstall", "my-ext"));
+    }
+
+    @Test
+    public void test_extension_delete() {
+        assertThat(parse("--extensionDelete", "my-ext")).includes(entry("extensionDelete", "my-ext"));
+    }
+
+    @Test
+    public void test_extension_not_set_by_default() {
+        Properties props = parse("");
+        assertThat(props.getProperty("extensionList")).isNull();
+        assertThat(props.getProperty("extensionInstall")).isNull();
+        assertThat(props.getProperty("extensionDelete")).isNull();
+    }
+
+    @Test
+    public void test_create_api_key() {
+        assertThat(parse("--createApiKey", "alice")).includes(entry("createApiKey", "alice"));
+    }
+
+    @Test
+    public void test_create_api_key_short_opt() {
+        assertThat(parse("-k", "alice")).includes(entry("createApiKey", "alice"));
+    }
+
+    @Test
+    public void test_get_api_key() {
+        assertThat(parse("--apiKey", "alice")).includes(entry("apiKey", "alice"));
+    }
+
+    @Test
+    public void test_delete_api_key() {
+        assertThat(parse("--deleteApiKey", "alice")).includes(entry("deleteApiKey", "alice"));
+    }
+
+    @Test
+    public void test_api_key_not_set_by_default() {
+        Properties props = parse("");
+        assertThat(props.getProperty("createApiKey")).isNull();
+        assertThat(props.getProperty("apiKey")).isNull();
+        assertThat(props.getProperty("deleteApiKey")).isNull();
+    }
+
+    @Test
+    public void test_default_port() {
+        assertThat(parse("")).includes(entry("tcpListenPort", "8080"));
+    }
+
+    @Test
+    public void test_port_alias() {
+        Properties props = parse("--port=7777");
+        assertThat(props).includes(entry("tcpListenPort", "7777"));
+        assertThat(props.getProperty("port")).isNull();
+    }
+
+    @Test
+    public void test_tcp_listen_port() {
+        assertThat(parse("--tcpListenPort=9090")).includes(entry("tcpListenPort", "9090"));
+    }
+
+    @Test
+    public void test_bind_host() {
+        assertThat(parse("--bind", "127.0.0.1")).includes(entry("bind", "127.0.0.1"));
+    }
+
+    @Test
+    public void test_bind_short_opt() {
+        assertThat(parse("-b", "0.0.0.0")).includes(entry("bind", "0.0.0.0"));
+    }
+
+    @Test
+    public void test_bind_not_set_by_default() {
+        assertThat(parse("").getProperty("bind")).isNull();
+    }
+
+    @Test
+    public void test_default_cors() {
+        assertThat(parse("")).includes(entry("cors", "no-cors"));
+    }
+
+    @Test
+    public void test_custom_cors() {
+        assertThat(parse("--cors", "http://localhost:3000")).includes(entry("cors", "http://localhost:3000"));
+    }
+
+    @Test
+    public void test_default_elasticsearch_address() {
+        Properties props = parse("");
+        assertThat(props.getProperty("elasticsearchAddress")).isNotNull();
+    }
+
+    @Test
+    public void test_custom_elasticsearch_address() {
+        assertThat(parse("--elasticsearchAddress", "http://es:9200"))
+                .includes(entry("elasticsearchAddress", "http://es:9200"));
+    }
+
+    @Test
+    public void test_default_elasticsearch_data_path() {
+        assertThat(parse("")).includes(entry("elasticsearchDataPath",
+                "/home/datashare/.local/share/datashare/es"));
+    }
+
+    @Test
+    public void test_default_data_dir() {
+        assertThat(parse("")).includes(entry("dataDir", "/home/datashare/Datashare"));
+    }
+
+    @Test
+    public void test_custom_data_dir() {
+        assertThat(parse("--dataDir", "/data/docs")).includes(entry("dataDir", "/data/docs"));
+    }
+
+    @Test
+    public void test_data_dir_short_opt() {
+        assertThat(parse("-d", "/data/docs")).includes(entry("dataDir", "/data/docs"));
+    }
+
+    @Test
+    public void test_default_plugins_dir() {
+        assertThat(parse("")).includes(entry("pluginsDir",
+                "/home/datashare/.local/share/datashare/plugins"));
+    }
+
+    @Test
+    public void test_custom_plugins_dir() {
+        assertThat(parse("--pluginsDir", "/opt/plugins")).includes(entry("pluginsDir", "/opt/plugins"));
+    }
+
+    @Test
+    public void test_default_extensions_dir() {
+        assertThat(parse("")).includes(entry("extensionsDir",
+                "/home/datashare/.local/share/datashare/extensions"));
+    }
+
+    @Test
+    public void test_custom_extensions_dir() {
+        assertThat(parse("--extensionsDir", "/opt/ext")).includes(entry("extensionsDir", "/opt/ext"));
+    }
+
+    @Test
+    public void test_batch_download_max_size() {
+        assertThat(parse("--batchDownloadMaxSize", "500M")).includes(entry("batchDownloadMaxSize", "500M"));
+    }
+
+    @Test
+    public void test_batch_download_max_size_numeric() {
+        assertThat(parse("--batchDownloadMaxSize", "123")).includes(entry("batchDownloadMaxSize", "123"));
+    }
+
+    @Test
+    public void test_embedded_document_download_max_size() {
+        assertThat(parse("--embeddedDocumentDownloadMaxSize", "2G"))
+                .includes(entry("embeddedDocumentDownloadMaxSize", "2G"));
+    }
+
+    @Test
+    public void test_relative_batch_download_dir() {
+        Properties props = parse("--batchDownloadDir", "downloads");
+        Path userDir = Path.of(System.getProperty("user.dir"));
+        assertThat(props).includes(entry("batchDownloadDir", userDir.resolve("downloads").toString()));
+    }
+
+    @Test
+    public void test_absolute_batch_download_dir() {
+        assertThat(parse("--batchDownloadDir", "/tmp/downloads"))
+                .includes(entry("batchDownloadDir", "/tmp/downloads"));
+    }
+
+    @Test
+    public void test_default_project() {
+        assertThat(parse("")).includes(entry("defaultProject", "local-datashare"));
+    }
+
+    @Test
+    public void test_custom_project() {
+        assertThat(parse("--defaultProject", "my-project")).includes(entry("defaultProject", "my-project"));
+    }
+
+    @Test
+    public void test_project_short_opt() {
+        assertThat(parse("-p", "my-project")).includes(entry("defaultProject", "my-project"));
+    }
+
+    @Test
+    public void test_digest_project_name_defaults_to_default_project() {
+        Properties props = parse("");
+        assertThat(props).includes(entry("defaultProject", "local-datashare"));
+        assertThat(props).includes(entry("digestProjectName", "local-datashare"));
+    }
+
+    @Test
+    public void test_digest_project_name_follows_default_project() {
+        Properties props = parse("--defaultProject=myproject");
+        assertThat(props).includes(entry("digestProjectName", "myproject"));
+    }
+
+    @Test
+    public void test_no_digest_project_clears_digest_project_name() {
+        Properties props = parse("--noDigestProject", "true");
+        assertThat(props).includes(entry("noDigestProject", "true"));
+        assertThat(props.getProperty("digestProjectName")).isNull();
+    }
+
+    @Test
+    public void test_explicit_digest_project_name_is_preserved() {
+        Properties props = parse("--digestProjectName", "custom-digest");
+        assertThat(props).includes(entry("digestProjectName", "custom-digest"));
+    }
+
+    @Test
+    public void test_default_nlp_pipeline() {
+        assertThat(parse("")).includes(entry("nlpPipeline", "CORENLP"));
+    }
+
+    @Test
+    public void test_custom_nlp_pipeline() {
+        assertThat(parse("--nlpPipeline", "SPACY")).includes(entry("nlpPipeline", "SPACY"));
+    }
+
+    @Test
+    public void test_nlp_pipeline_short_opt() {
+        assertThat(parse("-nlpp", "OPENNLP")).includes(entry("nlpPipeline", "OPENNLP"));
+    }
+
+    @Test
+    public void test_default_ocr_enabled() {
+        assertThat(parse("")).includes(entry("ocr", "true"));
+    }
+
+    @Test
+    public void test_ocr_disabled() {
+        assertThat(parse("--ocr", "false")).includes(entry("ocr", "false"));
+    }
+
+    @Test
+    public void test_no_default_language() {
+        assertThat(parse("").getProperty("language")).isNull();
+    }
+
+    @Test
+    public void test_custom_language() {
+        assertThat(parse("--language", "ENGLISH")).includes(entry("language", "ENGLISH"));
+    }
+
+    @Test
+    public void test_default_queue_capacity() {
+        assertThat(parse("")).includes(entry("queueCapacity", "1000000"));
+    }
+
+    @Test
+    public void test_custom_queue_capacity() {
+        assertThat(parse("--queueCapacity", "500")).includes(entry("queueCapacity", "500"));
+    }
+
+    @Test
+    public void test_default_redis_address() {
+        Properties props = parse("");
+        assertThat(props.getProperty("redisAddress")).isNotNull();
+    }
+
+    @Test
+    public void test_custom_redis_address() {
+        assertThat(parse("--redisAddress", "redis://redis:6379"))
+                .includes(entry("redisAddress", "redis://redis:6379"));
+    }
+
+    @Test
+    public void test_oauth_client_id() {
+        assertThat(parse("--oauthClientId", "my-client-id"))
+                .includes(entry("oauthClientId", "my-client-id"));
+    }
+
+    @Test
+    public void test_oauth_client_id_not_set_by_default() {
+        assertThat(parse("").getProperty("oauthClientId")).isNull();
+    }
+
+    @Test
+    public void test_auth_filter() {
+        assertThat(parse("--authFilter", "org.icij.datashare.BasicAuthFilter"))
+                .includes(entry("authFilter", "org.icij.datashare.BasicAuthFilter"));
+    }
+
+    @Test
+    public void test_default_user_name() {
+        assertThat(parse("")).includes(entry("defaultUserName", "local"));
+    }
+
+    @Test
+    public void test_custom_user_name() {
+        assertThat(parse("--defaultUserName", "admin")).includes(entry("defaultUserName", "admin"));
+    }
+
+    @Test
+    public void test_user_name_short_opt() {
+        assertThat(parse("-u", "admin")).includes(entry("defaultUserName", "admin"));
+    }
+
+    @Test
+    public void test_oauth_user_projects_attribute_sets_system_property() {
+        parse("--oauthUserProjectsAttribute", "org.groups");
+        assertThat(System.getProperty("datashare.user.projects")).isEqualTo("org.groups");
+        System.clearProperty("datashare.user.projects");
+    }
+
+    @Test
+    public void test_settings_short_opt() {
+        assertThat(parse("-s", "/conf/settings.properties"))
+                .includes(entry("settings", "/conf/settings.properties"));
+    }
+
+    @Test
+    public void test_settings_long_opt() {
+        assertThat(parse("--settings", "/conf/settings.properties"))
+                .includes(entry("settings", "/conf/settings.properties"));
+    }
+
+    @Test
+    public void test_default_log_level() {
+        assertThat(parse("")).includes(entry("logLevel", "INFO"));
+    }
+
+    @Test
+    public void test_custom_log_level() {
+        assertThat(parse("--logLevel", "DEBUG")).includes(entry("logLevel", "DEBUG"));
+    }
+
+    @Test
+    public void test_default_index_timeout() {
+        assertThat(parse("")).includes(entry("indexTimeout", "30"));
+    }
+
+    @Test
+    public void test_custom_index_timeout() {
+        assertThat(parse("--indexTimeout", "60")).includes(entry("indexTimeout", "60"));
+    }
+
+    @Test
+    public void test_server_mode_with_custom_port_and_project() {
+        Properties props = parse("--mode=SERVER", "--tcpListenPort=9090", "--defaultProject=prod");
+        assertThat(props).includes(entry("mode", "SERVER"));
+        assertThat(props).includes(entry("tcpListenPort", "9090"));
+        assertThat(props).includes(entry("defaultProject", "prod"));
+        assertThat(props).includes(entry("digestProjectName", "prod"));
+    }
+
+    @Test
+    public void test_cli_mode_with_stages_and_elasticsearch() {
+        Properties props = parse(
+                "--mode=CLI",
+                "--stages=SCAN,INDEX",
+                "--elasticsearchAddress", "http://es:9200",
+                "--defaultProject", "corpus");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("stages", "SCAN,INDEX"));
+        assertThat(props).includes(entry("elasticsearchAddress", "http://es:9200"));
+        assertThat(props).includes(entry("defaultProject", "corpus"));
+    }
+
+    @Test
+    public void test_task_worker_mode_with_redis() {
+        Properties props = parse(
+                "--mode=TASK_WORKER",
+                "--redisAddress", "redis://cache:6379",
+                "--taskWorkers", "4");
+        assertThat(props).includes(entry("mode", "TASK_WORKER"));
+        assertThat(props).includes(entry("redisAddress", "redis://cache:6379"));
+        assertThat(props).includes(entry("taskWorkers", "4"));
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
@@ -134,21 +134,21 @@ public class DatashareCommandTest {
 
     @Test
     public void test_stage_run_scan_index() {
-        Properties props = parse("stage", "run", "SCAN,INDEX");
+        Properties props = parse("stage", "run", "--stages", "SCAN,INDEX");
         assertThat(props).includes(entry("mode", "CLI"));
         assertThat(props).includes(entry("stages", "SCAN,INDEX"));
     }
 
     @Test
     public void test_stage_run_single_stage() {
-        Properties props = parse("stage", "run", "SCAN");
+        Properties props = parse("stage", "run", "--stages", "SCAN");
         assertThat(props).includes(entry("mode", "CLI"));
         assertThat(props).includes(entry("stages", "SCAN"));
     }
 
     @Test
     public void test_stage_run_all_main_stages() {
-        Properties props = parse("stage", "run", "SCAN,INDEX,NLP");
+        Properties props = parse("stage", "run", "--stages", "SCAN,INDEX,NLP");
         assertThat(props).includes(entry("stages", "SCAN,INDEX,NLP"));
     }
 
@@ -160,7 +160,7 @@ public class DatashareCommandTest {
 
     @Test
     public void test_stage_run_with_data_dir() {
-        Properties props = parse("--dataDir", "/data/docs", "stage", "run", "SCAN,INDEX");
+        Properties props = parse("--dataDir", "/data/docs", "stage", "run", "--stages", "SCAN,INDEX");
         assertThat(props).includes(entry("mode", "CLI"));
         assertThat(props).includes(entry("stages", "SCAN,INDEX"));
         assertThat(props).includes(entry("dataDir", "/data/docs"));
@@ -612,7 +612,7 @@ public class DatashareCommandTest {
 
     @Test
     public void test_nlp_parallelism() {
-        Properties props = parse("stage", "run", "NLP", "--nlpParallelism", "4");
+        Properties props = parse("stage", "run", "--stages", "NLP", "--nlpParallelism", "4");
         assertThat(props).includes(entry("nlpParallelism", "4"));
     }
 
@@ -687,7 +687,7 @@ public class DatashareCommandTest {
 
     @Test
     public void test_stage_run_overrides_shared_mode() {
-        Properties props = parse("stage", "run", "SCAN");
+        Properties props = parse("stage", "run", "--stages", "SCAN");
         assertThat(props).includes(entry("mode", "CLI"));
     }
 
@@ -725,7 +725,7 @@ public class DatashareCommandTest {
                 "--dataDir", "/data/docs",
                 "--queueType", "REDIS",
                 "--redisAddress", "redis://redis:6379",
-                "stage", "run", "SCAN,INDEX");
+                "stage", "run", "--stages", "SCAN,INDEX");
         assertThat(props).includes(entry("elasticsearchAddress", "http://es:9200"));
         assertThat(props).includes(entry("dataDir", "/data/docs"));
         assertThat(props).includes(entry("queueType", "REDIS"));
@@ -858,7 +858,7 @@ public class DatashareCommandTest {
 
     @Test
     public void test_global_option_after_stage_run() {
-        Properties props = parse("stage", "run", "SCAN", "--dataDir", "/my/docs");
+        Properties props = parse("stage", "run", "--stages", "SCAN", "--dataDir", "/my/docs");
         assertThat(props).includes(entry("dataDir", "/my/docs"));
     }
 

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
@@ -1,0 +1,906 @@
+package org.icij.datashare.cli.command;
+
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.OptionSpec;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
+public class DatashareCommandTest {
+
+    @Before
+    public void setUp() {
+        System.setProperty("user.home", "/home/datashare");
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("user.home");
+    }
+
+    private Properties parse(String... args) {
+        DatashareCommand cmd = new DatashareCommand();
+        CommandLine commandLine = new CommandLine(cmd);
+        commandLine.setOverwrittenOptionsAllowed(true);
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        commandLine.setExecutionStrategy(parseResult -> {
+            CommandLine.ParseResult sub = parseResult;
+            while (sub.hasSubcommand()) {
+                sub = sub.subcommand();
+            }
+            Object userObject = sub.commandSpec().userObject();
+            if (userObject instanceof DatashareSubcommand) {
+                cmd.setExecutedSubcommand((DatashareSubcommand) userObject);
+            }
+            return new CommandLine.RunLast().execute(parseResult);
+        });
+        commandLine.execute(args);
+        return cmd.collectProperties();
+    }
+
+    private int parseExitCode(String... args) {
+        DatashareCommand cmd = new DatashareCommand();
+        CommandLine commandLine = new CommandLine(cmd);
+        commandLine.setOverwrittenOptionsAllowed(true);
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        commandLine.setExecutionStrategy(parseResult -> {
+            CommandLine.ParseResult sub = parseResult;
+            while (sub.hasSubcommand()) {
+                sub = sub.subcommand();
+            }
+            Object userObject = sub.commandSpec().userObject();
+            if (userObject instanceof DatashareSubcommand) {
+                cmd.setExecutedSubcommand((DatashareSubcommand) userObject);
+            }
+            return new CommandLine.RunLast().execute(parseResult);
+        });
+        return commandLine.execute(args);
+    }
+
+    @Test
+    public void test_app_serve_defaults_to_local() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("mode", "LOCAL"));
+    }
+
+    @Test
+    public void test_app_serve_server() {
+        Properties props = parse("app", "start", "--mode", "server");
+        assertThat(props).includes(entry("mode", "SERVER"));
+    }
+
+    @Test
+    public void test_app_serve_embedded() {
+        Properties props = parse("app", "start", "--mode", "embedded");
+        assertThat(props).includes(entry("mode", "EMBEDDED"));
+    }
+
+    @Test
+    public void test_app_serve_ner() {
+        Properties props = parse("app", "start", "--mode", "ner");
+        assertThat(props).includes(entry("mode", "NER"));
+    }
+
+    @Test
+    public void test_app_serve_case_insensitive_uppercase() {
+        Properties props = parse("app", "start", "--mode", "SERVER");
+        assertThat(props).includes(entry("mode", "SERVER"));
+    }
+
+    @Test
+    public void test_app_serve_case_insensitive_mixed() {
+        Properties props = parse("app", "start", "--mode", "Local");
+        assertThat(props).includes(entry("mode", "LOCAL"));
+    }
+
+    @Test
+    public void test_app_serve_invalid_mode_rejected_by_parser() {
+        // picocli rejects unknown enum values at parse time — expect non-zero exit
+        int exitCode = parseExitCode("app", "start", "--mode", "INVALID");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_worker_run() {
+        Properties props = parse("worker", "run");
+        assertThat(props).includes(entry("mode", "TASK_WORKER"));
+    }
+
+    @Test
+    public void test_worker_run_with_shared_options() {
+        Properties props = parse("--redisAddress", "redis://my-redis:6379", "worker", "run");
+        assertThat(props).includes(entry("mode", "TASK_WORKER"));
+        assertThat(props).includes(entry("redisAddress", "redis://my-redis:6379"));
+    }
+
+    @Test
+    public void test_worker_run_with_task_workers() {
+        Properties props = parse("worker", "run", "--taskWorkers", "4");
+        assertThat(props).includes(entry("mode", "TASK_WORKER"));
+        assertThat(props).includes(entry("taskWorkers", "4"));
+    }
+
+    @Test
+    public void test_stage_run_scan_index() {
+        Properties props = parse("stage", "run", "SCAN,INDEX");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("stages", "SCAN,INDEX"));
+    }
+
+    @Test
+    public void test_stage_run_single_stage() {
+        Properties props = parse("stage", "run", "SCAN");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("stages", "SCAN"));
+    }
+
+    @Test
+    public void test_stage_run_all_main_stages() {
+        Properties props = parse("stage", "run", "SCAN,INDEX,NLP");
+        assertThat(props).includes(entry("stages", "SCAN,INDEX,NLP"));
+    }
+
+    @Test
+    public void test_stage_run_missing_stages_fails() {
+        int exitCode = parseExitCode("stage", "run");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_stage_run_with_data_dir() {
+        Properties props = parse("--dataDir", "/data/docs", "stage", "run", "SCAN,INDEX");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("stages", "SCAN,INDEX"));
+        assertThat(props).includes(entry("dataDir", "/data/docs"));
+    }
+
+    @Test
+    public void test_plugin_list_no_filter() {
+        Properties props = parse("plugin", "list");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("pluginList", "true"));
+    }
+
+    @Test
+    public void test_plugin_list_with_filter() {
+        Properties props = parse("plugin", "list", ".*foo.*");
+        assertThat(props).includes(entry("pluginList", ".*foo.*"));
+    }
+
+    @Test
+    public void test_plugin_install_by_id() {
+        Properties props = parse("plugin", "install", "my-plugin");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("pluginInstall", "my-plugin"));
+    }
+
+    @Test
+    public void test_plugin_install_by_url() {
+        Properties props = parse("plugin", "install", "https://example.com/plugin.jar");
+        assertThat(props).includes(entry("pluginInstall", "https://example.com/plugin.jar"));
+    }
+
+    @Test
+    public void test_plugin_install_by_path() {
+        Properties props = parse("plugin", "install", "/opt/plugins/my-plugin.jar");
+        assertThat(props).includes(entry("pluginInstall", "/opt/plugins/my-plugin.jar"));
+    }
+
+    @Test
+    public void test_plugin_install_missing_id_fails() {
+        int exitCode = parseExitCode("plugin", "install");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_plugin_delete() {
+        Properties props = parse("plugin", "delete", "my-plugin");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("pluginDelete", "my-plugin"));
+    }
+
+    @Test
+    public void test_plugin_delete_missing_id_fails() {
+        int exitCode = parseExitCode("plugin", "delete");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_plugin_list_with_custom_plugins_dir() {
+        Properties props = parse("--pluginsDir", "/custom/plugins", "plugin", "list");
+        assertThat(props).includes(entry("pluginsDir", "/custom/plugins"));
+        assertThat(props).includes(entry("pluginList", "true"));
+    }
+
+    @Test
+    public void test_extension_list_no_filter() {
+        Properties props = parse("extension", "list");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("extensionList", "true"));
+    }
+
+    @Test
+    public void test_extension_list_with_filter() {
+        Properties props = parse("extension", "list", ".*nlp.*");
+        assertThat(props).includes(entry("extensionList", ".*nlp.*"));
+    }
+
+    @Test
+    public void test_extension_install_by_id() {
+        Properties props = parse("extension", "install", "my-ext");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("extensionInstall", "my-ext"));
+    }
+
+    @Test
+    public void test_extension_install_by_url() {
+        Properties props = parse("extension", "install", "https://example.com/ext.jar");
+        assertThat(props).includes(entry("extensionInstall", "https://example.com/ext.jar"));
+    }
+
+    @Test
+    public void test_extension_install_missing_id_fails() {
+        int exitCode = parseExitCode("extension", "install");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_extension_delete() {
+        Properties props = parse("extension", "delete", "my-ext");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("extensionDelete", "my-ext"));
+    }
+
+    @Test
+    public void test_extension_delete_missing_id_fails() {
+        int exitCode = parseExitCode("extension", "delete");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_extension_list_with_custom_extensions_dir() {
+        Properties props = parse("--extensionsDir", "/custom/ext", "extension", "list");
+        assertThat(props).includes(entry("extensionsDir", "/custom/ext"));
+        assertThat(props).includes(entry("extensionList", "true"));
+    }
+
+    @Test
+    public void test_api_key_create() {
+        Properties props = parse("api-key", "create", "alice");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("createApiKey", "alice"));
+    }
+
+    @Test
+    public void test_api_key_get() {
+        Properties props = parse("api-key", "get", "alice");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("apiKey", "alice"));
+    }
+
+    @Test
+    public void test_api_key_delete() {
+        Properties props = parse("api-key", "delete", "alice");
+        assertThat(props).includes(entry("mode", "CLI"));
+        assertThat(props).includes(entry("deleteApiKey", "alice"));
+    }
+
+    @Test
+    public void test_api_key_create_missing_user_fails() {
+        int exitCode = parseExitCode("api-key", "create");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_api_key_get_missing_user_fails() {
+        int exitCode = parseExitCode("api-key", "get");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_api_key_delete_missing_user_fails() {
+        int exitCode = parseExitCode("api-key", "delete");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_default_mode_is_local() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("mode", "LOCAL"));
+    }
+
+    @Test
+    public void test_default_project() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("defaultProject", "local-datashare"));
+    }
+
+    @Test
+    public void test_default_port() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("tcpListenPort", "8080"));
+    }
+
+    @Test
+    public void test_custom_port() {
+        Properties props = parse("app", "start", "--tcpListenPort=7777");
+        assertThat(props).includes(entry("tcpListenPort", "7777"));
+    }
+
+    @Test
+    public void test_port_alias() {
+        Properties props = parse("app", "start", "--port=7777");
+        // port should be aliased to tcpListenPort
+        assertThat(props).includes(entry("tcpListenPort", "7777"));
+    }
+
+    @Test
+    public void test_default_log_level() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("logLevel", "INFO"));
+    }
+
+    @Test
+    public void test_custom_log_level() {
+        Properties props = parse("--logLevel", "DEBUG", "app", "start");
+        assertThat(props).includes(entry("logLevel", "DEBUG"));
+    }
+
+    @Test
+    public void test_default_cors() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("cors", "no-cors"));
+    }
+
+    @Test
+    public void test_data_dir_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("dataDir", "/home/datashare/Datashare"));
+    }
+
+    @Test
+    public void test_data_dir_custom() {
+        Properties props = parse("--dataDir", "/my/docs", "app", "start");
+        assertThat(props).includes(entry("dataDir", "/my/docs"));
+    }
+
+    @Test
+    public void test_data_dir_short_opt() {
+        Properties props = parse("-d", "/my/docs", "app", "start");
+        assertThat(props).includes(entry("dataDir", "/my/docs"));
+    }
+
+    @Test
+    public void test_elasticsearch_data_path_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("elasticsearchDataPath", "/home/datashare/.local/share/datashare/es"));
+    }
+
+    @Test
+    public void test_extensions_dir_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("extensionsDir", "/home/datashare/.local/share/datashare/extensions"));
+    }
+
+    @Test
+    public void test_plugins_dir_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("pluginsDir", "/home/datashare/.local/share/datashare/plugins"));
+    }
+
+    @Test
+    public void test_bind_host_opt() {
+        Properties props = parse("app", "start", "--bind", "127.0.0.1");
+        assertThat(props).includes(entry("bind", "127.0.0.1"));
+    }
+
+    @Test
+    public void test_bind_short_opt() {
+        Properties props = parse("app", "start", "-b", "0.0.0.0");
+        assertThat(props).includes(entry("bind", "0.0.0.0"));
+    }
+
+    @Test
+    public void test_bind_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("bind")).isNull();
+    }
+
+    @Test
+    public void test_queue_capacity_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("queueCapacity", "1000000"));
+    }
+
+    @Test
+    public void test_queue_capacity_custom() {
+        Properties props = parse("--queueCapacity", "10", "app", "start");
+        assertThat(props).includes(entry("queueCapacity", "10"));
+    }
+
+    @Test
+    public void test_index_timeout_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("indexTimeout", "30"));
+    }
+
+    @Test
+    public void test_index_timeout_custom() {
+        Properties props = parse("app", "start", "--indexTimeout", "10");
+        assertThat(props).includes(entry("indexTimeout", "10"));
+    }
+
+    @Test
+    public void test_no_default_language_value() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("language")).isNull();
+    }
+
+    @Test
+    public void test_custom_language() {
+        // language is a global option — can be passed before the subcommand
+        Properties props = parse("--language", "ENGLISH", "app", "start");
+        assertThat(props).includes(entry("language", "ENGLISH"));
+    }
+
+    @Test
+    public void test_default_user_name() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("defaultUserName", "local"));
+    }
+
+    @Test
+    public void test_custom_user_name_short() {
+        Properties props = parse("-u", "admin", "app", "start");
+        assertThat(props).includes(entry("defaultUserName", "admin"));
+    }
+
+    @Test
+    public void test_batch_download_max_size() {
+        Properties props = parse("app", "start", "--batchDownloadMaxSize", "123");
+        assertThat(props).includes(entry("batchDownloadMaxSize", "123"));
+    }
+
+    @Test
+    public void test_batch_download_max_size_with_suffix() {
+        Properties props = parse("app", "start", "--batchDownloadMaxSize", "123G");
+        assertThat(props).includes(entry("batchDownloadMaxSize", "123G"));
+    }
+
+    @Test
+    public void test_embedded_document_download_max_size() {
+        Properties props = parse("app", "start", "--embeddedDocumentDownloadMaxSize", "500M");
+        assertThat(props).includes(entry("embeddedDocumentDownloadMaxSize", "500M"));
+    }
+
+    @Test
+    public void test_relative_batch_download_dir() {
+        Properties props = parse("app", "start", "--batchDownloadDir", "foo");
+        Path userDir = Path.of(System.getProperty("user.dir"));
+        assertThat(props).includes(entry("batchDownloadDir", userDir.resolve("foo").toString()));
+    }
+
+    @Test
+    public void test_absolute_batch_download_dir() {
+        Properties props = parse("app", "start", "--batchDownloadDir", "/home/foo");
+        assertThat(props).includes(entry("batchDownloadDir", "/home/foo"));
+    }
+
+    @Test
+    public void test_default_ocr_enabled() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("ocr", "true"));
+    }
+
+    @Test
+    public void test_ocr_disabled() {
+        Properties props = parse("app", "start", "--ocr=false");
+        assertThat(props).includes(entry("ocr", "false"));
+    }
+
+    @Test
+    public void test_ocr_short_opt() {
+        Properties props = parse("app", "start", "-o=false");
+        assertThat(props).includes(entry("ocr", "false"));
+    }
+
+    @Test
+    public void test_session_ttl() {
+        Properties props = parse("app", "start", "--sessionTtlSeconds", "3600");
+        assertThat(props).includes(entry("sessionTtlSeconds", "3600"));
+    }
+
+    @Test
+    public void test_session_ttl_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("sessionTtlSeconds", "43200"));
+    }
+
+    @Test
+    public void test_redis_address() {
+        Properties props = parse("--redisAddress", "redis://localhost:6379", "app", "start");
+        assertThat(props).includes(entry("redisAddress", "redis://localhost:6379"));
+    }
+
+    @Test
+    public void test_elasticsearch_address() {
+        Properties props = parse("--elasticsearchAddress", "http://localhost:9200", "app", "start");
+        assertThat(props).includes(entry("elasticsearchAddress", "http://localhost:9200"));
+    }
+
+    @Test
+    public void test_data_source_url() {
+        Properties props = parse("--dataSourceUrl", "jdbc:postgresql://localhost/ds", "app", "start");
+        assertThat(props).includes(entry("dataSourceUrl", "jdbc:postgresql://localhost/ds"));
+    }
+
+    @Test
+    public void test_task_routing_strategy() {
+        Properties props = parse("app", "start", "--taskRoutingStrategy", "GROUP");
+        assertThat(props).includes(entry("taskRoutingStrategy", "GROUP"));
+    }
+
+    @Test
+    public void test_task_routing_strategy_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("taskRoutingStrategy", "UNIQUE"));
+    }
+
+    @Test
+    public void test_task_repository_type_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("taskRepositoryType", "DATABASE"));
+    }
+
+    @Test
+    public void test_bus_type_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("busType", "MEMORY"));
+    }
+
+    @Test
+    public void test_follow_symlinks_default() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("followSymlinks", "true"));
+    }
+
+    @Test
+    public void test_follow_symlinks_disabled() {
+        Properties props = parse("app", "start", "--followSymlinks=false");
+        assertThat(props).includes(entry("followSymlinks", "false"));
+    }
+
+    @Test
+    public void test_oauth_options() {
+        Properties props = parse("app", "start", "--mode", "server",
+                "--oauthClientId", "myId",
+                "--oauthClientSecret", "mySecret",
+                "--oauthAuthorizeUrl", "https://auth.example.com/authorize",
+                "--oauthTokenUrl", "https://auth.example.com/token",
+                "--oauthApiUrl", "https://api.example.com");
+        assertThat(props).includes(entry("oauthClientId", "myId"));
+        assertThat(props).includes(entry("oauthClientSecret", "mySecret"));
+        assertThat(props).includes(entry("oauthAuthorizeUrl", "https://auth.example.com/authorize"));
+        assertThat(props).includes(entry("oauthTokenUrl", "https://auth.example.com/token"));
+        assertThat(props).includes(entry("oauthApiUrl", "https://api.example.com"));
+        assertThat(props).includes(entry("mode", "SERVER"));
+    }
+
+    @Test
+    public void test_auth_filter() {
+        Properties props = parse("app", "start", "--mode", "server", "--authFilter", "org.icij.BasicAuthFilter");
+        assertThat(props).includes(entry("authFilter", "org.icij.BasicAuthFilter"));
+    }
+
+    @Test
+    public void test_nlp_pipeline() {
+        Properties props = parse("app", "start", "--nlpPipeline", "SPACY");
+        assertThat(props).includes(entry("nlpPipeline", "SPACY"));
+    }
+
+    @Test
+    public void test_nlp_parallelism() {
+        Properties props = parse("stage", "run", "NLP", "--nlpParallelism", "4");
+        assertThat(props).includes(entry("nlpParallelism", "4"));
+    }
+
+    @Test
+    public void test_settings_opt() {
+        Properties props = parse("-s", "/path/to/settings.properties", "app", "start");
+        assertThat(props).includes(entry("settings", "/path/to/settings.properties"));
+    }
+
+    @Test
+    public void test_settings_long_opt() {
+        Properties props = parse("--settings", "/path/to/settings.properties", "app", "start");
+        assertThat(props).includes(entry("settings", "/path/to/settings.properties"));
+    }
+
+    @Test
+    public void test_digest_project_name_defaults_to_default_project() {
+        Properties props = parse("app", "start");
+        assertThat(props).includes(entry("defaultProject", "local-datashare"));
+        assertThat(props).includes(entry("digestProjectName", "local-datashare"));
+    }
+
+    @Test
+    public void test_digest_project_name_with_custom_project() {
+        Properties props = parse("--defaultProject=myproject", "app", "start");
+        assertThat(props).includes(entry("digestProjectName", "myproject"));
+    }
+
+    @Test
+    public void test_no_digest_project_flag() {
+        Properties props = parse("--noDigestProject=true", "app", "start");
+        assertThat(props).includes(entry("defaultProject", "local-datashare"));
+        assertThat(props).includes(entry("noDigestProject", "true"));
+        assertThat(props.getProperty("digestProjectName")).isNull();
+    }
+
+    @Test
+    public void test_digest_project_name_left_as_is_when_provided() {
+        Properties props = parse("--digestProjectName", "foo", "app", "start");
+        assertThat(props).includes(entry("defaultProject", "local-datashare"));
+        assertThat(props).includes(entry("digestProjectName", "foo"));
+        assertThat(props).includes(entry("noDigestProject", "false"));
+    }
+
+    @Test
+    public void test_empty_default_project_falls_back_to_local_datashare() {
+        // An empty defaultProject should fall back to "local-datashare" for digestProjectName
+        Properties props = parse("--defaultProject", "", "app", "start");
+        assertThat(props.getProperty("digestProjectName")).isEqualTo("local-datashare");
+    }
+
+    @Test
+    public void test_short_project_opt() {
+        Properties props = parse("-P", "myproject", "app", "start");
+        assertThat(props).includes(entry("defaultProject", "myproject"));
+        assertThat(props).includes(entry("digestProjectName", "myproject"));
+    }
+
+    @Test
+    public void test_subcommand_overrides_shared_mode() {
+        // The shared option defaults mode to LOCAL,
+        // but "--mode SERVER" should override it to SERVER
+        Properties props = parse("app", "start", "--mode", "server");
+        assertThat(props).includes(entry("mode", "SERVER"));
+    }
+
+    @Test
+    public void test_worker_run_overrides_shared_mode() {
+        Properties props = parse("worker", "run");
+        assertThat(props).includes(entry("mode", "TASK_WORKER"));
+    }
+
+    @Test
+    public void test_stage_run_overrides_shared_mode() {
+        Properties props = parse("stage", "run", "SCAN");
+        assertThat(props).includes(entry("mode", "CLI"));
+    }
+
+    @Test
+    public void test_plugin_list_overrides_shared_mode() {
+        Properties props = parse("plugin", "list");
+        assertThat(props).includes(entry("mode", "CLI"));
+    }
+
+    @Test
+    public void test_api_key_create_overrides_shared_mode() {
+        Properties props = parse("api-key", "create", "bob");
+        assertThat(props).includes(entry("mode", "CLI"));
+    }
+
+    @Test
+    public void test_multiple_shared_options_with_app_serve() {
+        Properties props = parse(
+                "--defaultProject=foo",
+                "--elasticsearchAddress", "http://es:9200",
+                "--dataDir", "/data/docs",
+                "--logLevel", "DEBUG",
+                "app", "start", "--mode", "server");
+        assertThat(props).includes(entry("defaultProject", "foo"));
+        assertThat(props).includes(entry("elasticsearchAddress", "http://es:9200"));
+        assertThat(props).includes(entry("dataDir", "/data/docs"));
+        assertThat(props).includes(entry("logLevel", "DEBUG"));
+        assertThat(props).includes(entry("mode", "SERVER"));
+    }
+
+    @Test
+    public void test_multiple_shared_options_with_stage_run() {
+        Properties props = parse(
+                "--elasticsearchAddress", "http://es:9200",
+                "--dataDir", "/data/docs",
+                "--queueType", "REDIS",
+                "--redisAddress", "redis://redis:6379",
+                "stage", "run", "SCAN,INDEX");
+        assertThat(props).includes(entry("elasticsearchAddress", "http://es:9200"));
+        assertThat(props).includes(entry("dataDir", "/data/docs"));
+        assertThat(props).includes(entry("queueType", "REDIS"));
+        assertThat(props).includes(entry("redisAddress", "redis://redis:6379"));
+        assertThat(props).includes(entry("stages", "SCAN,INDEX"));
+        assertThat(props).includes(entry("mode", "CLI"));
+    }
+
+    @Test
+    public void test_unknown_subcommand_fails() {
+        int exitCode = parseExitCode("unknown");
+        assertThat(exitCode).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_app_without_serve_shows_help() {
+        int exitCode = parseExitCode("app");
+        assertThat(exitCode).isEqualTo(0);
+    }
+
+    @Test
+    public void test_worker_without_run_shows_help() {
+        int exitCode = parseExitCode("worker");
+        assertThat(exitCode).isEqualTo(0);
+    }
+
+    @Test
+    public void test_stage_without_run_shows_help() {
+        int exitCode = parseExitCode("stage");
+        assertThat(exitCode).isEqualTo(0);
+    }
+
+    @Test
+    public void test_plugin_without_subcommand_shows_help() {
+        int exitCode = parseExitCode("plugin");
+        assertThat(exitCode).isEqualTo(0);
+    }
+
+    @Test
+    public void test_extension_without_subcommand_shows_help() {
+        int exitCode = parseExitCode("extension");
+        assertThat(exitCode).isEqualTo(0);
+    }
+
+    @Test
+    public void test_api_key_without_subcommand_shows_help() {
+        int exitCode = parseExitCode("api-key");
+        assertThat(exitCode).isEqualTo(0);
+    }
+
+    @Test
+    public void test_oauth_client_id_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("oauthClientId")).isNull();
+    }
+
+    @Test
+    public void test_oauth_client_secret_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("oauthClientSecret")).isNull();
+    }
+
+    @Test
+    public void test_root_host_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("rootHost")).isNull();
+    }
+
+    @Test
+    public void test_session_signing_key_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("sessionSigningKey")).isNull();
+    }
+
+    @Test
+    public void test_create_index_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("createIndex")).isNull();
+    }
+
+    @Test
+    public void test_report_name_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("reportName")).isNull();
+    }
+
+    @Test
+    public void test_artifact_dir_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("artifactDir")).isNull();
+    }
+
+    @Test
+    public void test_search_query_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("searchQuery")).isNull();
+    }
+
+    @Test
+    public void test_ocr_language_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("ocrLanguage")).isNull();
+    }
+
+    @Test
+    public void test_task_routing_key_not_set_by_default() {
+        Properties props = parse("app", "start");
+        assertThat(props.getProperty("taskRoutingKey")).isNull();
+    }
+
+    // Global options accepted after subcommand name
+
+    @Test
+    public void test_global_option_after_app_start() {
+        Properties props = parse("app", "start", "--elasticsearchAddress", "http://es:9200");
+        assertThat(props).includes(entry("elasticsearchAddress", "http://es:9200"));
+    }
+
+    @Test
+    public void test_global_option_short_after_app_start() {
+        Properties props = parse("app", "start", "-d", "/my/docs");
+        assertThat(props).includes(entry("dataDir", "/my/docs"));
+    }
+
+    @Test
+    public void test_global_option_after_worker_run() {
+        Properties props = parse("worker", "run", "--redisAddress", "redis://my-redis:6379");
+        assertThat(props).includes(entry("redisAddress", "redis://my-redis:6379"));
+    }
+
+    @Test
+    public void test_global_option_after_stage_run() {
+        Properties props = parse("stage", "run", "SCAN", "--dataDir", "/my/docs");
+        assertThat(props).includes(entry("dataDir", "/my/docs"));
+    }
+
+    @Test
+    public void test_global_options_mixed_before_and_after_subcommand() {
+        Properties props = parse("--defaultProject", "myproject", "app", "start", "--logLevel", "DEBUG");
+        assertThat(props).includes(entry("defaultProject", "myproject"));
+        assertThat(props).includes(entry("logLevel", "DEBUG"));
+    }
+
+    @Test
+    public void test_global_and_subcommand_options_both_after_subcommand() {
+        Properties props = parse("worker", "run", "--taskWorkers", "4", "--redisAddress", "redis://x:6379");
+        assertThat(props).includes(entry("taskWorkers", "4"));
+        assertThat(props).includes(entry("redisAddress", "redis://x:6379"));
+    }
+
+    // Guard: no option name conflicts between GlobalOptions and subcommand-specific option classes
+
+    @Test
+    public void test_no_option_name_conflicts_between_global_and_subcommand_options() {
+        Set<String> globalNames = optionNamesOf(GlobalOptions.class);
+        assertNoOverlap(globalNames, ServerOptions.class);
+        assertNoOverlap(globalNames, WorkerOptions.class);
+        assertNoOverlap(globalNames, PipelineOptions.class);
+    }
+
+    private static Set<String> optionNamesOf(Class<?> clazz) {
+        Set<String> names = new HashSet<>();
+        for (Field field : clazz.getDeclaredFields()) {
+            CommandLine.Option opt = field.getAnnotation(CommandLine.Option.class);
+            if (opt != null) names.addAll(Arrays.asList(opt.names()));
+        }
+        return names;
+    }
+
+    private static void assertNoOverlap(Set<String> globalNames, Class<?> optionClass) {
+        Set<String> subNames = optionNamesOf(optionClass);
+        Set<String> conflicts = new HashSet<>(globalNames);
+        conflicts.retainAll(subNames);
+        assertThat(conflicts)
+            .as("Option name conflicts between GlobalOptions and " + optionClass.getSimpleName())
+            .isEmpty();
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
@@ -886,6 +886,76 @@ public class DatashareCommandTest {
         assertNoOverlap(globalNames, PipelineOptions.class);
     }
 
+    @Test
+    public void test_root_help_flag_exits_zero() {
+        assertThat(parseExitCode("--help")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_root_help_short_flag_exits_zero() {
+        assertThat(parseExitCode("-h")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_app_start_help_flag_exits_zero() {
+        assertThat(parseExitCode("app", "start", "--help")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_worker_run_help_flag_exits_zero() {
+        assertThat(parseExitCode("worker", "run", "--help")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_stage_run_help_flag_exits_zero() {
+        assertThat(parseExitCode("stage", "run", "--help")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_version_flag_exits_zero() {
+        assertThat(parseExitCode("--version")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_version_short_flag_exits_zero() {
+        assertThat(parseExitCode("-V")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_help_subcommand_exits_zero() {
+        assertThat(parseExitCode("help")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_help_subcommand_with_app_exits_zero() {
+        assertThat(parseExitCode("help", "app")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_help_subcommand_with_app_start_exits_zero() {
+        assertThat(parseExitCode("help", "app", "start")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_no_color_flag_is_accepted() {
+        assertThat(parseExitCode("--no-color", "app", "start")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_no_color_flag_after_subcommand_is_accepted() {
+        assertThat(parseExitCode("app", "start", "--no-color")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_unknown_flag_fails() {
+        assertThat(parseExitCode("--foo")).isNotEqualTo(0);
+    }
+
+    @Test
+    public void test_unknown_leaf_subcommand_fails() {
+        assertThat(parseExitCode("app", "foo")).isNotEqualTo(0);
+    }
+
     private static Set<String> optionNamesOf(Class<?> clazz) {
         Set<String> names = new HashSet<>();
         for (Field field : clazz.getDeclaredFields()) {

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareHelpFactoryTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareHelpFactoryTest.java
@@ -1,0 +1,297 @@
+package org.icij.datashare.cli.command;
+
+import org.junit.Test;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.OptionSpec;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.cli.command.DatashareHelpFactory.HELP_WIDTH;
+import static org.icij.datashare.cli.command.DatashareHelpFactory.optionLabel;
+import static org.icij.datashare.cli.command.DatashareHelpFactory.renderCommandList;
+import static org.icij.datashare.cli.command.DatashareHelpFactory.renderDescription;
+import static org.icij.datashare.cli.command.DatashareHelpFactory.renderGlobalOptionList;
+import static org.icij.datashare.cli.command.DatashareHelpFactory.renderOptionList;
+
+public class DatashareHelpFactoryTest {
+
+    // ===================================================================
+    // optionLabel
+    // ===================================================================
+
+    @Test
+    public void test_option_label_string_uses_value() {
+        OptionSpec opt = OptionSpec.builder("--cors").type(String.class).build();
+        assertThat(optionLabel(opt)).isEqualTo("--cors=<value>");
+    }
+
+    @Test
+    public void test_option_label_url_suffix_uses_url() {
+        OptionSpec opt = OptionSpec.builder("--elasticsearchAddress").type(String.class).build();
+        assertThat(optionLabel(opt)).isEqualTo("--elasticsearchAddress=<url>");
+    }
+
+    @Test
+    public void test_option_label_dir_suffix_uses_path() {
+        OptionSpec opt = OptionSpec.builder("--batchDownloadDir").type(String.class).build();
+        assertThat(optionLabel(opt)).isEqualTo("--batchDownloadDir=<path>");
+    }
+
+    @Test
+    public void test_option_label_bind_uses_host() {
+        OptionSpec opt = OptionSpec.builder("-b", "--bind").type(String.class).build();
+        assertThat(optionLabel(opt)).isEqualTo("-b, --bind=<host>");
+    }
+
+    @Test
+    public void test_option_label_int_uses_number() {
+        OptionSpec opt = OptionSpec.builder("--port").type(int.class).build();
+        assertThat(optionLabel(opt)).isEqualTo("--port=<number>");
+    }
+
+    @Test
+    public void test_option_label_boolean_no_equals() {
+        OptionSpec opt = OptionSpec.builder("--ocr").type(boolean.class).build();
+        assertThat(optionLabel(opt)).isEqualTo("--ocr");
+    }
+
+    // ===================================================================
+    // renderDescription: auto-bold section headings
+    // ===================================================================
+
+    @Test
+    public void test_render_description_bolds_heading_lines() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        String output = renderDescription(appServe.getHelp());
+        // "Examples:" heading is rendered (bold markup stripped in non-TTY test env)
+        assertThat(output).contains("Examples:");
+        // must not contain raw unprocessed markup
+        assertThat(output).doesNotContain("@|bold");
+    }
+
+    @Test
+    public void test_render_description_does_not_bold_indented_lines() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        String output = renderDescription(appServe.getHelp());
+        // indented example lines must appear verbatim
+        assertThat(output).contains("  datashare app start");
+    }
+
+    // ===================================================================
+    // renderOptionList: two-column alignment
+    // ===================================================================
+
+    @Test
+    public void test_render_option_list_all_descriptions_on_same_line() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        String output = renderOptionList(appServe.getHelp());
+
+        for (String line : lines(output)) {
+            if (line.isBlank()) continue;
+            // Each line should contain exactly one segment of content (no mid-line wrap artefacts)
+            assertThat(line.startsWith("      ")).as("no over-indented continuation line: " + line).isFalse();
+        }
+    }
+
+    @Test
+    public void test_render_option_list_one_line_per_option() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        CommandLine.Help help = appServe.getHelp();
+        String output = renderOptionList(help);
+
+        long visibleOptions = help.commandSpec().options().stream().filter(o -> !o.hidden() && !o.inherited()).count();
+        long nonBlankLines  = lines(output).stream().filter(l -> !l.isBlank()).count();
+        assertThat(nonBlankLines)
+                .as("each option must produce exactly one line")
+                .isEqualTo(visibleOptions);
+    }
+
+    @Test
+    public void test_render_command_list_two_columns() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        String output = renderCommandList(cmd.getHelp());
+        assertThat(output).contains("app");
+        assertThat(output).contains("worker");
+
+        long subCount    = cmd.getSubcommands().size();
+        long nonBlankLines = lines(output).stream().filter(l -> !l.isBlank()).count();
+        assertThat(nonBlankLines)
+                .as("each subcommand must produce exactly one line")
+                .isEqualTo(subCount);
+    }
+
+    // ===================================================================
+    // Section headings: bold markup, no indent
+    // ===================================================================
+
+    @Test
+    public void test_option_list_heading_is_bold_and_unindented() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        String section = cmd.getHelpSectionMap().get("optionList").render(appServe.getHelp());
+        // heading rendered without raw markup (ANSI stripped in non-TTY test env)
+        assertThat(section).contains("Options:");
+        assertThat(section).doesNotContain("@|bold");
+        // heading must not be preceded by spaces (left-aligned)
+        assertThat(section).contains("\nOptions:");
+    }
+
+    @Test
+    public void test_command_list_heading_is_bold_and_unindented() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        String section = cmd.getHelpSectionMap().get("commandList").render(cmd.getHelp());
+        assertThat(section).contains("Commands:");
+        assertThat(section).doesNotContain("@|bold");
+        assertThat(section).contains("\nCommands:");
+    }
+
+    // ===================================================================
+    // configure: settings applied recursively
+    // ===================================================================
+
+    @Test
+    public void test_configure_sets_abbreviated_synopsis_on_root() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        assertThat(cmd.getCommandSpec().usageMessage().abbreviateSynopsis()).isTrue();
+    }
+
+    @Test
+    public void test_configure_sets_width_on_root() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        assertThat(cmd.getCommandSpec().usageMessage().width()).isEqualTo(HELP_WIDTH);
+    }
+
+    @Test
+    public void test_configure_sets_sort_options_false_on_root() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        assertThat(cmd.getCommandSpec().usageMessage().sortOptions()).isFalse();
+    }
+
+    @Test
+    public void test_configure_applies_to_subcommands_recursively() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        for (CommandLine sub : cmd.getSubcommands().values()) {
+            assertThat(sub.getCommandSpec().usageMessage().abbreviateSynopsis())
+                    .as("abbreviateSynopsis on " + sub.getCommandName()).isTrue();
+            assertThat(sub.getCommandSpec().usageMessage().width())
+                    .as("width on " + sub.getCommandName()).isEqualTo(HELP_WIDTH);
+        }
+    }
+
+    @Test
+    public void test_configure_footer_set_on_root_only() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        assertThat(cmd.getCommandSpec().usageMessage().footer().length).isGreaterThan(0);
+        for (CommandLine sub : cmd.getSubcommands().values()) {
+            String[] f = sub.getCommandSpec().usageMessage().footer();
+            assertThat(f == null || f.length == 0)
+                    .as(sub.getCommandName() + " should have no footer").isTrue();
+        }
+    }
+
+    // ===================================================================
+    // renderGlobalOptionList: Global Options section
+    // ===================================================================
+
+    @Test
+    public void test_global_option_list_appears_in_leaf_subcommand() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        String output = renderGlobalOptionList(appServe.getHelp());
+        assertThat(output).isNotEmpty();
+        assertThat(output).contains("--logLevel");
+    }
+
+    @Test
+    public void test_global_option_list_absent_for_root_command() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        String output = renderGlobalOptionList(cmd.getHelp());
+        assertThat(output).isEmpty();
+    }
+
+    @Test
+    public void test_global_option_list_absent_for_intermediate_subcommand() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine app = cmd.getSubcommands().get("app");
+        String output = renderGlobalOptionList(app.getHelp());
+        assertThat(output).isEmpty();
+    }
+
+    @Test
+    public void test_global_option_list_section_heading_rendered() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        String section = cmd.getHelpSectionMap().get("globalOptionList").render(appServe.getHelp());
+        assertThat(section).contains("Global Options:");
+        assertThat(section).doesNotContain("@|bold");
+        assertThat(section).contains("\nGlobal Options:");
+    }
+
+    @Test
+    public void test_global_option_list_one_line_per_global_option() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine workerRun = cmd.getSubcommands().get("worker").getSubcommands().get("run");
+        CommandLine.Help help = workerRun.getHelp();
+        String output = renderGlobalOptionList(help);
+
+        long visibleGlobalOptions = help.commandSpec().root().options().stream()
+                .filter(o -> !o.hidden()).count();
+        long nonBlankLines = lines(output).stream().filter(l -> !l.isBlank()).count();
+        assertThat(nonBlankLines)
+                .as("each global option must produce exactly one line")
+                .isEqualTo(visibleGlobalOptions);
+    }
+
+    @Test
+    public void test_option_list_is_sorted_alphabetically() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine appServe = cmd.getSubcommands().get("app").getSubcommands().get("start");
+        List<String> keys = renderedOptionKeys(renderOptionList(appServe.getHelp()));
+        List<String> sorted = keys.stream().sorted().collect(Collectors.toList());
+        assertThat(keys).as("options must be sorted alphabetically").isEqualTo(sorted);
+    }
+
+    @Test
+    public void test_global_option_list_is_sorted_alphabetically() {
+        CommandLine cmd = DatashareHelpFactory.configure(new CommandLine(new DatashareCommand()));
+        CommandLine workerRun = cmd.getSubcommands().get("worker").getSubcommands().get("run");
+        List<String> keys = renderedOptionKeys(renderGlobalOptionList(workerRun.getHelp()));
+        List<String> sorted = keys.stream().sorted().collect(Collectors.toList());
+        assertThat(keys).as("global options must be sorted alphabetically").isEqualTo(sorted);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    private static List<String> lines(String text) {
+        return Arrays.asList(text.split("\n", -1));
+    }
+
+    /**
+     * Extracts the sort key for each non-blank line of rendered option output.
+     * Uses the long option name (--xxx) if present, otherwise the first option name, lowercased.
+     */
+    private static List<String> renderedOptionKeys(String rendered) {
+        Pattern longOpt = Pattern.compile("--([a-zA-Z][a-zA-Z0-9-]*)");
+        Pattern shortOpt = Pattern.compile("-([a-zA-Z])");
+        return lines(rendered).stream()
+                .filter(l -> !l.isBlank())
+                .map(l -> {
+                    Matcher m = longOpt.matcher(l);
+                    if (m.find()) return m.group(1).toLowerCase();
+                    Matcher s = shortOpt.matcher(l);
+                    return s.find() ? s.group(1).toLowerCase() : l.trim().toLowerCase();
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
@@ -100,7 +100,7 @@ public class RetroCompatibilityTest {
     @Test
     public void test_parity_mode_cli_with_stages() {
         Properties legacy = parseLegacy("--mode=CLI", "--stages=SCAN,INDEX");
-        Properties picocli = parseNew("stage", "run", "SCAN,INDEX");
+        Properties picocli = parseNew("stage", "run", "--stages", "SCAN,INDEX");
         assertPropertyEqual(legacy, picocli, "mode");
         assertPropertyEqual(legacy, picocli, "stages");
     }
@@ -368,7 +368,7 @@ public class RetroCompatibilityTest {
     @Test
     public void test_parity_nlp_parallelism() {
         Properties legacy = parseLegacy("--nlpParallelism", "4", "--stages", "SCAN,INDEX,NLP");
-        Properties picocli = parseNew("stage", "run", "SCAN,INDEX,NLP", "--nlpParallelism", "4");
+        Properties picocli = parseNew("stage", "run", "--stages", "SCAN,INDEX,NLP", "--nlpParallelism", "4");
         assertPropertyEqual(legacy, picocli, "nlpParallelism");
     }
 

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
@@ -338,6 +338,48 @@ public class RetroCompatibilityTest {
     }
 
     @Test
+    public void test_parity_batch_download_max_size() {
+        Properties legacy = parseLegacy("--batchDownloadMaxSize", "500M");
+        Properties picocli = parseNew("app", "start", "--batchDownloadMaxSize", "500M");
+        assertPropertyEqual(legacy, picocli, "batchDownloadMaxSize");
+    }
+
+    @Test
+    public void test_parity_batch_download_max_nb_files() {
+        Properties legacy = parseLegacy("--batchDownloadMaxNbFiles", "50");
+        Properties picocli = parseNew("app", "start", "--batchDownloadMaxNbFiles", "50");
+        assertPropertyEqual(legacy, picocli, "batchDownloadMaxNbFiles");
+    }
+
+    @Test
+    public void test_parity_batch_search_max_time_seconds() {
+        Properties legacy = parseLegacy("--batchSearchMaxTimeSeconds", "120");
+        Properties picocli = parseNew("app", "start", "--batchSearchMaxTimeSeconds", "120");
+        assertPropertyEqual(legacy, picocli, "batchSearchMaxTimeSeconds");
+    }
+
+    @Test
+    public void test_parity_ocr_language() {
+        Properties legacy = parseLegacy("--ocrLanguage", "fra");
+        Properties picocli = parseNew("app", "start", "--ocrLanguage", "fra");
+        assertPropertyEqual(legacy, picocli, "ocrLanguage");
+    }
+
+    @Test
+    public void test_parity_nlp_parallelism() {
+        Properties legacy = parseLegacy("--nlpParallelism", "4", "--stages", "SCAN,INDEX,NLP");
+        Properties picocli = parseNew("stage", "run", "SCAN,INDEX,NLP", "--nlpParallelism", "4");
+        assertPropertyEqual(legacy, picocli, "nlpParallelism");
+    }
+
+    @Test
+    public void test_parity_task_routing_key() {
+        Properties legacy = parseLegacy("--taskRoutingKey", "mykey");
+        Properties picocli = parseNew("app", "start", "--taskRoutingKey", "mykey");
+        assertPropertyEqual(legacy, picocli, "taskRoutingKey");
+    }
+
+    @Test
     public void test_legacy_mode_default() {
         Properties props = parseLegacy("");
         assertThat(props.getProperty("mode")).isEqualTo("LOCAL");

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
@@ -409,4 +409,46 @@ public class RetroCompatibilityTest {
         assertThat(props.getProperty("tcpListenPort")).isEqualTo("7777");
         assertThat(props.getProperty("port")).isNull();
     }
+
+    @Test
+    public void test_parity_bus_type() {
+        Properties legacy = parseLegacy("--busType", "REDIS");
+        Properties picocli = parseNew("app", "start", "--busType", "REDIS");
+        assertPropertyEqual(legacy, picocli, "busType");
+    }
+
+    @Test
+    public void test_parity_queue_type() {
+        Properties legacy = parseLegacy("--queueType", "REDIS");
+        Properties picocli = parseNew("app", "start", "--queueType", "REDIS");
+        assertPropertyEqual(legacy, picocli, "queueType");
+    }
+
+    @Test
+    public void test_parity_redis_address() {
+        Properties legacy = parseLegacy("--redisAddress", "redis://my-redis:6379");
+        Properties picocli = parseNew("app", "start", "--redisAddress", "redis://my-redis:6379");
+        assertPropertyEqual(legacy, picocli, "redisAddress");
+    }
+
+    @Test
+    public void test_parity_data_source_url() {
+        Properties legacy = parseLegacy("--dataSourceUrl", "jdbc:postgresql://db/ds");
+        Properties picocli = parseNew("app", "start", "--dataSourceUrl", "jdbc:postgresql://db/ds");
+        assertPropertyEqual(legacy, picocli, "dataSourceUrl");
+    }
+
+    @Test
+    public void test_parity_auth_filter() {
+        Properties legacy = parseLegacy("--authFilter", "org.icij.datashare.session.YesCookieAuthFilter", "--mode", "SERVER");
+        Properties picocli = parseNew("app", "start", "--authFilter", "org.icij.datashare.session.YesCookieAuthFilter");
+        assertPropertyEqual(legacy, picocli, "authFilter");
+    }
+
+    @Test
+    public void test_parity_parallelism() {
+        Properties legacy = parseLegacy("--parallelism", "8", "--stages", "SCAN,INDEX");
+        Properties picocli = parseNew("stage", "run", "--stages", "SCAN,INDEX", "--parallelism", "8");
+        assertPropertyEqual(legacy, picocli, "parallelism");
+    }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
@@ -1,0 +1,370 @@
+package org.icij.datashare.cli.command;
+
+import org.icij.datashare.cli.DatashareCli;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import picocli.CommandLine;
+
+import java.util.Properties;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * These tests verify that the new picocli subcommand path produces
+ * the same key properties as the legacy jopt-simple path for equivalent
+ * invocations.
+ */
+public class RetroCompatibilityTest {
+
+    @Before
+    public void setUp() {
+        System.setProperty("user.home", "/home/datashare");
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("user.home");
+    }
+
+    private Properties parseLegacy(String... args) {
+        DatashareCli cli = new DatashareCli();
+        cli.parseArguments(args);
+        return cli.properties;
+    }
+
+    private Properties parseNew(String... args) {
+        DatashareCommand cmd = new DatashareCommand();
+        CommandLine commandLine = new CommandLine(cmd);
+        commandLine.setOverwrittenOptionsAllowed(true);
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        commandLine.setExecutionStrategy(parseResult -> {
+            CommandLine.ParseResult sub = parseResult;
+            while (sub.hasSubcommand()) {
+                sub = sub.subcommand();
+            }
+            Object userObject = sub.commandSpec().userObject();
+            if (userObject instanceof DatashareSubcommand) {
+                cmd.setExecutedSubcommand((DatashareSubcommand) userObject);
+            }
+            return new CommandLine.RunLast().execute(parseResult);
+        });
+        commandLine.execute(args);
+        return cmd.collectProperties();
+    }
+
+    /**
+     * Verifies that two property sets agree on a specific key.
+     */
+    private void assertPropertyEqual(Properties legacy, Properties picocli, String key) {
+        assertThat(picocli.getProperty(key))
+                .as("Property '" + key + "' should be the same in both paths")
+                .isEqualTo(legacy.getProperty(key));
+    }
+
+    @Test
+    public void test_parity_mode_local() {
+        Properties legacy = parseLegacy("--mode=LOCAL");
+        Properties picocli = parseNew("app", "start", "--mode", "local");
+        assertPropertyEqual(legacy, picocli, "mode");
+    }
+
+    @Test
+    public void test_parity_mode_server() {
+        Properties legacy = parseLegacy("--mode=SERVER");
+        Properties picocli = parseNew("app", "start", "--mode", "server");
+        assertPropertyEqual(legacy, picocli, "mode");
+    }
+
+    @Test
+    public void test_parity_mode_embedded() {
+        Properties legacy = parseLegacy("--mode=EMBEDDED");
+        Properties picocli = parseNew("app", "start", "--mode", "embedded");
+        assertPropertyEqual(legacy, picocli, "mode");
+    }
+
+    @Test
+    public void test_parity_mode_ner() {
+        Properties legacy = parseLegacy("--mode=NER");
+        Properties picocli = parseNew("app", "start", "--mode", "ner");
+        assertPropertyEqual(legacy, picocli, "mode");
+    }
+
+    @Test
+    public void test_parity_mode_task_worker() {
+        Properties legacy = parseLegacy("--mode=TASK_WORKER");
+        Properties picocli = parseNew("worker", "run");
+        assertPropertyEqual(legacy, picocli, "mode");
+    }
+
+    @Test
+    public void test_parity_mode_cli_with_stages() {
+        Properties legacy = parseLegacy("--mode=CLI", "--stages=SCAN,INDEX");
+        Properties picocli = parseNew("stage", "run", "SCAN,INDEX");
+        assertPropertyEqual(legacy, picocli, "mode");
+        assertPropertyEqual(legacy, picocli, "stages");
+    }
+
+    @Test
+    public void test_parity_defaults() {
+        Properties legacy = parseLegacy("");
+        Properties picocli = parseNew("app", "start");
+
+        // Critical defaults that must match
+        assertPropertyEqual(legacy, picocli, "mode");
+        assertPropertyEqual(legacy, picocli, "defaultProject");
+        assertPropertyEqual(legacy, picocli, "tcpListenPort");
+        assertPropertyEqual(legacy, picocli, "logLevel");
+        assertPropertyEqual(legacy, picocli, "cors");
+        assertPropertyEqual(legacy, picocli, "dataDir");
+        assertPropertyEqual(legacy, picocli, "defaultUserName");
+        assertPropertyEqual(legacy, picocli, "digestProjectName");
+        assertPropertyEqual(legacy, picocli, "noDigestProject");
+        assertPropertyEqual(legacy, picocli, "queueCapacity");
+        assertPropertyEqual(legacy, picocli, "indexTimeout");
+        assertPropertyEqual(legacy, picocli, "nlpPipeline");
+        assertPropertyEqual(legacy, picocli, "ocr");
+        assertPropertyEqual(legacy, picocli, "followSymlinks");
+        assertPropertyEqual(legacy, picocli, "browserOpenLink");
+        assertPropertyEqual(legacy, picocli, "sessionTtlSeconds");
+        assertPropertyEqual(legacy, picocli, "redisPoolSize");
+        assertPropertyEqual(legacy, picocli, "scrollSize");
+        assertPropertyEqual(legacy, picocli, "scrollSlices");
+        assertPropertyEqual(legacy, picocli, "taskRoutingStrategy");
+        assertPropertyEqual(legacy, picocli, "taskRepositoryType");
+        assertPropertyEqual(legacy, picocli, "taskWorkers");
+    }
+
+    @Test
+    public void test_parity_data_dir_default() {
+        Properties legacy = parseLegacy("");
+        Properties picocli = parseNew("app", "start");
+        assertPropertyEqual(legacy, picocli, "dataDir");
+    }
+
+    @Test
+    public void test_parity_elasticsearch_data_path_default() {
+        Properties legacy = parseLegacy("");
+        Properties picocli = parseNew("app", "start");
+        assertPropertyEqual(legacy, picocli, "elasticsearchDataPath");
+    }
+
+    @Test
+    public void test_parity_extensions_dir_default() {
+        Properties legacy = parseLegacy("");
+        Properties picocli = parseNew("app", "start");
+        assertPropertyEqual(legacy, picocli, "extensionsDir");
+    }
+
+    @Test
+    public void test_parity_plugins_dir_default() {
+        Properties legacy = parseLegacy("");
+        Properties picocli = parseNew("app", "start");
+        assertPropertyEqual(legacy, picocli, "pluginsDir");
+    }
+
+    @Test
+    public void test_parity_port_alias() {
+        Properties legacy = parseLegacy("--port=7777");
+        Properties picocli = parseNew("app", "start", "--port=7777");
+        assertPropertyEqual(legacy, picocli, "tcpListenPort");
+        // Both should NOT have "port" as a key
+        assertThat(legacy.getProperty("port")).isNull();
+        assertThat(picocli.getProperty("port")).isNull();
+    }
+
+    @Test
+    public void test_parity_digest_project_name_default() {
+        Properties legacy = parseLegacy("");
+        Properties picocli = parseNew("app", "start");
+        assertPropertyEqual(legacy, picocli, "digestProjectName");
+    }
+
+    @Test
+    public void test_parity_digest_project_name_custom() {
+        Properties legacy = parseLegacy("--defaultProject=myproject");
+        Properties picocli = parseNew("--defaultProject=myproject", "app", "start");
+        assertPropertyEqual(legacy, picocli, "digestProjectName");
+    }
+
+    @Test
+    public void test_parity_no_digest_project() {
+        Properties legacy = parseLegacy("--noDigestProject", "true");
+        Properties picocli = parseNew("--noDigestProject=true", "app", "start");
+        assertPropertyEqual(legacy, picocli, "noDigestProject");
+        assertThat(legacy.getProperty("digestProjectName")).isNull();
+        assertThat(picocli.getProperty("digestProjectName")).isNull();
+    }
+
+    @Test
+    public void test_parity_digest_project_name_explicit() {
+        Properties legacy = parseLegacy("--digestProjectName", "foo");
+        Properties picocli = parseNew("--digestProjectName", "foo", "app", "start");
+        assertPropertyEqual(legacy, picocli, "digestProjectName");
+    }
+
+    @Test
+    public void test_parity_custom_bind() {
+        Properties legacy = parseLegacy("--bind", "0.0.0.0");
+        Properties picocli = parseNew("app", "start", "--bind", "0.0.0.0");
+        assertPropertyEqual(legacy, picocli, "bind");
+    }
+
+    @Test
+    public void test_parity_custom_bind_short() {
+        Properties legacy = parseLegacy("-b", "0.0.0.0");
+        Properties picocli = parseNew("app", "start", "-b", "0.0.0.0");
+        assertPropertyEqual(legacy, picocli, "bind");
+    }
+
+    @Test
+    public void test_parity_custom_elasticsearch_address() {
+        Properties legacy = parseLegacy("--elasticsearchAddress", "http://localhost:9200");
+        Properties picocli = parseNew("--elasticsearchAddress", "http://localhost:9200", "app", "start");
+        assertPropertyEqual(legacy, picocli, "elasticsearchAddress");
+    }
+
+    @Test
+    public void test_parity_custom_data_dir() {
+        Properties legacy = parseLegacy("-d", "/data/docs");
+        Properties picocli = parseNew("-d", "/data/docs", "app", "start");
+        assertPropertyEqual(legacy, picocli, "dataDir");
+    }
+
+    @Test
+    public void test_parity_batch_download_dir_relative() {
+        Properties legacy = parseLegacy("--batchDownloadDir", "foo");
+        Properties picocli = parseNew("app", "start", "--batchDownloadDir", "foo");
+        assertPropertyEqual(legacy, picocli, "batchDownloadDir");
+    }
+
+    @Test
+    public void test_parity_batch_download_dir_absolute() {
+        Properties legacy = parseLegacy("--batchDownloadDir", "/home/foo");
+        Properties picocli = parseNew("app", "start", "--batchDownloadDir", "/home/foo");
+        assertPropertyEqual(legacy, picocli, "batchDownloadDir");
+    }
+
+    @Test
+    public void test_parity_language() {
+        Properties legacy = parseLegacy("--language", "ENGLISH");
+        Properties picocli = parseNew("--language", "ENGLISH", "app", "start");
+        assertPropertyEqual(legacy, picocli, "language");
+    }
+
+    @Test
+    public void test_parity_no_language() {
+        Properties legacy = parseLegacy("");
+        Properties picocli = parseNew("app", "start");
+        assertThat(legacy.getProperty("language")).isNull();
+        assertThat(picocli.getProperty("language")).isNull();
+    }
+
+    @Test
+    public void test_parity_plugin_list() {
+        Properties legacy = parseLegacy("--pluginList");
+        Properties picocli = parseNew("plugin", "list");
+        assertPropertyEqual(legacy, picocli, "pluginList");
+    }
+
+    @Test
+    public void test_parity_plugin_list_with_filter() {
+        Properties legacy = parseLegacy("--pluginList=.*");
+        Properties picocli = parseNew("plugin", "list", ".*");
+        assertPropertyEqual(legacy, picocli, "pluginList");
+    }
+
+    @Test
+    public void test_parity_plugin_install() {
+        Properties legacy = parseLegacy("--pluginInstall", "my-plugin");
+        Properties picocli = parseNew("plugin", "install", "my-plugin");
+        assertPropertyEqual(legacy, picocli, "pluginInstall");
+    }
+
+    @Test
+    public void test_parity_plugin_delete() {
+        Properties legacy = parseLegacy("--pluginDelete", "my-plugin");
+        Properties picocli = parseNew("plugin", "delete", "my-plugin");
+        assertPropertyEqual(legacy, picocli, "pluginDelete");
+    }
+
+    @Test
+    public void test_parity_extension_list() {
+        Properties legacy = parseLegacy("--extensionList");
+        Properties picocli = parseNew("extension", "list");
+        assertPropertyEqual(legacy, picocli, "extensionList");
+    }
+
+    @Test
+    public void test_parity_extension_install() {
+        Properties legacy = parseLegacy("--extensionInstall", "my-ext");
+        Properties picocli = parseNew("extension", "install", "my-ext");
+        assertPropertyEqual(legacy, picocli, "extensionInstall");
+    }
+
+    @Test
+    public void test_parity_extension_delete() {
+        Properties legacy = parseLegacy("--extensionDelete", "my-ext");
+        Properties picocli = parseNew("extension", "delete", "my-ext");
+        assertPropertyEqual(legacy, picocli, "extensionDelete");
+    }
+
+    @Test
+    public void test_parity_create_api_key() {
+        Properties legacy = parseLegacy("--createApiKey", "alice");
+        Properties picocli = parseNew("api-key", "create", "alice");
+        assertPropertyEqual(legacy, picocli, "createApiKey");
+    }
+
+    @Test
+    public void test_parity_create_api_key_short() {
+        Properties legacy = parseLegacy("-k", "alice");
+        Properties picocli = parseNew("api-key", "create", "alice");
+        assertPropertyEqual(legacy, picocli, "createApiKey");
+    }
+
+    @Test
+    public void test_parity_get_api_key() {
+        Properties legacy = parseLegacy("--apiKey", "alice");
+        Properties picocli = parseNew("api-key", "get", "alice");
+        assertPropertyEqual(legacy, picocli, "apiKey");
+    }
+
+    @Test
+    public void test_parity_delete_api_key() {
+        Properties legacy = parseLegacy("--deleteApiKey", "alice");
+        Properties picocli = parseNew("api-key", "delete", "alice");
+        assertPropertyEqual(legacy, picocli, "deleteApiKey");
+    }
+
+    @Test
+    public void test_legacy_mode_default() {
+        Properties props = parseLegacy("");
+        assertThat(props.getProperty("mode")).isEqualTo("LOCAL");
+    }
+
+    @Test
+    public void test_legacy_mode_server() {
+        Properties props = parseLegacy("--mode=SERVER");
+        assertThat(props.getProperty("mode")).isEqualTo("SERVER");
+    }
+
+    @Test
+    public void test_legacy_stages() {
+        Properties props = parseLegacy("--stages=SCAN,INDEX,CATEGORIZE,NLP");
+        assertThat(props.getProperty("stages")).isEqualTo("SCAN,INDEX,CATEGORIZE,NLP");
+    }
+
+    @Test
+    public void test_legacy_override_last_option_wins() {
+        Properties props = parseLegacy("--mode=SERVER", "--mode=LOCAL");
+        assertThat(props.getProperty("mode")).isEqualTo("LOCAL");
+    }
+
+    @Test
+    public void test_legacy_port_alias() {
+        Properties props = parseLegacy("--port=7777");
+        assertThat(props.getProperty("tcpListenPort")).isEqualTo("7777");
+        assertThat(props.getProperty("port")).isNull();
+    }
+}

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -66,7 +66,7 @@ for i in "${!args[@]}"; do
     --mode=*)
       datashare_mode="${args[i]#*=}"
       ;;
-    -h|--help|-v|-V|--version)
+    -h|--help|-v|-V|--version|help)
       skip_es_setup=true
       ;;
   esac

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -48,7 +48,7 @@ cd $datashare_home || exit
 first_arg="${1:-}"
 is_subcommand=false
 case "$first_arg" in
-  app|worker|stage|plugin|extension|api-key)
+  app|worker|stage|plugin|extension|api-key|help)
     is_subcommand=true
     ;;
 esac
@@ -66,7 +66,7 @@ for i in "${!args[@]}"; do
     --mode=*)
       datashare_mode="${args[i]#*=}"
       ;;
-    -h|--help|-v|--version)
+    -h|--help|-v|-V|--version)
       skip_es_setup=true
       ;;
   esac

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -72,8 +72,8 @@ for i in "${!args[@]}"; do
   esac
 done
 
-# Setup Elasticsearch if needed (only in EMBEDDED mode and not for help/version, and not for subcommand help)
-if [ "$datashare_mode" = "EMBEDDED" ] && [ "$skip_es_setup" = false ] && [ "$is_subcommand" = false ]; then
+# Setup Elasticsearch if needed (only in EMBEDDED mode and not for help/version)
+if [ "$datashare_mode" = "EMBEDDED" ] && [ "$skip_es_setup" = false ]; then
   setup_script="/usr/bin/datashare-elasticsearch-setup.sh"
   local_setup_script="$script_dir/datashare-elasticsearch-setup.sh"
   if [ -f "$local_setup_script" ]; then
@@ -104,8 +104,13 @@ java_flags="
 java_cmd="$java_bin $java_opts $java_flags -cp ./dist:$datashare_jar org.icij.datashare.Main"
 
 if [ "$is_subcommand" = true ]; then
-  # New subcommand style: pass args as-is, no legacy option injection
-  $java_cmd "$@"
+  # New subcommand style: inject only environment-derived paths, then user args.
+  # ES paths are injected first so user-provided options override them.
+  $java_cmd \
+      --elasticsearchPath $datashare_elasticsearch_path \
+      --elasticsearchSettings $datashare_elasticsearch_settings \
+      --elasticsearchDataPath $datashare_elasticsearch_data_path \
+      "$@"
 else
   # Legacy style: inject default options before user args
   $java_cmd \

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -88,12 +88,19 @@ if [ "$datashare_mode" = "EMBEDDED" ] && [ "$skip_es_setup" = false ]; then
   fi
 fi
 
+# -XX:UseSVE=0 disables Scalable Vector Extension on ARM; not valid on x86_64
+_arch=$(uname -m)
+_arm_flags=""
+if [ "$_arch" = "aarch64" ] || [ "$_arch" = "arm64" ]; then
+  _arm_flags="-XX:UseSVE=0"
+fi
+
 java_flags="
   --add-opens java.base/java.lang=ALL-UNNAMED
   --add-opens java.base/java.util=ALL-UNNAMED
   --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
   --add-opens java.base/java.net=ALL-UNNAMED
-  -XX:UseSVE=0
+  $_arm_flags
   -Xshare:off
   -DPROD_MODE=true
   -Dfile.encoding=UTF-8

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -44,14 +44,18 @@ mkdir -p \
 
 cd $datashare_home || exit
 
-# Detect whether the user is using the new subcommand style (first non-option arg is a known subcommand)
-first_arg="${1:-}"
+# Detect whether the user is using the new subcommand style. Scan every arg so that
+# parent-command options (e.g. --pluginsDir) can appear before the subcommand name,
+# matching Main.isLegacyInvocation on the Java side.
 is_subcommand=false
-case "$first_arg" in
-  app|worker|stage|plugin|extension|api-key|help)
-    is_subcommand=true
-    ;;
-esac
+for _arg in "$@"; do
+  case "$_arg" in
+    app|worker|stage|plugin|extension|api-key|help)
+      is_subcommand=true
+      break
+      ;;
+  esac
+done
 
 # Parse command line arguments to check for mode override and quick exit flags
 args=("$@")

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -44,6 +44,15 @@ mkdir -p \
 
 cd $datashare_home || exit
 
+# Detect whether the user is using the new subcommand style (first non-option arg is a known subcommand)
+first_arg="${1:-}"
+is_subcommand=false
+case "$first_arg" in
+  app|worker|stage|plugin|extension|api-key)
+    is_subcommand=true
+    ;;
+esac
+
 # Parse command line arguments to check for mode override and quick exit flags
 args=("$@")
 skip_es_setup=false
@@ -63,8 +72,8 @@ for i in "${!args[@]}"; do
   esac
 done
 
-# Setup Elasticsearch if needed (only in EMBEDDED mode and not for help/version)
-if [ "$datashare_mode" = "EMBEDDED" ] && [ "$skip_es_setup" = false ]; then
+# Setup Elasticsearch if needed (only in EMBEDDED mode and not for help/version, and not for subcommand help)
+if [ "$datashare_mode" = "EMBEDDED" ] && [ "$skip_es_setup" = false ] && [ "$is_subcommand" = false ]; then
   setup_script="/usr/bin/datashare-elasticsearch-setup.sh"
   local_setup_script="$script_dir/datashare-elasticsearch-setup.sh"
   if [ -f "$local_setup_script" ]; then
@@ -79,17 +88,27 @@ if [ "$datashare_mode" = "EMBEDDED" ] && [ "$skip_es_setup" = false ]; then
   fi
 fi
 
-$java_bin $java_opts \
-    --add-opens java.base/java.lang=ALL-UNNAMED \
-    --add-opens java.base/java.util=ALL-UNNAMED \
-    --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED \
-    --add-opens java.base/java.net=ALL-UNNAMED \
-    -DPROD_MODE=true \
-    -Dfile.encoding=UTF-8 \
-    -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader \
-    -Djna.tmpdir=$datashare_jna_tmpdir \
-    -DDS_SYNC_NLP_MODELS=$datashare_sync_nlp_models \
-    -cp ./dist:$datashare_jar org.icij.datashare.Main \
+java_flags="
+  --add-opens java.base/java.lang=ALL-UNNAMED
+  --add-opens java.base/java.util=ALL-UNNAMED
+  --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED
+  --add-opens java.base/java.net=ALL-UNNAMED
+  -XX:UseSVE=0
+  -Xshare:off
+  -DPROD_MODE=true
+  -Dfile.encoding=UTF-8
+  -Djava.system.class.loader=org.icij.datashare.DynamicClassLoader
+  -Djna.tmpdir=$datashare_jna_tmpdir
+  -DDS_SYNC_NLP_MODELS=$datashare_sync_nlp_models
+"
+java_cmd="$java_bin $java_opts $java_flags -cp ./dist:$datashare_jar org.icij.datashare.Main"
+
+if [ "$is_subcommand" = true ]; then
+  # New subcommand style: pass args as-is, no legacy option injection
+  $java_cmd "$@"
+else
+  # Legacy style: inject default options before user args
+  $java_cmd \
       --mode $datashare_mode \
       --dataDir $datashare_data_dir \
       --queueType $datashare_queue_type \
@@ -103,3 +122,4 @@ $java_bin $java_opts \
       --elasticsearchSettings $datashare_elasticsearch_settings \
       --elasticsearchDataPath $datashare_elasticsearch_data_path \
       "$@"
+fi

--- a/run.sh
+++ b/run.sh
@@ -19,11 +19,13 @@ else
 fi
 
 export JDWP_TRANSPORT_PORT=${JDWP_TRANSPORT_PORT:-$port}
-export DS_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,address=$JDWP_TRANSPORT_PORT,suspend=n \
-  -Djava.net.preferIPv4Stack=true \
-  -Ddatashare.loghost=udp:localhost \
-  -Dlogback.configurationFile=logback.xml \
-  -Djavax.net.ssl.trustStorePassword=changeit"
+export DS_JAVA_OPTS="
+  -agentlib:jdwp=transport=dt_socket,server=y,address=$JDWP_TRANSPORT_PORT,suspend=n,quiet=y
+  -Djava.net.preferIPv4Stack=true
+  -Ddatashare.loghost=udp:localhost
+  -Dlogback.configurationFile=logback.xml
+  -Djavax.net.ssl.trustStorePassword=changeit
+"
 
 DATASHARE_POM_VERSION=$(head $DIR/pom.xml | grep '<version>[0-9.]\+' | sed -E 's/<version>([0-9a-z.-]+)<\/version>/\1/' | tr -d '[:space:]')
 export DATASHARE_HOME=$DIR

--- a/run.sh
+++ b/run.sh
@@ -4,11 +4,11 @@ export DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ## Find a free port for Java remote debugging
 BASE_PORT=8090
 port=$BASE_PORT
-isfree=$(lsof -i ":$port" -t)
+isfree=$(ss -tlnH "sport = :$port" 2>/dev/null || lsof -i ":$port" -t 2>/dev/null)
 
 while [ -n "$isfree" ] && [ $port -lt 8093 ]; do
     port=$((port+1))
-    isfree=$(lsof -i ":$port" -t)
+    isfree=$(ss -tlnH "sport = :$port" 2>/dev/null || lsof -i ":$port" -t 2>/dev/null)
 done
 
 if [ -n "$isfree" ]; then


### PR DESCRIPTION
As part of #1409, this PR introduces a picocli-based subcommand CLI architecture to replace the flat, flag-based jopt-simple interface. The legacy jopt-simple path is fully preserved and routed via `Main.isLegacyInvocation()`, ensuring backward compatibility during the transition. Several code quality improvements are included alongside the new CLI infrastructure.

## Glossary

- **Root command** — top-level entry point (`datashare`)
- **Subcommand** — named child of a parent command (`app`, `stage`, `plugin`)
- **Leaf command** — deepest subcommand, the one that executes (`start`, `run`, `list`)
- **Mixin** — reusable option group shared across commands (`GlobalOptions`, `ServerOptions`)
- **Option** — named flag with `--` prefix (`--dataDir`, `-d`)
- **Parameter** — positional argument without `--` (`<user>`, `<id>`)
- **Scope** — controls option inheritance; `ScopeType.INHERIT` propagates to all subcommands
- **Execution strategy** — decides which command runs after parsing; walks to the deepest leaf
- **Legacy invocation** — backward-compatible jopt-simple path, used when first arg starts with `-`


## To-do after merging

* [ ] https://github.com/ICIJ/datashare-docs/pull/12
* [ ] https://github.com/ICIJ/datashare-installer/pull/24

## Changes

- **feat:** picocli subcommand hierarchy (`app`, `worker`, `stage`, `plugin`, `extension`, `api-key`)
- **feat:** dual-path invocation with routes between jopt-simple and picocli
- **feat:** global options accepted at any argument position via `ScopeType.INHERIT` on `GlobalOptions`
- **feat:** custom help display with `DatashareHelpFactory`
- **refactor:** split `Main.main()` into focused private methods
- **refactor:** extract shared `putIfNotNull` to `DatashareOptions`
- **refactor:** add missing `OAUTH_CLAIM_ID_ATTRIBUTE_OPT` constant
- **fix:** resource leak in `DatashareVersionProvider` (try-with-resources)
- **fix:** empty `defaultProject` now falls back to `local-datashare` instead of passing through
- **test:** global option position
- **test:** option name conflict detection
- **test:** empty `defaultProject` fallback
- **test:** legacy invocation routing

## Breaking changes

The new subcommand interface is not yet the default path (the legacy invocation is still selected automatically for existing callers). However, users who integrate with the CLI programmatically or parse its output should be aware:

- The new picocli path produces a structurally different help output (two-column layout, separate Global Options section) compared to the jopt-simple `--help` output
- Subcommand names (`app start`, `worker run`, `stage run`, `plugin list/install/delete`, etc.) are new entry points that do not exist in the legacy interface; tooling that wraps the CLI will need updating when the legacy path is eventually removed

## Architecture

### Invocation routing

`Main.main()` is now a two-liner that delegates to `resolveProperties()`, which picks the right parser:

```mermaid
flowchart TD
    A["./datashare &lt;args&gt;"] --> B{isLegacyInvocation?}

    B -->|"no args\nfirst arg starts with -\nfirst arg not a known subcommand"| C[Legacy path\nDatashareCli / jopt-simple]
    B -->|"first arg is app / worker /\nstage / plugin / extension /\napi-key / help"| D[Picocli path\nrunPicocli]

    C --> E[cli.properties]
    D --> F[cmd.collectProperties]
    E --> G[startApplication]
    F --> G
```

### Subcommand tree

```
datashare [GLOBAL OPTIONS]
├── app
│   └── start      ← AppServeCommand    (mode, HTTP server, OAuth, batch…)
├── worker
│   └── run        ← WorkerRunCommand   (task worker)
├── stage
│   └── run        ← StageRunCommand    (pipeline stages)
├── plugin
│   ├── list       ← PluginListCommand
│   ├── install    ← PluginInstallCommand
│   └── delete     ← PluginDeleteCommand
├── extension
│   ├── list       ← ExtensionListCommand
│   ├── install    ← ExtensionInstallCommand
│   └── delete     ← ExtensionDeleteCommand
├── api-key
│   ├── create     ← ApiKeyCreateCommand
│   ├── get        ← ApiKeyGetCommand
│   └── delete     ← ApiKeyDeleteCommand
└── help
```

Parent commands (`app`, `worker`, etc.) print usage when invoked without a subcommand. All leaf commands implement both `Runnable` and `DatashareSubcommand`.

### Global options and position independence

Every option in `GlobalOptions` carries `scope = ScopeType.INHERIT`. picocli propagates them down to every leaf command spec, so they are accepted at any position:

```
datashare --elasticsearchAddress http://es:9200 app start
datashare app start --elasticsearchAddress http://es:9200   # identical result
```

`DatashareHelpFactory` filters `o.inherited()` from each subcommand's own option list to prevent duplicate rendering, then renders inherited options in a separate **Global Options** section.

### Help rendering

`DatashareHelpFactory` applies a yarn-inspired style to every command in the tree:

| Section | Content |
|---|---|
| Synopsis | Abbreviated (`[OPTIONS]`) |
| Description | Plain text; lines ending `:` are auto-bolded as headings |
| Arguments | Positional parameters (leaf commands only) |
| Options | Command-specific options (leaf commands only, inherited excluded) |
| Global Options | Options from `GlobalOptions` (leaf subcommands only) |
| Commands | Subcommand list (parent commands only) |

Column widths are sized to the widest option label across both the Options and Global Options sections so both blocks align. Options are sorted alphabetically by long name.

### Shell script routing

The `datashare` launch script detects the invocation style from the first argument:

```
┌───────────────────────────────────────────────────────────────────┐
│  first arg = app / worker / stage / plugin / extension / api-key  │
│                          │                                        │
│           ┌──────────────┴──────────────┐                         │
│     Subcommand path               Legacy path                     │
│     inject ES paths               inject all defaults             │
│     pass "$@" to Java             pass "$@" to Java               │
└───────────────────────────────────────────────────────────────────┘
```

Both paths inject `--elasticsearchPath`, `--elasticsearchSettings`, and `--elasticsearchDataPath` from shell-resolved defaults (`$DATASHARE_HOME`). User-provided options are appended last and override the injected defaults (picocli's `setOverwrittenOptionsAllowed(true)`). ES setup runs for `--mode EMBEDDED` in both paths.

## AI Disclosure

This branch was developed with Claude. AI assisted with:

- Scaffolding the picocli subcommand classes (commands, options, help factory)
- Refactoring Main.java into focused methods and DatashareHelpFactory.apply() for readability
- Writing tests in DatashareCommandTest, RetroCompatibilityTest, MainTest, LegacyInvocationTest, exit-code and parity tests
- Shell script fixes in subcommand detection, ES setup skip logic, help routing
- Code quality by converting String options to enums, extracting DatashareOptions helpers (put, putIfNotNull, putIfTrue, putAll), replacing hardcoded strings with constants
- Squashing the commit history from 25 iterative commits to 4 logical ones

