### PR TITLE
Fixes to be able to view (not yet execute) BatchSearch and BatchDownloads when using Temporal

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -635,7 +635,7 @@ public class TaskResource {
         filters = filters.withStates(states);
         // Names
         Optional<String> maybeName = query.keys().stream().filter(k -> k.equals("name")).findAny()
-            .map(k -> ".*" + query.get(k) + ".*");
+            .map(k -> query.get(k) + ".*");
         if (maybeName.isPresent()) {
             filters = filters.withNames(maybeName.get());
         }

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -1003,7 +1003,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         TaskFilters filters = taskFiltersFromContext(ctx, null);
         // Then
         TaskFilters expectedFilters = TaskFilters.empty().withStates(Set.of()).withArgs(List.of())
-            .withNames(".*someTask|someOtherTask.*");
+            .withNames("someTask|someOtherTask.*");
         assertThat(filters).isEqualTo(expectedFilters);
     }
 

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalQueryBuilder.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalQueryBuilder.java
@@ -26,7 +26,7 @@ public class TemporalQueryBuilder {
             // We don't handle args with are filtered afterward because we can't store them as search attributes
             ArrayList<String> statements = new ArrayList<>(3);
             Optional.ofNullable(fromStates(filters.getStates())).ifPresent(statements::add);
-            Optional.ofNullable(fromName(filters.getName())).ifPresent(statements::add);
+            Optional.ofNullable(fromNamePattern(filters.getName())).ifPresent(statements::add);
             Optional.ofNullable(fromUser(filters.getUser())).ifPresent(statements::add);
             if (!statements.isEmpty()) {
                 query = String.join(" AND ", statements.stream().map(s -> "( " + s + " )").toList());
@@ -54,23 +54,31 @@ public class TemporalQueryBuilder {
         );
     }
 
-    protected static String fromName(String name) {
-        if (name == null || name.isEmpty()) {
+    protected static String fromNamePattern(String namePattern) {
+        if (namePattern == null) {
             return null;
         }
-        String query = WORKFLOW_TYPE_ATTRIBUTE.getName();
-        if (!SUPPORTED_NAME_QUERY_PATTERN.matcher(name).matches()) {
-            String message = "invalid pattern " + name + " with Temporal, exact match or prefix queries are supported. "
-                + " Test your name query against the " + SUPPORTED_NAME_QUERY_PATTERN.pattern() + " pattern to ensure"
-                + " compatibility";
-            throw new RuntimeException(message);
+        if (namePattern.isEmpty()) {
+            throw new IllegalArgumentException("name pattern cannot be empty");
         }
-        if (name.endsWith(".*")) {
-            query += " STARTS_WITH " + "'" + name.substring(0, name.length() - 2) + "'";
-        } else {
-            query += " = " + "'" + name + "'";
+        String[] parts = namePattern.split("\\|");
+        List<String> clauses = new ArrayList<>();
+        for (String part : parts) {
+            if (part.isBlank()) {
+                throw new IllegalArgumentException("name pattern contains an empty alternative: '" + namePattern + "'");
+            }
+            String trimmed = part.trim();
+            if (!SUPPORTED_NAME_QUERY_PATTERN.matcher(trimmed).matches()) {
+                throw new IllegalArgumentException("invalid pattern " + trimmed + " with Temporal, exact match or prefix queries are supported."
+                    + " Test your name query against the " + SUPPORTED_NAME_QUERY_PATTERN.pattern() + " pattern to ensure compatibility");
+            }
+            if (trimmed.endsWith(".*")) {
+                clauses.add(WORKFLOW_TYPE_ATTRIBUTE.getName() + " STARTS_WITH '" + trimmed.substring(0, trimmed.length() - 2) + "'");
+            } else {
+                clauses.add(WORKFLOW_TYPE_ATTRIBUTE.getName() + " = '" + trimmed + "'");
+            }
         }
-        return query;
+        return String.join(" OR ", clauses);
     }
 
     protected static String fromUser(User user) {

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/TemporalQueryBuilderTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/TemporalQueryBuilderTest.java
@@ -1,0 +1,33 @@
+package org.icij.datashare.asynctasks.temporal;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class TemporalQueryBuilderTest extends TestCase {
+
+
+    @Test
+    public void testFromNamePatternWithMultiplePatterns() {
+        assertThat(TemporalQueryBuilder.fromNamePattern("abc|wild.*")).isEqualTo("WorkflowType = 'abc' OR WorkflowType STARTS_WITH 'wild'");
+    }
+
+    @Test
+    public void testFromNamePatternSinglePattern() {
+        assertThat(TemporalQueryBuilder.fromNamePattern("abc")).isEqualTo("WorkflowType = 'abc'");
+    }
+
+    @Test
+    public void testEmptyNamePattern() {
+        assertThrows(RuntimeException.class, () -> TemporalQueryBuilder.fromNamePattern(""));
+    }
+    @Test
+    public void testEmptyNamePatternWithinRegexp() {
+        assertThrows(RuntimeException.class, () -> TemporalQueryBuilder.fromNamePattern("abc| "));
+    }
+
+
+
+}


### PR DESCRIPTION

- Make the regexp used to select classes that must be retrieved in TaskResource compatible with Temporal query operators (there is no operator that allows the search to begin with .*). This is a short term fix before refactoring of the class selection in TaskResource

- Handle `|` character in Temporal queries, that acts as a separator for differents names. It works for other TaskManagers as a side effect of using regexp to select Tasks 