### PR TITLE
chore: upgrade extract to 9.5.1 (Tika 3.3.0)

### DIFF
--- a/datashare-app/pom.xml
+++ b/datashare-app/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
        	    <groupId>com.github.CodeStory</groupId>
        	    <artifactId>fluent-http</artifactId>
-            <version>2f7b204</version>
+            <version>a4598d5</version>
             <type>jar</type>
             <exclusions>
                 <exclusion>

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -9,6 +9,7 @@ import org.icij.datashare.cli.Mode;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Hasher;
 import org.icij.datashare.text.Project;
+import org.icij.datashare.text.nlp.DocumentMetadataConstants;
 import org.icij.extract.cleaner.MetadataCleaner;
 import org.icij.extract.document.DigestIdentifier;
 import org.icij.extract.document.DocumentFactory;
@@ -88,7 +89,8 @@ public class SourceExtractor {
         // used every available digesters to find it.
         for (DigestingParser.Digester digester : digesters) {
             Identifier identifier = new DigestIdentifier(hasher.toString(), Charset.defaultCharset());
-            TikaDocument rootDocument = new DocumentFactory().withIdentifier(identifier).create(document.getPath());
+            TikaDocument rootDocument = new DocumentFactory().withIdentifier(identifier).create(document.getPath(),
+                    (String) document.getMetadata().get(document.getField(DocumentMetadataConstants.TIKA_VERSION)));
 
             try {
                 EmbeddedDocumentExtractor embeddedExtractor = new EmbeddedDocumentExtractor(

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -89,8 +89,10 @@ public class SourceExtractor {
         // used every available digesters to find it.
         for (DigestingParser.Digester digester : digesters) {
             Identifier identifier = new DigestIdentifier(hasher.toString(), Charset.defaultCharset());
-            TikaDocument rootDocument = new DocumentFactory().withIdentifier(identifier).create(document.getPath(),
-                    (String) document.getMetadata().get(document.getField(DocumentMetadataConstants.TIKA_VERSION)));
+            String tikaVersionField = document.getField(DocumentMetadataConstants.TIKA_VERSION);
+            String tikaVersion = (String) document.getMetadata().get(tikaVersionField);
+            TikaDocument rootDocument = new DocumentFactory().withIdentifier(identifier)
+                    .create(document.getPath(), tikaVersion);
 
             try {
                 EmbeddedDocumentExtractor embeddedExtractor = new EmbeddedDocumentExtractor(

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.4.13</extract.version>
+        <extract.version>9.5.1</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.5.1</extract.version>
+        <extract.version>9.5.2</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>


### PR DESCRIPTION
Related to #2124 

Fixes retrocompatibility issue with embedded documents extracted using Tika < 3.3.0. 
The solution aims to store the Tika version in document metadata and preserve the digest computation behavior matching the original extraction version, ensuring consistent IDs regardless of the current Tika version. (see [commit](https://github.com/ICIJ/extract/commit/164161358231dffcb0e9c156bf909cb83c2ddafc))