### PR TITLE
Draft : Refactor Batch search to become Tasks

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -98,6 +98,7 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
             return new BatchSearchRunnerResult(0, 0);
         }
 
+        int nbQueriesWithoutResults = batchSearch.queries.size();
         String query = null;
         try {
             logger.info("running {} queries for batch search {} on projects {} with throttle {}ms and scroll size of {}",
@@ -130,6 +131,9 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
                         throw new CancelException(requeueCancel);
                     }
                     repository.saveResults(batchSearch.uuid, query, (List<Document>) docsToProcess, isFirstScroll);
+                    if (isFirstScroll) {
+                        nbQueriesWithoutResults--;
+                    }
                     if (DatashareTime.getInstance().currentTimeMillis() - beforeScrollLoop < maxTimeSeconds * 1000L) {
                         DatashareTime.getInstance().sleep(throttleMs);
                     } else {
@@ -157,7 +161,7 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
             repository.setState(taskView.id, searchException);
             throw searchException;
         }
-        return new BatchSearchRunnerResult(numberOfResults, batchSearch.nbQueriesWithoutResults);
+        return new BatchSearchRunnerResult(numberOfResults, nbQueriesWithoutResults);
     }
 
     @Override

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunnerResult.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunnerResult.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.io.Serializable;
 
 @JsonTypeName("BatchSearchRunnerResult")
-public record BatchSearchRunnerResult(int nbResults, int nbQueriesWithoutResults) implements Serializable {
+public record BatchSearchRunnerResult(int nbResults, int nbQueriesWithoutResults) implements Serializable, PersistedResult {
     public BatchSearchRunnerResult(@JsonProperty("nbResults") int nbResults, @JsonProperty("nbQueriesWithoutResults") int nbQueriesWithoutResults) {
         this.nbResults = nbResults;
         this.nbQueriesWithoutResults = nbQueriesWithoutResults;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PersistedResult.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PersistedResult.java
@@ -1,0 +1,8 @@
+package org.icij.datashare.tasks;
+
+/**
+ * Marker interface for task results that are persisted in an external store (database, filesystem, etc.)
+ * rather than carried in the Task object itself.
+ */
+public interface PersistedResult {
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
@@ -62,7 +62,7 @@ public class BatchSearchRunnerTest {
         BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
         when(repository.get(local(), search.uuid)).thenReturn(search);
 
-        assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(2);
+        assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(1);
 
         verify(progressCb).apply( 1.0);
     }


### PR DESCRIPTION
First step : Have BatchSearchRunner get batch search infos from args of Task instead of from DB