### PR TITLE
feat: Add in TaskRepository tasks started using Temporal 

### DIFF
--- a/commons-test/pom.xml
+++ b/commons-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datashare</artifactId>
         <groupId>org.icij.datashare</groupId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datashare-api/pom.xml
+++ b/datashare-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.icij.datashare</groupId>
         <artifactId>datashare</artifactId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
 
     <artifactId>datashare-api</artifactId>

--- a/datashare-app/pom.xml
+++ b/datashare-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.icij.datashare</groupId>
         <artifactId>datashare</artifactId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
 
     <artifactId>datashare-app</artifactId>

--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -1,7 +1,10 @@
 package org.icij.datashare;
 
+import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.asynctasks.TaskManagerTemporal;
 import org.icij.datashare.cli.DatashareCli;
 import org.icij.datashare.cli.Mode;
+import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.cli.command.DatashareCommand;
 import org.icij.datashare.cli.command.DatashareHelpFactory;
 import org.icij.datashare.cli.command.DatashareSubcommand;
@@ -115,6 +118,10 @@ public class Main {
             Closeable tray = DatashareSystemTray.create(port);
             ofNullable(tray).ifPresent(commonMode::addCloseable);
             WebApp.start(commonMode);
+            if(QueueType.TEMPORAL == commonMode.getCurrentQueueType()) {
+                TaskManagerTemporal taskManager = (TaskManagerTemporal) commonMode.get(TaskManager.class);
+                taskManager.reconcileTasks();
+            }
         } else if (mode == Mode.TASK_WORKER) {
             TaskWorkerApp.start(commonMode);
         } else {

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -460,6 +460,10 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
                 get(propertyName).orElse(defaultQueueType.name()).toUpperCase());
     }
 
+    public QueueType getCurrentQueueType() {
+        return getQueueType(propertiesProvider, QUEUE_TYPE_OPT, DEFAULT_QUEUE_TYPE);
+    }
+
     public void addCloseable(Closeable client) {
         closeables.add(client);
     }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -245,9 +245,9 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
 
     @Provides @Singleton
     TaskManagerTemporal provideTaskManagerTemporal(
-            TemporalInterlocutor temporal, PropertiesProvider propertiesProvider) {
+            TemporalInterlocutor temporal, TaskRepository taskRepository, PropertiesProvider propertiesProvider) {
         return new TaskManagerTemporal(
-                temporal, Utils.getRoutingStrategy(propertiesProvider));
+                temporal, taskRepository, Utils.getRoutingStrategy(propertiesProvider));
     }
 
     @Provides @Singleton
@@ -417,7 +417,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
                 workflows = TemporalHelper.discoverWorkflows(
                     "org.icij.datashare.tasks",
                     get(DatashareTaskFactory.class),
-                    temporal.client,
+                    temporal.getClient(),
                     Utils.getRoutingStrategy(propertiesProvider),
                     new Group(TaskGroupType.Java)
                 );

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.*;
 import com.google.inject.Module;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
-import io.temporal.worker.WorkerFactory;
-import io.temporal.worker.WorkerOptions;
 import net.codestory.http.Configuration;
 import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Prefix;
@@ -16,7 +14,6 @@ import net.codestory.http.routes.Routes;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
 import org.icij.datashare.asynctasks.*;
-import org.icij.datashare.asynctasks.temporal.TemporalHelper;
 import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.batch.BatchSearchRepository;
 import org.icij.datashare.cli.Mode;
@@ -38,7 +35,9 @@ import org.icij.datashare.policies.CasbinRuleAdapter;
 import org.icij.datashare.session.StatusCidrFilter;
 import org.icij.datashare.session.UsersInDb;
 import org.icij.datashare.session.UsersWritable;
-import org.icij.datashare.tasks.*;
+import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.TaskResultSubtypes;
+import org.icij.datashare.tasks.Utils;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.LanguageGuesser;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
@@ -60,7 +59,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -68,6 +66,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -408,26 +407,10 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
     private ExecutorService runTemporalWorkers() {
         if (getTaskWorkersNb() > 0) {
             TemporalInterlocutor temporal = get(TemporalInterlocutor.class);
-            WorkerOptions workerOptions = WorkerOptions.newBuilder()
-                .setMaxConcurrentWorkflowTaskExecutionSize(getTaskWorkersNb())
-                .setMaxConcurrentActivityExecutionSize(getTaskWorkersNb())
-                .build();
-            List<TemporalHelper.RegisteredWorkflow> workflows;
-            try {
-                workflows = TemporalHelper.discoverWorkflows(
-                    "org.icij.datashare.tasks",
-                    get(DatashareTaskFactory.class),
-                    temporal.getClient(),
-                    Utils.getRoutingStrategy(propertiesProvider),
-                    new Group(TaskGroupType.Java)
-                );
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-            WorkerFactory workerFactory = TemporalHelper.createTemporalWorkerFactory(workflows, temporal.getClient(), workerOptions);
             executorService.submit(() -> {
-                // Start and add to closable
-                closeables.add(new TemporalHelper.CloseableWorkerFactoryHandle(workerFactory));
+                closeables.add(temporal.discoverWorkflows(getTaskWorkersNb(), get(DatashareTaskFactory.class),
+                                Utils.getRoutingStrategy(propertiesProvider),
+                                new Group(TaskGroupType.Java)));
             });
         }
         return executorService;

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -424,7 +424,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
-            WorkerFactory workerFactory = TemporalHelper.createTemporalWorkerFactory(workflows, temporal.client, workerOptions);
+            WorkerFactory workerFactory = TemporalHelper.createTemporalWorkerFactory(workflows, temporal.getClient(), workerOptions);
             executorService.submit(() -> {
                 // Start and add to closable
                 closeables.add(new TemporalHelper.CloseableWorkerFactoryHandle(workerFactory));

--- a/datashare-cli/pom.xml
+++ b/datashare-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.icij.datashare</groupId>
         <artifactId>datashare</artifactId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
 
     <artifactId>datashare-cli</artifactId>

--- a/datashare-db/pom.xml
+++ b/datashare-db/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datashare</artifactId>
         <groupId>org.icij.datashare</groupId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datashare-dist/pom.xml
+++ b/datashare-dist/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>datashare</artifactId>
         <groupId>org.icij.datashare</groupId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
 
     <artifactId>datashare-dist</artifactId>

--- a/datashare-index/pom.xml
+++ b/datashare-index/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>datashare</artifactId>
         <groupId>org.icij.datashare</groupId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
 
     <artifactId>datashare-index</artifactId>

--- a/datashare-nlp-corenlp/pom.xml
+++ b/datashare-nlp-corenlp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>datashare</artifactId>
         <groupId>org.icij.datashare</groupId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
 
     <artifactId>datashare-nlp-corenlp</artifactId>

--- a/datashare-tasks/pom.xml
+++ b/datashare-tasks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.icij.datashare</groupId>
         <artifactId>datashare</artifactId>
-        <version>21.3.0</version>
+        <version>21.3.1</version>
     </parent>
 
     <artifactId>datashare-tasks</artifactId>

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -9,7 +9,9 @@ import org.icij.datashare.tasks.RoutingStrategy;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -22,6 +24,7 @@ public class TaskManagerTemporal implements TaskManager {
     private final TemporalInterlocutor temporal;
     private final RoutingStrategy routingStrategy;
     private final TaskRepository taskRepository;
+    private final ConcurrentHashMap<String, CompletableFuture<Serializable>> pendingListeners = new ConcurrentHashMap<>();
 
     // TODO: add support for continue-as-new https://docs.temporal.io/develop/java/continue-as-new
 
@@ -34,11 +37,15 @@ public class TaskManagerTemporal implements TaskManager {
     }
 
     @Override
-    public <V extends Serializable> String startTask(Task<V> taskView, Group group) throws TaskAlreadyExists {
+    public <V extends Serializable> String startTask(Task<V> taskView, Group group) throws IOException, TaskAlreadyExists {
         String taskId = taskView.id;
         try {
+            taskRepository.insert(taskView, group);
             temporal.createWorkflow(taskId, taskView.name, resolveWfTaskQueue(taskView.name ,group),
                     generateSearchAttributes(taskView), taskView.args);
+            taskView.setState(Task.State.RUNNING);
+            taskRepository.update(taskView);
+            attachCompletionListener(taskId);
         } catch (WorkflowExecutionAlreadyStarted ex) {
             throw new TaskAlreadyExists(taskId, ex);
         }
@@ -47,35 +54,39 @@ public class TaskManagerTemporal implements TaskManager {
 
     @Override
     public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
-        return temporal.getTask(taskId);
+        return taskRepository.getTask(taskId);
     }
 
     @Override
     public Stream<Task<?>> getTasks(TaskFilters filters) throws IOException {
-        Stream<Task<?>> tasks = temporal.getWorkflows(filters);
-        // Temporal doesn't allow to search by args we have to post filter task retrieved with other filters
-        if (filters.hasArgs()) {
-            TaskFilters byArgs = TaskFilters.empty().withArgs(filters.getArgs());
-            tasks = tasks.filter(byArgs::filter);
-        }
-        return tasks.sorted(Comparator.comparing(t -> t.createdAt));
+        return taskRepository.getTasks(filters);
     }
 
     @Override
     public Stream<String> getTaskIds(TaskFilters filters) throws IOException {
-        return temporal.getWorkflowsIds(filters);
+        return taskRepository.getTaskIds(filters);
     }
 
     @Override
     public <V extends Serializable> Task<V> clearTask(String taskId) throws UnknownTask, IOException {
-        Task<V> task = getTask(taskId);
+        if (this.getTask(taskId).getState() == Task.State.RUNNING) {
+            throw new IllegalStateException(String.format("task id <%s> is in RUNNING state", taskId));
+        }
+        logger.info("deleting task id <{}>", taskId);
         temporal.deleteExecution(taskId);
-        return task;
+        return taskRepository.delete(taskId);
     }
 
     @Override
     public boolean stopTask(String taskId) throws IOException, UnknownTask {
-        return temporal.terminateWorkflow(taskId);
+        //TODO Check if synchronous call
+        if(temporal.terminateWorkflow(taskId)) {
+            Task<?> task = taskRepository.getTask(taskId);
+            task.setState(Task.State.CANCELLED);
+            taskRepository.update(task);
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -85,8 +96,42 @@ public class TaskManagerTemporal implements TaskManager {
             states.retainAll(filters.getStates());
         }
         List<Task<?>> tasks = getTasks(filters.withStates(states)).toList();
-        tasks.stream().map(Task::getId).forEach(rethrowConsumer(temporal::deleteExecution));
+        tasks.stream().map(Task::getId).forEach(rethrowConsumer(id -> {
+            temporal.deleteExecution(id);
+            taskRepository.delete(id);
+        }));
         return tasks;
+    }
+
+    /**
+     * Add a listener to execute upon completion of a Task.
+     * Can be used upon creation of a Task, or at startup for reconciliation
+     * @param taskId
+     */
+    private void attachCompletionListener(String taskId) {
+        CompletableFuture<Serializable> future = temporal.createWorkflowStub(taskId)
+            .getResultAsync(Serializable.class);
+        pendingListeners.put(taskId, future);
+        future.whenComplete((result, ex) -> {
+            pendingListeners.remove(taskId);
+            if (ex instanceof CancellationException) {
+                return;
+            }
+            try {
+                Task<Serializable> storedTask = taskRepository.getTask(taskId);
+                if (storedTask.isFinished()) {
+                    //Do nothing
+                    return;
+                }
+                //Parse the state from temporal.
+                //Maybe we might want to limit the scope of what is retrieved
+                // (no need to get again the args for instance)
+                Task<Serializable> temporalTask = temporal.getTask(taskId);
+                taskRepository.update(temporalTask);
+            } catch (IOException | UnknownTask e) {
+                logger.warn("failed to update task {} on completion", taskId, e);
+            }
+        });
     }
 
     @Override
@@ -97,8 +142,14 @@ public class TaskManagerTemporal implements TaskManager {
 
     @Override
     public void clear() throws IOException {
+        // We need to cancel the Future first, or else it's complete lambda function will be called by Temporal,
+        // reintroducing it in the taskRepository.
+        new HashMap<>(pendingListeners).values().forEach(f -> f.cancel(false));
         Set<String> taskIds = getTaskIds().collect(Collectors.toSet());
-        taskIds.forEach(rethrowConsumer(temporal::deleteExecution));
+        taskIds.forEach(rethrowConsumer(id -> {
+            temporal.deleteExecution(id);
+            taskRepository.delete(id);
+        }));
     }
 
     @Override
@@ -151,21 +202,4 @@ public class TaskManagerTemporal implements TaskManager {
         });
         return builder.build();
     }
-
-    protected void awaitCleared(Set<String> taskIds, int timeout, TimeUnit timeUnit) throws IOException {
-        long startTime = System.currentTimeMillis();
-        long maxDuration = timeUnit.toMillis(timeout);
-        while ((System.currentTimeMillis() - startTime < maxDuration)) {
-            if (getTaskIds().noneMatch(taskIds::contains)) {
-                return;
-            }
-            try {
-                Thread.sleep(getTerminationPollingInterval());
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
-    }
-
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -24,7 +24,7 @@ public class TaskManagerTemporal implements TaskManager {
     private final TemporalInterlocutor temporal;
     private final RoutingStrategy routingStrategy;
     private final TaskRepository taskRepository;
-    private final ConcurrentHashMap<String, CompletableFuture<Serializable>> pendingListeners = new ConcurrentHashMap<>();
+    protected final ConcurrentHashMap<String, CompletableFuture<Serializable>> pendingListeners = new ConcurrentHashMap<>();
 
     // TODO: add support for continue-as-new https://docs.temporal.io/develop/java/continue-as-new
 
@@ -101,6 +101,28 @@ public class TaskManagerTemporal implements TaskManager {
             taskRepository.delete(id);
         }));
         return tasks;
+    }
+
+    /**
+     * Retrieves running task in DB to get their status in Temporal, and attach completion listener if needed
+     * @throws IOException
+     */
+    public void reconcileTasks() throws IOException {
+        taskRepository.getTasks(TaskFilters.empty().withStates(Set.of(Task.State.RUNNING)))
+            .forEach(repoTask -> {
+                try {
+                    Task<Serializable> temporalTask = temporal.getTask(repoTask.id);
+                    if (temporalTask.isFinished()) {
+                        taskRepository.update(temporalTask);
+                    } else {
+                        attachCompletionListener(repoTask.id);
+                    }
+                } catch (UnknownTask e) {
+                    logger.warn("Task {} is RUNNING in repository but not found in Temporal. The task will never complete", repoTask.id);
+                } catch (IOException e) {
+                    logger.warn("Failed to reconcile task {}", repoTask.id, e);
+                }
+            });
     }
 
     /**

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -1,116 +1,45 @@
 package org.icij.datashare.asynctasks;
 
-import static io.grpc.health.v1.HealthCheckResponse.ServingStatus.SERVING;
-import static io.temporal.api.enums.v1.WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING;
-import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
-import static org.icij.datashare.LambdaExceptionUtils.rethrowFunction;
-import static org.icij.datashare.asynctasks.Task.State.FINAL_STATES;
-import static org.icij.datashare.asynctasks.Task.USER_KEY;
-import static org.icij.datashare.asynctasks.bus.amqp.Event.MAX_RETRIES_LEFT;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asExecInfoFilter;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asTaskState;
-import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE_POLL_INTERVAL;
-import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.MAX_PROGRESS_CUSTOM_ATTRIBUTE;
-import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.PROGRESS_CUSTOM_ATTRIBUTE;
-import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.USER_CUSTOM_ATTRIBUTE;
-
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.temporal.api.common.v1.Payloads;
-import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
 import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
-import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
-import io.temporal.api.workflowservice.v1.DeleteWorkflowExecutionRequest;
-import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsRequest;
-import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse;
-import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
-import io.temporal.client.WorkflowClient;
-import io.temporal.client.WorkflowExecutionAlreadyStarted;
-import io.temporal.client.WorkflowExecutionDescription;
-import io.temporal.client.WorkflowExecutionMetadata;
-import io.temporal.client.WorkflowFailedException;
-import io.temporal.client.WorkflowNotFoundException;
-import io.temporal.client.WorkflowOptions;
-import io.temporal.client.WorkflowStub;
+import io.temporal.client.*;
 import io.temporal.common.SearchAttributes;
-import io.temporal.common.converter.DefaultDataConverter;
+import org.icij.datashare.asynctasks.temporal.TemporalInputPayload;
+import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
+import org.icij.datashare.tasks.RoutingStrategy;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import io.temporal.common.converter.JacksonJsonPayloadConverter;
-import org.icij.datashare.asynctasks.bus.amqp.TaskError;
-import org.icij.datashare.asynctasks.temporal.TemporalInputPayload;
-import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
-import org.icij.datashare.asynctasks.temporal.TemporalQueryBuilder;
-import org.icij.datashare.function.Pair;
-import org.icij.datashare.json.JsonObjectMapper;
-import org.icij.datashare.tasks.RoutingStrategy;
-import org.icij.datashare.user.User;
+import static io.temporal.api.enums.v1.WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING;
+import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
+import static org.icij.datashare.asynctasks.Task.State.FINAL_STATES;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.*;
 
 public class TaskManagerTemporal implements TaskManager {
-    // TODO: in-memory hack for strong consistence, maybe a repository would be a better implem
-    private final ConcurrentHashMap.KeySetView<String, Boolean> executions = ConcurrentHashMap.newKeySet();
 
-    public static final String DEFAULT_NAMESPACE = "datashare-default";
-
-    private final WorkflowClient client;
-    private final String namespace;
+    private final TemporalInterlocutor temporal;
     private final RoutingStrategy routingStrategy;
+    private final TaskRepository taskRepository;
 
     private static final Duration DEFAULT_WORKFLOW_TASK_TIMEOUT = Duration.ofDays(7);
-    private static final int DEFAULT_PAGE_SIZE = 100;
 
     // TODO: add support for continue-as-new https://docs.temporal.io/develop/java/continue-as-new
 
     private static final String TERMINATION_MSG = "terminated_by_user";
     public static final String WORKFLOWS_DEFAULT = "default-java";
 
-    private static final DefaultDataConverter defaultDataConverter = DefaultDataConverter.newDefaultInstance()
-            .withPayloadConverterOverrides(new JacksonJsonPayloadConverter(JsonObjectMapper.getMapper()));
-
-
-    private final WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub;
-
-    public TaskManagerTemporal(TemporalInterlocutor temporal, RoutingStrategy routingStrategy) {
-        this(temporal.client, temporal.client.getWorkflowServiceStubs().blockingStub(), routingStrategy);
-    }
-
-    protected TaskManagerTemporal(WorkflowClient client, RoutingStrategy routingStrategy) {
-        this(client, client.getWorkflowServiceStubs().blockingStub(), routingStrategy);
-    }
-
-    protected TaskManagerTemporal(
-        WorkflowClient client,
-        WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceStubs,
-        RoutingStrategy routingStrategy
-    ) {
-        this.client = client;
-        this.namespace = client.getOptions().getNamespace();
-        this.workflowServiceBlockingStub = workflowServiceStubs;
+    public TaskManagerTemporal(TemporalInterlocutor temporal, TaskRepository taskRepository, RoutingStrategy routingStrategy) {
+        this.temporal = temporal;
         this.routingStrategy = routingStrategy;
+        this.taskRepository = taskRepository;
     }
 
     @Override
@@ -123,25 +52,25 @@ public class TaskManagerTemporal implements TaskManager {
             .setTypedSearchAttributes(generateSearchAttributes(taskView))
             .setTaskQueue(resolveWfTaskQueue(taskView.name, group));
         try {
-            client.newUntypedWorkflowStub(taskView.name, optionBuilder.build())
+            temporal.newUntypedWorkflowStub(taskView.name, optionBuilder.build())
                 .start(new TemporalInputPayload(taskView.args));
         } catch (WorkflowExecutionAlreadyStarted ex) {
             throw new TaskAlreadyExists(taskId, ex);
         }
-        executions.add(taskId);
+
         // Super important force description to refresh the cache and make the task visible
-        client.newUntypedWorkflowStub(taskId).describe();
+        temporal.newUntypedWorkflowStub(taskId).describe();
         return taskId;
     }
 
     @Override
     public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
-        return parseTask(getWorkflowExecution(taskId));
+        return temporal.parseTask(getWorkflowExecution(taskId), this);
     }
 
     @Override
     public Stream<Task<?>> getTasks(TaskFilters filters) throws IOException {
-        Stream<Task<?>> tasks = eventuallyConsistentListExecutions(filters).map(rethrowFunction(this::parseTask));
+        Stream<Task<?>> tasks = temporal.getWorkflows(filters);
         // Temporal doesn't allow to search by args we have to post filter task retrieved with other filters
         if (filters.hasArgs()) {
             TaskFilters byArgs = TaskFilters.empty().withArgs(filters.getArgs());
@@ -152,34 +81,13 @@ public class TaskManagerTemporal implements TaskManager {
 
     @Override
     public Stream<String> getTaskIds(TaskFilters filters) throws IOException {
-        Stream<WorkflowExecutionInfo> execs = eventuallyConsistentListExecutions(filters);
-        Iterator<WorkflowExecutionInfo> iterator =
-            new StronglyConsistentExecutionIterator(execs, executions, this::fetchExecByIdsIfExist, filters);
-        execs = StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
-            false // not parallel
-        );
-        // Temporal doesn't allow to search by args we have to post filter task retrieved with other filters
-        if (filters.hasArgs()) {
-            TaskFilters byArgs = TaskFilters.empty().withArgs(filters.getArgs());
-            execs = execs.map(e -> new Pair<>(e, getArgs(e)))
-                .filter(p -> byArgs.filter(p._2()))
-                .map(Pair::_1);
-        }
-        return execs.map(e -> e.getExecution().getWorkflowId());
+        return temporal.getWorkflowsIds(filters);
     }
 
     @Override
     public <V extends Serializable> Task<V> clearTask(String taskId) throws UnknownTask, IOException {
         Task<V> task = getTask(taskId);
-        unknownIfNotFound(rethrowConsumer(t -> {
-            DeleteWorkflowExecutionRequest.Builder requestBuilder = DeleteWorkflowExecutionRequest.newBuilder();
-            requestBuilder
-                .setNamespace(namespace)
-                .setWorkflowExecution(requestBuilder.getWorkflowExecutionBuilder().setWorkflowId(t).build());
-            workflowServiceBlockingStub.deleteWorkflowExecution(requestBuilder.build());
-        }), taskId);
-        executions.remove(taskId);
+        temporal.deleteExecution(taskId);
         return task;
     }
 
@@ -187,7 +95,7 @@ public class TaskManagerTemporal implements TaskManager {
     public boolean stopTask(String taskId) throws IOException, UnknownTask {
         // TODO: add support for cancellation rather than termination, update the TaskManager API accordingly
         return unknownIfNotFound(tId -> {
-            WorkflowStub workflowStub = client.newUntypedWorkflowStub(tId);
+            WorkflowStub workflowStub = temporal.newUntypedWorkflowStub(tId);
             boolean isRunning = workflowStub.describe().getStatus() == WORKFLOW_EXECUTION_STATUS_RUNNING;
             try {
                 workflowStub.terminate(TERMINATION_MSG);
@@ -207,7 +115,7 @@ public class TaskManagerTemporal implements TaskManager {
             states.retainAll(filters.getStates());
         }
         List<Task<?>> tasks = getTasks(filters.withStates(states)).toList();
-        tasks.stream().map(Task::getId).forEach(rethrowConsumer(this::deleteExecution));
+        tasks.stream().map(Task::getId).forEach(rethrowConsumer(temporal::deleteExecution));
         return tasks;
     }
 
@@ -220,13 +128,13 @@ public class TaskManagerTemporal implements TaskManager {
     @Override
     public void clear() throws IOException {
         Set<String> taskIds = getTaskIds().collect(Collectors.toSet());
-        taskIds.forEach(rethrowConsumer(this::deleteExecution));
+        taskIds.forEach(rethrowConsumer(temporal::deleteExecution));
     }
 
     @Override
     public boolean getHealth() throws IOException {
         try {
-            return client.getWorkflowServiceStubs().healthCheck().getStatus().equals(SERVING);
+            return temporal.getHealth();
         } catch (StatusRuntimeException ignored) {
             return false;
         }
@@ -258,220 +166,14 @@ public class TaskManagerTemporal implements TaskManager {
         }
     }
 
-    private Stream<WorkflowExecutionInfo> eventuallyConsistentListExecutions(TaskFilters filters) {
-        PageFetcher<WorkflowExecutionInfo> fetcher =
-            getWorkflowExecutionFetcher(TemporalQueryBuilder.buildFromFilters(filters));
-        return StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(new TemporalPageIterator<>(fetcher), Spliterator.ORDERED), false);
-    }
-
-    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionMetadata response) {
-        return parseTask(response.getWorkflowExecutionInfo());
-    }
-
-    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionInfo workflowExecutionInfo) {
-        WorkflowExecution execution = workflowExecutionInfo.getExecution();
-        String taskId = execution.getWorkflowId();
-        String taskName = workflowExecutionInfo.getType().getName();
-        double progress = parseProgress(workflowExecutionInfo);
-        Date createdAt = new Date(workflowExecutionInfo.getStartTime().getSeconds() * 1000);
-        Date completedAt = null;
-        Timestamp closeTime = workflowExecutionInfo.getCloseTime();
-        if (!closeTime.equals(Timestamp.getDefaultInstance())) {
-            completedAt = new Date(closeTime.getSeconds() * 1000);
-        }
-        TaskResult<V> result = null;
-        TaskError error = null;
-        Task.State state = asTaskState(workflowExecutionInfo.getStatus());
-        if (Objects.requireNonNull(state) == Task.State.ERROR || state == Task.State.DONE) {
-            try {
-                Serializable res = client.newUntypedWorkflowStub(workflowExecutionInfo.getExecution().getWorkflowId())
-                        .getResult(Serializable.class);
-                //TODO this is a big hack because Temporal does not use the TYPE_INCLUSION_MAPPER
-                // to deserialize for now
-                if (res instanceof Map<?, ?>) {
-                    try {
-                        res = JsonObjectMapper.readValueTyped(
-                                JsonObjectMapper.writeValueAsString(res), Serializable.class);
-                    } catch (IOException e) {
-                        logger.warn("could not convert result to typed object", e);
-                    }
-                }
-                if (res != null) {
-                    result = new TaskResult<>((V) res);
-                }
-            } catch (WorkflowFailedException ex) {
-                error = new TaskError(ex.getCause());
-            }
-        }
-        Map<String, Object> args = getArgs(workflowExecutionInfo);
-        int retriesLeft = MAX_RETRIES_LEFT; // retriesLeft makes no sense in the context of a workflow,
-        // it only makes sense for subtasks/activities
-        return new Task<>(taskId, taskName, state, progress, createdAt, retriesLeft, completedAt, args, result, error);
-    }
-
-    private Map<String, Object> getArgs(WorkflowExecutionInfo workflowExecutionInfo) {
-        Map<String, Object> args = null;
-        WorkflowExecution execution = workflowExecutionInfo.getExecution();
-        Payloads payloads = client.fetchHistory(execution.getWorkflowId(), execution.getRunId()).getEvents().get(0)
-            .getWorkflowExecutionStartedEventAttributes().getInput();
-        if (payloads.getPayloadsCount() > 1) {
-            throw new RuntimeException("invalid payload count, expected exactly 1 payload");
-        }
-        TemporalInputPayload payload =
-            defaultDataConverter.fromPayload(payloads.getPayloads(0), TemporalInputPayload.class,
-                TemporalInputPayload.class);
-        if (payload != null) {
-            args = payload.args();
-            args.computeIfPresent(USER_KEY, (k, v) -> JsonObjectMapper.convertValue(v, User.class));
-        }
-        return args;
-    }
-
-    private static double parseProgress(WorkflowExecutionInfo workflowExecutionInfo) {
-        double maxProgress = defaultDataConverter.fromPayload(workflowExecutionInfo.getSearchAttributes()
-            .getIndexedFieldsOrThrow(MAX_PROGRESS_CUSTOM_ATTRIBUTE.getName()), Double.class, Double.class);
-        if (maxProgress == 0) {
-            return 0.0;
-        }
-        double currentProgress = defaultDataConverter.fromPayload(
-            workflowExecutionInfo.getSearchAttributes().getIndexedFieldsOrThrow(PROGRESS_CUSTOM_ATTRIBUTE.getName()),
-            Double.class, Double.class);
-        return currentProgress / maxProgress;
-    }
-
     protected String resolveWfTaskQueue(String taskName, Group group) {
         return resolveWfTaskQueue(routingStrategy, taskName, group);
     }
 
     private WorkflowExecutionDescription getWorkflowExecution(String taskId) throws UnknownTask {
         return unknownIfNotFound(t -> {
-            return client.newUntypedWorkflowStub(taskId).describe();
+            return temporal.newUntypedWorkflowStub(taskId).describe();
         }, taskId);
-    }
-
-    @FunctionalInterface
-    interface PageFetcher<P> {
-        Page<P> fetchPage(ByteString nextPageToken);
-    }
-
-    record Page<P>(List<P> items, ByteString nextPageToken) {
-    }
-
-    private static class TemporalPageIterator<P> implements Iterator<P> {
-        // TODO: check if Temporal returns a null of empty token at the ned
-        private ByteString nextPageToken = null;
-        private final PageFetcher<P> fetcher;
-        private Iterator<P> itemsIterator;
-
-        TemporalPageIterator(PageFetcher<P> fetcher) {
-            this.fetcher = fetcher;
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (itemsIterator != null && itemsIterator.hasNext()) {
-                return true;
-            }
-            if (itemsIterator != null && nextPageToken.equals(ByteString.EMPTY)) {
-                return false;
-            }
-            Page<P> newPage = fetcher.fetchPage(nextPageToken);
-            nextPageToken = newPage.nextPageToken;
-            itemsIterator = newPage.items.iterator();
-            return itemsIterator.hasNext();
-        }
-
-        @Override
-        public P next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return itemsIterator.next();
-        }
-    }
-
-    private PageFetcher<WorkflowExecutionInfo> getWorkflowExecutionFetcher(String query) {
-        return (ByteString nextPageToken) -> {
-            ListWorkflowExecutionsRequest.Builder requestBuilder =
-                ListWorkflowExecutionsRequest.newBuilder().setNamespace(namespace).setPageSize(DEFAULT_PAGE_SIZE);
-            if (nextPageToken != null) {
-                requestBuilder.setNextPageToken(nextPageToken);
-            }
-            Optional.ofNullable(query).ifPresent(q -> {
-                if (!q.isEmpty()) {
-                    requestBuilder.setQuery(q);
-                }
-            });
-            ListWorkflowExecutionsResponse response = workflowServiceBlockingStub
-                .listWorkflowExecutions(requestBuilder.build());
-            return new Page<>(response.getExecutionsList(), response.getNextPageToken());
-        };
-    }
-
-    private static class StronglyConsistentExecutionIterator implements Iterator<WorkflowExecutionInfo> {
-        private final Iterator<WorkflowExecutionInfo> listWorkflowsResults;
-        private final Set<String> remainingIds;
-        private final Function<Set<String>, Stream<WorkflowExecutionInfo>> fetchKnownExecInfoFn;
-        private final TaskFilters filters;
-
-        private Iterator<WorkflowExecutionInfo> missingItems = null;
-
-        StronglyConsistentExecutionIterator(Stream<WorkflowExecutionInfo> listWorkflowsResults, Set<String> knownIds,
-                                            Function<Set<String>, Stream<WorkflowExecutionInfo>> fetchKnownExecInfoFn,
-                                            TaskFilters filters) {
-            this.listWorkflowsResults = listWorkflowsResults.iterator();
-            this.remainingIds = new HashSet<>(knownIds);
-            this.fetchKnownExecInfoFn = fetchKnownExecInfoFn;
-            this.filters = filters;
-        }
-
-        @Override
-        public boolean hasNext() {
-            if (listWorkflowsResults.hasNext()) {
-                return true;
-            }
-            if (missingItems == null) {
-                if (!this.remainingIds.isEmpty()) {
-                    missingItems = fetchKnownExecInfoFn.apply(this.remainingIds)
-                        .filter(asExecInfoFilter(filters))
-                        .iterator();
-                } else {
-                    missingItems = Stream.<WorkflowExecutionInfo>of().iterator();
-                }
-            }
-            return missingItems.hasNext();
-        }
-
-        @Override
-        public WorkflowExecutionInfo next() {
-            if (listWorkflowsResults.hasNext()) {
-                WorkflowExecutionInfo fromSearch = listWorkflowsResults.next();
-                remainingIds.remove(fromSearch.getExecution().getWorkflowId());
-                return fromSearch;
-            }
-            return missingItems.next();
-        }
-    }
-
-    private static void unknownIfNotFound(Consumer<String> supplier, String taskId) {
-        unknownIfNotFound((t) -> {
-            supplier.accept(t);
-            return null;
-        }, taskId);
-    }
-
-    private static <T> T unknownIfNotFound(Function<String, T> function, String taskId) {
-        try {
-            return function.apply(taskId);
-        } catch (StatusRuntimeException e) {
-            if (e.getStatus().equals(Status.NOT_FOUND)) {
-                throw new UnknownTask(taskId);
-            }
-            throw e;
-        } catch (WorkflowNotFoundException e) {
-            throw new UnknownTask(taskId);
-        }
     }
 
     static SearchAttributes generateSearchAttributes(Task<?> taskView) {
@@ -502,31 +204,13 @@ public class TaskManagerTemporal implements TaskManager {
         throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
     }
 
-    protected void awaitCleared(int timeout, TimeUnit timeUnit) throws IOException {
-        long startTime = System.currentTimeMillis();
-        long maxDuration = timeUnit.toMillis(timeout);
-        while ((System.currentTimeMillis() - startTime < maxDuration)) {
-            try (Stream<String> taskIds = getTaskIds()) {
-                if (taskIds.count() == 0) {
-                    return;
-                }
-            }
-            try {
-                Thread.sleep(getTerminationPollingInterval());
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
-    }
-
     protected void awaitExecutionDeletion(Set<String> taskIds) throws InterruptedException {
         // TODO: avoid the infinite loop
         // TODO: implement throttling
         while (true) {
             boolean allDeleted = taskIds.stream().allMatch(tId -> {
                 try {
-                    client.newUntypedWorkflowStub(tId).describe();
+                    temporal.newUntypedWorkflowStub(tId).describe();
                 } catch (StatusRuntimeException ex) {
                     if (ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
                         return true;
@@ -542,40 +226,5 @@ public class TaskManagerTemporal implements TaskManager {
             // TODO: define a proper duration
             Thread.sleep(DEFAULT_NAMESPACE_POLL_INTERVAL.toMillis());
         }
-    }
-
-    private void deleteExecution(String workflowId) {
-        try {
-            DeleteWorkflowExecutionRequest deleteWorkflowExecutionRequest = DeleteWorkflowExecutionRequest.newBuilder()
-                .setNamespace(namespace)
-                .setWorkflowExecution(WorkflowExecution.newBuilder().setWorkflowId(workflowId))
-                .build();
-            workflowServiceBlockingStub.deleteWorkflowExecution(deleteWorkflowExecutionRequest);
-            // Try to refresh the cache
-            client.newUntypedWorkflowStub(workflowId).describe();
-        } catch (StatusRuntimeException ex) {
-            if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                throw ex;
-            }
-        } catch (WorkflowNotFoundException ignored) {
-        }
-        executions.remove(workflowId);
-    }
-
-    private Stream<WorkflowExecutionInfo> fetchExecByIdsIfExist(Set<String> executionIds) {
-        return executionIds.stream()
-            .map(id -> {
-                try {
-                    return client.newUntypedWorkflowStub(id).describe().getWorkflowExecutionInfo();
-                } catch (StatusRuntimeException ex) {
-                    if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                        throw ex;
-                    }
-                    return null;
-                } catch (WorkflowNotFoundException ignored) {
-                    return null;
-                }
-            })
-            .filter(Objects::nonNull);
     }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -47,7 +47,7 @@ public class TaskManagerTemporal implements TaskManager {
 
     @Override
     public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
-        return temporal.parseTask(temporal.getWorkflowExecution(taskId), this);
+        return temporal.getTask(taskId);
     }
 
     @Override

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -1,24 +1,18 @@
 package org.icij.datashare.asynctasks;
 
-import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
-import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
-import io.temporal.client.*;
+import io.temporal.client.WorkflowExecutionAlreadyStarted;
 import io.temporal.common.SearchAttributes;
-import org.icij.datashare.asynctasks.temporal.TemporalInputPayload;
 import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.tasks.RoutingStrategy;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.temporal.api.enums.v1.WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.asynctasks.Task.State.FINAL_STATES;
 import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.*;
@@ -29,11 +23,8 @@ public class TaskManagerTemporal implements TaskManager {
     private final RoutingStrategy routingStrategy;
     private final TaskRepository taskRepository;
 
-    private static final Duration DEFAULT_WORKFLOW_TASK_TIMEOUT = Duration.ofDays(7);
-
     // TODO: add support for continue-as-new https://docs.temporal.io/develop/java/continue-as-new
 
-    private static final String TERMINATION_MSG = "terminated_by_user";
     public static final String WORKFLOWS_DEFAULT = "default-java";
 
     public TaskManagerTemporal(TemporalInterlocutor temporal, TaskRepository taskRepository, RoutingStrategy routingStrategy) {
@@ -45,27 +36,18 @@ public class TaskManagerTemporal implements TaskManager {
     @Override
     public <V extends Serializable> String startTask(Task<V> taskView, Group group) throws TaskAlreadyExists {
         String taskId = taskView.id;
-        WorkflowOptions.Builder optionBuilder = WorkflowOptions.newBuilder().setWorkflowId(taskId)
-            .setWorkflowTaskTimeout(DEFAULT_WORKFLOW_TASK_TIMEOUT) // TODO: set this per task
-            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE)
-            .setWorkflowIdConflictPolicy(WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_FAIL)
-            .setTypedSearchAttributes(generateSearchAttributes(taskView))
-            .setTaskQueue(resolveWfTaskQueue(taskView.name, group));
         try {
-            temporal.newUntypedWorkflowStub(taskView.name, optionBuilder.build())
-                .start(new TemporalInputPayload(taskView.args));
+            temporal.createWorkflow(taskId, taskView.name, resolveWfTaskQueue(taskView.name ,group),
+                    generateSearchAttributes(taskView), taskView.args);
         } catch (WorkflowExecutionAlreadyStarted ex) {
             throw new TaskAlreadyExists(taskId, ex);
         }
-
-        // Super important force description to refresh the cache and make the task visible
-        temporal.newUntypedWorkflowStub(taskId).describe();
         return taskId;
     }
 
     @Override
     public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
-        return temporal.parseTask(getWorkflowExecution(taskId), this);
+        return temporal.parseTask(temporal.getWorkflowExecution(taskId), this);
     }
 
     @Override
@@ -93,19 +75,7 @@ public class TaskManagerTemporal implements TaskManager {
 
     @Override
     public boolean stopTask(String taskId) throws IOException, UnknownTask {
-        // TODO: add support for cancellation rather than termination, update the TaskManager API accordingly
-        return unknownIfNotFound(tId -> {
-            WorkflowStub workflowStub = temporal.newUntypedWorkflowStub(tId);
-            boolean isRunning = workflowStub.describe().getStatus() == WORKFLOW_EXECUTION_STATUS_RUNNING;
-            try {
-                workflowStub.terminate(TERMINATION_MSG);
-            } catch (WorkflowNotFoundException ex) {
-                if (!ex.getCause().getMessage().contains("workflow execution already completed")) {
-                    throw ex;
-                }
-            }
-            return isRunning;
-        }, taskId);
+        return temporal.terminateWorkflow(taskId);
     }
 
     @Override
@@ -170,12 +140,6 @@ public class TaskManagerTemporal implements TaskManager {
         return resolveWfTaskQueue(routingStrategy, taskName, group);
     }
 
-    private WorkflowExecutionDescription getWorkflowExecution(String taskId) throws UnknownTask {
-        return unknownIfNotFound(t -> {
-            return temporal.newUntypedWorkflowStub(taskId).describe();
-        }, taskId);
-    }
-
     static SearchAttributes generateSearchAttributes(Task<?> taskView) {
         SearchAttributes.Builder builder = SearchAttributes.newBuilder()
             .set(PROGRESS_CUSTOM_ATTRIBUTE, 0d)
@@ -204,27 +168,4 @@ public class TaskManagerTemporal implements TaskManager {
         throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
     }
 
-    protected void awaitExecutionDeletion(Set<String> taskIds) throws InterruptedException {
-        // TODO: avoid the infinite loop
-        // TODO: implement throttling
-        while (true) {
-            boolean allDeleted = taskIds.stream().allMatch(tId -> {
-                try {
-                    temporal.newUntypedWorkflowStub(tId).describe();
-                } catch (StatusRuntimeException ex) {
-                    if (ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                        return true;
-                    }
-                } catch (WorkflowNotFoundException ignored) {
-                    return true;
-                }
-                return false;
-            });
-            if (allDeleted) {
-                break;
-            }
-            // TODO: define a proper duration
-            Thread.sleep(DEFAULT_NAMESPACE_POLL_INTERVAL.toMillis());
-        }
-    }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/UnknownTask.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/UnknownTask.java
@@ -7,4 +7,9 @@ public class UnknownTask extends RuntimeException {
         super("unknown task \"%s\"".formatted(taskId));
         this.taskId = taskId;
     }
+
+    public UnknownTask(String taskId, Throwable throwable) {
+        super("unknown task \"%s\"".formatted(taskId), throwable);
+        this.taskId = taskId;
+    }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
@@ -5,11 +5,6 @@ import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
 import io.temporal.client.WorkflowClient;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.ApplicationFailure;
-import io.temporal.worker.Worker;
-import io.temporal.worker.WorkerFactory;
-import io.temporal.worker.WorkerOptions;
-import io.temporal.worker.WorkflowImplementationOptions;
-import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
 import org.icij.datashare.asynctasks.Group;
 import org.icij.datashare.asynctasks.Task;
@@ -18,12 +13,12 @@ import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.function.ThrowingSupplier;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
-import org.reflections.Reflections;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -31,93 +26,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.temporal.api.enums.v1.WorkflowExecutionStatus.*;
-import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
-import static org.icij.datashare.LambdaExceptionUtils.rethrowFunction;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.resolveWfTaskQueue;
 import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.USER_CUSTOM_ATTRIBUTE;
 
 public class TemporalHelper {
-    public record RegisteredActivity(ThrowingSupplier<?> activityFactory, String taskQueue) {
-    }
-
-    public record RegisteredWorkflow(Class<?> workflowCls, String taskQueue, List<RegisteredActivity> activities) {
-    }
-
-    private static WorkflowImplementationOptions WF_IMPLEMENTATION_DEFAULT_OPTIONS = WorkflowImplementationOptions.newBuilder()
-            .setFailWorkflowExceptionTypes(Error.class) // Unregistered workflows
-            .build();
 
     private static final String WORKFLOW_METHOD_CLASS_NAME = WorkflowMethod.class.getName();
         private static final DefaultDataConverter defaultDataConverter = DefaultDataConverter.newDefaultInstance();
 
-    public static class CloseableWorkerFactoryHandle implements Closeable {
-        private final WorkerFactory factory;
-
-        public CloseableWorkerFactoryHandle(WorkerFactory factory) {
-            this.factory = factory;
-            this.factory.start();
-        }
-
-        @Override
-        public void close() throws IOException {
-            synchronized (factory) {
-                if (!this.factory.isShutdown()) {
-                    this.factory.shutdown();
-                }
-            }
-        }
-
-        public WorkerFactory getFactory() {
-            return factory;
-        }
-    }
-
-    public static List<RegisteredWorkflow> discoverWorkflows(
-        String packageName,
-        TaskFactory taskFactory,
-        WorkflowClient client,
-        RoutingStrategy routingStrategy,
-        Group workerGroup
-    ) throws ClassNotFoundException {
-        Reflections reflections = new Reflections(packageName);
-        Predicate<Class<?>> workflowFilter = makeWorkflowFilter(routingStrategy, workerGroup);
-        // We rely on naming convention rather than on inspection, that's OK as code is generated
-        return reflections.getTypesAnnotatedWith(WorkflowInterface.class)
-            .stream()
-            .filter(workflowFilter)
-            .map(rethrowFunction(c -> {
-                String workflowKey = parseWorkflowKey(c);
-                String workflowClassName = c.getName();
-                String baseName = workflowClassName.replace("Workflow", "");
-                Class<TemporalWorkflowImpl> wfImplClass = (Class<TemporalWorkflowImpl>) Class.forName(workflowClassName + "Impl");
-                Class<TemporalActivityImpl<?, ?>> actImplCls = (Class<TemporalActivityImpl<?, ?>>) Class.forName(baseName + "ActivityImpl");
-                String taskQueue = resolveWfTaskQueue(routingStrategy, workflowKey, workerGroup);
-                List<RegisteredActivity> activities = List.of(new RegisteredActivity(activityFactory(actImplCls, taskFactory, client, 1d), taskQueue));
-                return new RegisteredWorkflow(wfImplClass, taskQueue, activities);
-            }))
-            .toList();
-    }
-
-    public static WorkerFactory createTemporalWorkerFactory(List<RegisteredWorkflow> registeredWorkflows, WorkflowClient client) {
-        return createTemporalWorkerFactory(registeredWorkflows, client, null);
-    }
-
-    public static WorkerFactory createTemporalWorkerFactory(
-        List<RegisteredWorkflow> registeredWorkflows, WorkflowClient client, WorkerOptions workerOptions
-    ) {
-        WorkerFactory workerFactory = WorkerFactory.newInstance(client);
-        HashMap<String, Worker> workers = new HashMap<>();
-        registeredWorkflows.forEach(rethrowConsumer(wf -> {
-            String wfTaskQueue = wf.taskQueue;
-            workers.computeIfAbsent(wfTaskQueue, workerFactory::newWorker)
-                .registerWorkflowImplementationTypes(WF_IMPLEMENTATION_DEFAULT_OPTIONS, wf.workflowCls);
-            wf.activities.forEach(rethrowConsumer(act -> {
-                workers.computeIfAbsent(act.taskQueue, q -> workerFactory.newWorker(q, workerOptions))
-                    .registerActivitiesImplementations(act.activityFactory.get());
-            }));
-        }));
-        return workerFactory;
-    }
 
     public static Task.State asTaskState(WorkflowExecutionStatus status) {
         return switch (status) {
@@ -198,7 +113,7 @@ public class TemporalHelper {
         return taskWrapper((t) -> taskSupplier.get(), null, Set.of());
     }
 
-    private static String parseWorkflowKey(Class<?> workflowInterface) {
+    static String parseWorkflowKey(Class<?> workflowInterface) {
         // We have to get method by name because of the dynamic class loader and proxies... inspection doesn't work
         // properly: m.isAnnotationPresent(WorkflowMethod.class) fails
         List<Method> annotated = Arrays.stream(workflowInterface.getDeclaredMethods())
@@ -210,7 +125,7 @@ public class TemporalHelper {
         return annotated.get(0).getAnnotation(WorkflowMethod.class).name();
     }
 
-    private static Predicate<Class<?>> makeWorkflowFilter(RoutingStrategy routingStrategy, Group workerGroup) {
+    static Predicate<Class<?>> makeWorkflowFilter(RoutingStrategy routingStrategy, Group workerGroup) {
         return c -> {
             if (!c.isInterface()) {
                 return false;

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
@@ -2,15 +2,12 @@ package org.icij.datashare.asynctasks.temporal;
 
 import io.temporal.api.enums.v1.WorkflowExecutionStatus;
 import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
-import io.temporal.client.WorkflowClient;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.failure.ApplicationFailure;
 import io.temporal.workflow.WorkflowMethod;
 import org.icij.datashare.asynctasks.Group;
 import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.asynctasks.TaskFactory;
 import org.icij.datashare.asynctasks.TaskFilters;
-import org.icij.datashare.function.ThrowingSupplier;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
 
@@ -61,17 +58,6 @@ public class TemporalHelper {
             case ERROR -> Stream.of(WORKFLOW_EXECUTION_STATUS_FAILED, WORKFLOW_EXECUTION_STATUS_TIMED_OUT);
             case DONE -> Stream.of(WORKFLOW_EXECUTION_STATUS_COMPLETED);
         };
-    }
-
-    public static <A extends TemporalActivityImpl<?, ?>> ThrowingSupplier<A> activityFactory(
-        Class<A> activityCls,
-        TaskFactory taskFactory,
-        WorkflowClient client,
-        double progressWeight
-    ) {
-        return () -> activityCls
-            .getConstructor(TaskFactory.class, WorkflowClient.class, Double.class)
-            .newInstance(taskFactory, client, progressWeight);
     }
 
     public static Predicate<WorkflowExecutionInfo> asExecInfoFilter(TaskFilters filters) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -163,6 +163,16 @@ public class TemporalInterlocutor {
         }
     }
 
+    public <A extends TemporalActivityImpl<?, ?>> ThrowingSupplier<A> activityFactory(
+        Class<A> activityCls,
+        TaskFactory taskFactory,
+        double progressWeight
+    ) {
+        return () -> activityCls
+            .getConstructor(TaskFactory.class, WorkflowClient.class, Double.class)
+            .newInstance(taskFactory, client, progressWeight);
+    }
+
     public void setupNamespace(Duration timeout) throws InterruptedException {
         long start = System.currentTimeMillis();
         long timeoutMillis = timeout.toMillis();
@@ -511,16 +521,6 @@ public class TemporalInterlocutor {
         throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
     }
 
-    /**
-     * this should not be used normally TemporalInterlocutor should encapsulate
-     * all interactions with the server.
-     * it is used in TemporalHelper
-     * @return WorkflowClient
-     */
-    public WorkflowClient getClient() {
-        return client;
-    }
-
     protected void awaitExecutionDeletion(Set<String> taskIds) throws InterruptedException {
         // TODO: avoid the infinite loop
         // TODO: implement throttling
@@ -566,7 +566,7 @@ public class TemporalInterlocutor {
                         Class<TemporalWorkflowImpl> wfImplClass = (Class<TemporalWorkflowImpl>) Class.forName(workflowClassName + "Impl");
                         Class<TemporalActivityImpl<?, ?>> actImplCls = (Class<TemporalActivityImpl<?, ?>>) Class.forName(baseName + "ActivityImpl");
                         String taskQueue = resolveWfTaskQueue(routingStrategy, workflowKey, group);
-                        List<RegisteredActivity> activities = List.of(new RegisteredActivity(activityFactory(actImplCls, taskFactory, client, 1d), taskQueue));
+                        List<RegisteredActivity> activities = List.of(new RegisteredActivity(activityFactory(actImplCls, taskFactory, 1d), taskQueue));
                         return new RegisteredWorkflow(wfImplClass, taskQueue, activities);
                     }))
                     .toList();

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -27,14 +27,23 @@ import io.temporal.serviceclient.OperatorServiceStubs;
 import io.temporal.serviceclient.OperatorServiceStubsOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.worker.Worker;
+import io.temporal.worker.WorkerFactory;
+import io.temporal.worker.WorkerOptions;
+import io.temporal.worker.WorkflowImplementationOptions;
+import io.temporal.workflow.WorkflowInterface;
 import org.icij.datashare.EnvUtils;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.*;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.function.Pair;
+import org.icij.datashare.function.ThrowingSupplier;
 import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
+import org.reflections.Reflections;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
@@ -44,6 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -52,14 +62,17 @@ import static io.temporal.api.enums.v1.WorkflowExecutionStatus.WORKFLOW_EXECUTIO
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowFunction;
 import static org.icij.datashare.asynctasks.Task.USER_KEY;
+import static org.icij.datashare.asynctasks.TaskManagerTemporal.resolveWfTaskQueue;
 import static org.icij.datashare.asynctasks.bus.amqp.Event.MAX_RETRIES_LEFT;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asExecInfoFilter;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asTaskState;
+import static org.icij.datashare.asynctasks.temporal.TemporalHelper.*;
 
 public class TemporalInterlocutor {
     private static final int DEFAULT_PAGE_SIZE = 100;
     private static final Duration DEFAULT_WORKFLOW_TASK_TIMEOUT = Duration.ofDays(7);
     private static final String TERMINATION_MSG = "terminated_by_user";
+    static WorkflowImplementationOptions WF_IMPLEMENTATION_DEFAULT_OPTIONS = WorkflowImplementationOptions.newBuilder()
+            .setFailWorkflowExceptionTypes(Error.class) // Unregistered workflows
+            .build();
     // TODO: in-memory hack for strong consistence, maybe a repository would be a better implem
     private final ConcurrentHashMap.KeySetView<String, Boolean> executions = ConcurrentHashMap.newKeySet();
 
@@ -538,8 +551,55 @@ public class TemporalInterlocutor {
         }, taskId);
     }
 
-    public record Page<P>(List<P> items, ByteString nextPageToken) {
+    List<RegisteredWorkflow> discoverWorkflows(String packageName, TaskFactory taskFactory, RoutingStrategy routingStrategy, Group group) {
+        Reflections reflections = new Reflections(packageName);
+        Predicate<Class<?>> workflowFilter = makeWorkflowFilter(routingStrategy, group);
+        // We rely on naming convention rather than on inspection, that's OK as code is generated
+        try {
+            return reflections.getTypesAnnotatedWith(WorkflowInterface.class)
+                    .stream()
+                    .filter(workflowFilter)
+                    .map(rethrowFunction(c -> {
+                        String workflowKey = parseWorkflowKey(c);
+                        String workflowClassName = c.getName();
+                        String baseName = workflowClassName.replace("Workflow", "");
+                        Class<TemporalWorkflowImpl> wfImplClass = (Class<TemporalWorkflowImpl>) Class.forName(workflowClassName + "Impl");
+                        Class<TemporalActivityImpl<?, ?>> actImplCls = (Class<TemporalActivityImpl<?, ?>>) Class.forName(baseName + "ActivityImpl");
+                        String taskQueue = resolveWfTaskQueue(routingStrategy, workflowKey, group);
+                        List<RegisteredActivity> activities = List.of(new RegisteredActivity(activityFactory(actImplCls, taskFactory, client, 1d), taskQueue));
+                        return new RegisteredWorkflow(wfImplClass, taskQueue, activities);
+                    }))
+                    .toList();
+        } catch (ClassNotFoundException e) {
+            throw new UnknownTask("Workflow class not found: ", e);
+        }
     }
+
+    public Closeable discoverWorkflows(int taskWorkersNb, TaskFactory taskFactory, RoutingStrategy routingStrategy, Group group) {
+        List<RegisteredWorkflow> registeredWorkflows = discoverWorkflows("org.icij.datashare.tasks", taskFactory, routingStrategy, group);
+        return createFactory(taskWorkersNb, registeredWorkflows);
+    }
+
+    public CloseableWorkerFactoryHandle createFactory(int taskWorkersNb, List<RegisteredWorkflow> registeredWorkflows) {
+        WorkerFactory workerFactory = WorkerFactory.newInstance(client);
+        HashMap<String, Worker> workers = new HashMap<>();
+        WorkerOptions workerOptions = WorkerOptions.newBuilder()
+                .setMaxConcurrentWorkflowTaskExecutionSize(taskWorkersNb)
+                .setMaxConcurrentActivityExecutionSize(taskWorkersNb)
+                .build();
+        registeredWorkflows.forEach(rethrowConsumer(wf -> {
+            String wfTaskQueue = wf.taskQueue();
+            workers.computeIfAbsent(wfTaskQueue, workerFactory::newWorker)
+                    .registerWorkflowImplementationTypes(WF_IMPLEMENTATION_DEFAULT_OPTIONS, wf.workflowCls());
+            wf.activities().forEach(rethrowConsumer(act -> {
+                workers.computeIfAbsent(act.taskQueue(), q -> workerFactory.newWorker(q, workerOptions))
+                        .registerActivitiesImplementations(act.activityFactory().get());
+            }));
+        }));
+        return new CloseableWorkerFactoryHandle(workerFactory);
+    }
+
+    public record Page<P>(List<P> items, ByteString nextPageToken) { }
     @FunctionalInterface
     public interface PageFetcher<P> {
         Page<P> fetchPage(ByteString nextPageToken);
@@ -622,4 +682,23 @@ public class TemporalInterlocutor {
             return missingItems.next();
         }
     }
+
+    public record CloseableWorkerFactoryHandle(WorkerFactory factory) implements Closeable {
+            public CloseableWorkerFactoryHandle(WorkerFactory factory) {
+                this.factory = factory;
+                this.factory.start();
+            }
+
+            @Override
+            public void close() throws IOException {
+                synchronized (factory) {
+                    if (!this.factory.isShutdown()) {
+                        this.factory.shutdown();
+                    }
+                }
+            }
+        }
+
+    public record RegisteredActivity(ThrowingSupplier<?> activityFactory, String taskQueue) { }
+    public record RegisteredWorkflow(Class<?> workflowCls, String taskQueue, List<RegisteredActivity> activities) { }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -150,7 +150,7 @@ public class TemporalInterlocutor {
         }, taskId);
     }
 
-    public static <T> T unknownIfNotFound(Function<String, T> function, String taskId) {
+    private static <T> T unknownIfNotFound(Function<String, T> function, String taskId) {
         try {
             return function.apply(taskId);
         } catch (StatusRuntimeException e) {
@@ -342,18 +342,6 @@ public class TemporalInterlocutor {
         }, taskId);
     }
 
-    public void deleteWorkflowExecution(String taskId) {
-        unknownIfNotFound(rethrowConsumer(t -> {
-            DeleteWorkflowExecutionRequest.Builder requestBuilder = DeleteWorkflowExecutionRequest.newBuilder();
-            requestBuilder
-                    .setNamespace(getNamespace())
-                    .setWorkflowExecution(requestBuilder.getWorkflowExecutionBuilder().setWorkflowId(t).build());
-            workflowServiceStubs.deleteWorkflowExecution(requestBuilder.build());
-        }), taskId);
-
-        executions.remove(taskId);
-    }
-
     public boolean getHealth() {
         return client.getWorkflowServiceStubs().healthCheck().getStatus().equals(SERVING);
     }
@@ -501,48 +489,6 @@ public class TemporalInterlocutor {
                 }
             })
             .filter(Objects::nonNull);
-    }
-
-    protected void awaitCleared(int timeout, TimeUnit timeUnit, TaskManagerTemporal taskManagerTemporal) throws IOException {
-        long startTime = System.currentTimeMillis();
-        long maxDuration = timeUnit.toMillis(timeout);
-        while ((System.currentTimeMillis() - startTime < maxDuration)) {
-            try (Stream<String> taskIds = taskManagerTemporal.getTaskIds()) {
-                if (taskIds.count() == 0) {
-                    return;
-                }
-            }
-            try {
-                Thread.sleep(taskManagerTemporal.getTerminationPollingInterval());
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
-    }
-
-    protected void awaitExecutionDeletion(Set<String> taskIds) throws InterruptedException {
-        // TODO: avoid the infinite loop
-        // TODO: implement throttling
-        while (true) {
-            boolean allDeleted = taskIds.stream().allMatch(tId -> {
-                try {
-                    createWorkflowStub(tId).describe();
-                } catch (StatusRuntimeException ex) {
-                    if (ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                        return true;
-                    }
-                } catch (WorkflowNotFoundException ignored) {
-                    return true;
-                }
-                return false;
-            });
-            if (allDeleted) {
-                break;
-            }
-            // TODO: define a proper duration
-            Thread.sleep(DEFAULT_NAMESPACE_POLL_INTERVAL.toMillis());
-        }
     }
 
     public WorkflowExecutionDescription getWorkflowExecution(String taskId) throws UnknownTask {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -9,6 +9,8 @@ import io.temporal.api.common.v1.Payloads;
 import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.IndexedValueType;
 import io.temporal.api.enums.v1.NamespaceState;
+import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
+import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
 import io.temporal.api.namespace.v1.NamespaceConfig;
 import io.temporal.api.operatorservice.v1.AddSearchAttributesRequest;
 import io.temporal.api.operatorservice.v1.DeleteNamespaceRequest;
@@ -18,6 +20,7 @@ import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
 import io.temporal.api.workflowservice.v1.*;
 import io.temporal.client.*;
 import io.temporal.common.SearchAttributeKey;
+import io.temporal.common.SearchAttributes;
 import io.temporal.common.converter.DefaultDataConverter;
 import io.temporal.common.converter.JacksonJsonPayloadConverter;
 import io.temporal.serviceclient.OperatorServiceStubs;
@@ -45,6 +48,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static io.grpc.health.v1.HealthCheckResponse.ServingStatus.SERVING;
+import static io.temporal.api.enums.v1.WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowFunction;
 import static org.icij.datashare.asynctasks.Task.USER_KEY;
@@ -54,6 +58,8 @@ import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asTaskState;
 
 public class TemporalInterlocutor {
     private static final int DEFAULT_PAGE_SIZE = 100;
+    private static final Duration DEFAULT_WORKFLOW_TASK_TIMEOUT = Duration.ofDays(7);
+    private static final String TERMINATION_MSG = "terminated_by_user";
     // TODO: in-memory hack for strong consistence, maybe a repository would be a better implem
     private final ConcurrentHashMap.KeySetView<String, Boolean> executions = ConcurrentHashMap.newKeySet();
 
@@ -102,7 +108,7 @@ public class TemporalInterlocutor {
         this.workflowServiceStubs = client.getWorkflowServiceStubs().blockingStub();
     }
 
-    // for tests
+    // for TaskManagerTemporal tests
     public TemporalInterlocutor(WorkflowClient client, WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub) {
         this.client = client;
         this.workflowServiceStubs = workflowServiceBlockingStub;
@@ -147,7 +153,7 @@ public class TemporalInterlocutor {
     public void setupNamespace(Duration timeout) throws InterruptedException {
         long start = System.currentTimeMillis();
         long timeoutMillis = timeout.toMillis();
-        String namespace = client.getOptions().getNamespace();
+        String namespace = getNamespace();
         WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub =
             client.getWorkflowServiceStubs().blockingStub();
         OperatorServiceGrpc.OperatorServiceBlockingStub operatorServiceBlockingStub =
@@ -275,18 +281,42 @@ public class TemporalInterlocutor {
         throw new RuntimeException("failed to delete namespace in " + timeout);
     }
 
-    public WorkflowStub newUntypedWorkflowStub(String name, WorkflowOptions build) {
-        //executions.add(taskId);
-        return null;
+    public void createWorkflow(String taskId, String name, String queueName, SearchAttributes searchAttributes, Map<String, Object> args) {
+        WorkflowOptions.Builder optionBuilder = WorkflowOptions.newBuilder().setWorkflowId(taskId)
+                .setWorkflowTaskTimeout(DEFAULT_WORKFLOW_TASK_TIMEOUT) // TODO: set this per task
+                .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE)
+                .setWorkflowIdConflictPolicy(WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_FAIL)
+                .setTypedSearchAttributes(searchAttributes)
+                .setTaskQueue(queueName);
+        WorkflowStub workflowStub = client.newUntypedWorkflowStub(name, optionBuilder.build());
+        workflowStub.start(new TemporalInputPayload(args));
+        // Super important force description to refresh the cache and make the task visible
+        workflowStub.describe();
+        executions.add(taskId);
     }
 
-    public WorkflowStub newUntypedWorkflowStub(String taskId) {
-        executions.add(taskId);
-        return null;
+    public WorkflowStub createWorkflowStub(String workflowId) {
+        return client.newUntypedWorkflowStub(workflowId);
     }
 
     public String getNamespace() {
-        return null;
+        return client.getOptions().getNamespace();
+    }
+
+    public boolean terminateWorkflow(String taskId) {
+        // TODO: add support for cancellation rather than termination, update the TaskManager API accordingly
+        return unknownIfNotFound(tId -> {
+            WorkflowStub workflowStub = createWorkflowStub(tId);
+            boolean isRunning = workflowStub.describe().getStatus() == WORKFLOW_EXECUTION_STATUS_RUNNING;
+            try {
+                workflowStub.terminate(TERMINATION_MSG);
+            } catch (WorkflowNotFoundException ex) {
+                if (!ex.getCause().getMessage().contains("workflow execution already completed")) {
+                    throw ex;
+                }
+            }
+            return isRunning;
+        }, taskId);
     }
 
     public void deleteWorkflowExecution(String taskId) {
@@ -408,7 +438,7 @@ public class TemporalInterlocutor {
         Task.State state = asTaskState(workflowExecutionInfo.getStatus());
         if (Objects.requireNonNull(state) == Task.State.ERROR || state == Task.State.DONE) {
             try {
-                Serializable res = newUntypedWorkflowStub(workflowExecutionInfo.getExecution().getWorkflowId())
+                Serializable res = createWorkflowStub(workflowExecutionInfo.getExecution().getWorkflowId())
                         .getResult(Serializable.class);
                 //TODO this is a big hack because Temporal does not use the TYPE_INCLUSION_MAPPER
                 // to deserialize for now
@@ -437,7 +467,7 @@ public class TemporalInterlocutor {
         return executionIds.stream()
             .map(id -> {
                 try {
-                    return newUntypedWorkflowStub(id).describe().getWorkflowExecutionInfo();
+                    return createWorkflowStub(id).describe().getWorkflowExecutionInfo();
                 } catch (StatusRuntimeException ex) {
                     if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
                         throw ex;
@@ -476,6 +506,36 @@ public class TemporalInterlocutor {
      */
     public WorkflowClient getClient() {
         return client;
+    }
+
+    protected void awaitExecutionDeletion(Set<String> taskIds) throws InterruptedException {
+        // TODO: avoid the infinite loop
+        // TODO: implement throttling
+        while (true) {
+            boolean allDeleted = taskIds.stream().allMatch(tId -> {
+                try {
+                    createWorkflowStub(tId).describe();
+                } catch (StatusRuntimeException ex) {
+                    if (ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                        return true;
+                    }
+                } catch (WorkflowNotFoundException ignored) {
+                    return true;
+                }
+                return false;
+            });
+            if (allDeleted) {
+                break;
+            }
+            // TODO: define a proper duration
+            Thread.sleep(DEFAULT_NAMESPACE_POLL_INTERVAL.toMillis());
+        }
+    }
+
+    public WorkflowExecutionDescription getWorkflowExecution(String taskId) throws UnknownTask {
+        return unknownIfNotFound(t -> {
+            return createWorkflowStub(taskId).describe();
+        }, taskId);
     }
 
     public record Page<P>(List<P> items, ByteString nextPageToken) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -50,8 +50,6 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -125,42 +123,6 @@ public class TemporalInterlocutor {
     public TemporalInterlocutor(WorkflowClient client, WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub) {
         this.client = client;
         this.workflowServiceStubs = workflowServiceBlockingStub;
-    }
-
-    private static WorkflowClient buildClient(WorkflowServiceStubs serviceStub, WorkflowClientOptions clientOptions) {
-        return WorkflowClient.newInstance(serviceStub, clientOptions);
-    }
-
-    private static double parseProgress(WorkflowExecutionInfo workflowExecutionInfo) {
-        double maxProgress = defaultDataConverter.fromPayload(workflowExecutionInfo.getSearchAttributes()
-            .getIndexedFieldsOrThrow(MAX_PROGRESS_CUSTOM_ATTRIBUTE.getName()), Double.class, Double.class);
-        if (maxProgress == 0) {
-            return 0.0;
-        }
-        double currentProgress = defaultDataConverter.fromPayload(
-            workflowExecutionInfo.getSearchAttributes().getIndexedFieldsOrThrow(PROGRESS_CUSTOM_ATTRIBUTE.getName()),
-            Double.class, Double.class);
-        return currentProgress / maxProgress;
-    }
-
-    private static void unknownIfNotFound(Consumer<String> supplier, String taskId) {
-        unknownIfNotFound((t) -> {
-            supplier.accept(t);
-            return null;
-        }, taskId);
-    }
-
-    private static <T> T unknownIfNotFound(Function<String, T> function, String taskId) {
-        try {
-            return function.apply(taskId);
-        } catch (StatusRuntimeException e) {
-            if (e.getStatus().equals(Status.NOT_FOUND)) {
-                throw new UnknownTask(taskId);
-            }
-            throw e;
-        } catch (WorkflowNotFoundException e) {
-            throw new UnknownTask(taskId);
-        }
     }
 
     public <A extends TemporalActivityImpl<?, ?>> ThrowingSupplier<A> activityFactory(
@@ -241,67 +203,6 @@ public class TemporalInterlocutor {
             .blockingStub()
             .deleteNamespace(DeleteNamespaceRequest.newBuilder().setNamespace(namespace).build());
         awaitNamespaceDeleted(client.getWorkflowServiceStubs().blockingStub(), namespace, timeout);
-    }
-
-    private static WorkflowClient buildClient(String target, String namespace) {
-        WorkflowClientOptions clientOptions = WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
-        WorkflowServiceStubsOptions serviceStubsOptions = WorkflowServiceStubsOptions.newBuilder()
-            .setTarget(target)
-            .build();
-        WorkflowServiceStubs serviceStub = WorkflowServiceStubs.newServiceStubs(serviceStubsOptions);
-        return buildClient(serviceStub, clientOptions);
-    }
-
-    private static boolean hasNamespace(WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub,
-                                        String namespace) {
-        NamespaceState namespaceState;
-        try {
-            namespaceState = workflowServiceBlockingStub.describeNamespace(
-                DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build()
-            ).getNamespaceInfo().getState();
-        } catch (StatusRuntimeException ex) {
-            if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                throw ex;
-            }
-            return false;
-        }
-        return namespaceState.equals(NamespaceState.NAMESPACE_STATE_REGISTERED);
-    }
-
-    private static boolean namespaceIsReady(OperatorServiceGrpc.OperatorServiceBlockingStub operatorServiceBlockingStub,
-                                            String namespace) {
-        Set<String> searchAttributes;
-        try {
-            searchAttributes = operatorServiceBlockingStub
-                    .listSearchAttributes(ListSearchAttributesRequest.newBuilder().setNamespace(namespace).build())
-                    .getCustomAttributesMap()
-                    .keySet();
-        } catch (StatusRuntimeException e) {
-            if (!e.getStatus().getCode().equals(Status.Code.NOT_FOUND) && !e.getStatus().getCode().equals(Status.Code.FAILED_PRECONDITION)) {
-                throw e;
-            }
-            return false;
-        }
-        return searchAttributes.containsAll(CUSTOM_SEARCH_ATTRIBUTES.keySet());
-    }
-
-    private static void awaitNamespaceDeleted(
-        WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub, String namespace, Duration timeout)
-        throws RuntimeException {
-        long startTime = System.currentTimeMillis();
-        long maxDuration = timeout.toMillis();
-        while ((System.currentTimeMillis() - startTime < maxDuration)) {
-            try {
-                workflowServiceBlockingStub.describeNamespace(
-                    DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build());
-            } catch (StatusRuntimeException e) {
-                if (!e.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                    throw e;
-                }
-                return;
-            }
-        }
-        throw new RuntimeException("failed to delete namespace in " + timeout);
     }
 
     public void createWorkflow(String taskId, String name, String queueName, SearchAttributes searchAttributes, Map<String, Object> args) {
@@ -429,72 +330,8 @@ public class TemporalInterlocutor {
         return eventuallyConsistentListExecutions(filters).map(rethrowFunction(this::parseTask));
     }
 
-    public <V extends Serializable> Task<V> parseTask(WorkflowExecutionMetadata response, TaskManagerTemporal taskManagerTemporal) {
-        return parseTask(response.getWorkflowExecutionInfo());
-    }
-
-    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionInfo workflowExecutionInfo) {
-        WorkflowExecution execution = workflowExecutionInfo.getExecution();
-        String taskId = execution.getWorkflowId();
-        String taskName = workflowExecutionInfo.getType().getName();
-        double progress = parseProgress(workflowExecutionInfo);
-        Date createdAt = new Date(workflowExecutionInfo.getStartTime().getSeconds() * 1000);
-        Date completedAt = null;
-        Timestamp closeTime = workflowExecutionInfo.getCloseTime();
-        if (!closeTime.equals(Timestamp.getDefaultInstance())) {
-            completedAt = new Date(closeTime.getSeconds() * 1000);
-        }
-        TaskResult<V> result = null;
-        TaskError error = null;
-        Task.State state = asTaskState(workflowExecutionInfo.getStatus());
-        if (Objects.requireNonNull(state) == Task.State.ERROR || state == Task.State.DONE) {
-            try {
-                Serializable res = createWorkflowStub(workflowExecutionInfo.getExecution().getWorkflowId())
-                        .getResult(Serializable.class);
-                //TODO this is a big hack because Temporal does not use the TYPE_INCLUSION_MAPPER
-                // to deserialize for now
-                if (res instanceof Map<?, ?>) {
-                    try {
-                        res = JsonObjectMapper.readValueTyped(
-                                JsonObjectMapper.writeValueAsString(res), Serializable.class);
-                    } catch (IOException e) {
-                        TaskManager.logger.warn("could not convert result to typed object", e);
-                    }
-                }
-                if (res != null) {
-                    result = new TaskResult<>((V) res);
-                }
-            } catch (WorkflowFailedException ex) {
-                error = new TaskError(ex.getCause());
-            }
-        }
-        Map<String, Object> args = getArgs(workflowExecutionInfo);
-        int retriesLeft = MAX_RETRIES_LEFT; // retriesLeft makes no sense in the context of a workflow,
-        // it only makes sense for subtasks/activities
-        return new Task<>(taskId, taskName, state, progress, createdAt, retriesLeft, completedAt, args, result, error);
-    }
-
-    private Stream<WorkflowExecutionInfo> fetchExecByIdsIfExist(Set<String> executionIds) {
-        return executionIds.stream()
-            .map(id -> {
-                try {
-                    return createWorkflowStub(id).describe().getWorkflowExecutionInfo();
-                } catch (StatusRuntimeException ex) {
-                    if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
-                        throw ex;
-                    }
-                    return null;
-                } catch (WorkflowNotFoundException ignored) {
-                    return null;
-                }
-            })
-            .filter(Objects::nonNull);
-    }
-
     public WorkflowExecutionDescription getWorkflowExecution(String taskId) throws UnknownTask {
-        return unknownIfNotFound(t -> {
-            return createWorkflowStub(taskId).describe();
-        }, taskId);
+        return unknownIfNotFound(t -> createWorkflowStub(taskId).describe(), taskId);
     }
 
     List<RegisteredWorkflow> discoverWorkflows(String packageName, TaskFactory taskFactory, RoutingStrategy routingStrategy, Group group) {
@@ -543,6 +380,10 @@ public class TemporalInterlocutor {
             }));
         }));
         return new CloseableWorkerFactoryHandle(workerFactory);
+    }
+
+    public <V extends Serializable> Task<V> getTask(String taskId) {
+        return parseTask(getWorkflowExecution(taskId));
     }
 
     public record Page<P>(List<P> items, ByteString nextPageToken) { }
@@ -647,4 +488,157 @@ public class TemporalInterlocutor {
 
     public record RegisteredActivity(ThrowingSupplier<?> activityFactory, String taskQueue) { }
     public record RegisteredWorkflow(Class<?> workflowCls, String taskQueue, List<RegisteredActivity> activities) { }
+
+    // ------------------------
+    // private utility functions
+    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionMetadata response) {
+        return parseTask(response.getWorkflowExecutionInfo());
+    }
+    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionInfo workflowExecutionInfo) {
+        WorkflowExecution execution = workflowExecutionInfo.getExecution();
+        String taskId = execution.getWorkflowId();
+        String taskName = workflowExecutionInfo.getType().getName();
+        double progress = parseProgress(workflowExecutionInfo);
+        Date createdAt = new Date(workflowExecutionInfo.getStartTime().getSeconds() * 1000);
+        Date completedAt = null;
+        Timestamp closeTime = workflowExecutionInfo.getCloseTime();
+        if (!closeTime.equals(Timestamp.getDefaultInstance())) {
+            completedAt = new Date(closeTime.getSeconds() * 1000);
+        }
+        TaskResult<V> result = null;
+        TaskError error = null;
+        Task.State state = asTaskState(workflowExecutionInfo.getStatus());
+        if (Objects.requireNonNull(state) == Task.State.ERROR || state == Task.State.DONE) {
+            try {
+                Serializable res = createWorkflowStub(workflowExecutionInfo.getExecution().getWorkflowId())
+                        .getResult(Serializable.class);
+                //TODO this is a big hack because Temporal does not use the TYPE_INCLUSION_MAPPER
+                // to deserialize for now
+                if (res instanceof Map<?, ?>) {
+                    try {
+                        res = JsonObjectMapper.readValueTyped(
+                                JsonObjectMapper.writeValueAsString(res), Serializable.class);
+                    } catch (IOException e) {
+                        TaskManager.logger.warn("could not convert result to typed object", e);
+                    }
+                }
+                if (res != null) {
+                    result = new TaskResult<>((V) res);
+                }
+            } catch (WorkflowFailedException ex) {
+                error = new TaskError(ex.getCause());
+            }
+        }
+        Map<String, Object> args = getArgs(workflowExecutionInfo);
+        int retriesLeft = MAX_RETRIES_LEFT; // retriesLeft makes no sense in the context of a workflow,
+        // it only makes sense for subtasks/activities
+        return new Task<>(taskId, taskName, state, progress, createdAt, retriesLeft, completedAt, args, result, error);
+    }
+
+    private static WorkflowClient buildClient(WorkflowServiceStubs serviceStub, WorkflowClientOptions clientOptions) {
+        return WorkflowClient.newInstance(serviceStub, clientOptions);
+    }
+
+    private Stream<WorkflowExecutionInfo> fetchExecByIdsIfExist(Set<String> executionIds) {
+        return executionIds.stream()
+                .map(id -> {
+                    try {
+                        return createWorkflowStub(id).describe().getWorkflowExecutionInfo();
+                    } catch (StatusRuntimeException ex) {
+                        if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                            throw ex;
+                        }
+                        return null;
+                    } catch (WorkflowNotFoundException ignored) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull);
+    }
+
+    private static double parseProgress(WorkflowExecutionInfo workflowExecutionInfo) {
+        double maxProgress = defaultDataConverter.fromPayload(workflowExecutionInfo.getSearchAttributes()
+                .getIndexedFieldsOrThrow(MAX_PROGRESS_CUSTOM_ATTRIBUTE.getName()), Double.class, Double.class);
+        if (maxProgress == 0) {
+            return 0.0;
+        }
+        double currentProgress = defaultDataConverter.fromPayload(
+                workflowExecutionInfo.getSearchAttributes().getIndexedFieldsOrThrow(PROGRESS_CUSTOM_ATTRIBUTE.getName()),
+                Double.class, Double.class);
+        return currentProgress / maxProgress;
+    }
+
+    private static <T> T unknownIfNotFound(Function<String, T> function, String taskId) {
+        try {
+            return function.apply(taskId);
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().equals(Status.NOT_FOUND)) {
+                throw new UnknownTask(taskId);
+            }
+            throw e;
+        } catch (WorkflowNotFoundException e) {
+            throw new UnknownTask(taskId);
+        }
+    }
+
+    private static WorkflowClient buildClient(String target, String namespace) {
+        WorkflowClientOptions clientOptions = WorkflowClientOptions.newBuilder().setNamespace(namespace).build();
+        WorkflowServiceStubsOptions serviceStubsOptions = WorkflowServiceStubsOptions.newBuilder()
+                .setTarget(target)
+                .build();
+        WorkflowServiceStubs serviceStub = WorkflowServiceStubs.newServiceStubs(serviceStubsOptions);
+        return buildClient(serviceStub, clientOptions);
+    }
+
+    private static boolean hasNamespace(WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub,
+                                        String namespace) {
+        NamespaceState namespaceState;
+        try {
+            namespaceState = workflowServiceBlockingStub.describeNamespace(
+                    DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build()
+            ).getNamespaceInfo().getState();
+        } catch (StatusRuntimeException ex) {
+            if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                throw ex;
+            }
+            return false;
+        }
+        return namespaceState.equals(NamespaceState.NAMESPACE_STATE_REGISTERED);
+    }
+
+    private static boolean namespaceIsReady(OperatorServiceGrpc.OperatorServiceBlockingStub operatorServiceBlockingStub,
+                                            String namespace) {
+        Set<String> searchAttributes;
+        try {
+            searchAttributes = operatorServiceBlockingStub
+                    .listSearchAttributes(ListSearchAttributesRequest.newBuilder().setNamespace(namespace).build())
+                    .getCustomAttributesMap()
+                    .keySet();
+        } catch (StatusRuntimeException e) {
+            if (!e.getStatus().getCode().equals(Status.Code.NOT_FOUND) && !e.getStatus().getCode().equals(Status.Code.FAILED_PRECONDITION)) {
+                throw e;
+            }
+            return false;
+        }
+        return searchAttributes.containsAll(CUSTOM_SEARCH_ATTRIBUTES.keySet());
+    }
+
+    private static void awaitNamespaceDeleted(
+            WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub, String namespace, Duration timeout)
+            throws RuntimeException {
+        long startTime = System.currentTimeMillis();
+        long maxDuration = timeout.toMillis();
+        while ((System.currentTimeMillis() - startTime < maxDuration)) {
+            try {
+                workflowServiceBlockingStub.describeNamespace(
+                        DescribeNamespaceRequest.newBuilder().setNamespace(namespace).build());
+            } catch (StatusRuntimeException e) {
+                if (!e.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                    throw e;
+                }
+                return;
+            }
+        }
+        throw new RuntimeException("failed to delete namespace in " + timeout);
+    }
 }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -56,7 +56,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static io.grpc.health.v1.HealthCheckResponse.ServingStatus.SERVING;
-import static io.temporal.api.enums.v1.WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING;
+import static io.temporal.api.enums.v1.WorkflowExecutionStatus.*;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowFunction;
 import static org.icij.datashare.asynctasks.Task.USER_KEY;
@@ -213,7 +213,7 @@ public class TemporalInterlocutor {
                 .setTypedSearchAttributes(searchAttributes)
                 .setTaskQueue(queueName);
         WorkflowStub workflowStub = client.newUntypedWorkflowStub(name, optionBuilder.build());
-        workflowStub.start(new TemporalInputPayload(args));
+        WorkflowExecution exec = workflowStub.start(new TemporalInputPayload(args));
         // Super important force description to refresh the cache and make the task visible
         workflowStub.describe();
         executions.add(taskId);
@@ -231,7 +231,9 @@ public class TemporalInterlocutor {
         // TODO: add support for cancellation rather than termination, update the TaskManager API accordingly
         return unknownIfNotFound(tId -> {
             WorkflowStub workflowStub = createWorkflowStub(tId);
-            boolean isRunning = workflowStub.describe().getStatus() == WORKFLOW_EXECUTION_STATUS_RUNNING;
+            if(workflowStub.describe().getStatus() != WORKFLOW_EXECUTION_STATUS_RUNNING) {
+                return false;
+            }
             try {
                 workflowStub.terminate(TERMINATION_MSG);
             } catch (WorkflowNotFoundException ex) {
@@ -239,7 +241,7 @@ public class TemporalInterlocutor {
                     throw ex;
                 }
             }
-            return isRunning;
+            return workflowStub.describe().getStatus() == WORKFLOW_EXECUTION_STATUS_TERMINATED;
         }, taskId);
     }
 
@@ -382,6 +384,11 @@ public class TemporalInterlocutor {
         return new CloseableWorkerFactoryHandle(workerFactory);
     }
 
+    /**
+     * Get the information of a Workflow running in Temporal represented as a Task
+     * @param taskId
+     * @return
+     */
     public <V extends Serializable> Task<V> getTask(String taskId) {
         return parseTask(getWorkflowExecution(taskId));
     }

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -1,10 +1,12 @@
 package org.icij.datashare.asynctasks.temporal;
 
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.DEFAULT_NAMESPACE;
-
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.temporal.api.common.v1.Payloads;
+import io.temporal.api.common.v1.WorkflowExecution;
 import io.temporal.api.enums.v1.IndexedValueType;
 import io.temporal.api.enums.v1.NamespaceState;
 import io.temporal.api.namespace.v1.NamespaceConfig;
@@ -12,26 +14,53 @@ import io.temporal.api.operatorservice.v1.AddSearchAttributesRequest;
 import io.temporal.api.operatorservice.v1.DeleteNamespaceRequest;
 import io.temporal.api.operatorservice.v1.ListSearchAttributesRequest;
 import io.temporal.api.operatorservice.v1.OperatorServiceGrpc;
-import io.temporal.api.workflowservice.v1.DescribeNamespaceRequest;
-import io.temporal.api.workflowservice.v1.RegisterNamespaceRequest;
-import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
-import io.temporal.client.WorkflowClient;
-import io.temporal.client.WorkflowClientOptions;
+import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
+import io.temporal.api.workflowservice.v1.*;
+import io.temporal.client.*;
 import io.temporal.common.SearchAttributeKey;
+import io.temporal.common.converter.DefaultDataConverter;
+import io.temporal.common.converter.JacksonJsonPayloadConverter;
 import io.temporal.serviceclient.OperatorServiceStubs;
 import io.temporal.serviceclient.OperatorServiceStubsOptions;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.util.Map;
-import java.util.Set;
 import org.icij.datashare.EnvUtils;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.asynctasks.TaskManagerTemporal;
+import org.icij.datashare.asynctasks.*;
+import org.icij.datashare.asynctasks.bus.amqp.TaskError;
+import org.icij.datashare.function.Pair;
+import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.user.User;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static io.grpc.health.v1.HealthCheckResponse.ServingStatus.SERVING;
+import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
+import static org.icij.datashare.LambdaExceptionUtils.rethrowFunction;
+import static org.icij.datashare.asynctasks.Task.USER_KEY;
+import static org.icij.datashare.asynctasks.bus.amqp.Event.MAX_RETRIES_LEFT;
+import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asExecInfoFilter;
+import static org.icij.datashare.asynctasks.temporal.TemporalHelper.asTaskState;
 
 public class TemporalInterlocutor {
-    public final WorkflowClient client;
+    private static final int DEFAULT_PAGE_SIZE = 100;
+    // TODO: in-memory hack for strong consistence, maybe a repository would be a better implem
+    private final ConcurrentHashMap.KeySetView<String, Boolean> executions = ConcurrentHashMap.newKeySet();
+
+    public static final String DEFAULT_NAMESPACE = "datashare-default";
+    public static final DefaultDataConverter defaultDataConverter = DefaultDataConverter.newDefaultInstance()
+            .withPayloadConverterOverrides(new JacksonJsonPayloadConverter(JsonObjectMapper.getMapper()));
+    private final WorkflowClient client;
 
     // See https://docs.temporal.io/list-filter#supported-operators
     public static final SearchAttributeKey<String> WORKFLOW_TYPE_ATTRIBUTE =
@@ -53,10 +82,12 @@ public class TemporalInterlocutor {
     private static final Set<Status.Code> NAMESPACE_EXISTS = Set.of(Status.ALREADY_EXISTS.getCode());
     private static final NamespaceConfig DEFAULT_NAMESPACE_CONFIG =
         NamespaceConfig.newBuilder().setWorkflowExecutionRetentionTtl(Durations.fromDays(365)).build();
+    private final WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceStubs;
 
 
     public TemporalInterlocutor(String target, String namespace) throws InterruptedException {
         this.client = buildClient(target, namespace);
+        this.workflowServiceStubs = client.getWorkflowServiceStubs().blockingStub();
         setupNamespace(Duration.ofSeconds(30));
     }
 
@@ -65,8 +96,52 @@ public class TemporalInterlocutor {
             propertiesProvider.get("temporalNamespace").orElse(DEFAULT_NAMESPACE));
     }
 
+    // for tests
+    TemporalInterlocutor(WorkflowClient client) {
+        this.client = client;
+        this.workflowServiceStubs = client.getWorkflowServiceStubs().blockingStub();
+    }
+
+    // for tests
+    public TemporalInterlocutor(WorkflowClient client, WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub) {
+        this.client = client;
+        this.workflowServiceStubs = workflowServiceBlockingStub;
+    }
+
     private static WorkflowClient buildClient(WorkflowServiceStubs serviceStub, WorkflowClientOptions clientOptions) {
         return WorkflowClient.newInstance(serviceStub, clientOptions);
+    }
+
+    private static double parseProgress(WorkflowExecutionInfo workflowExecutionInfo) {
+        double maxProgress = defaultDataConverter.fromPayload(workflowExecutionInfo.getSearchAttributes()
+            .getIndexedFieldsOrThrow(MAX_PROGRESS_CUSTOM_ATTRIBUTE.getName()), Double.class, Double.class);
+        if (maxProgress == 0) {
+            return 0.0;
+        }
+        double currentProgress = defaultDataConverter.fromPayload(
+            workflowExecutionInfo.getSearchAttributes().getIndexedFieldsOrThrow(PROGRESS_CUSTOM_ATTRIBUTE.getName()),
+            Double.class, Double.class);
+        return currentProgress / maxProgress;
+    }
+
+    private static void unknownIfNotFound(Consumer<String> supplier, String taskId) {
+        unknownIfNotFound((t) -> {
+            supplier.accept(t);
+            return null;
+        }, taskId);
+    }
+
+    public static <T> T unknownIfNotFound(Function<String, T> function, String taskId) {
+        try {
+            return function.apply(taskId);
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().equals(Status.NOT_FOUND)) {
+                throw new UnknownTask(taskId);
+            }
+            throw e;
+        } catch (WorkflowNotFoundException e) {
+            throw new UnknownTask(taskId);
+        }
     }
 
     public void setupNamespace(Duration timeout) throws InterruptedException {
@@ -200,4 +275,291 @@ public class TemporalInterlocutor {
         throw new RuntimeException("failed to delete namespace in " + timeout);
     }
 
+    public WorkflowStub newUntypedWorkflowStub(String name, WorkflowOptions build) {
+        //executions.add(taskId);
+        return null;
+    }
+
+    public WorkflowStub newUntypedWorkflowStub(String taskId) {
+        executions.add(taskId);
+        return null;
+    }
+
+    public String getNamespace() {
+        return null;
+    }
+
+    public void deleteWorkflowExecution(String taskId) {
+        unknownIfNotFound(rethrowConsumer(t -> {
+            DeleteWorkflowExecutionRequest.Builder requestBuilder = DeleteWorkflowExecutionRequest.newBuilder();
+            requestBuilder
+                    .setNamespace(getNamespace())
+                    .setWorkflowExecution(requestBuilder.getWorkflowExecutionBuilder().setWorkflowId(t).build());
+            workflowServiceStubs.deleteWorkflowExecution(requestBuilder.build());
+        }), taskId);
+
+        executions.remove(taskId);
+    }
+
+    public boolean getHealth() {
+        return client.getWorkflowServiceStubs().healthCheck().getStatus().equals(SERVING);
+    }
+
+    public Map<String, Object> getArgs(WorkflowExecutionInfo workflowExecutionInfo) {
+        Map<String, Object> args = null;
+        WorkflowExecution execution = workflowExecutionInfo.getExecution();
+        Payloads payloads = client.fetchHistory(execution.getWorkflowId(), execution.getRunId()).getEvents().get(0)
+            .getWorkflowExecutionStartedEventAttributes().getInput();
+        if (payloads.getPayloadsCount() > 1) {
+            throw new RuntimeException("invalid payload count, expected exactly 1 payload");
+        }
+        TemporalInputPayload payload =
+            defaultDataConverter.fromPayload(payloads.getPayloads(0), TemporalInputPayload.class,
+                TemporalInputPayload.class);
+        if (payload != null) {
+            args = payload.args();
+            args.computeIfPresent(USER_KEY, (k, v) -> JsonObjectMapper.convertValue(v, User.class));
+        }
+        return args;
+    }
+
+    public PageFetcher<WorkflowExecutionInfo> getWorkflowExecutionFetcher(String query) {
+        return (ByteString nextPageToken) -> {
+            ListWorkflowExecutionsRequest.Builder requestBuilder =
+                ListWorkflowExecutionsRequest.newBuilder().setNamespace(getNamespace()).setPageSize(DEFAULT_PAGE_SIZE);
+            if (nextPageToken != null) {
+                requestBuilder.setNextPageToken(nextPageToken);
+            }
+            Optional.ofNullable(query).ifPresent(q -> {
+                if (!q.isEmpty()) {
+                    requestBuilder.setQuery(q);
+                }
+            });
+            ListWorkflowExecutionsResponse response = workflowServiceStubs
+                .listWorkflowExecutions(requestBuilder.build());
+            return new Page<>(response.getExecutionsList(), response.getNextPageToken());
+        };
+    }
+
+    public void deleteExecution(String workflowId) {
+        try {
+            DeleteWorkflowExecutionRequest deleteWorkflowExecutionRequest = DeleteWorkflowExecutionRequest.newBuilder()
+                .setNamespace(getNamespace())
+                .setWorkflowExecution(WorkflowExecution.newBuilder().setWorkflowId(workflowId))
+                .build();
+            workflowServiceStubs.deleteWorkflowExecution(deleteWorkflowExecutionRequest);
+            // Try to refresh the cache
+            client.newUntypedWorkflowStub(workflowId).describe();
+        } catch (StatusRuntimeException ex) {
+            if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                throw ex;
+            }
+        } catch (WorkflowNotFoundException ignored) {
+        }
+        executions.remove(workflowId);
+    }
+
+    public Stream<String> getWorkflowsIds(TaskFilters filters) {
+        Stream<WorkflowExecutionInfo> execs = eventuallyConsistentListExecutions(filters);
+        Iterator<WorkflowExecutionInfo> iterator =
+                new TemporalInterlocutor.StronglyConsistentExecutionIterator(execs, executions, this::fetchExecByIdsIfExist, filters);
+        execs = StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
+                false // not parallel
+        );
+        // Temporal doesn't allow to search by args we have to post filter task retrieved with other filters
+        if (filters.hasArgs()) {
+            TaskFilters byArgs = TaskFilters.empty().withArgs(filters.getArgs());
+            execs = execs.map(e -> new Pair<>(e, getArgs(e)))
+                    .filter(p -> byArgs.filter(p._2()))
+                    .map(Pair::_1);
+        }
+        return execs.map(e -> e.getExecution().getWorkflowId());
+    }
+
+    public Stream<WorkflowExecutionInfo> eventuallyConsistentListExecutions(TaskFilters filters) {
+        PageFetcher<WorkflowExecutionInfo> fetcher =
+            getWorkflowExecutionFetcher(TemporalQueryBuilder.buildFromFilters(filters));
+        return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(new TemporalPageIterator<>(fetcher), Spliterator.ORDERED), false);
+    }
+
+    public Stream<Task<?>> getWorkflows(TaskFilters filters) {
+        return eventuallyConsistentListExecutions(filters).map(rethrowFunction(this::parseTask));
+    }
+
+    public <V extends Serializable> Task<V> parseTask(WorkflowExecutionMetadata response, TaskManagerTemporal taskManagerTemporal) {
+        return parseTask(response.getWorkflowExecutionInfo());
+    }
+
+    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionInfo workflowExecutionInfo) {
+        WorkflowExecution execution = workflowExecutionInfo.getExecution();
+        String taskId = execution.getWorkflowId();
+        String taskName = workflowExecutionInfo.getType().getName();
+        double progress = parseProgress(workflowExecutionInfo);
+        Date createdAt = new Date(workflowExecutionInfo.getStartTime().getSeconds() * 1000);
+        Date completedAt = null;
+        Timestamp closeTime = workflowExecutionInfo.getCloseTime();
+        if (!closeTime.equals(Timestamp.getDefaultInstance())) {
+            completedAt = new Date(closeTime.getSeconds() * 1000);
+        }
+        TaskResult<V> result = null;
+        TaskError error = null;
+        Task.State state = asTaskState(workflowExecutionInfo.getStatus());
+        if (Objects.requireNonNull(state) == Task.State.ERROR || state == Task.State.DONE) {
+            try {
+                Serializable res = newUntypedWorkflowStub(workflowExecutionInfo.getExecution().getWorkflowId())
+                        .getResult(Serializable.class);
+                //TODO this is a big hack because Temporal does not use the TYPE_INCLUSION_MAPPER
+                // to deserialize for now
+                if (res instanceof Map<?, ?>) {
+                    try {
+                        res = JsonObjectMapper.readValueTyped(
+                                JsonObjectMapper.writeValueAsString(res), Serializable.class);
+                    } catch (IOException e) {
+                        TaskManager.logger.warn("could not convert result to typed object", e);
+                    }
+                }
+                if (res != null) {
+                    result = new TaskResult<>((V) res);
+                }
+            } catch (WorkflowFailedException ex) {
+                error = new TaskError(ex.getCause());
+            }
+        }
+        Map<String, Object> args = getArgs(workflowExecutionInfo);
+        int retriesLeft = MAX_RETRIES_LEFT; // retriesLeft makes no sense in the context of a workflow,
+        // it only makes sense for subtasks/activities
+        return new Task<>(taskId, taskName, state, progress, createdAt, retriesLeft, completedAt, args, result, error);
+    }
+
+    private Stream<WorkflowExecutionInfo> fetchExecByIdsIfExist(Set<String> executionIds) {
+        return executionIds.stream()
+            .map(id -> {
+                try {
+                    return newUntypedWorkflowStub(id).describe().getWorkflowExecutionInfo();
+                } catch (StatusRuntimeException ex) {
+                    if (!ex.getStatus().getCode().equals(Status.Code.NOT_FOUND)) {
+                        throw ex;
+                    }
+                    return null;
+                } catch (WorkflowNotFoundException ignored) {
+                    return null;
+                }
+            })
+            .filter(Objects::nonNull);
+    }
+
+    protected void awaitCleared(int timeout, TimeUnit timeUnit, TaskManagerTemporal taskManagerTemporal) throws IOException {
+        long startTime = System.currentTimeMillis();
+        long maxDuration = timeUnit.toMillis(timeout);
+        while ((System.currentTimeMillis() - startTime < maxDuration)) {
+            try (Stream<String> taskIds = taskManagerTemporal.getTaskIds()) {
+                if (taskIds.count() == 0) {
+                    return;
+                }
+            }
+            try {
+                Thread.sleep(taskManagerTemporal.getTerminationPollingInterval());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("failed to clear task in " + timeout + " " + timeUnit);
+    }
+
+    /**
+     * this should not be used normally TemporalInterlocutor should encapsulate
+     * all interactions with the server.
+     * it is used in TemporalHelper
+     * @return WorkflowClient
+     */
+    public WorkflowClient getClient() {
+        return client;
+    }
+
+    public record Page<P>(List<P> items, ByteString nextPageToken) {
+    }
+    @FunctionalInterface
+    public interface PageFetcher<P> {
+        Page<P> fetchPage(ByteString nextPageToken);
+    }
+
+    public static class TemporalPageIterator<P> implements Iterator<P> {
+        // TODO: check if Temporal returns a null of empty token at the ned
+        private ByteString nextPageToken = null;
+        private final PageFetcher<P> fetcher;
+        private Iterator<P> itemsIterator;
+
+        TemporalPageIterator(PageFetcher<P> fetcher) {
+            this.fetcher = fetcher;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (itemsIterator != null && itemsIterator.hasNext()) {
+                return true;
+            }
+            if (itemsIterator != null && nextPageToken.equals(ByteString.EMPTY)) {
+                return false;
+            }
+            Page<P> newPage = fetcher.fetchPage(nextPageToken);
+            nextPageToken = newPage.nextPageToken;
+            itemsIterator = newPage.items.iterator();
+            return itemsIterator.hasNext();
+        }
+
+        @Override
+        public P next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return itemsIterator.next();
+        }
+    }
+
+    public static class StronglyConsistentExecutionIterator implements Iterator<WorkflowExecutionInfo> {
+        private final Iterator<WorkflowExecutionInfo> listWorkflowsResults;
+        private final Set<String> remainingIds;
+        private final Function<Set<String>, Stream<WorkflowExecutionInfo>> fetchKnownExecInfoFn;
+        private final TaskFilters filters;
+
+        private Iterator<WorkflowExecutionInfo> missingItems = null;
+
+        StronglyConsistentExecutionIterator(Stream<WorkflowExecutionInfo> listWorkflowsResults, Set<String> knownIds,
+                                            Function<Set<String>, Stream<WorkflowExecutionInfo>> fetchKnownExecInfoFn,
+                                            TaskFilters filters) {
+            this.listWorkflowsResults = listWorkflowsResults.iterator();
+            this.remainingIds = new HashSet<>(knownIds);
+            this.fetchKnownExecInfoFn = fetchKnownExecInfoFn;
+            this.filters = filters;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (listWorkflowsResults.hasNext()) {
+                return true;
+            }
+            if (missingItems == null) {
+                if (!this.remainingIds.isEmpty()) {
+                    missingItems = fetchKnownExecInfoFn.apply(this.remainingIds)
+                        .filter(asExecInfoFilter(filters))
+                        .iterator();
+                } else {
+                    missingItems = Stream.<WorkflowExecutionInfo>of().iterator();
+                }
+            }
+            return missingItems.hasNext();
+        }
+
+        @Override
+        public WorkflowExecutionInfo next() {
+            if (listWorkflowsResults.hasNext()) {
+                WorkflowExecutionInfo fromSearch = listWorkflowsResults.next();
+                remainingIds.remove(fromSearch.getExecution().getWorkflowId());
+                return fromSearch;
+            }
+            return missingItems.next();
+        }
+    }
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -2,8 +2,6 @@ package org.icij.datashare.asynctasks;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.temporal.client.WorkflowClient;
-import io.temporal.worker.WorkerFactory;
 import org.icij.datashare.EnvUtils;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.temporal.*;
@@ -29,7 +27,6 @@ import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.asynctasks.Task.State.*;
 import static org.icij.datashare.asynctasks.TaskManagerTemporal.WORKFLOWS_DEFAULT;
 import static org.icij.datashare.asynctasks.temporal.TemporalHelper.activityFactory;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.createTemporalWorkerFactory;
 import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -42,13 +39,9 @@ public class TaskManagerTemporalIntTest {
     static TaskRepository taskRepository = new TaskRepositoryRedis(redissonClient, "tasks:queue:test");
     @Mock
     private TaskFactory taskFactory;
-
     private static TemporalInterlocutor temporal;
-
     private static TaskManagerTemporal taskManager;
-
-    private List<TemporalHelper.RegisteredWorkflow> registeredWorkflows;
-
+    private List<TemporalInterlocutor.RegisteredWorkflow> registeredWorkflows;
 
     @BeforeClass
     public static void setUpClass() throws InterruptedException {
@@ -67,14 +60,14 @@ public class TaskManagerTemporalIntTest {
             }
         }
         registeredWorkflows = List.of(
-            new TemporalHelper.RegisteredWorkflow(
+            new TemporalInterlocutor.RegisteredWorkflow(
                 HelloWorldWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalHelper.RegisteredActivity(activityFactory(HelloWorldActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT))),
-            new TemporalHelper.RegisteredWorkflow(
+                List.of(new TemporalInterlocutor.RegisteredActivity(activityFactory(HelloWorldActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT))),
+            new TemporalInterlocutor.RegisteredWorkflow(
                 FailingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalHelper.RegisteredActivity(activityFactory(FailingActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT)))
+                List.of(new TemporalInterlocutor.RegisteredActivity(activityFactory(FailingActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT)))
         );
 
         temporal.setupNamespace(Duration.ofSeconds(5));
@@ -85,14 +78,6 @@ public class TaskManagerTemporalIntTest {
     @Before
     public void tearDown() throws Exception {
         Optional.ofNullable(mocks).ifPresent(rethrowConsumer(AutoCloseable::close));
-    }
-
-    private TemporalHelper.CloseableWorkerFactoryHandle testCloseableWorkerFactory(WorkflowClient client) {
-        return new TemporalHelper.CloseableWorkerFactoryHandle(testWorkerFactory(client));
-    }
-
-    private WorkerFactory testWorkerFactory(WorkflowClient client) {
-        return createTemporalWorkerFactory(registeredWorkflows, client);
     }
 
     @Test
@@ -202,7 +187,7 @@ public class TaskManagerTemporalIntTest {
 
     @Test(timeout = 10000)
     public void test_get_task_result() throws IOException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
+        try (TemporalInterlocutor.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal)) {
             Task<String> task = new Task<>("hello-world", User.local(), Map.of("name", "world"));
 
             taskManager.startTask(task);
@@ -216,7 +201,7 @@ public class TaskManagerTemporalIntTest {
 
     @Test(timeout = 20000)
     public void test_task_error() throws IOException, InterruptedException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
+        try (TemporalInterlocutor.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal)) {
             Task<String> task = new Task<>("failing", User.local(), Map.of());
 
             taskManager.startTask(task);
@@ -256,7 +241,7 @@ public class TaskManagerTemporalIntTest {
     @Ignore("keeping this one for manual test as it can take very long to complete")
     @Test
     public void test_clear_done_tasks() throws Exception {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
+        try (TemporalInterlocutor.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal)) {
             Task<String> task = new Task<>("hello-world", User.local(), Map.of("key", "value"));
             taskManager.startTask(task);
             assertThat(taskManager.awaitTermination(2, TimeUnit.SECONDS));
@@ -271,7 +256,7 @@ public class TaskManagerTemporalIntTest {
     @Ignore("keeping this one for manual test as it can take very long to complete")
     @Test
     public void test_clear_done_tasks_with_args_filter() throws IOException, InterruptedException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
+        try (TemporalInterlocutor.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal)) {
             Task<String> first = new Task<>("hello-world", User.local(), Map.of("key", "value"));
             Task<String> second = new Task<>("hello-world", User.local(), Map.of("otherKey", "otherValue"));
             taskManager.startTask(first);
@@ -303,19 +288,18 @@ public class TaskManagerTemporalIntTest {
                 return () -> task.id;
             }
         };
-        List<TemporalHelper.RegisteredWorkflow> workflows = List.of(
-            new TemporalHelper.RegisteredWorkflow(
+        List<TemporalInterlocutor.RegisteredWorkflow> workflows = List.of(
+            new TemporalInterlocutor.RegisteredWorkflow(
                 DoNothingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalHelper.RegisteredActivity(
+                List.of(new TemporalInterlocutor.RegisteredActivity(
                     activityFactory(DoNothingActivityImpl.class, capturingFactory, temporal.getClient(), 1.0d),
                     WORKFLOWS_DEFAULT
                 ))
             )
         );
 
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored =
-                new TemporalHelper.CloseableWorkerFactoryHandle(createTemporalWorkerFactory(workflows, temporal.getClient()))) {
+        try (TemporalInterlocutor.CloseableWorkerFactoryHandle ignored = temporal.createFactory(1, workflows)) {
             Task<String> task = new Task<>(DoNothingTask.class.getName(), User.local(), Map.of());
 
             taskManager.startTask(task);
@@ -346,5 +330,9 @@ public class TaskManagerTemporalIntTest {
         assertThat(stopped).isTrue();
         boolean stoppedAgain = taskManager.stopTask(task.getId());
         assertThat(stoppedAgain).isFalse();
+    }
+
+    private TemporalInterlocutor.CloseableWorkerFactoryHandle testCloseableWorkerFactory(TemporalInterlocutor temporal) {
+        return temporal.createFactory(1, registeredWorkflows);
     }
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -1,47 +1,12 @@
 package org.icij.datashare.asynctasks;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
-import static org.icij.datashare.asynctasks.Task.State.CANCELLED;
-import static org.icij.datashare.asynctasks.Task.State.DONE;
-import static org.icij.datashare.asynctasks.Task.State.ERROR;
-import static org.icij.datashare.asynctasks.Task.State.RUNNING;
-import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.WORKFLOWS_DEFAULT;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.activityFactory;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.createTemporalWorkerFactory;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.MockitoAnnotations.openMocks;
-
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.temporal.client.WorkflowClient;
-import io.temporal.client.WorkflowClientOptions;
-import io.temporal.serviceclient.WorkflowServiceStubs;
-import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.worker.WorkerFactory;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.icij.datashare.EnvUtils;
 import org.icij.datashare.PropertiesProvider;
-import org.icij.datashare.asynctasks.temporal.DoNothingWorkflowImpl;
-import org.icij.datashare.asynctasks.temporal.DoNothingActivityImpl;
-import org.icij.datashare.asynctasks.temporal.DoNothingTask;
-import org.icij.datashare.asynctasks.temporal.FailingActivityImpl;
-import org.icij.datashare.asynctasks.temporal.FailingWorkflowImpl;
-import org.icij.datashare.asynctasks.temporal.HelloWorldActivityImpl;
-import org.icij.datashare.asynctasks.temporal.HelloWorldWorkflowImpl;
-import org.icij.datashare.asynctasks.temporal.TemporalHelper;
-import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
+import org.icij.datashare.asynctasks.temporal.*;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
 import org.icij.extract.redis.RedissonClientFactory;
@@ -52,6 +17,23 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.redisson.api.RedissonClient;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
+import static org.icij.datashare.asynctasks.Task.State.*;
+import static org.icij.datashare.asynctasks.TaskManagerTemporal.WORKFLOWS_DEFAULT;
+import static org.icij.datashare.asynctasks.temporal.TemporalHelper.activityFactory;
+import static org.icij.datashare.asynctasks.temporal.TemporalHelper.createTemporalWorkerFactory;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class TaskManagerTemporalIntTest {
     private AutoCloseable mocks;

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -9,6 +9,7 @@ import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
 import org.icij.extract.redis.RedissonClientFactory;
 import org.icij.task.Options;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -35,6 +36,7 @@ public class TaskManagerTemporalIntTest {
     private AutoCloseable mocks;
     static RedissonClient redissonClient = new RedissonClientFactory().withOptions(
             Options.from(new PropertiesProvider(Map.of("redisAddress", EnvUtils.resolveUri("redis", "redis://redis:6379"))).getProperties())).create();
+    // Warning : the order is not guaranteed for redisson map for tasks
     static TaskRepository taskRepository = new TaskRepositoryRedis(redissonClient, "tasks:queue:test");
     @Mock
     private TaskFactory taskFactory;
@@ -124,7 +126,6 @@ public class TaskManagerTemporalIntTest {
         Thread.sleep(1000); // Sleep 1sec to test the sort on timestamp in ms
         taskManager.startTask(bar);
 
-        // Get task is only eventually consistent, we just check that result are returned within a decent timeout
         TaskFilters filter = TaskFilters.empty();
         List<Task<?>> tasks;
         while (true) {
@@ -136,7 +137,8 @@ public class TaskManagerTemporalIntTest {
                 Thread.sleep(100);
             }
         }
-        assertThat(tasks.stream().map(Task::getId).toList()).isEqualTo(List.of(foo.id, bar.id));
+        // The order is not guaranteed by Redisson map for tasks
+        assertThat(tasks.stream().map(Task::getId).toList()).contains(foo.id, bar.id);
     }
 
     @Test(timeout = 5000)
@@ -248,7 +250,7 @@ public class TaskManagerTemporalIntTest {
 
             taskManager.clearDoneTasks();
 
-            taskManager.awaitCleared(Set.of(task.id), 30, TimeUnit.SECONDS);
+            awaitClearedInTemporal(Set.of(task.id), 30, TimeUnit.SECONDS);
         }
     }
 
@@ -266,7 +268,7 @@ public class TaskManagerTemporalIntTest {
 
             taskManager.clearDoneTasks(filter);
 
-            taskManager.awaitCleared(Set.of(second.id), 1, TimeUnit.MINUTES);
+            awaitClearedInTemporal(Set.of(second.id), 1, TimeUnit.MINUTES);
         }
     }
 
@@ -333,5 +335,21 @@ public class TaskManagerTemporalIntTest {
 
     private TemporalInterlocutor.CloseableWorkerFactoryHandle testCloseableWorkerFactory(TemporalInterlocutor temporal) {
         return temporal.createFactory(1, registeredWorkflows);
+    }
+
+    protected void awaitClearedInTemporal(Set<String> taskIds, int timeout, TimeUnit timeUnit) throws IOException {
+        long startTime = System.currentTimeMillis();
+        long maxDuration = timeUnit.toMillis(timeout);
+        while ((System.currentTimeMillis() - startTime < maxDuration)) {
+            if (taskManager.getTaskIds().noneMatch(taskIds::contains)) {
+                return;
+            }
+            try {
+                Thread.sleep(taskManager.getTerminationPollingInterval());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        Assert.fail("failed to clear task in " + timeout + " " + timeUnit);
     }
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -6,7 +6,7 @@ import static org.icij.datashare.asynctasks.Task.State.CANCELLED;
 import static org.icij.datashare.asynctasks.Task.State.DONE;
 import static org.icij.datashare.asynctasks.Task.State.ERROR;
 import static org.icij.datashare.asynctasks.Task.State.RUNNING;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.DEFAULT_NAMESPACE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
 import static org.icij.datashare.asynctasks.TaskManagerTemporal.WORKFLOWS_DEFAULT;
 import static org.icij.datashare.asynctasks.temporal.TemporalHelper.activityFactory;
 import static org.icij.datashare.asynctasks.temporal.TemporalHelper.createTemporalWorkerFactory;
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.icij.datashare.EnvUtils;
+import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.temporal.DoNothingWorkflowImpl;
 import org.icij.datashare.asynctasks.temporal.DoNothingActivityImpl;
 import org.icij.datashare.asynctasks.temporal.DoNothingTask;
@@ -43,15 +44,20 @@ import org.icij.datashare.asynctasks.temporal.TemporalHelper;
 import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
+import org.icij.extract.redis.RedissonClientFactory;
+import org.icij.task.Options;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.redisson.api.RedissonClient;
 
 public class TaskManagerTemporalIntTest {
     private AutoCloseable mocks;
-
+    static RedissonClient redissonClient = new RedissonClientFactory().withOptions(
+            Options.from(new PropertiesProvider(Map.of("redisAddress", EnvUtils.resolveUri("redis", "redis://redis:6379"))).getProperties())).create();
+    static TaskRepository taskRepository = new TaskRepositoryRedis(redissonClient, "tasks:queue:test");
     @Mock
     private TaskFactory taskFactory;
 
@@ -65,7 +71,7 @@ public class TaskManagerTemporalIntTest {
     @BeforeClass
     public static void setUpClass() throws InterruptedException {
         temporal = new TemporalInterlocutor(EnvUtils.resolve("temporalTarget", "temporal:7233"), DEFAULT_NAMESPACE);
-        taskManager = new TaskManagerTemporal(temporal, RoutingStrategy.UNIQUE);
+        taskManager = new TaskManagerTemporal(temporal, taskRepository, RoutingStrategy.UNIQUE);
     }
 
     @Before
@@ -82,11 +88,11 @@ public class TaskManagerTemporalIntTest {
             new TemporalHelper.RegisteredWorkflow(
                 HelloWorldWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalHelper.RegisteredActivity(activityFactory(HelloWorldActivityImpl.class, taskFactory, temporal.client, 1.0d), WORKFLOWS_DEFAULT))),
+                List.of(new TemporalHelper.RegisteredActivity(activityFactory(HelloWorldActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT))),
             new TemporalHelper.RegisteredWorkflow(
                 FailingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalHelper.RegisteredActivity(activityFactory(FailingActivityImpl.class, taskFactory, temporal.client, 1.0d), WORKFLOWS_DEFAULT)))
+                List.of(new TemporalHelper.RegisteredActivity(activityFactory(FailingActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT)))
         );
 
         temporal.setupNamespace(Duration.ofSeconds(5));
@@ -214,7 +220,7 @@ public class TaskManagerTemporalIntTest {
 
     @Test(timeout = 10000)
     public void test_get_task_result() throws IOException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
             Task<String> task = new Task<>("hello-world", User.local(), Map.of("name", "world"));
 
             taskManager.startTask(task);
@@ -228,7 +234,7 @@ public class TaskManagerTemporalIntTest {
 
     @Test(timeout = 20000)
     public void test_task_error() throws IOException, InterruptedException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
             Task<String> task = new Task<>("failing", User.local(), Map.of());
 
             taskManager.startTask(task);
@@ -268,7 +274,7 @@ public class TaskManagerTemporalIntTest {
     @Ignore("keeping this one for manual test as it can take very long to complete")
     @Test
     public void test_clear_done_tasks() throws Exception {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
             Task<String> task = new Task<>("hello-world", User.local(), Map.of("key", "value"));
             taskManager.startTask(task);
             assertThat(taskManager.awaitTermination(2, TimeUnit.SECONDS));
@@ -283,7 +289,7 @@ public class TaskManagerTemporalIntTest {
     @Ignore("keeping this one for manual test as it can take very long to complete")
     @Test
     public void test_clear_done_tasks_with_args_filter() throws IOException, InterruptedException {
-        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.client)) {
+        try (TemporalHelper.CloseableWorkerFactoryHandle ignored = testCloseableWorkerFactory(temporal.getClient())) {
             Task<String> first = new Task<>("hello-world", User.local(), Map.of("key", "value"));
             Task<String> second = new Task<>("hello-world", User.local(), Map.of("otherKey", "otherValue"));
             taskManager.startTask(first);
@@ -320,14 +326,14 @@ public class TaskManagerTemporalIntTest {
                 DoNothingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
                 List.of(new TemporalHelper.RegisteredActivity(
-                    activityFactory(DoNothingActivityImpl.class, capturingFactory, temporal.client, 1.0d),
+                    activityFactory(DoNothingActivityImpl.class, capturingFactory, temporal.getClient(), 1.0d),
                     WORKFLOWS_DEFAULT
                 ))
             )
         );
 
         try (TemporalHelper.CloseableWorkerFactoryHandle ignored =
-                new TemporalHelper.CloseableWorkerFactoryHandle(createTemporalWorkerFactory(workflows, temporal.client))) {
+                new TemporalHelper.CloseableWorkerFactoryHandle(createTemporalWorkerFactory(workflows, temporal.getClient()))) {
             Task<String> task = new Task<>(DoNothingTask.class.getName(), User.local(), Map.of());
 
             taskManager.startTask(task);
@@ -359,26 +365,4 @@ public class TaskManagerTemporalIntTest {
         boolean stoppedAgain = taskManager.stopTask(task.getId());
         assertThat(stoppedAgain).isFalse();
     }
-
-    @Test
-    public void test_health_ok() throws IOException {
-        assertThat(taskManager.getHealth()).isTrue();
-    }
-
-    @Test
-    public void test_health_ko() throws Exception {
-        WorkflowServiceStubsOptions serviceStubsOptions = WorkflowServiceStubsOptions.newBuilder()
-            .setTarget("localhost:1111")
-            .build();
-        WorkflowServiceStubs serviceStub = WorkflowServiceStubs.newServiceStubs(serviceStubsOptions);
-        WorkflowClient koClient = WorkflowClient.newInstance(
-            serviceStub, WorkflowClientOptions.newBuilder().setNamespace(DEFAULT_NAMESPACE).build()
-        );
-
-        try (
-            TaskManagerTemporal koTaskManager = new TaskManagerTemporal(koClient, RoutingStrategy.UNIQUE)) {
-            assertThat(koTaskManager.getHealth()).isFalse();
-        }
-    }
-
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -26,7 +26,6 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.asynctasks.Task.State.*;
 import static org.icij.datashare.asynctasks.TaskManagerTemporal.WORKFLOWS_DEFAULT;
-import static org.icij.datashare.asynctasks.temporal.TemporalHelper.activityFactory;
 import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -63,11 +62,11 @@ public class TaskManagerTemporalIntTest {
             new TemporalInterlocutor.RegisteredWorkflow(
                 HelloWorldWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalInterlocutor.RegisteredActivity(activityFactory(HelloWorldActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT))),
+                List.of(new TemporalInterlocutor.RegisteredActivity(temporal.activityFactory(HelloWorldActivityImpl.class, taskFactory, 1.0d), WORKFLOWS_DEFAULT))),
             new TemporalInterlocutor.RegisteredWorkflow(
                 FailingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalInterlocutor.RegisteredActivity(activityFactory(FailingActivityImpl.class, taskFactory, temporal.getClient(), 1.0d), WORKFLOWS_DEFAULT)))
+                List.of(new TemporalInterlocutor.RegisteredActivity(temporal.activityFactory(FailingActivityImpl.class, taskFactory, 1.0d), WORKFLOWS_DEFAULT)))
         );
 
         temporal.setupNamespace(Duration.ofSeconds(5));
@@ -293,7 +292,7 @@ public class TaskManagerTemporalIntTest {
                 DoNothingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
                 List.of(new TemporalInterlocutor.RegisteredActivity(
-                    activityFactory(DoNothingActivityImpl.class, capturingFactory, temporal.getClient(), 1.0d),
+                    temporal.activityFactory(DoNothingActivityImpl.class, capturingFactory, 1.0d),
                     WORKFLOWS_DEFAULT
                 ))
             )

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
@@ -3,31 +3,28 @@ package org.icij.datashare.asynctasks;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.asynctasks.Task.State.ERROR;
-import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-import io.temporal.api.common.v1.WorkflowExecution;
-import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsRequest;
-import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsResponse;
-import io.temporal.api.workflowservice.v1.WorkflowServiceGrpc;
-import io.temporal.client.WorkflowClient;
-import io.temporal.client.WorkflowClientOptions;
-import io.temporal.client.WorkflowNotFoundException;
-import io.temporal.client.WorkflowOptions;
 import io.temporal.client.WorkflowStub;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
+import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
@@ -40,23 +37,20 @@ import org.mockito.Mock;
 public class TaskManagerTemporalTest {
     private AutoCloseable mocks;
     @Mock
-    private WorkflowClient client;
+    private TemporalInterlocutor temporal;
+    @Mock
+    private TaskRepository taskRepository;
     private TaskManagerTemporal taskManager;
     @Mock
-    private WorkflowServiceGrpc.WorkflowServiceBlockingStub workflowServiceBlockingStub;
-
+    private WorkflowStub workflowStubMock;
 
     @Before
-    public void setUp() throws InterruptedException {
+    public void setUp() throws Exception {
         mocks = openMocks(this);
-        when(client.getOptions()).thenReturn(WorkflowClientOptions.newBuilder().setNamespace(DEFAULT_NAMESPACE).build());
-        workflowServiceBlockingStub = mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
-        when(workflowServiceBlockingStub.listWorkflowExecutions(any(ListWorkflowExecutionsRequest.class)))
-            .thenReturn(ListWorkflowExecutionsResponse.newBuilder().build());
-        when(client.newUntypedWorkflowStub(anyString(), any(WorkflowOptions.class)))
-            .thenReturn(mock(WorkflowStub.class));
-        when(client.newUntypedWorkflowStub(anyString())).thenReturn(mock(WorkflowStub.class));
-        taskManager = new TaskManagerTemporal(new TemporalInterlocutor(client, workflowServiceBlockingStub), null,  RoutingStrategy.UNIQUE);
+        when(workflowStubMock.getResultAsync(any())).thenReturn(new CompletableFuture<>());
+        when(temporal.createWorkflowStub(anyString())).thenReturn(workflowStubMock);
+        doNothing().when(temporal).createWorkflow(anyString(), anyString(), anyString(), any(), any());
+        taskManager = new TaskManagerTemporal(temporal, taskRepository, RoutingStrategy.UNIQUE);
     }
 
     @After
@@ -66,170 +60,70 @@ public class TaskManagerTemporalTest {
 
     @Test
     public void test_start_task_with_group_routing() throws Exception {
-        TaskGroupType key = TaskGroupType.Test;
-        String taskName = "taskName";
-        Map<String, Object> args = Map.of("someKey", "fooValue");
-        Task<String> task = new Task<>(taskName, User.local(), args);
-        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(new TemporalInterlocutor(client, workflowServiceBlockingStub), null, RoutingStrategy.GROUP)) {
-            groupTaskManager.startTask(task, new Group(key));
+        Task<String> task = new Task<>("taskName", User.local(), Map.of("someKey", "fooValue"));
+        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(temporal, taskRepository, RoutingStrategy.GROUP)) {
+            groupTaskManager.startTask(task, new Group(TaskGroupType.Test));
 
-            verify(client).newUntypedWorkflowStub(eq(taskName), argThat(o -> o.getTaskQueue().equals("test")));
+            verify(temporal).createWorkflow(anyString(), anyString(), eq("test"), any(), any());
         }
     }
 
     @Test
     public void test_start_task_with_name_routing() throws Exception {
-        TaskGroupType key = TaskGroupType.Test;
-        String taskName = "taskName";
-        Map<String, Object> args = Map.of();
-        Task<String> task = new Task<>(taskName, User.local(), args);
-        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(new TemporalInterlocutor(client, workflowServiceBlockingStub), null, RoutingStrategy.NAME)) {
-            groupTaskManager.startTask(task, new Group(key));
+        Task<String> task = new Task<>("taskName", User.local(), Map.of());
+        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(temporal, taskRepository, RoutingStrategy.NAME)) {
+            groupTaskManager.startTask(task, new Group(TaskGroupType.Test));
 
-            verify(client).newUntypedWorkflowStub(eq(taskName), argThat(o -> o.getTaskQueue().equals("taskname")));
+            verify(temporal).createWorkflow(anyString(), anyString(), eq("taskname"), any(), any());
         }
     }
 
     @Test
-    public void test_get_tasks_with_state_filter() throws IOException {
-        TaskFilters filter = TaskFilters.empty().withStates(Set.of(Task.State.CANCELLED));
-
-        taskManager.getTasks(filter).toList();
-
-        String expectedQuery = "( ExecutionStatus= 'Canceled' OR ExecutionStatus= 'Terminated' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_get_tasks_with_name_filter() throws IOException {
-        TaskFilters filter = TaskFilters.empty().withNames("foo");
-
-        taskManager.getTasks(filter).toList();
-
-        String expectedQuery = "( WorkflowType = 'foo' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_get_tasks_with_name_prefix_filter() throws IOException {
-        TaskFilters filter = TaskFilters.empty().withNames("foo.*");
-
-        taskManager.getTasks(filter).toList();
-
-        String expectedQuery = "( WorkflowType STARTS_WITH 'foo' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_get_tasks_with_unsupported_name_pattern_filter() throws IOException {
-        Task<String> foo = new Task<>("foo", User.local(), Map.of("user", User.local()));
-        taskManager.startTask(foo);
-
-        TaskFilters filter = TaskFilters.empty().withNames("*.foo");
-        assertThat(assertThrows(RuntimeException.class, () -> taskManager.getTasks(filter).toList()).getMessage())
-            .startsWith("invalid pattern *.foo with Temporal");
-    }
-
-    @Test
-    public void test_get_tasks_with_user_filter() throws IOException {
-        User fooUser = new User("foo");
-        TaskFilters filter = TaskFilters.empty().withUser(fooUser);
-
-        taskManager.getTasks(filter).toList();
-
-        String expectedQuery = "( UserId = 'foo' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_get_task_ids_with_state_filter() throws IOException {
-        TaskFilters filter = TaskFilters.empty().withStates(Set.of(Task.State.CANCELLED));
-
-        taskManager.getTaskIds(filter).toList();
-
-        String expectedQuery = "( ExecutionStatus= 'Canceled' OR ExecutionStatus= 'Terminated' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_get_task_ids_with_name_filter() throws IOException {
-        TaskFilters filter = TaskFilters.empty().withNames("foo");
-
-        taskManager.getTaskIds(filter).toList();
-
-        String expectedQuery = "( WorkflowType = 'foo' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_get_task_ids_with_name_prefix_filter() throws IOException {
-        TaskFilters filter = TaskFilters.empty().withNames("foo.*");
-
-        taskManager.getTaskIds(filter).toList();
-
-        String expectedQuery = "( WorkflowType STARTS_WITH 'foo' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_get_task_ids_with_user_filter() throws IOException {
-        User fooUser = new User("foo");
-        TaskFilters filter = TaskFilters.empty().withUser(fooUser);
-
-        taskManager.getTaskIds(filter).toList();
-
-        String expectedQuery = "( UserId = 'foo' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
     public void test_clear_done_tasks_with_state_filter() throws IOException {
-        TaskFilters filters = TaskFilters.empty().withStates(Set.of(ERROR));
+        Task<String> task = new Task<>("someTask", User.local(), Map.of());
+        when(taskRepository.getTasks(any())).thenReturn(Stream.of(task));
 
-        taskManager.clearDoneTasks(filters);
+        taskManager.clearDoneTasks(TaskFilters.empty().withStates(Set.of(ERROR)));
 
-        String expectedQuery = "( ExecutionStatus= 'Failed' OR ExecutionStatus= 'TimedOut' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_clear_done_tasks_with_name_filter() throws IOException {
-        TaskFilters filters = TaskFilters.empty().withNames("hello_world");
-
-        taskManager.clearDoneTasks(filters);
-
-        String expectedQuery =
-            "( ExecutionStatus= 'Canceled' "
-                + "OR ExecutionStatus= 'Terminated' "
-                + "OR ExecutionStatus= 'Failed' "
-                + "OR ExecutionStatus= 'TimedOut' "
-                + "OR ExecutionStatus= 'Completed'"
-                + " ) "
-                + "AND ( WorkflowType = 'hello_world' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
-    }
-
-    @Test
-    public void test_clear_done_tasks_with_user_filter() throws IOException {
-        TaskFilters filter = TaskFilters.empty().withUser(new User("foo"));
-
-        taskManager.clearDoneTasks(filter);
-
-        String expectedQuery =
-            "( ExecutionStatus= 'Canceled' "
-                + "OR ExecutionStatus= 'Terminated' "
-                + "OR ExecutionStatus= 'Failed' "
-                + "OR ExecutionStatus= 'TimedOut' "
-                + "OR ExecutionStatus= 'Completed'"
-                + " ) "
-                + "AND ( UserId = 'foo' )";
-        verify(workflowServiceBlockingStub).listWorkflowExecutions(argThat(r -> r.getQuery().equals(expectedQuery)));
+        verify(taskRepository).getTasks(argThat(f -> f.getStates().equals(Set.of(ERROR))));
+        verify(taskRepository).delete(task.id);
     }
 
     @Test
     public void test_stop_unknown_task() {
-        when(client.newUntypedWorkflowStub(anyString()).describe())
-            .thenThrow(new WorkflowNotFoundException(WorkflowExecution.newBuilder().build(), null, null));
+        when(temporal.terminateWorkflow(anyString())).thenThrow(new UnknownTask("unknown-id"));
         assertThat(assertThrows(UnknownTask.class, () -> taskManager.stopTask("unknown-id")));
+    }
+
+    @Test
+    public void test_completion_listener_updates_repo_on_success() throws Exception {
+        CompletableFuture<Serializable> future = new CompletableFuture<>();
+        when(workflowStubMock.getResultAsync(any(Class.class))).thenReturn(future);
+
+        Task<String> task = new Task<>("taskName", User.local(), Map.of());
+        Task<String> doneTaskInTemporal = new Task<>(task.id, task.name, Task.State.DONE, 1.0, task.createdAt, 0, null, task.args, new TaskResult<>("result"), null);
+        doReturn(task).when(taskRepository).getTask(task.id);
+        doReturn(doneTaskInTemporal).when(temporal).getTask(task.id);
+        taskManager.startTask(task, new Group(TaskGroupType.Test));
+
+        future.complete("someResult");
+
+        verify(taskRepository, atLeastOnce()).update(argThat(t -> t.getState() == Task.State.DONE));
+    }
+
+    @Test
+    public void test_completion_listener_updates_repo_on_error() throws Exception {
+        CompletableFuture<Serializable> future = new CompletableFuture<>();
+        when(workflowStubMock.getResultAsync(any(Class.class))).thenReturn(future);
+
+        Task<String> task = new Task<>("taskName", User.local(), Map.of());
+        Task<String> errorTaskInTemporal = new Task<>(task.id, task.name, Task.State.ERROR, 0, task.createdAt, 0, null, task.args, null, new TaskError(new RuntimeException("workflow failed")));
+        doReturn(task).when(taskRepository).getTask(task.id);
+        doReturn(errorTaskInTemporal).when(temporal).getTask(task.id);
+        taskManager.startTask(task, new Group(TaskGroupType.Test));
+
+        future.completeExceptionally(new RuntimeException("workflow failed"));
+
+        verify(taskRepository, atLeastOnce()).update(argThat(t -> t.getState() == Task.State.ERROR));
     }
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
@@ -96,6 +96,33 @@ public class TaskManagerTemporalTest {
     }
 
     @Test
+    public void test_reconcile_tasks_attaches_listener_for_running_task() throws Exception {
+        Task<String> runningTask = new Task<>("taskName", User.local(), Map.of());
+        runningTask.setState(Task.State.RUNNING);
+        when(taskRepository.getTasks(argThat(f -> f.getStates().equals(Set.of(Task.State.RUNNING)))))
+            .thenReturn(Stream.of(runningTask));
+        doReturn(runningTask).when(temporal).getTask(runningTask.id);
+
+        taskManager.reconcileTasks();
+
+        assertThat(taskManager.pendingListeners.get(runningTask.id)).isNotNull();
+    }
+
+    @Test
+    public void test_reconcile_Tasks_updates_repo_for_finished_task() throws Exception {
+        Task<String> runningTask = new Task<>("taskName", User.local(), Map.of());
+        runningTask.setState(Task.State.RUNNING);
+        Task<String> doneTask = new Task<>(runningTask.id, runningTask.name, Task.State.DONE, 1.0, runningTask.createdAt, 0, null, runningTask.args, new TaskResult<>("result"), null);
+        when(taskRepository.getTasks(argThat(f -> f.getStates().equals(Set.of(Task.State.RUNNING)))))
+            .thenReturn(Stream.of(runningTask));
+        doReturn(doneTask).when(temporal).getTask(runningTask.id);
+
+        taskManager.reconcileTasks();
+
+        verify(taskRepository).update(argThat(t -> t.getState() == Task.State.DONE));
+    }
+
+    @Test
     public void test_completion_listener_updates_repo_on_success() throws Exception {
         CompletableFuture<Serializable> future = new CompletableFuture<>();
         when(workflowStubMock.getResultAsync(any(Class.class))).thenReturn(future);

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
@@ -3,7 +3,7 @@ package org.icij.datashare.asynctasks;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.asynctasks.Task.State.ERROR;
-import static org.icij.datashare.asynctasks.TaskManagerTemporal.DEFAULT_NAMESPACE;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
 import org.icij.datashare.tasks.RoutingStrategy;
 import org.icij.datashare.user.User;
 import org.junit.After;
@@ -45,7 +47,7 @@ public class TaskManagerTemporalTest {
 
 
     @Before
-    public void setUp() {
+    public void setUp() throws InterruptedException {
         mocks = openMocks(this);
         when(client.getOptions()).thenReturn(WorkflowClientOptions.newBuilder().setNamespace(DEFAULT_NAMESPACE).build());
         workflowServiceBlockingStub = mock(WorkflowServiceGrpc.WorkflowServiceBlockingStub.class);
@@ -54,7 +56,7 @@ public class TaskManagerTemporalTest {
         when(client.newUntypedWorkflowStub(anyString(), any(WorkflowOptions.class)))
             .thenReturn(mock(WorkflowStub.class));
         when(client.newUntypedWorkflowStub(anyString())).thenReturn(mock(WorkflowStub.class));
-        taskManager = new TaskManagerTemporal(client, workflowServiceBlockingStub, RoutingStrategy.UNIQUE);
+        taskManager = new TaskManagerTemporal(new TemporalInterlocutor(client, workflowServiceBlockingStub), null,  RoutingStrategy.UNIQUE);
     }
 
     @After
@@ -68,7 +70,7 @@ public class TaskManagerTemporalTest {
         String taskName = "taskName";
         Map<String, Object> args = Map.of("someKey", "fooValue");
         Task<String> task = new Task<>(taskName, User.local(), args);
-        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(client, workflowServiceBlockingStub, RoutingStrategy.GROUP)) {
+        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(new TemporalInterlocutor(client, workflowServiceBlockingStub), null, RoutingStrategy.GROUP)) {
             groupTaskManager.startTask(task, new Group(key));
 
             verify(client).newUntypedWorkflowStub(eq(taskName), argThat(o -> o.getTaskQueue().equals("test")));
@@ -81,7 +83,7 @@ public class TaskManagerTemporalTest {
         String taskName = "taskName";
         Map<String, Object> args = Map.of();
         Task<String> task = new Task<>(taskName, User.local(), args);
-        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(client, workflowServiceBlockingStub, RoutingStrategy.NAME)) {
+        try (TaskManagerTemporal groupTaskManager = new TaskManagerTemporal(new TemporalInterlocutor(client, workflowServiceBlockingStub), null, RoutingStrategy.NAME)) {
             groupTaskManager.startTask(task, new Group(key));
 
             verify(client).newUntypedWorkflowStub(eq(taskName), argThat(o -> o.getTaskQueue().equals("taskname")));

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutorTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutorTest.java
@@ -1,0 +1,39 @@
+package org.icij.datashare.asynctasks.temporal;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import org.icij.datashare.EnvUtils;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.DEFAULT_NAMESPACE;
+
+public class TemporalInterlocutorTest {
+    @Test
+    public void test_health_ok() throws InterruptedException {
+        TemporalInterlocutor temporal = new TemporalInterlocutor(EnvUtils.resolve("temporalTarget", "temporal:7233"), DEFAULT_NAMESPACE);
+        assertThat(temporal.getHealth()).isTrue();
+    }
+
+    @Test
+    public void test_health_ko() {
+        WorkflowServiceStubsOptions serviceStubsOptions = WorkflowServiceStubsOptions.newBuilder()
+                .setTarget("localhost:1111")
+                .build();
+        WorkflowServiceStubs serviceStub = WorkflowServiceStubs.newServiceStubs(serviceStubsOptions);
+        WorkflowClient koClient = WorkflowClient.newInstance(
+                serviceStub, WorkflowClientOptions.newBuilder().setNamespace(DEFAULT_NAMESPACE).build()
+        );
+
+        try {
+            TemporalInterlocutor koInterlocutor = new TemporalInterlocutor(koClient);
+            assertThat(koInterlocutor.getHealth()).isFalse();
+        } catch(StatusRuntimeException sre) {
+            assertThat(sre.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.icij.datashare</groupId>
     <artifactId>datashare</artifactId>
-    <version>21.3.0</version>
+    <version>21.3.1</version>
     <packaging>pom</packaging>
 
     <name>ICIJ Datashare</name>


### PR DESCRIPTION
TemporalTaskManager now uses TaskRepository too to avoid reading tasks directly from Temporal.

Solution implemented relies on completion listeners (Callbacks) called by TemporalClient upon completion or error.
Reconciliation is necessary upon startup to attach those callbacks again.

Another solution possible, would be to have generic Workflows that writes in the TaskRepository, which are responsible to start the effective workflow as children, but this solution is avoided for now because of the overhead in Temporal.