### PR TITLE
feat: PUT project upsert

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -131,12 +131,15 @@
             return notFoundIfNull(getUserProject((DatashareUser) context.currentUser(), id));
         }
 
-        @Operation(description = "Updates a project",
+        @Operation(description = "Updates a project, or creates it if it does not exist. Creation requires INSTANCE_ADMIN or DOMAIN_ADMIN; PROJECT_ADMIN can only update existing projects.",
                 requestBody = @RequestBody(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Project.class)), required = true)
         )
         @ApiResponse(responseCode = "200", description = "if project has been updated")
-        @ApiResponse(responseCode = "404", description = "if project doesn't exist in database")
-        @ApiResponse(responseCode = "500", description = "if project json id is not the same as the url id or if save failed")
+        @ApiResponse(responseCode = "201", description = "if project did not exist and has been created")
+        @ApiResponse(responseCode = "400", description = "if `name` is empty or `sourcePath` is null or outside data dir")
+        @ApiResponse(responseCode = "403", description = "if the user lacks PROJECT_ADMIN+ on the project id")
+        @ApiResponse(responseCode = "404", description = "if path id does not match body id, or if existing project is not accessible to the user")
+        @ApiResponse(responseCode = "500", description = "if save failed")
         @Put("/:id")
         @Policy(role = Role.PROJECT_ADMIN, idParam = "id")
         public Payload projectUpdate(String id, Project projectPayload, Context context) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -143,25 +143,30 @@
             if (isProjectNameEmpty(projectPayload)) {
                 return PayloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
             }
-            //check if the current user has access to the requested project
-            DatashareUser user = (DatashareUser) context.currentUser();
-            Project project = getUserProject(user, id);
-            if (project == null || !Objects.equals(projectPayload.getId(), id) || !projectExists(projectPayload)) {
-                return PayloadFormatter.error("Project not found", HttpStatus.NOT_FOUND);
+            if (!Objects.equals(projectPayload.getId(), id)) {
+                return PayloadFormatter.error("Project id mismatch.", HttpStatus.NOT_FOUND);
             }
-
             if (isProjectSourcePathNull(projectPayload) || !dataDirVerifier.allowed(projectPayload.getSourcePath())) {
                 return PayloadFormatter.error(String.format("`sourcePath` is required and must not be outside %s.", dataDirVerifier.value()), HttpStatus.BAD_REQUEST);
             }
 
+            if (!projectExists(projectPayload)) {
+                if (!repository.save(projectPayload) || !createIndexOnce(projectPayload.getId())) {
+                    return PayloadFormatter.error("Unable to create the project", HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+                return new Payload(projectPayload).withCode(HttpStatus.CREATED);
+            }
+
+            DatashareUser user = (DatashareUser) context.currentUser();
+            if (getUserProject(user, id) == null) {
+                return PayloadFormatter.error("Project not found", HttpStatus.NOT_FOUND);
+            }
             if (!repository.save(projectPayload)) {
                 return PayloadFormatter.error("Unable to save the project", HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
             return new Payload(projectPayload).withCode(HttpStatus.OK);
         }
-
-
 
         @Operation(description = "Deletes the project from database and elasticsearch index.",
                 parameters = {@Parameter(name = "id", description = "project id")}

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -219,6 +219,20 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
                 .contain("\"sourcePath\":\"file:///vault/newFoo/test\"");
     }
 
+    @Test
+    public void test_put_creates_project_when_it_does_not_exist() throws IOException {
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject("foo")).thenReturn(null);
+        when(repository.save((Project) any())).thenReturn(true);
+        when(indexer.createIndex("foo")).thenReturn(true);
+
+        String body = "{ \"name\": \"foo\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
+        put("/api/project/foo", body).should().respond(201)
+                .contain("\"name\":\"foo\"")
+                .contain("\"label\":\"Foo\"")
+                .contain("\"sourcePath\":\"file:///vault/foo\"");
+    }
+
     @Before
     public void setUp() throws IOException {
         initMocks(this);

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -371,6 +371,29 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
                 .contain("\"name\":\"foo\"");
     }
 
+    @Test
+    public void test_put_create_in_server_mode_forbidden_for_project_admin_of_other_project() {
+        PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
+            put("mode", Mode.SERVER.name());
+            put("dataDir", "/my-dir");
+        }});
+        ProjectResource projectResource = new ProjectResource(repository, indexer, taskManager, propertiesProvider, documentCollectionFactory);
+
+        // grant PROJECT_ADMIN on "bar", then PUT to "foo" (which does not exist)
+        User john = mockUser("john", "bar", Role.PROJECT_ADMIN);
+        PolicyAnnotation policyAnnotation = new PolicyAnnotation(authorizer);
+
+        configure(routes -> {
+            BasicAuthFilter basicAuthFilter = new BasicAuthFilter("/", "icij", DatashareUser.singleUser(john));
+            routes.filter(basicAuthFilter).registerAroundAnnotation(Policy.class, policyAnnotation).add(new PolicyResource(authorizer, repository)).add(projectResource);
+        });
+
+        when(repository.getProject("foo")).thenReturn(null);
+
+        String body = "{ \"name\": \"foo\", \"sourcePath\": \"/my-dir/foo\"}";
+        put("/api/project/foo", body).withPreemptiveAuthentication("john", "pass").should().respond(403);
+    }
+
 
     @Test
     public void test_is_allowed() {

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -342,6 +342,35 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         put("/api/project/foo", body).withPreemptiveAuthentication("elios", "pass").should().respond(403);
     }
 
+    @Test
+    public void test_put_create_in_server_mode_by_instance_admin() throws IOException {
+        String projectId = "foo";
+        PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
+            put("mode", Mode.SERVER.name());
+            put("dataDir", "/my-dir");
+        }});
+
+        ProjectResource projectResource = new ProjectResource(repository, indexer, taskManager, propertiesProvider, documentCollectionFactory);
+
+        DatashareUser jane = new DatashareUser(localUser("jane"));
+        authorizer.addRoleForUserInInstance(jane, Role.INSTANCE_ADMIN);
+        PolicyAnnotation policyAnnotation = new PolicyAnnotation(authorizer);
+
+        configure(routes -> {
+            BasicAuthFilter basicAuthFilter = new BasicAuthFilter("/", "icij", DatashareUser.singleUser(jane));
+            routes.filter(basicAuthFilter).registerAroundAnnotation(Policy.class, policyAnnotation).add(new PolicyResource(authorizer, repository)).add(projectResource);
+        });
+
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject(projectId)).thenReturn(null);
+        when(repository.save((Project) any())).thenReturn(true);
+        when(indexer.createIndex(projectId)).thenReturn(true);
+
+        String body = "{ \"name\": \"foo\", \"sourcePath\": \"/my-dir/foo\", \"label\": \"Foo\"}";
+        put("/api/project/foo", body).withPreemptiveAuthentication("jane", "pass").should().respond(201)
+                .contain("\"name\":\"foo\"");
+    }
+
 
     @Test
     public void test_is_allowed() {

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -239,7 +239,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         when(repository.getProject("foo")).thenReturn(null);
 
         String body = "{ \"name\": \"foo\", \"label\": \"Foo\", \"sourcePath\": \"/etc/passwd\"}";
-        put("/api/project/foo", body).should().respond(400);
+        put("/api/project/foo", body).should().respond(400).contain("sourcePath");
     }
 
     @Test
@@ -248,7 +248,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         when(repository.getProject("foo")).thenReturn(null);
 
         String body = "{ \"name\": \"\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
-        put("/api/project/foo", body).should().respond(400);
+        put("/api/project/foo", body).should().respond(400).contain("name");
     }
 
     @Test
@@ -258,7 +258,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
 
         // path id is "foo", body id is "bar"
         String body = "{ \"name\": \"bar\", \"label\": \"Bar\", \"sourcePath\": \"/vault/bar\"}";
-        put("/api/project/foo", body).should().respond(404);
+        put("/api/project/foo", body).should().respond(404).contain("mismatch");
     }
 
     @Before

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -419,7 +419,7 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         when(repository.save((Project) any())).thenReturn(true);
 
         String body = "{ \"name\": \"foo\", \"sourcePath\": \"/my-dir/foo\"}";
-        put("/api/project/foo", body).withPreemptiveAuthentication("jane", "pass").should().respond(404);
+        put("/api/project/foo", body).withPreemptiveAuthentication("jane", "pass").should().respond(404).contain("Project not found");
     }
 
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -251,6 +251,16 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         put("/api/project/foo", body).should().respond(400);
     }
 
+    @Test
+    public void test_put_returns_404_when_body_id_does_not_match_path_id() {
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject("foo")).thenReturn(null);
+
+        // path id is "foo", body id is "bar"
+        String body = "{ \"name\": \"bar\", \"label\": \"Bar\", \"sourcePath\": \"/vault/bar\"}";
+        put("/api/project/foo", body).should().respond(404);
+    }
+
     @Before
     public void setUp() throws IOException {
         initMocks(this);

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -394,6 +394,34 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         put("/api/project/foo", body).withPreemptiveAuthentication("john", "pass").should().respond(403);
     }
 
+    @Test
+    public void test_put_update_still_requires_user_access() {
+        PropertiesProvider propertiesProvider = new PropertiesProvider(new HashMap<>() {{
+            put("mode", Mode.SERVER.name());
+            put("dataDir", "/my-dir");
+        }});
+        ProjectResource projectResource = new ProjectResource(repository, indexer, taskManager, propertiesProvider, documentCollectionFactory);
+
+        // jane is INSTANCE_ADMIN so policy check passes, but getUserProject must still gate the update branch
+        DatashareUser jane = new DatashareUser(localUser("jane"));
+        authorizer.addRoleForUserInInstance(jane, Role.INSTANCE_ADMIN);
+        PolicyAnnotation policyAnnotation = new PolicyAnnotation(authorizer);
+
+        configure(routes -> {
+            BasicAuthFilter basicAuthFilter = new BasicAuthFilter("/", "icij", DatashareUser.singleUser(jane));
+            routes.filter(basicAuthFilter).registerAroundAnnotation(Policy.class, policyAnnotation).add(new PolicyResource(authorizer, repository)).add(projectResource);
+        });
+
+        // project EXISTS in repo, but jane does NOT have it in her project list
+        Project existingFoo = new Project("foo", Path.of("/my-dir/foo"));
+        when(repository.getProject("foo")).thenReturn(existingFoo);
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>()); // jane sees no projects
+        when(repository.save((Project) any())).thenReturn(true);
+
+        String body = "{ \"name\": \"foo\", \"sourcePath\": \"/my-dir/foo\"}";
+        put("/api/project/foo", body).withPreemptiveAuthentication("jane", "pass").should().respond(404);
+    }
+
 
     @Test
     public void test_is_allowed() {

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -242,6 +242,15 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         put("/api/project/foo", body).should().respond(400);
     }
 
+    @Test
+    public void test_put_create_returns_400_when_name_empty() {
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject("foo")).thenReturn(null);
+
+        String body = "{ \"name\": \"\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
+        put("/api/project/foo", body).should().respond(400);
+    }
+
     @Before
     public void setUp() throws IOException {
         initMocks(this);

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -233,6 +233,15 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
                 .contain("\"sourcePath\":\"file:///vault/foo\"");
     }
 
+    @Test
+    public void test_put_create_returns_400_when_source_path_outside_data_dir() {
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject("foo")).thenReturn(null);
+
+        String body = "{ \"name\": \"foo\", \"label\": \"Foo\", \"sourcePath\": \"/etc/passwd\"}";
+        put("/api/project/foo", body).should().respond(400);
+    }
+
     @Before
     public void setUp() throws IOException {
         initMocks(this);


### PR DESCRIPTION
This PR makes PUT `/api/project/:id` an upsert: if the project doesn't exist, an `INSTANCE_ADMIN` or `DOMAIN_ADMIN` can create it via the same call that would normally update it. 

The endpoint now returns 201 Created on first push and 200 OK on subsequent updates, with all existing validation (name, sourcePath, dataDir) preserved. The role-hierarchy check ensures regular `PROJECT_ADMIN`s still cannot conjure new projects out of thin air (only wildcard admins can) and the user-access check on the update branch is kept intact.

In short: it closes the gap between "OAuth claims grant access to project X" and "project X actually exists in the project table," letting SERVER-mode deployments provision projects through one idempotent admin call instead of a two-step dance.
