### PR TITLE
feat: async search proxy

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/asyncsearch/AsyncSearchOwner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/asyncsearch/AsyncSearchOwner.java
@@ -1,0 +1,22 @@
+package org.icij.datashare.asyncsearch;
+
+import java.util.List;
+
+/**
+ * Records who submitted an async search and on which projects, so poll/cancel
+ * requests carrying only the opaque ES id can be authorized.
+ *
+ * Public no-arg constructor and public fields are required by the Redisson
+ * JSON codec used in {@link RedisAsyncSearchStore}.
+ */
+public class AsyncSearchOwner {
+    public String userId;
+    public List<String> projects;
+
+    public AsyncSearchOwner() {}
+
+    public AsyncSearchOwner(String userId, List<String> projects) {
+        this.userId = userId;
+        this.projects = projects;
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/asyncsearch/AsyncSearchStore.java
+++ b/datashare-app/src/main/java/org/icij/datashare/asyncsearch/AsyncSearchStore.java
@@ -1,0 +1,15 @@
+package org.icij.datashare.asyncsearch;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Strict-ownership record store for async searches, keyed by the ES async id.
+ * Records expire after keepAlive so the store stays in lockstep with ES.
+ */
+public interface AsyncSearchStore {
+    void put(String asyncId, AsyncSearchOwner owner, Duration keepAlive);
+    Optional<AsyncSearchOwner> get(String asyncId);
+    void remove(String asyncId);
+    void refresh(String asyncId, Duration keepAlive);
+}

--- a/datashare-app/src/main/java/org/icij/datashare/asyncsearch/EsDuration.java
+++ b/datashare-app/src/main/java/org/icij/datashare/asyncsearch/EsDuration.java
@@ -24,6 +24,9 @@ public final class EsDuration {
             return fallback;
         }
         long amount = Long.parseLong(matcher.group(1));
+        if (amount < 1) {
+            return fallback;
+        }
         return switch (matcher.group(2)) {
             case "ms" -> Duration.ofMillis(amount);
             case "s" -> Duration.ofSeconds(amount);

--- a/datashare-app/src/main/java/org/icij/datashare/asyncsearch/EsDuration.java
+++ b/datashare-app/src/main/java/org/icij/datashare/asyncsearch/EsDuration.java
@@ -1,0 +1,36 @@
+package org.icij.datashare.asyncsearch;
+
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses Elasticsearch time-value strings (e.g. "5m", "30s", "1h", "2d",
+ * "500ms") into a {@link Duration}. Returns the fallback for null, blank, or
+ * unparseable input.
+ */
+public final class EsDuration {
+    // "ms" must precede "s" so the alternation matches two-char units first.
+    private static final Pattern PATTERN = Pattern.compile("^(\\d+)(ms|s|m|h|d)$");
+
+    private EsDuration() {}
+
+    public static Duration parse(String value, Duration fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        Matcher matcher = PATTERN.matcher(value.trim());
+        if (!matcher.matches()) {
+            return fallback;
+        }
+        long amount = Long.parseLong(matcher.group(1));
+        return switch (matcher.group(2)) {
+            case "ms" -> Duration.ofMillis(amount);
+            case "s" -> Duration.ofSeconds(amount);
+            case "m" -> Duration.ofMinutes(amount);
+            case "h" -> Duration.ofHours(amount);
+            case "d" -> Duration.ofDays(amount);
+            default -> fallback;
+        };
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/asyncsearch/MemoryAsyncSearchStore.java
+++ b/datashare-app/src/main/java/org/icij/datashare/asyncsearch/MemoryAsyncSearchStore.java
@@ -1,0 +1,56 @@
+package org.icij.datashare.asyncsearch;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-process ownership store for LOCAL/EMBEDDED (single-process) modes.
+ * Entries expire lazily on access. Cross-instance correctness is not required
+ * here because memory mode runs in a single process.
+ */
+public class MemoryAsyncSearchStore implements AsyncSearchStore {
+    private record Entry(AsyncSearchOwner owner, Instant expiresAt) {}
+
+    private final ConcurrentHashMap<String, Entry> entries = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    public MemoryAsyncSearchStore() {
+        this(Clock.systemUTC());
+    }
+
+    public MemoryAsyncSearchStore(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public void put(String asyncId, AsyncSearchOwner owner, Duration keepAlive) {
+        entries.put(asyncId, new Entry(owner, clock.instant().plus(keepAlive)));
+    }
+
+    @Override
+    public Optional<AsyncSearchOwner> get(String asyncId) {
+        Entry entry = entries.get(asyncId);
+        if (entry == null) {
+            return Optional.empty();
+        }
+        if (!entry.expiresAt().isAfter(clock.instant())) {
+            entries.remove(asyncId);
+            return Optional.empty();
+        }
+        return Optional.of(entry.owner());
+    }
+
+    @Override
+    public void remove(String asyncId) {
+        entries.remove(asyncId);
+    }
+
+    @Override
+    public void refresh(String asyncId, Duration keepAlive) {
+        entries.computeIfPresent(asyncId, (k, entry) ->
+                new Entry(entry.owner(), clock.instant().plus(keepAlive)));
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/asyncsearch/RedisAsyncSearchStore.java
+++ b/datashare-app/src/main/java/org/icij/datashare/asyncsearch/RedisAsyncSearchStore.java
@@ -1,0 +1,44 @@
+package org.icij.datashare.asyncsearch;
+
+import org.redisson.api.RMapCache;
+import org.redisson.api.RedissonClient;
+import org.redisson.codec.JsonJacksonCodec;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redis-backed ownership store for server modes (REDIS/AMQP/TEMPORAL).
+ * Uses an RMapCache so each entry expires independently after keepAlive, and
+ * the record is shared across all backend instances.
+ */
+public class RedisAsyncSearchStore implements AsyncSearchStore {
+    private static final String MAP_NAME = "datashare:async-search";
+    private final RMapCache<String, AsyncSearchOwner> map;
+
+    public RedisAsyncSearchStore(RedissonClient redissonClient) {
+        java.util.Objects.requireNonNull(redissonClient, "redissonClient must not be null");
+        this.map = redissonClient.getMapCache(MAP_NAME, new JsonJacksonCodec());
+    }
+
+    @Override
+    public void put(String asyncId, AsyncSearchOwner owner, Duration keepAlive) {
+        map.put(asyncId, owner, keepAlive.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Optional<AsyncSearchOwner> get(String asyncId) {
+        return Optional.ofNullable(map.get(asyncId));
+    }
+
+    @Override
+    public void remove(String asyncId) {
+        map.remove(asyncId);
+    }
+
+    @Override
+    public void refresh(String asyncId, Duration keepAlive) {
+        map.updateEntryExpiration(asyncId, keepAlive.toMillis(), TimeUnit.MILLISECONDS, 0, TimeUnit.MILLISECONDS);
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -15,6 +15,9 @@ import net.codestory.http.misc.Env;
 import net.codestory.http.routes.Routes;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
+import org.icij.datashare.asyncsearch.AsyncSearchStore;
+import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
+import org.icij.datashare.asyncsearch.RedisAsyncSearchStore;
 import org.icij.datashare.asynctasks.*;
 import org.icij.datashare.asynctasks.temporal.TemporalHelper;
 import org.icij.datashare.asynctasks.temporal.TemporalInterlocutor;
@@ -288,6 +291,14 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         return switch (getQueueType(propertiesProvider, QUEUE_TYPE_OPT, DEFAULT_QUEUE_TYPE)) {
             case MEMORY -> new MemoryDocumentCollectionFactory<>(propertiesProvider);
             case REDIS, AMQP, TEMPORAL -> new RedisDocumentCollectionFactory<>(propertiesProvider, get(RedissonClient.class));
+        };
+    }
+
+    @Provides @Singleton
+    AsyncSearchStore provideAsyncSearchStore(final PropertiesProvider propertiesProvider) {
+        return switch (getQueueType(propertiesProvider, QUEUE_TYPE_OPT, DEFAULT_QUEUE_TYPE)) {
+            case MEMORY -> new MemoryAsyncSearchStore();
+            case REDIS, AMQP, TEMPORAL -> new RedisAsyncSearchStore(get(RedissonClient.class));
         };
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -75,7 +75,7 @@ public class IndexAccessVerifier {
         return areAllIndexesGranted && (isMethodGet || isSearchPath || isCountPath || isAsyncSearchPath);
     }
 
-    static String getUrlString(Context context, String s) {
+    public static String getUrlString(Context context, String s) {
         if (context.query().keyValues().size() > 0) {
             s += "?" + getQueryAsString(context.query());
         }

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -40,6 +40,26 @@ public class IndexAccessVerifier {
         throw new UnauthorizedException();
     }
 
+    /** True for an async-search submit: "<index>/_async_search" (index in pathParts[0]). */
+    public static boolean isAsyncSearchSubmit(String path) {
+        String[] pathParts = path.split("/");
+        return pathParts.length >= 2 && "_async_search".equals(pathParts[1]);
+    }
+
+    /** True for an async-search poll/cancel: "_async_search/<id>" (no index segment). */
+    public static boolean isAsyncSearchStatusPath(String path) {
+        String[] pathParts = path.split("/");
+        return pathParts.length >= 2 && "_async_search".equals(pathParts[0]);
+    }
+
+    /** The opaque ES async id: everything after the leading "_async_search/". */
+    public static String asyncSearchId(String path) {
+        if (path == null || !path.startsWith("_async_search/")) {
+            throw new IllegalArgumentException("Not an async-search status path: '" + path + "'");
+        }
+        return path.substring("_async_search/".length());
+    }
+
     static private boolean isSearchScrollPath(String path) {
         String[] pathParts = path.split("/");
         return "_search".equals(pathParts[0]) && "scroll".equals(pathParts[1]);
@@ -50,8 +70,9 @@ public class IndexAccessVerifier {
         boolean isMethodGet = "GET".equalsIgnoreCase(context.method());
         boolean isSearchPath = "_search".equals(pathParts[1]);
         boolean isCountPath = "_count".equals(pathParts[1]);
+        boolean isAsyncSearchPath = "_async_search".equals(pathParts[1]);
         boolean areAllIndexesGranted = stream(indexes).allMatch(currentUser::isGranted);
-        return areAllIndexesGranted && (isMethodGet || isSearchPath || isCountPath);
+        return areAllIndexesGranted && (isMethodGet || isSearchPath || isCountPath || isAsyncSearchPath);
     }
 
     static String getUrlString(Context context, String s) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -201,7 +201,7 @@ public class IndexResource {
             return PayloadFormatter.error("async search not found", HttpStatus.NOT_FOUND);
         }
         try {
-            String response = indexer.executeRaw(method, withQueryParams(path, context), null);
+            String response = indexer.executeRaw(method, IndexAccessVerifier.getUrlString(context, path), null);
             if ("DELETE".equalsIgnoreCase(method)) {
                 asyncSearchStore.remove(id);
             } else {
@@ -275,7 +275,7 @@ public class IndexResource {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
             String path = IndexAccessVerifier.checkIndices(index) + "/_close";
-            return PayloadFormatter.json(indexer.executeRaw("POST", withQueryParams(path, context), null));
+            return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
@@ -293,7 +293,7 @@ public class IndexResource {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
             String path = IndexAccessVerifier.checkIndices(index) + "/_open";
-            return PayloadFormatter.json(indexer.executeRaw("POST", withQueryParams(path, context), null));
+            return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
@@ -380,7 +380,7 @@ public class IndexResource {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         String path = "_snapshot/" + repository + "/" + snapshot;
         String body = request.contentAsBytes().length > 0 ? new String(request.contentAsBytes()) : null;
-        return PayloadFormatter.json(indexer.executeRaw("PUT", withQueryParams(path, context), body));
+        return PayloadFormatter.json(indexer.executeRaw("PUT", IndexAccessVerifier.getUrlString(context, path), body));
     }
 
     @Operation(description = "Restore a snapshot. Only available in LOCAL and EMBEDDED modes.")
@@ -397,7 +397,7 @@ public class IndexResource {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         String path = "_snapshot/" + repository + "/" + snapshot + "/_restore";
         String body = request.contentAsBytes().length > 0 ? new String(request.contentAsBytes()) : null;
-        return PayloadFormatter.json(indexer.executeRaw("POST", withQueryParams(path, context), body));
+        return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), body));
     }
 
     @Operation(description = "Delete a snapshot. Only available in LOCAL and EMBEDDED modes.")
@@ -438,13 +438,5 @@ public class IndexResource {
     public Payload getClusterSettings() throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         return PayloadFormatter.json(indexer.executeRaw("GET", "_cluster/settings", null));
-    }
-
-    private String withQueryParams(String path, Context context) {
-        String queryString = context.query().keyValues().entrySet().stream()
-                .map(e -> e.getKey() + "=" + e.getValue())
-                .reduce((a, b) -> a + "&" + b)
-                .orElse("");
-        return queryString.isEmpty() ? path : path + "?" + queryString;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.web;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,13 +12,21 @@ import net.codestory.http.annotations.*;
 import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asyncsearch.AsyncSearchOwner;
+import org.icij.datashare.asyncsearch.AsyncSearchStore;
+import org.icij.datashare.asyncsearch.EsDuration;
+import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
 import org.icij.datashare.cli.Mode;
+import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.utils.IndexAccessVerifier;
 import org.icij.datashare.utils.ModeVerifier;
 import org.icij.datashare.utils.PayloadFormatter;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
 
 import static net.codestory.http.payload.Payload.created;
 import static net.codestory.http.payload.Payload.ok;
@@ -26,12 +35,23 @@ import static net.codestory.http.payload.Payload.ok;
 @Prefix("/api/index")
 public class IndexResource {
     private final Indexer indexer;
+    private final AsyncSearchStore asyncSearchStore;
     private final ModeVerifier modeVerifier;
+    private final Duration defaultKeepAlive;
 
     @Inject
-    public IndexResource(Indexer indexer, PropertiesProvider propertiesProvider) {
+    public IndexResource(Indexer indexer, AsyncSearchStore asyncSearchStore, PropertiesProvider propertiesProvider) {
         this.indexer = indexer;
+        this.asyncSearchStore = asyncSearchStore;
         this.modeVerifier = new ModeVerifier(propertiesProvider);
+        this.defaultKeepAlive = EsDuration.parse(
+                propertiesProvider.get("asyncSearchKeepAlive").orElse("5m"), Duration.ofMinutes(5));
+    }
+
+    // Backwards-compatible constructor used by existing tests; defaults to an
+    // in-memory ownership store.
+    public IndexResource(Indexer indexer, PropertiesProvider propertiesProvider) {
+        this(indexer, new MemoryAsyncSearchStore(), propertiesProvider);
     }
 
     @Operation(description = "Get Elasticsearch cluster info (root endpoint). Only available in LOCAL and EMBEDDED modes.")
@@ -93,16 +113,34 @@ public class IndexResource {
             - index_name1,index_name2/_count
             - index_name/doc/_search
             - index_name1,index_name2/doc/_search
+            - index_name/_async_search
+            - index_name1,index_name2/_async_search
             """)
     @ApiResponse(responseCode = "200", description = "returns 200")
     @ApiResponse(responseCode = "400", description = "returns 400 if there is an error from ElasticSearch")
     @Post("/search/:path:")
     public Payload esPost(@Parameter(name = "index", description = "elasticsearch path", in = ParameterIn.PATH) final String path, Context context, final net.codestory.http.Request request) throws IOException {
         try {
-            return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.checkPath(path, context), new String(request.contentAsBytes())));
+            String response = indexer.executeRaw("POST", IndexAccessVerifier.checkPath(path, context), new String(request.contentAsBytes()));
+            if (IndexAccessVerifier.isAsyncSearchSubmit(path)) {
+                recordAsyncSearchOwnership(path, context, response);
+            }
+            return PayloadFormatter.json(response);
         } catch ( IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
+    }
+
+    private void recordAsyncSearchOwnership(String path, Context context, String esResponse) throws IOException {
+        JsonNode idNode = JsonObjectMapper.getMapper().readTree(esResponse).get("id");
+        if (idNode == null || idNode.isNull()) {
+            return; // search completed within wait_for_completion_timeout: no id, no polling
+        }
+        DatashareUser user = (DatashareUser) context.currentUser();
+        // pathParts[0] was already validated as granted indices by checkPath() above
+        List<String> projects = List.of(path.split("/")[0].split(","));
+        Duration keepAlive = EsDuration.parse(context.get("keep_alive"), defaultKeepAlive);
+        asyncSearchStore.put(idNode.asText(), new AsyncSearchOwner(user.id, projects), keepAlive);
     }
 
     @Operation(description = """

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -27,6 +27,9 @@ import org.icij.datashare.utils.PayloadFormatter;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.ResponseException;
 
 import static net.codestory.http.payload.Payload.created;
 import static net.codestory.http.payload.Payload.ok;
@@ -153,9 +156,47 @@ public class IndexResource {
     @Get("/search/:path:")
     public Payload esGet(@Parameter(name = "path", description = "elasticsearch path", in = ParameterIn.PATH) final String path, Context context) throws IOException {
         try {
+            if (IndexAccessVerifier.isAsyncSearchStatusPath(path)) {
+                return asyncSearchStatus("GET", path, context);
+            }
             return PayloadFormatter.json(indexer.executeRaw("GET", IndexAccessVerifier.checkPath(path, context), ""));
         } catch (IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private Payload asyncSearchStatus(String method, String path, Context context) throws IOException {
+        String id = IndexAccessVerifier.asyncSearchId(path);
+        DatashareUser user = (DatashareUser) context.currentUser();
+        Optional<AsyncSearchOwner> owner = asyncSearchStore.get(id);
+        if (owner.isEmpty()) {
+            return PayloadFormatter.error("async search not found", HttpStatus.NOT_FOUND);
+        }
+        AsyncSearchOwner record = owner.get();
+        if (!record.userId.equals(user.id) || !record.projects.stream().allMatch(user::isGranted)) {
+            return PayloadFormatter.error("async search not found", HttpStatus.NOT_FOUND);
+        }
+        try {
+            String response = indexer.executeRaw(method, withQueryParams(path, context), null);
+            if ("DELETE".equalsIgnoreCase(method)) {
+                asyncSearchStore.remove(id);
+            } else {
+                Duration keepAlive = EsDuration.parse(context.get("keep_alive"), null);
+                if (keepAlive != null) {
+                    asyncSearchStore.refresh(id, keepAlive);
+                }
+            }
+            return PayloadFormatter.json(response);
+        // Deliberate: this endpoint is an ES proxy, so we translate the ES low-level
+        // client's ResponseException into the same HTTP status/body rather than a 500.
+        } catch (ResponseException e) {
+            int status = e.getResponse().getStatusLine().getStatusCode();
+            if (status == HttpStatus.NOT_FOUND) {
+                asyncSearchStore.remove(id); // ES dropped it before our record expired
+            }
+            String body = e.getResponse().getEntity() != null
+                    ? EntityUtils.toString(e.getResponse().getEntity()) : "";
+            return PayloadFormatter.json(body).withCode(status);
         }
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -41,14 +41,17 @@ public class IndexResource {
     private final AsyncSearchStore asyncSearchStore;
     private final ModeVerifier modeVerifier;
     private final Duration defaultKeepAlive;
+    private final String defaultKeepAliveParam;
 
     @Inject
     public IndexResource(Indexer indexer, AsyncSearchStore asyncSearchStore, PropertiesProvider propertiesProvider) {
         this.indexer = indexer;
         this.asyncSearchStore = asyncSearchStore;
         this.modeVerifier = new ModeVerifier(propertiesProvider);
-        this.defaultKeepAlive = EsDuration.parse(
-                propertiesProvider.get("asyncSearchKeepAlive").orElse("5m"), Duration.ofMinutes(5));
+        String configuredKeepAlive = propertiesProvider.get("asyncSearchKeepAlive").orElse("5m");
+        Duration parsedKeepAlive = EsDuration.parse(configuredKeepAlive, null);
+        this.defaultKeepAlive = parsedKeepAlive != null ? parsedKeepAlive : Duration.ofMinutes(5);
+        this.defaultKeepAliveParam = parsedKeepAlive != null ? configuredKeepAlive : "5m";
     }
 
     // Backwards-compatible constructor used by existing tests; defaults to an
@@ -124,7 +127,15 @@ public class IndexResource {
     @Post("/search/:path:")
     public Payload esPost(@Parameter(name = "index", description = "elasticsearch path", in = ParameterIn.PATH) final String path, Context context, final net.codestory.http.Request request) throws IOException {
         try {
-            String response = indexer.executeRaw("POST", IndexAccessVerifier.checkPath(path, context), new String(request.contentAsBytes()));
+            String esUrl = IndexAccessVerifier.checkPath(path, context);
+            String keepAlive = context.get("keep_alive");
+            if (IndexAccessVerifier.isAsyncSearchSubmit(path) && (keepAlive == null || keepAlive.isEmpty())) {
+                // Keep ES's result lifetime in lockstep with our ownership record: when the client
+                // omits keep_alive, inject our default so ES doesn't retain the search for its
+                // multi-day default while our record expires in minutes.
+                esUrl += (esUrl.contains("?") ? "&" : "?") + "keep_alive=" + defaultKeepAliveParam;
+            }
+            String response = indexer.executeRaw("POST", esUrl, new String(request.contentAsBytes()));
             if (IndexAccessVerifier.isAsyncSearchSubmit(path)) {
                 recordAsyncSearchOwnership(path, context, response);
             }

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -200,6 +200,18 @@ public class IndexResource {
         }
     }
 
+    @Operation(description = "Cancel an async search. Only the async-search status path (_async_search/<id>) is allowed; any other DELETE is rejected.")
+    @ApiResponse(responseCode = "200", description = "async search cancelled")
+    @ApiResponse(responseCode = "404", description = "async search not found or not owned by the current user")
+    @ApiResponse(responseCode = "405", description = "DELETE is not allowed on non async-search paths")
+    @Delete("/search/:path:")
+    public Payload esDelete(@Parameter(name = "path", description = "elasticsearch path", in = ParameterIn.PATH) final String path, Context context) throws IOException {
+        if (!IndexAccessVerifier.isAsyncSearchStatusPath(path)) {
+            return PayloadFormatter.error("method not allowed", HttpStatus.METHOD_NOT_ALLOWED);
+        }
+        return asyncSearchStatus("DELETE", path, context);
+    }
+
     @Operation(description = "Preflight request with OPTIONS")
     @ApiResponse(responseCode = "200", description = "returns OPTIONS")
     @ApiResponse(responseCode = "400", description = "returns 400 if there is an error from ElasticSearch")

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -212,11 +212,17 @@ public class IndexResource {
         return asyncSearchStatus("DELETE", path, context);
     }
 
-    @Operation(description = "Preflight request with OPTIONS")
-    @ApiResponse(responseCode = "200", description = "returns OPTIONS")
+    @Operation(description = "Preflight request with OPTIONS. For an async-search status path (_async_search/<id>) it returns Allow: OPTIONS, GET, DELETE without forwarding to Elasticsearch.")
+    @ApiResponse(responseCode = "200", description = "returns OPTIONS (or OPTIONS, GET, DELETE for an async-search status path)")
     @ApiResponse(responseCode = "400", description = "returns 400 if there is an error from ElasticSearch")
     @Options("/search/:path:")
     public Payload esOptions(final String index, final String path, Context context) throws IOException {
+        // For OPTIONS on "_async_search/<id>", net.codestory puts the whole splat in
+        // `index` and leaves `path` empty, so fall back to `index` in that case.
+        String effectivePath = (path != null && !path.isEmpty()) ? path : index;
+        if (effectivePath != null && IndexAccessVerifier.isAsyncSearchStatusPath(effectivePath)) {
+            return PayloadFormatter.allowMethods("OPTIONS", "GET", "DELETE");
+        }
         try {
             IndexAccessVerifier.checkIndices(index);
             return PayloadFormatter.allowMethods(indexer.executeRaw("OPTIONS", path, null));

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -23,6 +23,8 @@ import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.utils.IndexAccessVerifier;
 import org.icij.datashare.utils.ModeVerifier;
 import org.icij.datashare.utils.PayloadFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -37,6 +39,7 @@ import static net.codestory.http.payload.Payload.ok;
 @Singleton
 @Prefix("/api/index")
 public class IndexResource {
+    private static final Logger logger = LoggerFactory.getLogger(IndexResource.class);
     private final Indexer indexer;
     private final AsyncSearchStore asyncSearchStore;
     private final ModeVerifier modeVerifier;
@@ -130,7 +133,12 @@ public class IndexResource {
             String esUrl = withInjectedKeepAlive(IndexAccessVerifier.checkPath(path, context), path, context);
             String response = indexer.executeRaw("POST", esUrl, new String(request.contentAsBytes()));
             if (IndexAccessVerifier.isAsyncSearchSubmit(path)) {
-                recordAsyncSearchOwnership(path, context, response);
+                try {
+                    recordAsyncSearchOwnership(path, context, response);
+                } catch (IOException e) {
+                    logger.warn("async search submitted but ownership could not be recorded: {}", e.getMessage());
+                    return PayloadFormatter.error("async search submitted but response could not be parsed", HttpStatus.BAD_GATEWAY);
+                }
             }
             return PayloadFormatter.json(response);
         } catch ( IllegalArgumentException e){
@@ -142,17 +150,14 @@ public class IndexResource {
     // omits keep_alive, ES would otherwise retain the result for its multi-day default while our
     // record expires in minutes. Injecting our default keeps the two on the same schedule.
     private String withInjectedKeepAlive(String esUrl, String path, Context context) {
+        String keepAlive = context.get("keep_alive");
         boolean isSubmitWithoutKeepAlive = IndexAccessVerifier.isAsyncSearchSubmit(path)
-                && isBlank(context.get("keep_alive"));
+                && (keepAlive == null || keepAlive.isBlank());
         if (!isSubmitWithoutKeepAlive) {
             return esUrl;
         }
         String parameterSeparator = esUrl.contains("?") ? "&" : "?";
         return esUrl + parameterSeparator + "keep_alive=" + defaultKeepAliveParam;
-    }
-
-    private static boolean isBlank(String value) {
-        return value == null || value.isEmpty();
     }
 
     private void recordAsyncSearchOwnership(String path, Context context, String esResponse) throws IOException {
@@ -203,7 +208,13 @@ public class IndexResource {
         try {
             String response = indexer.executeRaw(method, IndexAccessVerifier.getUrlString(context, path), null);
             if ("DELETE".equalsIgnoreCase(method)) {
-                asyncSearchStore.remove(id);
+                // ES already cancelled the search; a store failure (e.g. Redis down) shouldn't surface
+                // as a 500 to the user. The TTL will reap the orphaned record on its own.
+                try {
+                    asyncSearchStore.remove(id);
+                } catch (Exception e) {
+                    logger.warn("async search cancelled on ES but ownership record could not be removed: {}", e.getMessage());
+                }
             } else {
                 Duration keepAlive = EsDuration.parse(context.get("keep_alive"), null);
                 if (keepAlive != null) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -127,14 +127,7 @@ public class IndexResource {
     @Post("/search/:path:")
     public Payload esPost(@Parameter(name = "index", description = "elasticsearch path", in = ParameterIn.PATH) final String path, Context context, final net.codestory.http.Request request) throws IOException {
         try {
-            String esUrl = IndexAccessVerifier.checkPath(path, context);
-            String keepAlive = context.get("keep_alive");
-            if (IndexAccessVerifier.isAsyncSearchSubmit(path) && (keepAlive == null || keepAlive.isEmpty())) {
-                // Keep ES's result lifetime in lockstep with our ownership record: when the client
-                // omits keep_alive, inject our default so ES doesn't retain the search for its
-                // multi-day default while our record expires in minutes.
-                esUrl += (esUrl.contains("?") ? "&" : "?") + "keep_alive=" + defaultKeepAliveParam;
-            }
+            String esUrl = withInjectedKeepAlive(IndexAccessVerifier.checkPath(path, context), path, context);
             String response = indexer.executeRaw("POST", esUrl, new String(request.contentAsBytes()));
             if (IndexAccessVerifier.isAsyncSearchSubmit(path)) {
                 recordAsyncSearchOwnership(path, context, response);
@@ -145,16 +138,36 @@ public class IndexResource {
         }
     }
 
+    // Keep ES's result lifetime in lockstep with our ownership record: when an async-search submit
+    // omits keep_alive, ES would otherwise retain the result for its multi-day default while our
+    // record expires in minutes. Injecting our default keeps the two on the same schedule.
+    private String withInjectedKeepAlive(String esUrl, String path, Context context) {
+        boolean isSubmitWithoutKeepAlive = IndexAccessVerifier.isAsyncSearchSubmit(path)
+                && isBlank(context.get("keep_alive"));
+        if (!isSubmitWithoutKeepAlive) {
+            return esUrl;
+        }
+        String parameterSeparator = esUrl.contains("?") ? "&" : "?";
+        return esUrl + parameterSeparator + "keep_alive=" + defaultKeepAliveParam;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isEmpty();
+    }
+
     private void recordAsyncSearchOwnership(String path, Context context, String esResponse) throws IOException {
         JsonNode idNode = JsonObjectMapper.getMapper().readTree(esResponse).get("id");
+        // an async submit that completed within wait_for_completion_timeout has no id, so nothing to poll later
         if (idNode == null || idNode.isNull()) {
-            return; // search completed within wait_for_completion_timeout: no id, no polling
+            return;
         }
-        DatashareUser user = (DatashareUser) context.currentUser();
-        // pathParts[0] was already validated as granted indices by checkPath() above
-        List<String> projects = List.of(path.split("/")[0].split(","));
+        DatashareUser submitter = (DatashareUser) context.currentUser();
+        // the first path segment holds the comma-separated indices, already validated as granted by checkPath() above
+        String indexSegment = path.split("/")[0];
+        List<String> grantedProjects = List.of(indexSegment.split(","));
         Duration keepAlive = EsDuration.parse(context.get("keep_alive"), defaultKeepAlive);
-        asyncSearchStore.put(idNode.asText(), new AsyncSearchOwner(user.id, projects), keepAlive);
+        String asyncSearchId = idNode.asText();
+        asyncSearchStore.put(asyncSearchId, new AsyncSearchOwner(submitter.id, grantedProjects), keepAlive);
     }
 
     @Operation(description = """
@@ -183,8 +196,8 @@ public class IndexResource {
         if (owner.isEmpty()) {
             return PayloadFormatter.error("async search not found", HttpStatus.NOT_FOUND);
         }
-        AsyncSearchOwner record = owner.get();
-        if (!record.userId.equals(user.id) || !record.projects.stream().allMatch(user::isGranted)) {
+        AsyncSearchOwner ownerRecord = owner.get();
+        if (!isOwnedByCurrentUser(ownerRecord, user)) {
             return PayloadFormatter.error("async search not found", HttpStatus.NOT_FOUND);
         }
         try {
@@ -209,6 +222,14 @@ public class IndexResource {
                     ? EntityUtils.toString(e.getResponse().getEntity()) : "";
             return PayloadFormatter.json(body).withCode(status);
         }
+    }
+
+    // The current user owns the async search only if they submitted it AND still hold a grant on
+    // every project it spans (a project grant can be revoked between submit and a later poll/cancel).
+    private boolean isOwnedByCurrentUser(AsyncSearchOwner ownerRecord, DatashareUser user) {
+        boolean isSubmitter = ownerRecord.userId.equals(user.id);
+        boolean isStillGrantedAllProjects = ownerRecord.projects.stream().allMatch(user::isGranted);
+        return isSubmitter && isStillGrantedAllProjects;
     }
 
     @Operation(description = "Cancel an async search. Only the async-search status path (_async_search/<id>) is allowed; any other DELETE is rejected.")

--- a/datashare-app/src/test/java/org/icij/datashare/asyncsearch/EsDurationTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/asyncsearch/EsDurationTest.java
@@ -38,4 +38,10 @@ public class EsDurationTest {
         assertThat(EsDuration.parse("banana", fallback)).isEqualTo(fallback);
         assertThat(EsDuration.parse("5", fallback)).isEqualTo(fallback);
     }
+
+    @Test
+    public void test_zero_amount_returns_fallback() {
+        assertThat(EsDuration.parse("0m", fallback)).isEqualTo(fallback);
+        assertThat(EsDuration.parse("0s", fallback)).isEqualTo(fallback);
+    }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/asyncsearch/EsDurationTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/asyncsearch/EsDurationTest.java
@@ -1,0 +1,41 @@
+package org.icij.datashare.asyncsearch;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class EsDurationTest {
+    private final Duration fallback = Duration.ofMinutes(5);
+
+    @Test
+    public void test_parse_seconds() {
+        assertThat(EsDuration.parse("30s", fallback)).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    public void test_parse_minutes() {
+        assertThat(EsDuration.parse("10m", fallback)).isEqualTo(Duration.ofMinutes(10));
+    }
+
+    @Test
+    public void test_parse_hours_days_millis() {
+        assertThat(EsDuration.parse("2h", fallback)).isEqualTo(Duration.ofHours(2));
+        assertThat(EsDuration.parse("1d", fallback)).isEqualTo(Duration.ofDays(1));
+        assertThat(EsDuration.parse("500ms", fallback)).isEqualTo(Duration.ofMillis(500));
+    }
+
+    @Test
+    public void test_null_or_blank_returns_fallback() {
+        assertThat(EsDuration.parse(null, fallback)).isEqualTo(fallback);
+        assertThat(EsDuration.parse("", fallback)).isEqualTo(fallback);
+        assertThat(EsDuration.parse("   ", fallback)).isEqualTo(fallback);
+    }
+
+    @Test
+    public void test_unparseable_returns_fallback() {
+        assertThat(EsDuration.parse("banana", fallback)).isEqualTo(fallback);
+        assertThat(EsDuration.parse("5", fallback)).isEqualTo(fallback);
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/asyncsearch/MemoryAsyncSearchStoreTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/asyncsearch/MemoryAsyncSearchStoreTest.java
@@ -1,0 +1,71 @@
+package org.icij.datashare.asyncsearch;
+
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class MemoryAsyncSearchStoreTest {
+
+    /** Mutable test clock so expiry is deterministic without sleeping. */
+    static class MutableClock extends Clock {
+        Instant now = Instant.parse("2026-05-27T00:00:00Z");
+        @Override public Instant instant() { return now; }
+        @Override public ZoneOffset getZone() { return ZoneOffset.UTC; }
+        @Override public Clock withZone(java.time.ZoneId zone) { return this; }
+        void advance(Duration d) { now = now.plus(d); }
+    }
+
+    private final MutableClock clock = new MutableClock();
+    private final MemoryAsyncSearchStore store = new MemoryAsyncSearchStore(clock);
+    private final AsyncSearchOwner owner = new AsyncSearchOwner("alice", List.of("alice-datashare"));
+
+    @Test
+    public void test_put_then_get_returns_owner() {
+        store.put("id-1", owner, Duration.ofMinutes(5));
+        assertThat(store.get("id-1").isPresent()).isTrue();
+        assertThat(store.get("id-1").get().userId).isEqualTo("alice");
+        assertThat(store.get("id-1").get().projects).containsExactly("alice-datashare");
+    }
+
+    @Test
+    public void test_get_unknown_id_is_empty() {
+        assertThat(store.get("nope").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_remove() {
+        store.put("id-1", owner, Duration.ofMinutes(5));
+        store.remove("id-1");
+        assertThat(store.get("id-1").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_entry_expires_after_keep_alive() {
+        store.put("id-1", owner, Duration.ofMinutes(5));
+        clock.advance(Duration.ofMinutes(4));
+        assertThat(store.get("id-1").isPresent()).isTrue();
+        clock.advance(Duration.ofMinutes(2)); // now 6 minutes, past the 5m TTL
+        assertThat(store.get("id-1").isPresent()).isFalse();
+
+        // at exactly the expiry instant, the entry is treated as expired
+        MemoryAsyncSearchStore boundaryStore = new MemoryAsyncSearchStore(clock);
+        boundaryStore.put("id-boundary", owner, Duration.ofMinutes(5));
+        clock.advance(Duration.ofMinutes(5)); // now == expiresAt
+        assertThat(boundaryStore.get("id-boundary").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_refresh_extends_expiry() {
+        store.put("id-1", owner, Duration.ofMinutes(5));
+        clock.advance(Duration.ofMinutes(4));
+        store.refresh("id-1", Duration.ofMinutes(5)); // expiry now at 9 minutes
+        clock.advance(Duration.ofMinutes(3)); // now 7 minutes
+        assertThat(store.get("id-1").isPresent()).isTrue();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/asyncsearch/RedisAsyncSearchStoreTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/asyncsearch/RedisAsyncSearchStoreTest.java
@@ -1,0 +1,67 @@
+package org.icij.datashare.asyncsearch;
+
+import org.icij.datashare.EnvUtils;
+import org.icij.extract.redis.RedissonClientFactory;
+import org.icij.task.Options;
+import org.junit.After;
+import org.junit.Test;
+import org.redisson.api.RedissonClient;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class RedisAsyncSearchStoreTest {
+    private static final String REDIS_ADDRESS = EnvUtils.resolveUri("redis", "redis://redis:6379");
+    private final RedissonClient client = new RedissonClientFactory()
+            .withOptions(Options.from(Map.of("redisAddress", REDIS_ADDRESS, "redisPoolSize", "5"))).create();
+    private final RedisAsyncSearchStore store = new RedisAsyncSearchStore(client);
+    private final AsyncSearchOwner owner = new AsyncSearchOwner("alice", List.of("alice-datashare"));
+
+    @Test
+    public void test_put_then_get_returns_owner() {
+        store.put("id-redis-1", owner, Duration.ofMinutes(5));
+        assertThat(store.get("id-redis-1").isPresent()).isTrue();
+        assertThat(store.get("id-redis-1").get().userId).isEqualTo("alice");
+        assertThat(store.get("id-redis-1").get().projects).containsExactly("alice-datashare");
+    }
+
+    @Test
+    public void test_get_unknown_id_is_empty() {
+        assertThat(store.get("id-redis-unknown").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_remove() {
+        store.put("id-redis-2", owner, Duration.ofMinutes(5));
+        store.remove("id-redis-2");
+        assertThat(store.get("id-redis-2").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_entry_expires_after_keep_alive() throws InterruptedException {
+        store.put("id-redis-3", owner, Duration.ofMillis(200));
+        assertThat(store.get("id-redis-3").isPresent()).isTrue();
+        Thread.sleep(400);
+        assertThat(store.get("id-redis-3").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_refresh_extends_expiry() throws InterruptedException {
+        store.put("id-redis-4", owner, Duration.ofMillis(300));
+        store.refresh("id-redis-4", Duration.ofSeconds(10)); // extend well past the original 300ms
+        Thread.sleep(500); // past the original TTL
+        assertThat(store.get("id-redis-4").isPresent()).isTrue();
+    }
+
+    @After
+    public void tearDown() {
+        store.remove("id-redis-1");
+        store.remove("id-redis-2");
+        store.remove("id-redis-3");
+        store.remove("id-redis-4");
+        client.shutdown();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -5,6 +5,7 @@ import com.google.inject.Injector;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asyncsearch.AsyncSearchStore;
 import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
+import org.icij.datashare.asyncsearch.RedisAsyncSearchStore;
 import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskSupplier;
@@ -106,5 +107,15 @@ public class CommonModeTest {
             put("queueType", QueueType.MEMORY.name());
         }}));
         assertThat(injector.getInstance(AsyncSearchStore.class)).isInstanceOf(MemoryAsyncSearchStore.class);
+    }
+
+    @Test
+    public void test_async_search_store_is_redis_in_redis_mode() {
+        Injector injector = Guice.createInjector(CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
+            put("queueType", QueueType.REDIS.name());
+            put("redisAddress", "redis://redis:6379");
+        }}));
+        assertThat(injector.getInstance(AsyncSearchStore.class)).isInstanceOf(RedisAsyncSearchStore.class);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -5,7 +5,6 @@ import com.google.inject.Injector;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asyncsearch.AsyncSearchStore;
 import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
-import org.icij.datashare.asyncsearch.RedisAsyncSearchStore;
 import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskSupplier;
@@ -107,15 +106,5 @@ public class CommonModeTest {
             put("queueType", QueueType.MEMORY.name());
         }}));
         assertThat(injector.getInstance(AsyncSearchStore.class)).isInstanceOf(MemoryAsyncSearchStore.class);
-    }
-
-    @Test
-    public void test_async_search_store_is_redis_in_redis_mode() {
-        Injector injector = Guice.createInjector(CommonMode.create(new HashMap<>() {{
-            put("mode", Mode.LOCAL.name());
-            put("queueType", QueueType.REDIS.name());
-            put("redisAddress", "redis://redis:6379");
-        }}));
-        assertThat(injector.getInstance(AsyncSearchStore.class)).isInstanceOf(RedisAsyncSearchStore.class);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -3,6 +3,8 @@ package org.icij.datashare.mode;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asyncsearch.AsyncSearchStore;
+import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
 import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskSupplier;
@@ -95,5 +97,14 @@ public class CommonModeTest {
             put("authUsersProvider", "org.icij.UnknownClass");
         }});
         assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInDb.class);
+    }
+
+    @Test
+    public void test_async_search_store_is_memory_in_memory_mode() {
+        Injector injector = Guice.createInjector(CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
+            put("queueType", QueueType.MEMORY.name());
+        }}));
+        assertThat(injector.getInstance(AsyncSearchStore.class)).isInstanceOf(MemoryAsyncSearchStore.class);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -33,4 +33,29 @@ public class IndexAccessVerifierTest {
             IndexAccessVerifier.checkIndices("bar,foo!");
         });
     }
+
+    @Test
+    public void test_is_async_search_submit() {
+        assertThat(IndexAccessVerifier.isAsyncSearchSubmit("my-index/_async_search")).isTrue();
+        assertThat(IndexAccessVerifier.isAsyncSearchSubmit("a,b/_async_search")).isTrue();
+        assertThat(IndexAccessVerifier.isAsyncSearchSubmit("my-index/_search")).isFalse();
+        assertThat(IndexAccessVerifier.isAsyncSearchSubmit("_async_search/some-id")).isFalse();
+        assertThat(IndexAccessVerifier.isAsyncSearchSubmit("_async_search")).isFalse();
+    }
+
+    @Test
+    public void test_is_async_search_status_path() {
+        assertThat(IndexAccessVerifier.isAsyncSearchStatusPath("_async_search/some-id")).isTrue();
+        assertThat(IndexAccessVerifier.isAsyncSearchStatusPath("_async_search/a/b==")).isTrue();
+        assertThat(IndexAccessVerifier.isAsyncSearchStatusPath("my-index/_async_search")).isFalse();
+        assertThat(IndexAccessVerifier.isAsyncSearchStatusPath("my-index/_search")).isFalse();
+        assertThat(IndexAccessVerifier.isAsyncSearchStatusPath("_async_search")).isFalse();
+    }
+
+    @Test
+    public void test_async_search_id_reconstructs_full_id() {
+        assertThat(IndexAccessVerifier.asyncSearchId("_async_search/abc==")).isEqualTo("abc==");
+        // ES ids may contain slashes; the id is everything after "_async_search/"
+        assertThat(IndexAccessVerifier.asyncSearchId("_async_search/ab/cd==")).isEqualTo("ab/cd==");
+    }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -417,6 +417,18 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         delete("/api/index/search/foo/bar").should().respond(405);
     }
 
+    @Test
+    public void test_async_search_options_advertises_get_and_delete() {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));
+        options("/api/index/search/_async_search/some-id").should().respond(200);
+        // The short-circuit must advertise GET/DELETE (set by allowMethods via the
+        // Access-Control-Allow-Methods header), not just return a generic 200.
+        Response response = options("/api/index/search/_async_search/some-id").response();
+        String allowMethods = String.join(",", response.header("Access-Control-Allow-Methods"));
+        assertThat(allowMethods).contains("GET").contains("DELETE");
+    }
+
     @Before
     public void setUp() {
         initMocks(this);

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -456,6 +456,25 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
                 .withPreemptiveAuthentication("cecile", "").should().respond(200).contain("\"is_running\"");
     }
 
+    @Test
+    public void test_async_search_submit_injects_default_keep_alive_when_absent() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        indexer.add("cecile-datashare", DocumentBuilder.createDoc("doc-ka-1").build());
+
+        // No keep_alive param: the proxy must inject the default (5m) into the ES request.
+        Response response = post(
+                "/api/index/search/cecile-datashare/_async_search?wait_for_completion_timeout=0&keep_on_completion=true",
+                "{\"query\":{\"match_all\":{}}}")
+                .withPreemptiveAuthentication("cecile", "").response();
+
+        com.fasterxml.jackson.databind.JsonNode root = JsonObjectMapper.getMapper().readTree(response.content());
+        long expiration = root.get("expiration_time_in_millis").asLong();
+        long now = System.currentTimeMillis();
+        // With the 5m default injected, expiration is minutes away; ES's un-injected default is ~5 days.
+        assertThat(expiration - now).isLessThan(java.time.Duration.ofHours(1).toMillis());
+    }
+
     @Before
     public void setUp() {
         initMocks(this);

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -383,6 +383,40 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         assertThat(asyncSearchStore.get(id).isPresent()).isFalse();
     }
 
+    @Test
+    public void test_async_search_cancel_as_owner_removes_record() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", twoUsersGrantedTo(es.getIndexName()))));
+        indexer.add(es.getIndexName(), DocumentBuilder.createDoc("doc-cancel-1").build());
+
+        String id = submitAsyncSearchAs("alice", es.getIndexName());
+        assertThat(asyncSearchStore.get(id).isPresent()).isTrue();
+
+        delete("/api/index/search/_async_search/" + urlEncode(id))
+                .withPreemptiveAuthentication("alice", "").should().respond(200);
+        assertThat(asyncSearchStore.get(id).isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_async_search_cancel_as_other_user_returns_404() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", twoUsersGrantedTo(es.getIndexName()))));
+        indexer.add(es.getIndexName(), DocumentBuilder.createDoc("doc-cancel-2").build());
+
+        String id = submitAsyncSearchAs("alice", es.getIndexName());
+        delete("/api/index/search/_async_search/" + urlEncode(id))
+                .withPreemptiveAuthentication("bob", "").should().respond(404);
+        // alice's record is untouched
+        assertThat(asyncSearchStore.get(id).isPresent()).isTrue();
+    }
+
+    @Test
+    public void test_delete_on_non_async_path_still_method_not_allowed() {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));
+        delete("/api/index/search/foo/bar").should().respond(405);
+    }
+
     @Before
     public void setUp() {
         initMocks(this);

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -4,7 +4,9 @@ import co.elastic.clients.elasticsearch._types.Refresh;
 import net.codestory.http.filters.basic.BasicAuthFilter;
 import net.codestory.http.security.Users;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
 import org.icij.datashare.db.JooqRepository;
+import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.test.ElasticsearchRule;
@@ -17,12 +19,15 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import net.codestory.rest.Response;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -284,6 +289,26 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         configure(routes -> routes.add(new IndexResource(indexer, serverModeProvider))
                 .filter(new LocalUserFilter(serverModeProvider, jooqRepository, es.getIndexNames())));
         get("/api/index/_cluster/settings").should().respond(403);
+    }
+
+    private final MemoryAsyncSearchStore asyncSearchStore = new MemoryAsyncSearchStore();
+
+    @Test
+    public void test_async_search_submit_records_ownership() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        indexer.add("cecile-datashare", DocumentBuilder.createDoc("doc-async-1").build());
+
+        // keep_on_completion=true forces ES to return an id even on a fast/tiny index
+        Response response = post(
+                "/api/index/search/cecile-datashare/_async_search?wait_for_completion_timeout=0&keep_on_completion=true&keep_alive=5m",
+                "{\"query\":{\"match_all\":{}}}")
+                .withPreemptiveAuthentication("cecile", "").response();
+
+        String id = JsonObjectMapper.getMapper().readTree(response.content()).get("id").asText();
+        assertThat(asyncSearchStore.get(id).isPresent()).isTrue();
+        assertThat(asyncSearchStore.get(id).get().userId).isEqualTo("cecile");
+        assertThat(asyncSearchStore.get(id).get().projects).containsExactly("cecile-datashare");
     }
 
     @Before

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -311,6 +311,78 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         assertThat(asyncSearchStore.get(id).get().projects).containsExactly("cecile-datashare");
     }
 
+    private net.codestory.http.security.Users twoUsersGrantedTo(String index) {
+        DatashareUser alice = new DatashareUser(org.icij.datashare.user.User.localUser("alice", index));
+        DatashareUser bob = new DatashareUser(org.icij.datashare.user.User.localUser("bob", index));
+        return new net.codestory.http.security.Users() {
+            @Override public net.codestory.http.security.User find(String login, String pass) { return find(login); }
+            @Override public net.codestory.http.security.User find(String login) {
+                if ("alice".equals(login)) return alice;
+                if ("bob".equals(login)) return bob;
+                return null;
+            }
+        };
+    }
+
+    private String submitAsyncSearchAs(String login, String index) throws IOException {
+        Response response = post(
+                "/api/index/search/%s/_async_search?wait_for_completion_timeout=0&keep_on_completion=true&keep_alive=5m".formatted(index),
+                "{\"query\":{\"match_all\":{}}}")
+                .withPreemptiveAuthentication(login, "").response();
+        return JsonObjectMapper.getMapper().readTree(response.content()).get("id").asText();
+    }
+
+    private String urlEncode(String value) {
+        return java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void test_async_search_poll_as_owner_returns_result() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", twoUsersGrantedTo(es.getIndexName()))));
+        indexer.add(es.getIndexName(), DocumentBuilder.createDoc("doc-poll-1").build());
+
+        String id = submitAsyncSearchAs("alice", es.getIndexName());
+        get("/api/index/search/_async_search/" + urlEncode(id))
+                .withPreemptiveAuthentication("alice", "").should()
+                .respond(200).contain("\"is_running\"");
+    }
+
+    @Test
+    public void test_async_search_poll_as_other_user_returns_404() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", twoUsersGrantedTo(es.getIndexName()))));
+        indexer.add(es.getIndexName(), DocumentBuilder.createDoc("doc-poll-2").build());
+
+        String id = submitAsyncSearchAs("alice", es.getIndexName());
+        get("/api/index/search/_async_search/" + urlEncode(id))
+                .withPreemptiveAuthentication("bob", "").should().respond(404);
+    }
+
+    @Test
+    public void test_async_search_poll_unknown_id_returns_404() {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", twoUsersGrantedTo(es.getIndexName()))));
+        get("/api/index/search/_async_search/does-not-exist")
+                .withPreemptiveAuthentication("alice", "").should().respond(404);
+    }
+
+    @Test
+    public void test_async_search_poll_after_es_expiry_returns_404_and_cleans_up() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", twoUsersGrantedTo(es.getIndexName()))));
+        indexer.add(es.getIndexName(), DocumentBuilder.createDoc("doc-poll-3").build());
+
+        String id = submitAsyncSearchAs("alice", es.getIndexName());
+        // Drop it directly on ES, leaving the ownership record behind so the
+        // proxy's GET hits an ES 404 (the store-vs-ES divergence case).
+        indexer.executeRaw("DELETE", "_async_search/" + id, null);
+
+        get("/api/index/search/_async_search/" + urlEncode(id))
+                .withPreemptiveAuthentication("alice", "").should().respond(404);
+        assertThat(asyncSearchStore.get(id).isPresent()).isFalse();
+    }
+
     @Before
     public void setUp() {
         initMocks(this);

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -429,6 +429,33 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         assertThat(allowMethods).contains("GET").contains("DELETE");
     }
 
+    @Test
+    public void test_async_search_submit_records_both_projects_for_multi_index() throws IOException {
+        String idx1 = es.getIndexNames()[1];
+        String idx2 = es.getIndexNames()[2];
+        DatashareUser user = new DatashareUser(new HashMap<>() {{
+            put("uid", "cecile");
+            put("groups_by_applications", Map.of("datashare", List.of(idx1, idx2)));
+        }});
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser(user))));
+        indexer.add(idx1, DocumentBuilder.createDoc("doc-multi-1").build());
+        indexer.add(idx2, DocumentBuilder.createDoc("doc-multi-2").build());
+
+        Response response = post(
+                "/api/index/search/%s,%s/_async_search?wait_for_completion_timeout=0&keep_on_completion=true&keep_alive=5m".formatted(idx1, idx2),
+                "{\"query\":{\"match_all\":{}}}")
+                .withPreemptiveAuthentication("cecile", "").response();
+        String id = JsonObjectMapper.getMapper().readTree(response.content()).get("id").asText();
+
+        assertThat(asyncSearchStore.get(id).isPresent()).isTrue();
+        assertThat(asyncSearchStore.get(id).get().projects).containsExactly(idx1, idx2);
+
+        // owner can poll the multi-index async search
+        get("/api/index/search/_async_search/" + urlEncode(id))
+                .withPreemptiveAuthentication("cecile", "").should().respond(200).contain("\"is_running\"");
+    }
+
     @Before
     public void setUp() {
         initMocks(this);


### PR DESCRIPTION
Searches that fan out across many project indices can take long enough that the gateway in front of Datashare times out before Elasticsearch answers. This adds backend support for Elasticsearch async search so the frontend can stop waiting on a single blocking request: it can submit a search, poll it while it runs, and cancel it when the user moves on. This hides the latency, it does not reduce it. This is part of icij/datashare#2153.

Async searches go through the existing search proxy. Each one is tied to the user who submitted it, so only that user can poll or cancel it, and the result's lifetime in Elasticsearch is kept in step with the backend so it does not linger after the search is finished.

## Changes

- feat: support Elasticsearch async search (submit, poll, cancel) through the index proxy
- feat: bind each async search to the user who submitted it, and authorize poll and cancel per user
- feat: keep async ownership in memory for local mode and in Redis for server modes
- feat: keep the Elasticsearch result lifetime aligned with the backend on submit
- refactor: tidy the index resource
- test: cover the async search flows and the ownership store
