### PR TITLE
fix: resolve 403 for published batch searches viewed by non-owners

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
@@ -2,21 +2,15 @@ package org.icij.datashare.tasks;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import net.codestory.http.errors.ForbiddenException;
 import org.icij.datashare.Entity;
-import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.asynctasks.TaskFilters;
-import org.icij.datashare.asynctasks.TaskManager;
-import org.icij.datashare.asynctasks.TaskResult;
-import org.icij.datashare.asynctasks.UnknownTask;
+import org.icij.datashare.asynctasks.*;
 import org.icij.datashare.batch.BatchSearchRecord;
 import org.icij.datashare.batch.BatchSearchRepository;
 import org.icij.datashare.user.User;
 
 import java.io.IOException;
-import java.util.EnumMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
@@ -91,7 +85,9 @@ public class TaskFinder {
      */
     public Task<?> findVisibleTaskFor(User user, String id) throws IOException {
         try {
-            return taskManager.getTask(id);
+            Task<?> task = taskManager.getTask(id);
+            if (!Objects.equals(task.getUser(), user)) throw new ForbiddenException();
+            return task;
         } catch (UnknownTask e) {
             return batchSearchRepository.getRecords(user, user.getProjectNames())
                     .stream()

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
@@ -81,6 +81,7 @@ public class TaskFinder {
      * @param id   the task id
      * @return the task, either from the task repository or converted from a batch search record
      * @throws UnknownTask if no task or batch search record matches the given id
+     * @throws net.codestory.http.errors.ForbiddenException if a managed task exists but the user has no access to it
      * @throws IOException if an I/O error occurs while fetching batch search records
      */
     public Task<?> findVisibleTaskFor(User user, String id) throws IOException {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
@@ -84,18 +84,20 @@ public class TaskFinder {
      * @throws IOException if an I/O error occurs while fetching batch search records
      */
     public Task<?> findVisibleTaskFor(User user, String id) throws IOException {
+        boolean foundInManager = false;
         try {
             Task<?> task = taskManager.getTask(id);
-            if (!Objects.equals(task.getUser(), user)) throw new ForbiddenException();
-            return task;
-        } catch (UnknownTask e) {
-            return batchSearchRepository.getRecords(user, user.getProjectNames())
-                    .stream()
-                    .filter(r -> r.uuid.equals(id))
-                    .findFirst()
-                    .map(TaskFinder::taskify)
-                    .orElseThrow(() -> new UnknownTask(id));
+            if (Objects.equals(task.getUser(), user)) return task;
+            foundInManager = true;
+        } catch (UnknownTask ignored) {
+            // not in task manager, fall through to batch search check
         }
+        Optional<BatchSearchRecord> record = batchSearchRepository.getRecords(user, user.getProjectNames())
+                .stream()
+                .filter(r -> r.uuid.equals(id))
+                .findFirst();
+        if (record.isPresent()) return taskify(record.get());
+        throw foundInManager ? new ForbiddenException() : new UnknownTask(id);
     }
 
     private static Task<Integer> taskify(BatchSearchRecord batchSearchRecord) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/TaskFinder.java
@@ -84,20 +84,23 @@ public class TaskFinder {
      * @throws IOException if an I/O error occurs while fetching batch search records
      */
     public Task<?> findVisibleTaskFor(User user, String id) throws IOException {
-        boolean foundInManager = false;
-        try {
-            Task<?> task = taskManager.getTask(id);
-            if (Objects.equals(task.getUser(), user)) return task;
-            foundInManager = true;
-        } catch (UnknownTask ignored) {
-            // not in task manager, fall through to batch search check
+        Optional<Task<?>> managed = getTaskFromManager(id);
+        if (managed.filter(t -> Objects.equals(t.getUser(), user)).isPresent()) {
+            return managed.get();
         }
-        Optional<BatchSearchRecord> record = batchSearchRepository.getRecords(user, user.getProjectNames())
-                .stream()
+        return batchSearchRepository.getRecords(user, user.getProjectNames()).stream()
                 .filter(r -> r.uuid.equals(id))
-                .findFirst();
-        if (record.isPresent()) return taskify(record.get());
-        throw foundInManager ? new ForbiddenException() : new UnknownTask(id);
+                .findFirst()
+                .map(TaskFinder::taskify)
+                .orElseThrow(() -> managed.isPresent() ? new ForbiddenException() : new UnknownTask(id));
+    }
+
+    private Optional<Task<?>> getTaskFromManager(String id) throws IOException {
+        try {
+            return Optional.of(taskManager.getTask(id));
+        } catch (UnknownTask e) {
+            return Optional.empty();
+        }
     }
 
     private static Task<Integer> taskify(BatchSearchRecord batchSearchRecord) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -143,7 +143,7 @@ public class TaskResource {
     @ApiResponse(responseCode = "404", description = "returns 404 if the task doesn't exist")
     @Get("/:id")
     public Task<?> getTask(@Parameter(name = "id", description = "task id", in = ParameterIn.PATH) String id, Context context) throws IOException {
-        return forbiddenIfNotSameUser(context, notFoundIfUnknown(() -> taskFinder.findVisibleTaskFor((User) context.currentUser(), id)));
+        return notFoundIfUnknown(() -> taskFinder.findVisibleTaskFor((User) context.currentUser(), id));
     }
 
     @Operation(description = "Create a task with JSON body",

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -173,7 +173,7 @@ public class TaskResource {
     @ApiResponse(responseCode = "404", description = "returns 404 if the task doesn't exist")
     @Get("/:id/result")
     public Payload getTaskResult(@Parameter(name = "id", description = "task id", in = ParameterIn.PATH) String id, Context context) throws IOException {
-        Task<?> task = forbiddenIfNotSameUser(context, notFoundIfUnknown(() -> taskManager.getTask(id)));
+        Task<?> task = notFoundIfUnknown(() -> taskFinder.findVisibleTaskFor((User) context.currentUser(), id));
         Object result = ofNullable(task.getResult()).map(TaskResult::value).orElse(null);
         if (result instanceof DownloadableResult downloadableResult) {
             Path filePath = Path.of(downloadableResult.getUri().getPath());

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -169,7 +169,7 @@ public class TaskResource {
     @Operation(description = "Gets task result with its id")
     @ApiResponse(responseCode = "200", description = "returns 200 and the result")
     @ApiResponse(responseCode = "204", description = "returns 204 if there is no result")
-    @ApiResponse(responseCode = "403", description = "returns 403 if the task is not belonging to current user")
+    @ApiResponse(responseCode = "403", description = "returns 403 if the task belongs to another user and is not a published batch search")
     @ApiResponse(responseCode = "404", description = "returns 404 if the task doesn't exist")
     @Get("/:id/result")
     public Payload getTaskResult(@Parameter(name = "id", description = "task id", in = ParameterIn.PATH) String id, Context context) throws IOException {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskFinderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskFinderTest.java
@@ -9,6 +9,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import net.codestory.http.errors.ForbiddenException;
+import org.icij.datashare.asynctasks.UnknownTask;
+
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
@@ -154,6 +157,52 @@ public class TaskFinderTest {
         List<Task<?>> tasks = taskFinder.findVisibleTasksFor(user, TaskFilters.empty()).toList();
         assertThat(tasks).hasSize(1);
         assertThat(tasks.get(0).name).isEqualTo("name");
+    }
+
+    @Test
+    public void test_find_visible_task_for_owner() throws IOException {
+        User user = User.local();
+        Task<String> task = new Task<>("name", user, new HashMap<>());
+        taskManager.startTask(task, null);
+
+        assertThat(taskFinder.findVisibleTaskFor(user, task.id)).isEqualTo(task);
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void test_find_visible_task_for_non_owner_without_batch_search() throws IOException {
+        User owner = User.localUser("owner");
+        User other = User.localUser("other");
+        Task<String> task = new Task<>("name", owner, new HashMap<>());
+        taskManager.startTask(task, null);
+        when(batchSearchRepository.getRecords(eq(other), anyList())).thenReturn(List.of());
+
+        taskFinder.findVisibleTaskFor(other, task.id);
+    }
+
+    @Test
+    public void test_find_visible_task_for_published_batch_search_in_task_manager() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User owner = User.localUser("owner");
+        User member = User.localUser("member");
+        List<String> projects = List.of("project");
+        BatchSearchRecord publishedRecord = new BatchSearchRecord(
+                UUID.randomUUID().toString(), projects, "name", "description",
+                123, 0, new Date(), BatchSearchRecord.State.RUNNING, uri, owner, 0, true, null, null);
+        // Simulate the batch search task is also live in the task manager (owned by owner)
+        Task<Integer> liveTask = new Task<>(publishedRecord.uuid, "org.icij.datashare.tasks.BatchSearchRunnerProxy", owner, new HashMap<>());
+        taskManager.startTask(liveTask, null);
+        // member belongs to the project, so getRecords returns the published batch search
+        when(batchSearchRepository.getRecords(eq(member), anyList())).thenReturn(List.of(publishedRecord));
+
+        Task<?> result = taskFinder.findVisibleTaskFor(member, publishedRecord.uuid);
+        assertThat(result.id).isEqualTo(publishedRecord.uuid);
+        assertThat(result.getUser()).isEqualTo(owner);
+    }
+
+    @Test(expected = UnknownTask.class)
+    public void test_find_visible_task_for_unknown_id() throws IOException {
+        when(batchSearchRepository.getRecords(any(), anyList())).thenReturn(List.of());
+        taskFinder.findVisibleTaskFor(User.local(), "nonexistent-id");
     }
 
     @After

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskFinderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskFinderTest.java
@@ -200,6 +200,21 @@ public class TaskFinderTest {
     }
 
     @Test(expected = UnknownTask.class)
+    public void test_find_visible_task_for_non_published_batch_search_owned_by_different_user() throws IOException {
+        String uri = "/?q=&from=0&size=25&sort=relevance&indices=test&field=all";
+        User owner = User.localUser("owner");
+        User member = User.localUser("member");
+        List<String> projects = List.of("project");
+        BatchSearchRecord nonPublishedRecord = new BatchSearchRecord(
+                UUID.randomUUID().toString(), projects, "name", "description",
+                123, 0, new Date(), BatchSearchRecord.State.SUCCESS, uri, owner, 0, false, null, null);
+        // getRecords returns empty for member because the record is not published (SQL filter)
+        when(batchSearchRepository.getRecords(eq(member), anyList())).thenReturn(List.of());
+
+        taskFinder.findVisibleTaskFor(member, nonPublishedRecord.uuid);
+    }
+
+    @Test(expected = UnknownTask.class)
     public void test_find_visible_task_for_unknown_id() throws IOException {
         when(batchSearchRepository.getRecords(any(), anyList())).thenReturn(List.of());
         taskFinder.findVisibleTaskFor(User.local(), "nonexistent-id");

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -125,6 +125,16 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_get_task_result_for_published_batch_search_owned_by_different_user() {
+        BatchSearchRecord publishedRecord = new BatchSearchRecord(
+                UUID.randomUUID().toString(), List.of("project"), "name", "description",
+                123, 123, new Date(), BatchSearchRecord.State.SUCCESS, "/",
+                User.localUser("differentUser"), 0, true, null, null);
+        when(batchSearchRepository.getRecords(any(), any())).thenReturn(List.of(publishedRecord));
+        get("/api/task/" + publishedRecord.uuid + "/result").should().respond(200);
+    }
+
+    @Test
     public void test_get_tasks_with_correct_id() throws IOException {
         String dummyTaskId = taskManager.startTask(TestSleepingTask.class, User.local(), new HashMap<>());
         get("/api/task").should()

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -125,6 +125,13 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_get_task_result_with_different_user() throws IOException {
+        String taskIdOfOtherUser = taskManager.startTask(TestSleepingTask.class, User.localUser("differentUser"), new HashMap<>());
+        taskManager.stopTask(taskIdOfOtherUser);
+        get("/api/task/" + taskIdOfOtherUser + "/result").should().respond(403);
+    }
+
+    @Test
     public void test_get_task_result_for_published_batch_search_owned_by_different_user() {
         BatchSearchRecord publishedRecord = new BatchSearchRecord(
                 UUID.randomUUID().toString(), List.of("project"), "name", "description",

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -12,7 +12,6 @@ import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskManagerMemory;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
-import java.util.concurrent.CountDownLatch;
 import org.icij.datashare.asynctasks.bus.amqp.TaskCreation;
 import org.icij.datashare.batch.BatchSearchRecord;
 import org.icij.datashare.batch.BatchSearchRepository;
@@ -43,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -112,6 +112,16 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         taskManager.stopTask(taskIdOfOtherUser);
         // The test setup will make the request come from local user different from "differentUser"
         get("/api/task/"+taskIdOfOtherUser).should().respond(403);
+    }
+
+    @Test
+    public void test_get_task_for_published_batch_search_owned_by_different_user() {
+        BatchSearchRecord publishedRecord = new BatchSearchRecord(
+                UUID.randomUUID().toString(), List.of("project"), "name", "description",
+                123, 123, new Date(), BatchSearchRecord.State.SUCCESS, "/",
+                User.localUser("differentUser"), 0, true, null, null);
+        when(batchSearchRepository.getRecords(any(), any())).thenReturn(List.of(publishedRecord));
+        get("/api/task/" + publishedRecord.uuid).should().respond(200);
     }
 
     @Test


### PR DESCRIPTION
Related to https://github.com/ICIJ/datashare/issues/2157

## Summary

- Fix 403 error when a project member views a published batch search they did not create
- The ownership check in `findVisibleTaskFor` was short-circuiting before the batch search repository fallback, which is the only place published batch searches are resolved
- Refactor `findVisibleTaskFor` to use an `Optional`-based pipeline, eliminating a boolean flag

## Root cause

`findVisibleTaskFor` first looks up the task in the task manager, then falls back to `batchSearchRepository.getRecords` for batch searches. The previous fix added an ownership check after the task manager lookup but threw `ForbiddenException` immediately when the user was not the owner — before the repository fallback could check whether the batch search was published and accessible to the user.

## Changes

- **`TaskFinder.findVisibleTaskFor`**: when the task is found in the manager but the user is not the owner, fall through to the repository check instead of throwing. Throw 403 only if the repo check also fails; throw 404 if the task was never in the manager.
- **`TaskFinder.getTaskFromManager`**: new private helper wrapping the `try/catch` as `Optional<Task<?>>`, making the main method read as a clean pipeline.
- **`TaskFinderTest`**: 4 new cases — owner access, non-owner without a batch search record (403), non-owner with a live published batch search in the task manager (the bug scenario), unknown id (404).


Result for a batch search owned by "bar" (not current user): 
- batch search name is loaded, 
- the batch search card is loaded, 
- no 403 error:

<img width="1279" height="760" alt="image" src="https://github.com/user-attachments/assets/6c30a9a5-b7ce-4596-9968-c5d2c13542c5" />
