### PR TITLE
fix(security): prevent zip slip and zip bomb in plugin archive extraction

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/Plugin.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Plugin.java
@@ -10,7 +10,6 @@ import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.net.URL;
@@ -27,6 +26,9 @@ import static org.apache.commons.io.FilenameUtils.getExtension;
 
 public class Plugin extends Extension {
     private static final Pattern versionBeginsWithV = Pattern.compile("v[0-9.]*");
+    private static final int  MAX_ENTRY_COUNT = 10_000;
+    private static final long MAX_ENTRY_SIZE  = 100L * 1024 * 1024;  // 100 MB per entry
+    private static final long MAX_TOTAL_SIZE  = 1024L * 1024 * 1024; // 1 GB total
     public final List<String> extensions;
 
     @JsonCreator
@@ -87,6 +89,10 @@ public class Plugin extends Extension {
         }
         logger.info("installing plugin from file {} into {}", pluginFile, pluginsDir);
 
+        Path canonicalPluginsDir = pluginsDir.toAbsolutePath().normalize();
+        long totalExtractedSize = 0;
+        int entryCount = 0;
+
         InputStream is = new BufferedInputStream(new FileInputStream(pluginFile));
         if (pluginFile.getName().endsWith("gz")) {
             is = new BufferedInputStream(new GZIPInputStream(is));
@@ -94,17 +100,25 @@ public class Plugin extends Extension {
         try (ArchiveInputStream zippedArchiveInputStream = new ArchiveStreamFactory().createArchiveInputStream(is)) {
             ArchiveEntry entry;
             while ((entry = zippedArchiveInputStream.getNextEntry()) != null) {
-                final File outputFile = new File(pluginsDir.toFile(), entry.getName());
+                if (++entryCount > MAX_ENTRY_COUNT) {
+                    throw new IOException("Archive contains too many entries (limit: " + MAX_ENTRY_COUNT + ")");
+                }
+                Path resolvedPath = canonicalPluginsDir.resolve(entry.getName()).normalize();
+                if (!resolvedPath.startsWith(canonicalPluginsDir)) {
+                    throw new IOException("Archive entry escapes target directory: " + entry.getName());
+                }
+                final File outputFile = resolvedPath.toFile();
                 if (entry.isDirectory()) {
-                    if (!outputFile.exists()) {
-                        if (!outputFile.mkdirs()) {
-                            throw new IllegalStateException(String.format("Couldn't create directory %s.", outputFile.getAbsolutePath()));
-                        }
+                    if (!outputFile.exists() && !outputFile.mkdirs()) {
+                        throw new IllegalStateException("Couldn't create directory " + outputFile.getAbsolutePath());
                     }
                 } else {
-                    final OutputStream outputFileStream = new FileOutputStream(outputFile);
-                    IOUtils.copy(zippedArchiveInputStream, outputFileStream);
-                    outputFileStream.close();
+                    try (OutputStream outputFileStream = new FileOutputStream(outputFile)) {
+                        totalExtractedSize += copyBounded(zippedArchiveInputStream, outputFileStream, MAX_ENTRY_SIZE);
+                    }
+                    if (totalExtractedSize > MAX_TOTAL_SIZE) {
+                        throw new IOException("Archive total extracted size exceeds limit (" + MAX_TOTAL_SIZE + " bytes)");
+                    }
                 }
             }
         } catch (ArchiveException e) {
@@ -126,5 +140,19 @@ public class Plugin extends Extension {
 
     protected boolean isHostSpecific() {
         return false;
+    }
+
+    private long copyBounded(InputStream in, OutputStream out, long maxBytes) throws IOException {
+        byte[] buf = new byte[8192];
+        long total = 0;
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            total += n;
+            if (total > maxBytes) {
+                throw new IOException("Archive entry exceeds size limit (" + maxBytes + " bytes)");
+            }
+            out.write(buf, 0, n);
+        }
+        return total;
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/PluginServiceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/PluginServiceTest.java
@@ -1,6 +1,10 @@
 package org.icij.datashare;
 
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -8,6 +12,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -327,6 +332,55 @@ public class PluginServiceTest {
         // Then
         assertThat(extensionDir.toPath().resolve("my-extension-1.0.1.jar").toFile()).exists();
         assertThat(pluginFolder.getRoot().toPath().resolve("my-plugin-1.1.0").toFile()).exists();
+    }
+
+    @Test(expected = IOException.class)
+    public void test_install_rejects_zip_slip_entry() throws Exception {
+        File maliciousZip = pluginFolder.newFile("malicious.zip");
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(maliciousZip)) {
+            ZipArchiveEntry entry = new ZipArchiveEntry("../../evil.txt");
+            zos.putArchiveEntry(entry);
+            zos.write("pwned".getBytes());
+            zos.closeArchiveEntry();
+        }
+        new Plugin(maliciousZip.toURI().toURL())
+                .install(maliciousZip, pluginFolder.getRoot().toPath());
+    }
+
+    @Test(expected = IOException.class)
+    public void test_install_rejects_too_many_entries() throws Exception {
+        File bomb = pluginFolder.newFile("bomb.zip");
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(bomb)) {
+            for (int i = 0; i <= 10_001; i++) {
+                ZipArchiveEntry entry = new ZipArchiveEntry("file" + i + ".txt");
+                zos.putArchiveEntry(entry);
+                zos.write(new byte[0]);
+                zos.closeArchiveEntry();
+            }
+        }
+        new Plugin(bomb.toURI().toURL())
+                .install(bomb, pluginFolder.getRoot().toPath());
+    }
+
+    @Test(expected = IOException.class)
+    public void test_install_rejects_oversized_entry() throws Exception {
+        File bomb = pluginFolder.newFile("bomb.tar");
+        try (TarArchiveOutputStream tos = new TarArchiveOutputStream(new FileOutputStream(bomb))) {
+            long size = 101L * 1024 * 1024; // just over 100 MB
+            TarArchiveEntry entry = new TarArchiveEntry("huge.bin");
+            entry.setSize(size);
+            tos.putArchiveEntry(entry);
+            byte[] chunk = new byte[8192];
+            long written = 0;
+            while (written < size) {
+                int len = (int) Math.min(chunk.length, size - written);
+                tos.write(chunk, 0, len);
+                written += len;
+            }
+            tos.closeArchiveEntry();
+        }
+        new Plugin(bomb.toURI().toURL())
+                .install(bomb, pluginFolder.getRoot().toPath());
     }
 
 }


### PR DESCRIPTION
The install() method accepts arbitrary archive files (including local installs bypassing the registry), so hardening extraction is appropriate regardless of the distribution channel.

Currently not a risk since all plugins are developped by ICIJ and hosted on our Github + listed in `plugins.json` but can secure plugins install from external sources
 
## Summary
Fixes two security vulnerabilities in the plugin archive extraction logic (Plugin.java):
- Zip Slip - archive entries with path traversal sequences (e.g. ../../evil.txt) could write files outside the intended plugins directory. The fix resolves and normalizes each entry path against the canonical destination directory, rejecting any entry that escapes it.
- Zip Bomb - a maliciously crafted archive with a huge number of entries or entries that decompress to a very large size could exhaust disk space or memory. The fix enforces three limits:
  * Max 10,000 entries per archive
  * Max 100 MB per individual entry
  * Max 1 GB total extracted size

+ the file-copy loop now uses a bounded helper (`copyBounded`) instead of `IOUtils.copy`, which streams data through a fixed buffer while tracking the running total - giving early failure rather than exhausting resources.

## Changes
- `Plugin.java`: 
  * path traversal check using `Path.normalize() + startsWith()`
  * entry/size counters with configurable constants; `copyBounded` helper replacing `IOUtils.copy`
  * resources closed via try-with-resources

- `PluginServiceTest.java`: three new tests covering zip slip, too-many-entries, and oversized-entry cases

## Testing
- `test_install_rejects_zip_slip_entry -verifies` a `../../`-prefixed entry throws `IOException`
- `test_install_rejects_too_many_entries` - verifies an archive with >10,000 entries throws `IOException`
- `test_install_rejects_oversized_entry` - verifies a single entry >100 MB throws `IOException`