### PR TITLE
Add jackson annotation to serialize BatchSearchRunnerResult correctly

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunnerResult.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunnerResult.java
@@ -1,11 +1,13 @@
 package org.icij.datashare.tasks;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.io.Serializable;
 
 @JsonTypeName("BatchSearchRunnerResult")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@type")
 public record BatchSearchRunnerResult(int nbResults, int nbQueriesWithoutResults) implements Serializable {
     public BatchSearchRunnerResult(@JsonProperty("nbResults") int nbResults, @JsonProperty("nbQueriesWithoutResults") int nbQueriesWithoutResults) {
         this.nbResults = nbResults;

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerResultTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerResultTest.java
@@ -26,8 +26,7 @@ public class BatchSearchRunnerResultTest {
 
     @Test
     public void test_deserialize() throws IOException {
-        String json = "{\"nbResults\":10,\"nbQueriesWithoutResults\":5}";
-
+        String json = "{\"@type\":\"org.icij.datashare.tasks.BatchSearchRunnerResult\",\"nbResults\":10,\"nbQueriesWithoutResults\":5}";
         assertThat(JsonObjectMapper.readValueTyped(json, BatchSearchRunnerResult.class)).isEqualTo(new BatchSearchRunnerResult(10, 5));
     }
 


### PR DESCRIPTION
It was previously missing the annotation so that it can be deserialized when reading the taskRepository