### PR TITLE
feat: auth mode enum

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -169,6 +169,8 @@ Standard server mode using OAuth (e.g., Keycloak). This is the recommended setup
 
 Basic authentication is intended for testing or constrained environments.
 
+> The authentication method is selected with `--auth` (`oauth` is the default; other values: `form`, `basic`, `yesCookie`, `yesBasic`). The older `--authFilter=<class-name>` option is deprecated and kept only for custom filter classes.
+
 **Basic Auth with Redis:**
 
 See: [Basic with Redis documentation](https://icij.gitbook.io/datashare/server-mode/authentication-providers/basic-with-redis)
@@ -176,7 +178,7 @@ See: [Basic with Redis documentation](https://icij.gitbook.io/datashare/server-m
 ```sh
 ./run.sh \
   --mode SERVER \
-  --authFilter org.icij.datashare.session.BasicAuthAdaptorFilter \
+  --auth basic \
   --redisAddress redis://redis:6379
 ```
 
@@ -187,7 +189,7 @@ See: [Basic with Database documentation](https://icij.gitbook.io/datashare/serve
 ```sh
 ./run.sh \
   --mode SERVER \
-  --authFilter org.icij.datashare.session.BasicAuthAdaptorFilter \
+  --auth basic \
   --authUsersProvider org.icij.datashare.session.UsersInDb \
   --dataSourceUrl "jdbc:postgresql://postgres/datashare?user=dstest&password=test"
 ```

--- a/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
@@ -21,6 +21,8 @@ import org.icij.datashare.web.*;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.icij.datashare.cli.DatashareCliOptions.AUTH_FILTER_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.AUTH_MODE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.SESSION_STORE_TYPE_OPT;
 
 public class ServerMode extends CommonMode {
@@ -37,22 +39,7 @@ public class ServerMode extends CommonMode {
             bind(SessionIdStore.class).to(RedisSessionIdStore.class);
         }
         bind(ApiKeyStore.class).to(ApiKeyStoreAdapter.class);
-        String authFilterClassName = propertiesProvider.get("authFilter").orElse("");
-        Class<? extends Filter> authFilterClass = OAuth2CookieFilter.class;
-        if (!authFilterClassName.isEmpty()) {
-            try {
-                authFilterClass = (Class<? extends Filter>) Class.forName(authFilterClassName, true, ClassLoader.getSystemClassLoader());
-                logger.info("setting auth filter to {}", authFilterClass);
-            } catch (ClassNotFoundException e) {
-                logger.warn("\"{}\" auth filter class not found. Setting filter to {}", authFilterClassName, authFilterClass);
-            }
-        }
-        bind(Filter.class).to(authFilterClass);
-        if (BasicAuthFilter.class.isAssignableFrom(authFilterClass)) {
-            bind(ApiKeyFilter.class).toInstance(getDummyApiKeyFilter());
-        } else if (authFilterClass.equals(YesCookieAuthFilter.class)) {
-            bind(YesCookieAuthFilter.class).toInstance(getYesCookieAuthFilter());
-        }
+        bindAuthFilter(resolveAuthFilterClass());
         bind(StatusResource.class).asEagerSingleton();
         configurePersistence();
     }
@@ -65,6 +52,38 @@ public class ServerMode extends CommonMode {
             case YES_COOKIE: return YesCookieAuthFilter.class;
             case YES_BASIC:  return YesBasicAuthFilter.class;
             default:         throw new IllegalStateException("Unhandled auth mode: " + mode);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    Class<? extends Filter> resolveAuthFilterClass() {
+        String authMode = propertiesProvider.get(AUTH_MODE_OPT).orElse("");
+        String authFilterClassName = propertiesProvider.get(AUTH_FILTER_OPT).orElse("");
+        if (!authMode.isEmpty()) {
+            if (!authFilterClassName.isEmpty()) {
+                logger.warn("--authFilter is deprecated and ignored because --auth is set");
+            }
+            return filterClassFor(AuthMode.fromString(authMode));
+        }
+        if (!authFilterClassName.isEmpty()) {
+            logger.warn("--authFilter is deprecated; prefer --auth (oauth, form, basic, yesCookie, yesBasic)");
+            try {
+                return (Class<? extends Filter>) Class.forName(authFilterClassName, true, ClassLoader.getSystemClassLoader());
+            } catch (ClassNotFoundException e) {
+                logger.warn("\"{}\" auth filter class not found. Using default {}", authFilterClassName, OAuth2CookieFilter.class);
+                return OAuth2CookieFilter.class;
+            }
+        }
+        return filterClassFor(AuthMode.OAUTH);
+    }
+
+    void bindAuthFilter(Class<? extends Filter> authFilterClass) {
+        logger.info("setting auth filter to {}", authFilterClass);
+        bind(Filter.class).to(authFilterClass);
+        if (BasicAuthFilter.class.isAssignableFrom(authFilterClass)) {
+            bind(ApiKeyFilter.class).toInstance(getDummyApiKeyFilter());
+        } else if (authFilterClass.equals(YesCookieAuthFilter.class)) {
+            bind(YesCookieAuthFilter.class).toInstance(getYesCookieAuthFilter());
         }
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
@@ -7,6 +7,7 @@ import net.codestory.http.filters.basic.BasicAuthFilter;
 import net.codestory.http.payload.Payload;
 import net.codestory.http.routes.Routes;
 import net.codestory.http.security.SessionIdStore;
+import org.icij.datashare.cli.AuthMode;
 import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.db.RepositoryFactoryImpl;
@@ -54,6 +55,17 @@ public class ServerMode extends CommonMode {
         }
         bind(StatusResource.class).asEagerSingleton();
         configurePersistence();
+    }
+
+    static Class<? extends Filter> filterClassFor(AuthMode mode) {
+        switch (mode) {
+            case OAUTH:      return OAuth2CookieFilter.class;
+            case FORM:       return FormAuthFilter.class;
+            case BASIC:      return BasicAuthAdaptorFilter.class;
+            case YES_COOKIE: return YesCookieAuthFilter.class;
+            case YES_BASIC:  return YesBasicAuthFilter.class;
+            default:         throw new IllegalStateException("Unhandled auth mode: " + mode);
+        }
     }
 
     protected ApiKeyFilter getDummyApiKeyFilter() {

--- a/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
@@ -93,14 +93,6 @@ public class ServerModeTest {
     }
 
     @Test
-    public void test_auth_mode_default_is_oauth_when_nothing_set() {
-        CommonMode mode = CommonMode.create(new HashMap<>() {{
-            put("mode", "SERVER");
-        }});
-        assertThat(mode.get(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
-    }
-
-    @Test
     public void test_auth_mode_wins_over_deprecated_auth_filter() {
         CommonMode mode = CommonMode.create(new HashMap<>() {{
             put("mode", "SERVER");
@@ -117,5 +109,23 @@ public class ServerModeTest {
             put("authFilter", "org.icij.datashare.session.BasicAuthAdaptorFilter");
         }});
         assertThat(mode.get(Filter.class)).isInstanceOf(BasicAuthAdaptorFilter.class);
+    }
+
+    @Test
+    public void test_invalid_auth_value_fails_fast() {
+        // An unknown `auth` value (this programmatic path bypasses the picocli converter)
+        // must make SERVER mode creation fail rather than silently falling back to a default.
+        // AuthMode.fromString throws IllegalArgumentException("Unknown auth mode: ...") inside
+        // ServerMode.configure(); Guice aborts injector creation and propagates a Throwable.
+        Throwable thrown = null;
+        try {
+            CommonMode.create(new HashMap<>() {{
+                put("mode", "SERVER");
+                put("auth", "garbage");
+            }});
+        } catch (Throwable t) {
+            thrown = t;
+        }
+        assertThat(thrown).isNotNull();
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
@@ -2,6 +2,7 @@ package org.icij.datashare.mode;
 
 import net.codestory.http.filters.Filter;
 import net.codestory.http.security.SessionIdStore;
+import org.icij.datashare.cli.AuthMode;
 import org.icij.datashare.cli.QueueType;
 import org.icij.datashare.session.*;
 import org.junit.Test;
@@ -53,6 +54,15 @@ public class ServerModeTest {
             put("sessionStoreType", QueueType.REDIS.name());
         }});
         assertThat(mode.get(SessionIdStore.class)).isInstanceOf(RedisSessionIdStore.class);
+    }
+
+    @Test
+    public void test_filter_class_for_maps_every_auth_mode() {
+        assertThat(ServerMode.filterClassFor(AuthMode.OAUTH)).isEqualTo(OAuth2CookieFilter.class);
+        assertThat(ServerMode.filterClassFor(AuthMode.FORM)).isEqualTo(FormAuthFilter.class);
+        assertThat(ServerMode.filterClassFor(AuthMode.BASIC)).isEqualTo(BasicAuthAdaptorFilter.class);
+        assertThat(ServerMode.filterClassFor(AuthMode.YES_COOKIE)).isEqualTo(YesCookieAuthFilter.class);
+        assertThat(ServerMode.filterClassFor(AuthMode.YES_BASIC)).isEqualTo(YesBasicAuthFilter.class);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
@@ -73,4 +73,49 @@ public class ServerModeTest {
         }});
         assertThat(mode.get(SessionIdStore.class)).isInstanceOf(net.codestory.http.security.SessionIdStore.inMemory().getClass());
     }
+
+    @Test
+    public void test_auth_mode_form() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
+            put("auth", "form");
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(FormAuthFilter.class);
+    }
+
+    @Test
+    public void test_auth_mode_basic() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
+            put("auth", "basic");
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(BasicAuthAdaptorFilter.class);
+    }
+
+    @Test
+    public void test_auth_mode_default_is_oauth_when_nothing_set() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
+    }
+
+    @Test
+    public void test_auth_mode_wins_over_deprecated_auth_filter() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
+            put("auth", "form");
+            put("authFilter", "org.icij.datashare.session.BasicAuthAdaptorFilter");
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(FormAuthFilter.class);
+    }
+
+    @Test
+    public void test_legacy_auth_filter_still_resolves() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", "SERVER");
+            put("authFilter", "org.icij.datashare.session.BasicAuthAdaptorFilter");
+        }});
+        assertThat(mode.get(Filter.class)).isInstanceOf(BasicAuthAdaptorFilter.class);
+    }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/AuthMode.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/AuthMode.java
@@ -29,6 +29,9 @@ public enum AuthMode {
     }
 
     public static AuthMode fromString(String s) {
+        if (s == null) {
+            throw new IllegalArgumentException("Auth mode must not be null");
+        }
         String normalized = normalize(s);
         for (AuthMode v : values()) {
             if (normalize(v.cliName).equals(normalized)) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/AuthMode.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/AuthMode.java
@@ -1,0 +1,57 @@
+package org.icij.datashare.cli;
+
+import picocli.CommandLine.ITypeConverter;
+import picocli.CommandLine.TypeConversionException;
+
+/**
+ * Server authentication method, selected via the {@code --auth} option.
+ *
+ * <p>This enum is intentionally label-only: it carries no reference to the actual
+ * authentication {@code Filter} classes, which live in the downstream {@code datashare-app}
+ * module. The mapping from {@code AuthMode} to a concrete filter class is owned by
+ * {@code ServerMode}.</p>
+ */
+public enum AuthMode {
+    OAUTH("oauth"),
+    FORM("form"),
+    BASIC("basic"),
+    YES_COOKIE("yesCookie"),
+    YES_BASIC("yesBasic");
+
+    public final String cliName;
+
+    AuthMode(String cliName) {
+        this.cliName = cliName;
+    }
+
+    private static String normalize(String s) {
+        return s.toLowerCase().replaceAll("[_\\-]", "");
+    }
+
+    public static AuthMode fromString(String s) {
+        String normalized = normalize(s);
+        for (AuthMode v : values()) {
+            if (normalize(v.cliName).equals(normalized)) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unknown auth mode: " + s + " (valid: oauth, form, basic, yesCookie, yesBasic)");
+    }
+
+    @Override
+    public String toString() {
+        return cliName;
+    }
+
+    public static class PicocliConverter implements ITypeConverter<AuthMode> {
+        @Override
+        public AuthMode convert(String s) {
+            try {
+                return fromString(s);
+            } catch (IllegalArgumentException e) {
+                throw new TypeConversionException(e.getMessage());
+            }
+        }
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -29,6 +29,7 @@ import static org.icij.datashare.PropertiesProvider.*;
 
 public final class DatashareCliOptions {
     public static final String AUTH_FILTER_OPT = "authFilter";
+    public static final String AUTH_MODE_OPT = "auth";
     public static final String AUTH_USERS_PROVIDER_OPT = "authUsersProvider";
     public static final String BIND_HOST_ABBR_OPT = "b";
     public static final String BIND_HOST_OPT = "bind";

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.cli.command;
 
+import org.icij.datashare.cli.AuthMode;
 import org.icij.datashare.cli.QueueType;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -78,6 +79,10 @@ public class ServerOptions {
 
     @Option(names = {"--authFilter"}, description = "Auth filter class")
     String authFilter;
+
+    @Option(names = {"--auth"}, converter = AuthMode.PicocliConverter.class,
+            description = "Authentication method: oauth (default), form, basic, yesCookie, yesBasic. Preferred over the deprecated --authFilter.")
+    AuthMode auth;
 
     @Option(names = {"--sessionSigningKey"}, description = "HMAC key for session signing. Prefer passing via a settings file to avoid leaking into shell history.")
     String sessionSigningKey;
@@ -178,6 +183,9 @@ public class ServerOptions {
         DatashareOptions.putIfNotNull(props, OAUTH_SCOPE_OPT, oauthScope);
         DatashareOptions.putIfNotNull(props, OAUTH_CLAIM_ID_ATTRIBUTE_OPT, oauthClaimIdAttribute);
         DatashareOptions.putIfNotNull(props, AUTH_USERS_PROVIDER_OPT, authUsersProvider);
+        if (auth != null) {
+            DatashareOptions.put(props, AUTH_MODE_OPT, auth.cliName);
+        }
         DatashareOptions.putIfNotNull(props, AUTH_FILTER_OPT, authFilter);
         DatashareOptions.putIfNotNull(props, SESSION_SIGNING_KEY_OPT, sessionSigningKey);
         DatashareOptions.put(props, SESSION_TTL_SECONDS_OPT, sessionTtlSeconds);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
@@ -81,7 +81,7 @@ public class ServerOptions {
     String authFilter;
 
     @Option(names = {"--auth"}, converter = AuthMode.PicocliConverter.class,
-            description = "Authentication method: oauth (default), form, basic, yesCookie, yesBasic. Preferred over the deprecated --authFilter.")
+            description = "Authentication method (default: oauth when not set): form, basic, yesCookie, yesBasic. Preferred over the deprecated --authFilter.")
     AuthMode auth;
 
     @Option(names = {"--sessionSigningKey"}, description = "HMAC key for session signing. Prefer passing via a settings file to avoid leaking into shell history.")
@@ -183,6 +183,7 @@ public class ServerOptions {
         DatashareOptions.putIfNotNull(props, OAUTH_SCOPE_OPT, oauthScope);
         DatashareOptions.putIfNotNull(props, OAUTH_CLAIM_ID_ATTRIBUTE_OPT, oauthClaimIdAttribute);
         DatashareOptions.putIfNotNull(props, AUTH_USERS_PROVIDER_OPT, authUsersProvider);
+        // Use cliName ("yesCookie"), not the enum name() ("YES_COOKIE") that the generic putIfNotNull overload would write.
         if (auth != null) {
             DatashareOptions.put(props, AUTH_MODE_OPT, auth.cliName);
         }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
@@ -81,7 +81,7 @@ public class ServerOptions {
     String authFilter;
 
     @Option(names = {"--auth"}, converter = AuthMode.PicocliConverter.class,
-            description = "Authentication method (default: oauth when not set): form, basic, yesCookie, yesBasic. Preferred over the deprecated --authFilter.")
+            description = "Authentication method: oauth, form, basic, yesCookie, yesBasic (default: oauth when not set). Preferred over the deprecated --authFilter.")
     AuthMode auth;
 
     @Option(names = {"--sessionSigningKey"}, description = "HMAC key for session signing. Prefer passing via a settings file to avoid leaking into shell history.")

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/AuthModeTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/AuthModeTest.java
@@ -30,6 +30,11 @@ public class AuthModeTest {
     }
 
     @Test
+    public void test_from_string_null_throws() {
+        assertThrows(IllegalArgumentException.class, () -> AuthMode.fromString(null));
+    }
+
+    @Test
     public void test_to_string_returns_cli_name() {
         assertThat(AuthMode.YES_COOKIE.toString()).isEqualTo("yesCookie");
     }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/AuthModeTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/AuthModeTest.java
@@ -1,0 +1,46 @@
+package org.icij.datashare.cli;
+
+import org.junit.Test;
+import picocli.CommandLine.TypeConversionException;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class AuthModeTest {
+    @Test
+    public void test_from_string_exact_cli_names() {
+        assertThat(AuthMode.fromString("oauth")).isEqualTo(AuthMode.OAUTH);
+        assertThat(AuthMode.fromString("form")).isEqualTo(AuthMode.FORM);
+        assertThat(AuthMode.fromString("basic")).isEqualTo(AuthMode.BASIC);
+        assertThat(AuthMode.fromString("yesCookie")).isEqualTo(AuthMode.YES_COOKIE);
+        assertThat(AuthMode.fromString("yesBasic")).isEqualTo(AuthMode.YES_BASIC);
+    }
+
+    @Test
+    public void test_from_string_is_case_and_separator_insensitive() {
+        assertThat(AuthMode.fromString("OAUTH")).isEqualTo(AuthMode.OAUTH);
+        assertThat(AuthMode.fromString("yes-cookie")).isEqualTo(AuthMode.YES_COOKIE);
+        assertThat(AuthMode.fromString("YES_COOKIE")).isEqualTo(AuthMode.YES_COOKIE);
+        assertThat(AuthMode.fromString("yescookie")).isEqualTo(AuthMode.YES_COOKIE);
+    }
+
+    @Test
+    public void test_from_string_unknown_throws() {
+        assertThrows(IllegalArgumentException.class, () -> AuthMode.fromString("ldap"));
+    }
+
+    @Test
+    public void test_to_string_returns_cli_name() {
+        assertThat(AuthMode.YES_COOKIE.toString()).isEqualTo("yesCookie");
+    }
+
+    @Test
+    public void test_picocli_converter_success() {
+        assertThat(new AuthMode.PicocliConverter().convert("form")).isEqualTo(AuthMode.FORM);
+    }
+
+    @Test
+    public void test_picocli_converter_unknown_throws_type_conversion() {
+        assertThrows(TypeConversionException.class, () -> new AuthMode.PicocliConverter().convert("nope"));
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
@@ -312,6 +312,24 @@ public class DatashareCommandTest extends AbstractDatashareCommandTest {
     }
 
     @Test
+    public void test_auth_mode() {
+        Properties props = parse("app", "start", "--mode", "server", "--auth", "form");
+        assertThat(props).includes(entry("auth", "form"));
+    }
+
+    @Test
+    public void test_auth_mode_normalizes_value() {
+        Properties props = parse("app", "start", "--auth", "yes-cookie");
+        assertThat(props).includes(entry("auth", "yesCookie"));
+    }
+
+    @Test
+    public void test_auth_mode_absent_writes_no_property() {
+        Properties props = parse("app", "start");
+        assertThat(props.containsKey("auth")).isFalse();
+    }
+
+    @Test
     public void test_nlp_pipeline() {
         Properties props = parse("app", "start", "--nlpPipeline", "SPACY");
         assertThat(props).includes(entry("nlpPipeline", "SPACY"));


### PR DESCRIPTION
As described in #2088, the current way to change the authentification method in datashare is to add the option `--authFilter=org.icij.datashare.session.FormAuthFilter`. This PR use a new `--auth` param that use an enum for the different authentication filters. Currently we support:

* `oauth` - OAuth2 (the default)
* `form` - A HTML form for login (pulling users from database or Redis)
* `basic` - A basic HTTP prompt (pulling users from database or Redis)
* `yesCookie` - A transparent random session (for demo)
* `yesBasic` - A always-right basic HTTP prompt (for demo)