### PR TITLE
feat: auth users provider enum

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -169,7 +169,9 @@ Standard server mode using OAuth (e.g., Keycloak). This is the recommended setup
 
 Basic authentication is intended for testing or constrained environments.
 
-> The authentication method is selected with `--auth` (`oauth` is the default; other values: `form`, `basic`, `yesCookie`, `yesBasic`). The older `--authFilter=<class-name>` option is deprecated and kept only for custom filter classes.
+> The authentication method is selected with `--auth` (`form` is the default; other values: `oauth`, `basic`, `yesCookie`, `yesBasic`). The older `--authFilter=<class-name>` option is deprecated and kept only for custom filter classes.
+>
+> The users provider is selected with `--authUsersProvider` (`database` is the default; other value: `redis`). A fully-qualified class name is still accepted for custom providers.
 
 **Basic Auth with Redis:**
 
@@ -190,7 +192,7 @@ See: [Basic with Database documentation](https://icij.gitbook.io/datashare/serve
 ./run.sh \
   --mode SERVER \
   --auth basic \
-  --authUsersProvider org.icij.datashare.session.UsersInDb \
+  --authUsersProvider database \
   --dataSourceUrl "jdbc:postgresql://postgres/datashare?user=dstest&password=test"
 ```
 

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -40,7 +40,9 @@ import org.icij.datashare.user.admin.UserAdminServiceImpl;
 import org.icij.datashare.project.admin.ProjectAdminService;
 import org.icij.datashare.project.admin.ProjectAdminServiceImpl;
 import org.icij.datashare.session.StatusCidrFilter;
+import org.icij.datashare.cli.AuthUsersProvider;
 import org.icij.datashare.session.UsersInDb;
+import org.icij.datashare.session.UsersInRedis;
 import org.icij.datashare.session.UsersWritable;
 import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.tasks.TaskResultSubtypes;
@@ -72,6 +74,7 @@ import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -310,16 +313,34 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
 
     @Provides @Singleton
     UsersWritable provideUsersWritable(final PropertiesProvider propertiesProvider, final Injector injector) {
-        String authUsersProviderClassName = propertiesProvider.get("authUsersProvider").orElse(UsersInDb.class.getName());
-        Class<? extends UsersWritable> authUsersProviderClass;
-        try {
-            authUsersProviderClass = (Class<? extends UsersWritable>) Class.forName(authUsersProviderClassName, true, ClassLoader.getSystemClassLoader());
-            logger.info("setting auth users provider to {}", authUsersProviderClass);
-        } catch (ClassNotFoundException | ClassCastException e) {
-            logger.warn("\"{}\" auth users provider class not found or invalid. Setting provider to UsersInDb", authUsersProviderClassName);
-            authUsersProviderClass = UsersInDb.class;
+        return injector.getInstance(resolveUsersProviderClass());
+    }
+
+    static Class<? extends UsersWritable> classFor(AuthUsersProvider provider) {
+        switch (provider) {
+            case DATABASE: return UsersInDb.class;
+            case REDIS:    return UsersInRedis.class;
+            default:       throw new IllegalStateException("Unhandled users provider: " + provider);
         }
-        return injector.getInstance(authUsersProviderClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    Class<? extends UsersWritable> resolveUsersProviderClass() {
+        String raw = propertiesProvider.get(AUTH_USERS_PROVIDER_OPT).orElse(AuthUsersProvider.DATABASE.cliName);
+        Optional<AuthUsersProvider> provider = AuthUsersProvider.tryFromString(raw);
+        if (provider.isPresent()) {
+            Class<? extends UsersWritable> providerClass = classFor(provider.get());
+            logger.info("setting auth users provider to {}", providerClass);
+            return providerClass;
+        }
+        try {
+            Class<? extends UsersWritable> providerClass = (Class<? extends UsersWritable>) Class.forName(raw, true, ClassLoader.getSystemClassLoader());
+            logger.info("setting auth users provider to {}", providerClass);
+            return providerClass;
+        } catch (ClassNotFoundException | ClassCastException e) {
+            logger.warn("\"{}\" auth users provider class not found or invalid. Setting provider to UsersInDb", raw);
+            return UsersInDb.class;
+        }
     }
 
 

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -312,8 +312,10 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
     }
 
     @Provides @Singleton
-    UsersWritable provideUsersWritable(final PropertiesProvider propertiesProvider, final Injector injector) {
-        return injector.getInstance(resolveUsersProviderClass());
+    UsersWritable provideUsersWritable(final Injector injector) {
+        Class<? extends UsersWritable> providerClass = resolveUsersProviderClass();
+        logger.info("setting auth users provider to {}", providerClass);
+        return injector.getInstance(providerClass);
     }
 
     static Class<? extends UsersWritable> classFor(AuthUsersProvider provider) {
@@ -329,14 +331,10 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         String raw = propertiesProvider.get(AUTH_USERS_PROVIDER_OPT).orElse(AuthUsersProvider.DATABASE.cliName);
         Optional<AuthUsersProvider> provider = AuthUsersProvider.tryFromString(raw);
         if (provider.isPresent()) {
-            Class<? extends UsersWritable> providerClass = classFor(provider.get());
-            logger.info("setting auth users provider to {}", providerClass);
-            return providerClass;
+            return classFor(provider.get());
         }
         try {
-            Class<? extends UsersWritable> providerClass = (Class<? extends UsersWritable>) Class.forName(raw, true, ClassLoader.getSystemClassLoader());
-            logger.info("setting auth users provider to {}", providerClass);
-            return providerClass;
+            return (Class<? extends UsersWritable>) Class.forName(raw, true, ClassLoader.getSystemClassLoader());
         } catch (ClassNotFoundException | ClassCastException e) {
             logger.warn("\"{}\" auth users provider class not found or invalid. Setting provider to UsersInDb", raw);
             return UsersInDb.class;

--- a/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
@@ -70,11 +70,11 @@ public class ServerMode extends CommonMode {
             try {
                 return (Class<? extends Filter>) Class.forName(authFilterClassName, true, ClassLoader.getSystemClassLoader());
             } catch (ClassNotFoundException e) {
-                logger.warn("\"{}\" auth filter class not found. Using default {}", authFilterClassName, OAuth2CookieFilter.class);
-                return OAuth2CookieFilter.class;
+                logger.warn("\"{}\" auth filter class not found. Using default {}", authFilterClassName, FormAuthFilter.class);
+                return FormAuthFilter.class;
             }
         }
-        return filterClassFor(AuthMode.OAUTH);
+        return filterClassFor(AuthMode.FORM);
     }
 
     void bindAuthFilter(Class<? extends Filter> authFilterClass) {

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -117,6 +117,16 @@ public class CommonModeTest {
     }
 
     @Test
+    public void test_users_provider_label_redis() {
+        // UsersInRedis builds its JedisPool lazily, so this resolves without a live Redis.
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
+            put("authUsersProvider", "redis");
+        }});
+        assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInRedis.class);
+    }
+
+    @Test
     public void test_users_provider_default_is_database() {
         CommonMode mode = CommonMode.create(new HashMap<>() {{
             put("mode", Mode.LOCAL.name());

--- a/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/CommonModeTest.java
@@ -10,7 +10,9 @@ import org.icij.datashare.asynctasks.TaskModifier;
 import org.icij.datashare.asynctasks.TaskSupplier;
 import org.icij.datashare.cli.Mode;
 import org.icij.datashare.cli.QueueType;
+import org.icij.datashare.cli.AuthUsersProvider;
 import org.icij.datashare.session.UsersInDb;
+import org.icij.datashare.session.UsersInRedis;
 import org.icij.datashare.session.UsersWritable;
 import org.junit.Test;
 
@@ -95,6 +97,38 @@ public class CommonModeTest {
         CommonMode mode = CommonMode.create(new HashMap<>() {{
             put("mode", Mode.LOCAL.name());
             put("authUsersProvider", "org.icij.UnknownClass");
+        }});
+        assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInDb.class);
+    }
+
+    @Test
+    public void test_class_for_maps_every_users_provider() {
+        assertThat(CommonMode.classFor(AuthUsersProvider.DATABASE)).isEqualTo(UsersInDb.class);
+        assertThat(CommonMode.classFor(AuthUsersProvider.REDIS)).isEqualTo(UsersInRedis.class);
+    }
+
+    @Test
+    public void test_users_provider_label_database() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
+            put("authUsersProvider", "database");
+        }});
+        assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInDb.class);
+    }
+
+    @Test
+    public void test_users_provider_default_is_database() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
+        }});
+        assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInDb.class);
+    }
+
+    @Test
+    public void test_legacy_users_provider_class_name_still_resolves() {
+        CommonMode mode = CommonMode.create(new HashMap<>() {{
+            put("mode", Mode.LOCAL.name());
+            put("authUsersProvider", "org.icij.datashare.session.UsersInDb");
         }});
         assertThat(mode.get(UsersWritable.class)).isInstanceOf(UsersInDb.class);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/mode/ServerModeTest.java
@@ -17,7 +17,7 @@ public class ServerModeTest {
         CommonMode mode = CommonMode.create(new HashMap<>() {{
             put("mode", "SERVER");
         }});
-        assertThat(mode.get(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
+        assertThat(mode.get(Filter.class)).isInstanceOf(FormAuthFilter.class);
     }
 
     @Test
@@ -35,7 +35,7 @@ public class ServerModeTest {
             put("mode", "SERVER");
             put("authFilter", "org.icij.UnknownClass");
         }});
-        assertThat(mode.get(Filter.class)).isInstanceOf(OAuth2CookieFilter.class);
+        assertThat(mode.get(Filter.class)).isInstanceOf(FormAuthFilter.class);
     }
 
     @Test

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/AuthUsersProvider.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/AuthUsersProvider.java
@@ -42,6 +42,11 @@ public enum AuthUsersProvider {
         return Optional.empty();
     }
 
+    /**
+     * Strict label lookup that throws on unknown/null input. Retained for symmetry with
+     * {@code AuthMode.fromString}; the dual-mode resolver uses {@link #tryFromString} instead
+     * (it must tolerate non-label values to fall through to class-name resolution).
+     */
     public static AuthUsersProvider fromString(String s) {
         if (s == null) {
             throw new IllegalArgumentException("Auth users provider must not be null");

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/AuthUsersProvider.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/AuthUsersProvider.java
@@ -1,0 +1,57 @@
+package org.icij.datashare.cli;
+
+import java.util.Optional;
+
+/**
+ * Server users provider, selected via the {@code --authUsersProvider} option.
+ *
+ * <p>This enum is intentionally label-only: it carries no reference to the actual
+ * {@code UsersWritable} classes, which live in the downstream {@code datashare-app}
+ * module. The mapping from {@code AuthUsersProvider} to a concrete provider class is
+ * owned by {@code CommonMode}.</p>
+ *
+ * <p>The {@code --authUsersProvider} flag is dual-mode: it accepts these labels and
+ * also a fully-qualified class name (back-compat). {@link #tryFromString} returns
+ * empty for anything that is not a known label, which is how the resolver decides to
+ * fall through to class-name interpretation.</p>
+ */
+public enum AuthUsersProvider {
+    DATABASE("database"),
+    REDIS("redis");
+
+    public final String cliName;
+
+    AuthUsersProvider(String cliName) {
+        this.cliName = cliName;
+    }
+
+    private static String normalize(String s) {
+        return s.toLowerCase().replaceAll("[_\\-]", "");
+    }
+
+    public static Optional<AuthUsersProvider> tryFromString(String s) {
+        if (s == null) {
+            return Optional.empty();
+        }
+        String normalized = normalize(s);
+        for (AuthUsersProvider v : values()) {
+            if (normalize(v.cliName).equals(normalized)) {
+                return Optional.of(v);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static AuthUsersProvider fromString(String s) {
+        if (s == null) {
+            throw new IllegalArgumentException("Auth users provider must not be null");
+        }
+        return tryFromString(s).orElseThrow(() -> new IllegalArgumentException(
+                "Unknown auth users provider: " + s + " (valid: database, redis)"));
+    }
+
+    @Override
+    public String toString() {
+        return cliName;
+    }
+}

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -787,7 +787,7 @@ public final class DatashareCliOptions {
 
     static void authUsersProvider(OptionParser parser) {
         parser.acceptsAll(
-                singletonList(AUTH_USERS_PROVIDER_OPT), "Server mode auth users provider class")
+                singletonList(AUTH_USERS_PROVIDER_OPT), "Server mode users provider: database, redis, or a fully-qualified class name (default: database)")
                 .withRequiredArg()
                 .ofType(String.class);
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/ServerOptions.java
@@ -74,14 +74,14 @@ public class ServerOptions {
     @Option(names = {"--oauthClaimIdAttribute"}, description = "OAuth claim id attribute")
     String oauthClaimIdAttribute;
 
-    @Option(names = {"--authUsersProvider"}, description = "Auth users provider class")
+    @Option(names = {"--authUsersProvider"}, description = "Users provider: database, redis, or a fully-qualified class name (default: database when not set)")
     String authUsersProvider;
 
     @Option(names = {"--authFilter"}, description = "Auth filter class")
     String authFilter;
 
     @Option(names = {"--auth"}, converter = AuthMode.PicocliConverter.class,
-            description = "Authentication method: oauth, form, basic, yesCookie, yesBasic (default: oauth when not set). Preferred over the deprecated --authFilter.")
+            description = "Authentication method: oauth, form, basic, yesCookie, yesBasic (default: form when not set). Preferred over the deprecated --authFilter.")
     AuthMode auth;
 
     @Option(names = {"--sessionSigningKey"}, description = "HMAC key for session signing. Prefer passing via a settings file to avoid leaking into shell history.")

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/AuthUsersProviderTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/AuthUsersProviderTest.java
@@ -1,0 +1,54 @@
+package org.icij.datashare.cli;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class AuthUsersProviderTest {
+    @Test
+    public void test_from_string_exact_cli_names() {
+        assertThat(AuthUsersProvider.fromString("database")).isEqualTo(AuthUsersProvider.DATABASE);
+        assertThat(AuthUsersProvider.fromString("redis")).isEqualTo(AuthUsersProvider.REDIS);
+    }
+
+    @Test
+    public void test_from_string_is_case_and_separator_insensitive() {
+        assertThat(AuthUsersProvider.fromString("DATABASE")).isEqualTo(AuthUsersProvider.DATABASE);
+        assertThat(AuthUsersProvider.fromString("Redis")).isEqualTo(AuthUsersProvider.REDIS);
+    }
+
+    @Test
+    public void test_from_string_unknown_throws() {
+        assertThrows(IllegalArgumentException.class, () -> AuthUsersProvider.fromString("ldap"));
+    }
+
+    @Test
+    public void test_from_string_null_throws() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> AuthUsersProvider.fromString(null));
+        assertThat(e.getMessage()).isEqualTo("Auth users provider must not be null");
+    }
+
+    @Test
+    public void test_try_from_string_known_label_present() {
+        assertThat(AuthUsersProvider.tryFromString("redis")).isEqualTo(Optional.of(AuthUsersProvider.REDIS));
+    }
+
+    @Test
+    public void test_try_from_string_unknown_is_empty() {
+        // A fully-qualified class name is not a label: the resolver must fall through to Class.forName.
+        assertThat(AuthUsersProvider.tryFromString("org.icij.datashare.session.UsersInDb")).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void test_try_from_string_null_is_empty() {
+        assertThat(AuthUsersProvider.tryFromString(null)).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void test_to_string_returns_cli_name() {
+        assertThat(AuthUsersProvider.DATABASE.toString()).isEqualTo("database");
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/DatashareCommandTest.java
@@ -330,6 +330,18 @@ public class DatashareCommandTest extends AbstractDatashareCommandTest {
     }
 
     @Test
+    public void test_auth_users_provider_label() {
+        Properties props = parse("app", "start", "--mode", "server", "--authUsersProvider", "database");
+        assertThat(props).includes(entry("authUsersProvider", "database"));
+    }
+
+    @Test
+    public void test_auth_users_provider_class_name_passthrough() {
+        Properties props = parse("app", "start", "--authUsersProvider", "org.icij.datashare.session.UsersInDb");
+        assertThat(props).includes(entry("authUsersProvider", "org.icij.datashare.session.UsersInDb"));
+    }
+
+    @Test
     public void test_nlp_pipeline() {
         Properties props = parse("app", "start", "--nlpPipeline", "SPACY");
         assertThat(props).includes(entry("nlpPipeline", "SPACY"));


### PR DESCRIPTION
Following up #2172, this PR uses an enum for `--authUsersProvider` too and change the default values to user the "database" by default and the the "form" as auth mechanism. The `--authUsersProvider` param now accept "database" and "redis" as provider, and is retro compatible with the old class notation.

## AI Disclosure

Entirely done using superpowers, based on #2172, supervised and reviewed by a human before submitting the PR.