### PR TITLE
feat: update the progress field of tasks started using Temporal

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -445,6 +445,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
             TemporalInterlocutor temporal = get(TemporalInterlocutor.class);
             executorService.submit(() -> {
                 closeables.add(temporal.discoverWorkflows(getTaskWorkersNb(), get(DatashareTaskFactory.class),
+                                get(TaskRepository.class),
                                 Utils.getRoutingStrategy(propertiesProvider),
                                 new Group(TaskGroupType.Java)));
             });

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -145,16 +145,38 @@ public class TaskManagerTemporal implements TaskManager {
                     //Do nothing
                     return;
                 }
-                //Parse the state from temporal.
-                //Maybe we might want to limit the scope of what is retrieved
-                // (no need to get again the args for instance)
-                Task<Serializable> temporalTask = temporal.getTask(taskId);
-                taskRepository.update(temporalTask);
+                updateTaskWithCompletionInfoFromTemporal(storedTask);
+                taskRepository.update(storedTask);
             } catch (IOException | UnknownTask e) {
                 logger.warn("failed to update task {} on completion", taskId, e);
             }
         });
     }
+
+
+    /**
+     * Updates the task in parameter {@param inRepository} with state, result and error from Temporal
+     * @param inRepository
+     */
+    private <T extends Serializable> void updateTaskWithCompletionInfoFromTemporal(Task<T> inRepository) {
+        Task<T> inTemporal = temporal.getTask(inRepository.getId());
+        if(inTemporal == null) {
+            logger.warn("Unable to retrieve task {} from Temporal. Cannot update completion infos in repository", inRepository.getId());
+            return;
+        }
+        inRepository.setState(inTemporal.getState());
+
+        if(inTemporal.getResult() != null) {
+            inRepository.setResult(inTemporal.getResult());
+        }
+
+        if(inTemporal.getError() != null) {
+            inRepository.setError(inTemporal.getError());
+        }
+
+    }
+
+
 
     @Override
     public boolean shutdown() throws IOException {
@@ -216,7 +238,7 @@ public class TaskManagerTemporal implements TaskManager {
     static SearchAttributes generateSearchAttributes(Task<?> taskView) {
         SearchAttributes.Builder builder = SearchAttributes.newBuilder()
             .set(PROGRESS_CUSTOM_ATTRIBUTE, 0d)
-            .set(MAX_PROGRESS_CUSTOM_ATTRIBUTE, 0d);
+            .set(MAX_PROGRESS_CUSTOM_ATTRIBUTE, 1d);
         Optional.ofNullable(taskView.getUser()).ifPresent(u -> {
             if(u.getId() != null) {
                 builder.set(USER_CUSTOM_ATTRIBUTE, u.getId());

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalActivityImpl.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalActivityImpl.java
@@ -7,6 +7,7 @@ import io.temporal.activity.Activity;
 import io.temporal.activity.ActivityInfo;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowStub;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -17,16 +18,22 @@ import org.icij.datashare.asynctasks.ProgressSmoother;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskFactory;
 import org.icij.datashare.asynctasks.TaskFactoryHelper;
+import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.user.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class TemporalActivityImpl<R, T extends Callable<R>> {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final TaskFactory factory;
-    private final Double progressWeight;
     private final WorkflowClient client;
+    private final TaskRepository taskRepository;
+    private final Double progressWeight;
 
-    public TemporalActivityImpl(TaskFactory factory, WorkflowClient client, Double progressWeight) {
+    public TemporalActivityImpl(TaskFactory factory, WorkflowClient client, TaskRepository taskRepository, Double progressWeight) {
         this.factory = factory;
         this.client = client;
+        this.taskRepository = taskRepository;
         this.progressWeight = progressWeight;
     }
 
@@ -38,8 +45,18 @@ public abstract class TemporalActivityImpl<R, T extends Callable<R>> {
 
     protected BiConsumer<String, Double> getProgressFn(ActivityInfo info) {
         WorkflowStub workflow = client.newUntypedWorkflowStub(info.getWorkflowId());
-        return (ignored, progress) -> workflow.signal("progress",
-            new ProgressSignal(info.getRunId(), info.getActivityId(), progress, this.progressWeight));
+        String taskId = info.getWorkflowId();
+        return (ignored, progress) -> {
+            workflow.signal("progress", new ProgressSignal(info.getRunId(), info.getActivityId(), progress, this.progressWeight));
+            try {
+                logger.debug("Setting progress of {} to {}", taskId, progress);
+                Task<?> task = taskRepository.getTask(taskId);
+                task.setProgress(progress);
+                taskRepository.update(task);
+            } catch (IOException | RuntimeException e) {
+                logger.warn("failed to update progress for task {}", taskId, e);
+            }
+        };
     }
 
     protected Set<Class<? extends Exception>> getRetriables() {
@@ -56,7 +73,7 @@ public abstract class TemporalActivityImpl<R, T extends Callable<R>> {
             // TODO : This is a design that relies on unwritten convention, so it should be changed
             Task<?> task = new Task<>(info.getWorkflowId(), getTaskClass().getSimpleName(), user, inputArgs);
             BiConsumer<String, Double> progressFn = getProgressFn(info);
-            ProgressSmoother smoothedProgress = new ProgressSmoother(progressFn, 1000);
+            ProgressSmoother smoothedProgress = new ProgressSmoother(progressFn, 10);
             Callable<R> taskFn = (Callable<R>) TaskFactoryHelper.createTaskCallable(
                 getTaskFactory(), getTaskClass().getName(), task, task.progress(smoothedProgress)
             );

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalHelper.java
@@ -111,9 +111,23 @@ public class TemporalHelper {
         return annotated.get(0).getAnnotation(WorkflowMethod.class).name();
     }
 
+    /**
+     * Returns a predicate that filters all the interfaces that can be used as effective Workflow interfaces.
+     * The filter will reject all the interfaces that don't have at least one WorkflowMethod
+     * @param routingStrategy
+     * @param workerGroup
+     * @return
+     */
     static Predicate<Class<?>> makeWorkflowFilter(RoutingStrategy routingStrategy, Group workerGroup) {
         return c -> {
             if (!c.isInterface()) {
+                return false;
+            }
+            // Skip signal/query-only interfaces (like TemporalWorkflow) that have no @WorkflowMethod
+            boolean hasWorkflowMethod = Arrays.stream(c.getDeclaredMethods())
+                .anyMatch(m -> Arrays.stream(m.getAnnotations())
+                    .anyMatch(a -> a.annotationType().getName().equals(WORKFLOW_METHOD_CLASS_NAME)));
+            if (!hasWorkflowMethod) {
                 return false;
             }
             switch (routingStrategy) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -130,11 +130,12 @@ public class TemporalInterlocutor {
     public <A extends TemporalActivityImpl<?, ?>> ThrowingSupplier<A> activityFactory(
         Class<A> activityCls,
         TaskFactory taskFactory,
+        TaskRepository taskRepository,
         double progressWeight
     ) {
         return () -> activityCls
-            .getConstructor(TaskFactory.class, WorkflowClient.class, Double.class)
-            .newInstance(taskFactory, client, progressWeight);
+            .getConstructor(TaskFactory.class, WorkflowClient.class, TaskRepository.class, Double.class)
+            .newInstance(taskFactory, client, taskRepository, progressWeight);
     }
 
     public void setupNamespace(Duration timeout) throws InterruptedException {
@@ -338,7 +339,7 @@ public class TemporalInterlocutor {
         return unknownIfNotFound(t -> createWorkflowStub(taskId).describe(), taskId);
     }
 
-    List<RegisteredWorkflow> discoverWorkflows(String packageName, TaskFactory taskFactory, RoutingStrategy routingStrategy, Group group) {
+    List<RegisteredWorkflow> discoverWorkflows(String packageName, TaskFactory taskFactory, TaskRepository taskRepository, RoutingStrategy routingStrategy, Group group) {
         Reflections reflections = new Reflections(packageName);
         Predicate<Class<?>> workflowFilter = makeWorkflowFilter(routingStrategy, group);
         // We rely on naming convention rather than on inspection, that's OK as code is generated
@@ -353,7 +354,7 @@ public class TemporalInterlocutor {
                         Class<TemporalWorkflowImpl> wfImplClass = (Class<TemporalWorkflowImpl>) Class.forName(workflowClassName + "Impl");
                         Class<TemporalActivityImpl<?, ?>> actImplCls = (Class<TemporalActivityImpl<?, ?>>) Class.forName(baseName + "ActivityImpl");
                         String taskQueue = resolveWfTaskQueue(routingStrategy, workflowKey, group);
-                        List<RegisteredActivity> activities = List.of(new RegisteredActivity(activityFactory(actImplCls, taskFactory, 1d), taskQueue));
+                        List<RegisteredActivity> activities = List.of(new RegisteredActivity(activityFactory(actImplCls, taskFactory, taskRepository, 1d), taskQueue));
                         return new RegisteredWorkflow(wfImplClass, taskQueue, activities);
                     }))
                     .toList();
@@ -362,8 +363,8 @@ public class TemporalInterlocutor {
         }
     }
 
-    public Closeable discoverWorkflows(int taskWorkersNb, TaskFactory taskFactory, RoutingStrategy routingStrategy, Group group) {
-        List<RegisteredWorkflow> registeredWorkflows = discoverWorkflows("org.icij.datashare.tasks", taskFactory, routingStrategy, group);
+    public Closeable discoverWorkflows(int taskWorkersNb, TaskFactory taskFactory, TaskRepository taskRepository, RoutingStrategy routingStrategy, Group group) {
+        List<RegisteredWorkflow> registeredWorkflows = discoverWorkflows("org.icij.datashare.tasks", taskFactory, taskRepository, routingStrategy, group);
         return createFactory(taskWorkersNb, registeredWorkflows);
     }
 

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalInterlocutor.java
@@ -331,10 +331,6 @@ public class TemporalInterlocutor {
             Spliterators.spliteratorUnknownSize(new TemporalPageIterator<>(fetcher), Spliterator.ORDERED), false);
     }
 
-    public Stream<Task<?>> getWorkflows(TaskFilters filters) {
-        return eventuallyConsistentListExecutions(filters).map(rethrowFunction(this::parseTask));
-    }
-
     public WorkflowExecutionDescription getWorkflowExecution(String taskId) throws UnknownTask {
         return unknownIfNotFound(t -> createWorkflowStub(taskId).describe(), taskId);
     }
@@ -501,14 +497,15 @@ public class TemporalInterlocutor {
 
     // ------------------------
     // private utility functions
-    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionMetadata response) {
-        return parseTask(response.getWorkflowExecutionInfo());
-    }
-    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionInfo workflowExecutionInfo) {
+    private <V extends Serializable> Task<V> parseTask(WorkflowExecutionDescription workflowExecutionDescription) {
+        WorkflowExecutionInfo workflowExecutionInfo = workflowExecutionDescription.getWorkflowExecutionInfo();
         WorkflowExecution execution = workflowExecutionInfo.getExecution();
         String taskId = execution.getWorkflowId();
+
+        // Use the search attributes of the workflowExecutionDescription which retrieves the updated search attributes.
+        // The search attributes from workflowExecutionInfo are called indexedFields, and are not updated over time
+        double progress = parseProgress(workflowExecutionDescription.getTypedSearchAttributes());
         String taskName = workflowExecutionInfo.getType().getName();
-        double progress = parseProgress(workflowExecutionInfo);
         Date createdAt = new Date(workflowExecutionInfo.getStartTime().getSeconds() * 1000);
         Date completedAt = null;
         Timestamp closeTime = workflowExecutionInfo.getCloseTime();
@@ -566,16 +563,13 @@ public class TemporalInterlocutor {
                 .filter(Objects::nonNull);
     }
 
-    private static double parseProgress(WorkflowExecutionInfo workflowExecutionInfo) {
-        double maxProgress = defaultDataConverter.fromPayload(workflowExecutionInfo.getSearchAttributes()
-                .getIndexedFieldsOrThrow(MAX_PROGRESS_CUSTOM_ATTRIBUTE.getName()), Double.class, Double.class);
-        if (maxProgress == 0) {
+    private static double parseProgress(SearchAttributes searchAttributes) {
+        Double progress = searchAttributes.get(PROGRESS_CUSTOM_ATTRIBUTE);
+        Double maxProgress = searchAttributes.get(MAX_PROGRESS_CUSTOM_ATTRIBUTE);
+        if(maxProgress == 0d) {
             return 0.0;
         }
-        double currentProgress = defaultDataConverter.fromPayload(
-                workflowExecutionInfo.getSearchAttributes().getIndexedFieldsOrThrow(PROGRESS_CUSTOM_ATTRIBUTE.getName()),
-                Double.class, Double.class);
-        return currentProgress / maxProgress;
+        return progress == null ? 0.0 : progress / maxProgress;
     }
 
     private static <T> T unknownIfNotFound(Function<String, T> function, String taskId) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflow.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflow.java
@@ -1,0 +1,14 @@
+package org.icij.datashare.asynctasks.temporal;
+
+import io.temporal.workflow.QueryMethod;
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.WorkflowInterface;
+
+@WorkflowInterface
+public interface TemporalWorkflow {
+    @SignalMethod
+    void progress(ProgressSignal progressSignal);
+
+    @QueryMethod(name = "progress")
+    double getProgress();
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflowGenerator.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflowGenerator.java
@@ -44,6 +44,7 @@ import javax.lang.model.type.MirroredTypesException;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.JavaFileObject;
 import org.icij.datashare.asynctasks.TaskFactory;
+import org.icij.datashare.asynctasks.TaskRepository;
 
 @SupportedAnnotationTypes("org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow")
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
@@ -206,8 +207,9 @@ public class TemporalWorkflowGenerator extends AbstractProcessor {
             .addModifiers(Modifier.PUBLIC)
             .addParameter(TaskFactory.class, "factory")
             .addParameter(WorkflowClient.class, "client")
+            .addParameter(TaskRepository.class, "taskRepository")
             .addParameter(Double.class, "progressWeight")
-            .addCode("super(factory, client, progressWeight);")
+            .addCode("super(factory, client, taskRepository, progressWeight);")
             .build();
         MethodSpec run = MethodSpec.methodBuilder("run")
             .addAnnotation(Override.class)

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflowImpl.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflowImpl.java
@@ -1,39 +1,27 @@
 package org.icij.datashare.asynctasks.temporal;
 
-import io.temporal.workflow.QueryMethod;
-import io.temporal.workflow.SignalMethod;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import org.icij.datashare.function.Pair;
+import io.temporal.workflow.Workflow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public abstract class TemporalWorkflowImpl {
-    ConcurrentHashMap<Pair<String, String>, Double> progress = new ConcurrentHashMap<>();
-    ConcurrentHashMap<Pair<String, String>, Double> maxProgress = new ConcurrentHashMap<>();
+import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.PROGRESS_CUSTOM_ATTRIBUTE;
 
-    @SignalMethod
+public abstract class TemporalWorkflowImpl implements TemporalWorkflow {
+    public static final Logger logger = LoggerFactory.getLogger(TemporalWorkflowImpl.class);
+
+    private double currentProgress = 0d;
+
+    @Override
     public void progress(ProgressSignal progressSignal) {
-        Pair<String, String> key = new Pair<>(progressSignal.runId(), progressSignal.activityId());
-        progress.putIfAbsent(key, 0.0);
-        maxProgress.putIfAbsent(key, 0.0);
-        progress.compute(key, (ignored, p) -> p + progressSignal.progress());
-        maxProgress.compute(key, (ignored, maxP) -> maxP + progressSignal.progress());
+        logger.info("Received progressSignal for activity {}, currentProgress : {}",progressSignal.activityId(), progressSignal.progress());
+        currentProgress = progressSignal.progress();
+        Workflow.upsertTypedSearchAttributes(
+            PROGRESS_CUSTOM_ATTRIBUTE.valueSet(currentProgress)
+        );
     }
 
-    @QueryMethod(name = "progress")
-    public double getProgress(String runId) {
-        double maxP = maxProgress.entrySet()
-            .stream()
-            .filter(e -> e.getKey()._1().equals(runId))
-            .map(Map.Entry::getValue)
-            .reduce(0.0, Double::sum);
-        if (maxP == 0.0) {
-            return maxP;
-        }
-        double p = progress.entrySet()
-            .stream()
-            .filter(e -> e.getKey()._1().equals(runId))
-            .map(Map.Entry::getValue)
-            .reduce(0.0, Double::sum);
-        return p / maxP;
+    @Override
+    public double getProgress() {
+        return this.currentProgress;
     }
 }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -20,8 +20,10 @@ import org.redisson.api.RedissonClient;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
@@ -331,6 +333,42 @@ public class TaskManagerTemporalIntTest {
         assertThat(stopped).isTrue();
         boolean stoppedAgain = taskManager.stopTask(task.getId());
         assertThat(stoppedAgain).isFalse();
+    }
+
+    @Test(timeout = 15000)
+    public void test_progress_is_stored_in_repository_and_temporal() throws Exception {
+        TaskFactory progressFactory = new TaskFactory() {
+            public Callable<String> createDoNothingTask(Task<?> task, Function<Double, Void> progress) {
+                return () -> {
+                    progress.apply(0.5);
+                    return "done";
+                };
+            }
+        };
+        List<TemporalInterlocutor.RegisteredWorkflow> workflows = List.of(
+            new TemporalInterlocutor.RegisteredWorkflow(
+                DoNothingWorkflowImpl.class,
+                WORKFLOWS_DEFAULT,
+                List.of(new TemporalInterlocutor.RegisteredActivity(
+                    temporal.activityFactory(DoNothingActivityImpl.class, progressFactory, taskRepository, 1d),
+                    WORKFLOWS_DEFAULT
+                ))
+            )
+        );
+
+        try (TemporalInterlocutor.CloseableWorkerFactoryHandle ignored = temporal.createFactory(1, workflows)) {
+            Task<String> task = new Task<>(DoNothingTask.class.getName(), User.local(), Map.of());
+            taskManager.startTask(task);
+            taskManager.waitTasksToBeDone(15, TimeUnit.SECONDS);
+
+            // Repository side: progress must have reached 1.0
+            Task<?> fromRepo = taskRepository.getTask(task.id);
+            assertThat(fromRepo.getProgress()).isEqualTo(1.0);
+
+            // Temporal side: search attributes must reflect final progress 1.0
+            Task<?> fromTemporal = temporal.getTask(task.id);
+            assertThat(fromTemporal.getProgress()).isEqualTo(1.0);
+        }
     }
 
     private TemporalInterlocutor.CloseableWorkerFactoryHandle testCloseableWorkerFactory(TemporalInterlocutor temporal) {

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalIntTest.java
@@ -64,11 +64,11 @@ public class TaskManagerTemporalIntTest {
             new TemporalInterlocutor.RegisteredWorkflow(
                 HelloWorldWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalInterlocutor.RegisteredActivity(temporal.activityFactory(HelloWorldActivityImpl.class, taskFactory, 1.0d), WORKFLOWS_DEFAULT))),
+                List.of(new TemporalInterlocutor.RegisteredActivity(temporal.activityFactory(HelloWorldActivityImpl.class, taskFactory, taskRepository, 1.0d), WORKFLOWS_DEFAULT))),
             new TemporalInterlocutor.RegisteredWorkflow(
                 FailingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
-                List.of(new TemporalInterlocutor.RegisteredActivity(temporal.activityFactory(FailingActivityImpl.class, taskFactory, 1.0d), WORKFLOWS_DEFAULT)))
+                List.of(new TemporalInterlocutor.RegisteredActivity(temporal.activityFactory(FailingActivityImpl.class, taskFactory, taskRepository, 1.0d), WORKFLOWS_DEFAULT)))
         );
 
         temporal.setupNamespace(Duration.ofSeconds(5));
@@ -294,7 +294,7 @@ public class TaskManagerTemporalIntTest {
                 DoNothingWorkflowImpl.class,
                 WORKFLOWS_DEFAULT,
                 List.of(new TemporalInterlocutor.RegisteredActivity(
-                    temporal.activityFactory(DoNothingActivityImpl.class, capturingFactory, 1.0d),
+                    temporal.activityFactory(DoNothingActivityImpl.class, capturingFactory, taskRepository, 1.0d),
                     WORKFLOWS_DEFAULT
                 ))
             )

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/DoNothingActivityImpl.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/DoNothingActivityImpl.java
@@ -3,11 +3,12 @@ package org.icij.datashare.asynctasks.temporal;
 import io.temporal.client.WorkflowClient;
 import java.util.Map;
 import org.icij.datashare.asynctasks.TaskFactory;
+import org.icij.datashare.asynctasks.TaskRepository;
 
 public class DoNothingActivityImpl extends TemporalActivityImpl<String, DoNothingTask> implements DoNothingActivity {
 
-    public DoNothingActivityImpl(TaskFactory factory, WorkflowClient client, Double progressWeight) {
-        super(factory, client, progressWeight);
+    public DoNothingActivityImpl(TaskFactory factory, WorkflowClient client, TaskRepository taskRepository, Double progressWeight) {
+        super(factory, client, taskRepository, progressWeight);
     }
 
     @Override

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/FailingActivityImpl.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/FailingActivityImpl.java
@@ -6,10 +6,11 @@ import io.temporal.client.WorkflowClient;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import org.icij.datashare.asynctasks.TaskFactory;
+import org.icij.datashare.asynctasks.TaskRepository;
 
 public class FailingActivityImpl extends TemporalActivityImpl<String, Callable<String>> implements FailingActivity {
-    public FailingActivityImpl(TaskFactory factory, WorkflowClient client, Double progressWeight) {
-        super(factory, client, progressWeight);
+    public FailingActivityImpl(TaskFactory factory, WorkflowClient client, TaskRepository taskRepository, Double progressWeight) {
+        super(factory, client, taskRepository, progressWeight);
     }
 
     @Override

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/HelloWorldActivityImpl.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/HelloWorldActivityImpl.java
@@ -6,11 +6,12 @@ import io.temporal.client.WorkflowClient;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import org.icij.datashare.asynctasks.TaskFactory;
+import org.icij.datashare.asynctasks.TaskRepository;
 
 public class HelloWorldActivityImpl extends TemporalActivityImpl<String, Callable<String>> implements HelloWorldActivity {
 
-    public HelloWorldActivityImpl(TaskFactory factory, WorkflowClient client, Double progressWeight) {
-        super(factory, client, progressWeight);
+    public HelloWorldActivityImpl(TaskFactory factory, WorkflowClient client, TaskRepository taskRepository, Double progressWeight) {
+        super(factory, client, taskRepository, progressWeight);
     }
 
     @Override

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflowGeneratorTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/temporal/TemporalWorkflowGeneratorTest.java
@@ -150,11 +150,12 @@ public class TemporalWorkflowGeneratorTest {
                 import java.util.Map;
                 import java.util.Set;
                 import org.icij.datashare.asynctasks.TaskFactory;
+                import org.icij.datashare.asynctasks.TaskRepository;
            
                 public class HelloWorldActivityImpl extends TemporalActivityImpl<String, HelloWorldTask> implements HelloWorldActivity {
 
-                    public HelloWorldActivityImpl(TaskFactory factory, WorkflowClient client, Double progressWeight) {
-                        super(factory, client, progressWeight);
+                    public HelloWorldActivityImpl(TaskFactory factory, WorkflowClient client, TaskRepository taskRepository, Double progressWeight) {
+                        super(factory, client, taskRepository, progressWeight);
                     }
                 
                     @Override


### PR DESCRIPTION
To update the progress field of tasks that are viewed in the frontend, Activities need an access to taskRepository so that it can update the field. 

The PR also fixes the issue where the update of the task in repository upon completion in Temporal overrides all the values, including progress in repository (which results in a 0% progress rate after completion)

The PR fixes https://github.com/ICIJ/datashare/issues/2185

Used Claude to replace all the calls to TemporalActivityImpl that needed TaskRepository, and to detect why adding the TemporalWorkflow interface made the worker crash