### PR TITLE
fix: report actual nbQueriesWithoutResults in batch search task result

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -82,6 +82,7 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
     public BatchSearchRunnerResult call() throws Exception {
         int numberOfResults = 0;
         int totalProcessed = 0;
+        int queriesWithoutResults = 0;
 
         int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse(DEFAULT_BATCH_THROTTLE));
         int maxTimeSeconds = parseInt(propertiesProvider.get(BATCH_SEARCH_MAX_TIME_OPT).orElse(DEFAULT_BATCH_SEARCH_MAX_TIME));
@@ -121,9 +122,15 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
                     docsToProcess = searcher.scroll(scrollDuration).collect(toList());
                 }
 
+                // count queries with no hits from what this run observes; the DB NB_QUERIES_WITHOUT_RESULTS
+                // column is a live progress counter and is not the source of truth for the task result
+                if (docsToProcess.isEmpty()) {
+                    queriesWithoutResults++;
+                }
+
                 long beforeScrollLoop = DatashareTime.getInstance().currentTimeMillis();
                 boolean isFirstScroll = true;
-                while (docsToProcess.size() != 0 && numberOfResults < MAX_BATCH_RESULT_SIZE - MAX_SCROLL_SIZE) {
+                while (!docsToProcess.isEmpty() && numberOfResults < MAX_BATCH_RESULT_SIZE - MAX_SCROLL_SIZE) {
                     if (cancelAsked) {
                         logger.info("cancelling batch search {} requeue={}", batchSearch.uuid, requeueCancel);
                         repository.reset(batchSearch.uuid);
@@ -157,7 +164,7 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
             repository.setState(taskView.id, searchException);
             throw searchException;
         }
-        return new BatchSearchRunnerResult(numberOfResults, batchSearch.nbQueriesWithoutResults);
+        return new BatchSearchRunnerResult(numberOfResults, queriesWithoutResults);
     }
 
     @Override

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
@@ -57,14 +57,38 @@ public class BatchSearchRunnerTest {
 
     @Test
     public void test_run_batch_search() throws Exception {
+        // query1 matches two documents, query2 matches nothing
         Document[] documents = {createDoc("doc1").build(), createDoc("doc2").build()};
-        mockSearch.willReturn(1, documents);
+        mockSearch.willReturn("query1", documents);
+        mockSearch.willReturn("query2");
+        BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
+        when(repository.get(local(), search.uuid)).thenReturn(search);
+
+        BatchSearchRunnerResult result = new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call();
+
+        assertThat(result.nbResults()).isEqualTo(2);
+        assertThat(result.nbQueriesWithoutResults()).isEqualTo(1);
+        verify(progressCb).apply( 1.0);
+    }
+
+    @Test
+    public void test_run_batch_search_when_all_queries_have_results() throws Exception {
+        mockSearch.willReturn("query1", createDoc("doc1").build());
+        mockSearch.willReturn("query2", createDoc("doc2").build());
+        BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
+        when(repository.get(local(), search.uuid)).thenReturn(search);
+
+        assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(0);
+    }
+
+    @Test
+    public void test_run_batch_search_when_no_query_has_results() throws Exception {
+        mockSearch.willReturn("query1");
+        mockSearch.willReturn("query2");
         BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
         when(repository.get(local(), search.uuid)).thenReturn(search);
 
         assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(2);
-
-        verify(progressCb).apply( 1.0);
     }
 
     private Task<?> taskView(BatchSearch search) {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/MockSearch.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/MockSearch.java
@@ -3,6 +3,7 @@ package org.icij.datashare.tasks;
 import org.icij.datashare.Entity;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.SearchQuery;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.IOException;
@@ -26,7 +27,7 @@ class MockSearch<S extends Indexer.Searcher> {
         Indexer.Searcher searcher = mock(Indexer.Searcher.class);
         when(searcher.scroll(any(String.class))).thenThrow(expectedClassException);
         when(searcher.scroll(any(String.class), any(String.class))).thenThrow(expectedClassException);
-        prepareSearcher(0, searcher);
+        prepareSearcher(0, searcher, null);
     }
 
     void willReturn(int nbOfScrolls, Document... documents) throws IOException {
@@ -41,10 +42,26 @@ class MockSearch<S extends Indexer.Searcher> {
             ongoingStubbing = ongoingStubbing.thenAnswer(a -> Stream.of(documents));
         }
         ongoingStubbing.thenAnswer(a -> Stream.empty());
-        prepareSearcher(documents.length, searcher);
+        prepareSearcher(documents.length, searcher, null);
     }
 
-    private void prepareSearcher(long length, Indexer.Searcher searcher) {
+    /**
+     * Stubs the search of a single query so it returns the given documents on its first scroll
+     * (then empty), or returns nothing at all when no document is passed. Unlike
+     * {@link #willReturn(int, Document...)}, each query gets its own searcher, so emptiness
+     * reflects the query rather than a shared, sequentially-drained stub.
+     */
+    void willReturn(String query, Document... documents) throws IOException {
+        S searcher = mock(searcherInstance);
+        OngoingStubbing<? extends Stream<? extends Entity>> ongoingStubbing = when(searcher.scroll(anyString()));
+        if (documents.length > 0) {
+            ongoingStubbing = ongoingStubbing.thenAnswer(a -> Stream.of(documents));
+        }
+        ongoingStubbing.thenAnswer(a -> Stream.empty());
+        prepareSearcher(documents.length, searcher, new SearchQuery(query));
+    }
+
+    private void prepareSearcher(long length, Indexer.Searcher searcher, SearchQuery query) {
         when(searcher.with(anyInt(), anyBoolean())).thenReturn(searcher);
         when(searcher.withoutSource(any())).thenReturn(searcher);
         if (searcher instanceof Indexer.QueryBuilderSearcher) {
@@ -53,6 +70,10 @@ class MockSearch<S extends Indexer.Searcher> {
         }
         when(searcher.limit(anyInt())).thenReturn(searcher);
         when(searcher.totalHits()).thenReturn(length).thenReturn(0L);
-        when(mockIndexer.search(eq(singletonList("test-datashare")), eq(Document.class), any())).thenReturn(searcher);
+        if (query == null) {
+            when(mockIndexer.search(eq(singletonList("test-datashare")), eq(Document.class), any())).thenReturn(searcher);
+        } else {
+            when(mockIndexer.search(eq(singletonList("test-datashare")), eq(Document.class), eq(query))).thenReturn(searcher);
+        }
     }
 }


### PR DESCRIPTION
As described, in #2168, the `nbQueriesWithoutResults` value is currently wrong.

This PR increment this value correctly and add tests to make sure there will be no regressions again.