### PR TITLE
fix: batch search nb queries reload from db

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -160,8 +160,12 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
         // NB_QUERIES_WITHOUT_RESULTS is maintained incrementally in DB by saveResults (decremented on
         // the first scroll that persists results for a query), so it is the source of truth. Reload the
         // batch search to report the persisted value rather than recomputing it from what this run observed.
-        int nbQueriesWithoutResults = repository.get(taskView.getUser(), taskView.id).nbQueriesWithoutResults;
-        return new BatchSearchRunnerResult(numberOfResults, nbQueriesWithoutResults);
+        BatchSearch persisted = repository.get(taskView.getUser(), taskView.id);
+        if (persisted == null) {
+            logger.warn("batch search {} disappeared before reloading final counters, reporting last known nbQueriesWithoutResults", taskView.id);
+            return new BatchSearchRunnerResult(numberOfResults, batchSearch.nbQueriesWithoutResults);
+        }
+        return new BatchSearchRunnerResult(numberOfResults, persisted.nbQueriesWithoutResults);
     }
 
     @Override

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchSearchRunner.java
@@ -82,7 +82,6 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
     public BatchSearchRunnerResult call() throws Exception {
         int numberOfResults = 0;
         int totalProcessed = 0;
-        int queriesWithoutResults = 0;
 
         int throttleMs = parseInt(propertiesProvider.get(BATCH_THROTTLE_OPT).orElse(DEFAULT_BATCH_THROTTLE));
         int maxTimeSeconds = parseInt(propertiesProvider.get(BATCH_SEARCH_MAX_TIME_OPT).orElse(DEFAULT_BATCH_SEARCH_MAX_TIME));
@@ -122,12 +121,6 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
                     docsToProcess = searcher.scroll(scrollDuration).collect(toList());
                 }
 
-                // count queries with no hits from what this run observes; the DB NB_QUERIES_WITHOUT_RESULTS
-                // column is a live progress counter and is not the source of truth for the task result
-                if (docsToProcess.isEmpty()) {
-                    queriesWithoutResults++;
-                }
-
                 long beforeScrollLoop = DatashareTime.getInstance().currentTimeMillis();
                 boolean isFirstScroll = true;
                 while (!docsToProcess.isEmpty() && numberOfResults < MAX_BATCH_RESULT_SIZE - MAX_SCROLL_SIZE) {
@@ -164,7 +157,11 @@ public class BatchSearchRunner implements CancellableTask, UserTask, Callable<Ba
             repository.setState(taskView.id, searchException);
             throw searchException;
         }
-        return new BatchSearchRunnerResult(numberOfResults, queriesWithoutResults);
+        // NB_QUERIES_WITHOUT_RESULTS is maintained incrementally in DB by saveResults (decremented on
+        // the first scroll that persists results for a query), so it is the source of truth. Reload the
+        // batch search to report the persisted value rather than recomputing it from what this run observed.
+        int nbQueriesWithoutResults = repository.get(taskView.getUser(), taskView.id).nbQueriesWithoutResults;
+        return new BatchSearchRunnerResult(numberOfResults, nbQueriesWithoutResults);
     }
 
     @Override

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
@@ -84,6 +84,19 @@ public class BatchSearchRunnerTest {
         assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(1);
     }
 
+    @Test
+    public void test_run_batch_search_when_reload_returns_null_falls_back_without_npe() throws Exception {
+        mockSearch.willReturn("query1", createDoc("doc1").build());
+        mockSearch.willReturn("query2");
+        BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
+        // the batch search is deleted concurrently before the final reload
+        when(repository.get(local(), search.uuid)).thenReturn(search, (BatchSearch) null);
+
+        BatchSearchRunnerResult result = new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call();
+
+        assertThat(result.nbQueriesWithoutResults()).isEqualTo(2); // last known in-memory value
+    }
+
     private Task<?> taskView(BatchSearch search) {
         return new Task<>(search.uuid, BatchSearchRunner.class.getName(), local());
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerTest.java
@@ -57,12 +57,13 @@ public class BatchSearchRunnerTest {
 
     @Test
     public void test_run_batch_search() throws Exception {
-        // query1 matches two documents, query2 matches nothing
         Document[] documents = {createDoc("doc1").build(), createDoc("doc2").build()};
         mockSearch.willReturn("query1", documents);
         mockSearch.willReturn("query2");
         BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
-        when(repository.get(local(), search.uuid)).thenReturn(search);
+        // the runner reloads the batch search at the end to report the persisted NB_QUERIES_WITHOUT_RESULTS,
+        // which saveResults decremented once (query1 had results), leaving one query without results
+        when(repository.get(local(), search.uuid)).thenReturn(search, reloaded(search, 1));
 
         BatchSearchRunnerResult result = new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call();
 
@@ -72,27 +73,28 @@ public class BatchSearchRunnerTest {
     }
 
     @Test
-    public void test_run_batch_search_when_all_queries_have_results() throws Exception {
+    public void test_run_batch_search_reports_persisted_count_not_observed() throws Exception {
+        // both queries observe hits during the run, yet the persisted count is the source of truth:
+        // the runner must report what the reloaded record holds, not what it counted from the scrolls
         mockSearch.willReturn("query1", createDoc("doc1").build());
         mockSearch.willReturn("query2", createDoc("doc2").build());
         BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
-        when(repository.get(local(), search.uuid)).thenReturn(search);
+        when(repository.get(local(), search.uuid)).thenReturn(search, reloaded(search, 1));
 
-        assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(0);
-    }
-
-    @Test
-    public void test_run_batch_search_when_no_query_has_results() throws Exception {
-        mockSearch.willReturn("query1");
-        mockSearch.willReturn("query2");
-        BatchSearch search = new BatchSearch("uuid1", singletonList(project("test-datashare")), "name1", "desc1", asSet("query1", "query2"), new Date(), BatchSearch.State.QUEUED, User.local());
-        when(repository.get(local(), search.uuid)).thenReturn(search);
-
-        assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(2);
+        assertThat(new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call().nbQueriesWithoutResults()).isEqualTo(1);
     }
 
     private Task<?> taskView(BatchSearch search) {
         return new Task<>(search.uuid, BatchSearchRunner.class.getName(), local());
+    }
+
+    // builds the batch search as it would be reloaded from DB after the run, carrying the persisted
+    // NB_QUERIES_WITHOUT_RESULTS value maintained by saveResults
+    private BatchSearch reloaded(BatchSearch search, int nbQueriesWithoutResults) {
+        return new BatchSearch(search.uuid, search.projects, search.name, search.description, search.queries,
+                nbQueriesWithoutResults, search.date, BatchSearch.State.SUCCESS, search.uri, search.user,
+                search.nbResults, search.published, search.fileTypes, null, search.paths, search.fuzziness,
+                search.phraseMatches, search.errorMessage, search.errorQuery);
     }
 
     @Test(expected = RuntimeException.class)

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -289,10 +289,18 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
         DSLContext context = DSL.using(dataSource, dialect);
         return context.transactionResult(configuration -> {
             DSLContext inner = DSL.using(configuration);
-            UpdateSetMoreStep<org.icij.datashare.db.tables.records.BatchSearchRecord> updateBatchSearch = inner.update(BATCH_SEARCH).set(BATCH_SEARCH.STATE, State.QUEUED.name());
-            updateBatchSearch.where(BATCH_SEARCH.UUID.eq(batchId)).execute();
+            // requeue the batch and restore the live progress counters maintained by saveResults to their
+            // initial values, so a rerun starts from a clean slate instead of double-counting results or
+            // ending up with a stale (possibly negative) NB_QUERIES_WITHOUT_RESULTS
+            inner.update(BATCH_SEARCH)
+                    .set(BATCH_SEARCH.STATE, State.QUEUED.name())
+                    .set(BATCH_SEARCH.BATCH_RESULTS, 0)
+                    .set(BATCH_SEARCH.NB_QUERIES_WITHOUT_RESULTS, BATCH_SEARCH.NB_QUERIES)
+                    .where(BATCH_SEARCH.UUID.eq(batchId)).execute();
+            inner.update(BATCH_SEARCH_QUERY)
+                    .set(BATCH_SEARCH_QUERY.QUERY_RESULTS, 0)
+                    .where(BATCH_SEARCH_QUERY.SEARCH_UUID.eq(batchId)).execute();
             return inner.deleteFrom(BATCH_SEARCH_RESULT).where(BATCH_SEARCH_RESULT.SEARCH_UUID.eq(batchId)).execute() > 0;
-
         });
 
     }

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -695,11 +695,21 @@ public class JooqBatchSearchRepositoryTest {
         BatchSearch batchSearch = new BatchSearch("uuid", singletonList(proxy("prj")), "name1", "description1",
                 asSet("q1", "q2"), new Date(), State.RUNNING, User.local());
         repository.save(batchSearch);
-        repository.saveResults(batchSearch.uuid, "query",asList(createDoc("doc1").build(),createDoc("doc2").build()));
+        repository.saveResults(batchSearch.uuid, "q1", asList(createDoc("doc1").build(), createDoc("doc2").build()));
+
+        // the partial run decremented the live progress counters maintained by saveResults
+        assertThat(repository.get(User.local(), batchSearch.uuid).nbResults).isEqualTo(2);
+        assertThat(repository.get(User.local(), batchSearch.uuid).nbQueriesWithoutResults).isEqualTo(1);
 
         assertThat(repository.reset(batchSearch.uuid)).isTrue();
         assertThat(repository.get(batchSearch.uuid).state).isEqualTo(State.QUEUED);
         assertThat(repository.getResults(User.local(), batchSearch.uuid)).hasSize(0);
+
+        // counters are restored to their initial values so a rerun starts from a clean slate
+        BatchSearch afterReset = repository.get(User.local(), batchSearch.uuid);
+        assertThat(afterReset.nbResults).isEqualTo(0);
+        assertThat(afterReset.nbQueriesWithoutResults).isEqualTo(2);
+        assertThat(afterReset.queries).includes(entry("q1", 0), entry("q2", 0));
     }
 
     @Test


### PR DESCRIPTION
`BatchSearchRunner` now reports `nbQueriesWithoutResults` by reloading the batch search from DB at the end of a run, instead of recomputing it locally. `NB_QUERIES_WITHOUT_RESULTS` is maintained incrementally by `saveResults`, so the DB is the single source of truth.

Reloading exposed that the DB counter wasn't reset-safe, so this PR also fixes that:

- `reset()` now restores the live progress counters (`BATCH_RESULTS`, `NB_QUERIES_WITHOUT_RESULTS`, per-query `QUERY_RESULTS`). It previously only set state to `QUEUED` and deleted result rows, so a requeued batch reran on top of decremented counters, double-counting results and leaving a stale (possibly negative) `NB_QUERIES_WITHOUT_RESULTS`. This counter bug predates this branch; reloading from DB is what made it observable.
- The final reload is guarded against a null record (the batch search can be deleted concurrently during a run), falling back to the last known in-memory value instead of throwing an NPE..