### PR TITLE
feat: batch search edit title and description

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/batch/BatchSearch.java
+++ b/datashare-api/src/main/java/org/icij/datashare/batch/BatchSearch.java
@@ -21,6 +21,28 @@ public class BatchSearch extends BatchSearchRecord {
     public final int fuzziness;
     public final boolean phraseMatches;
     public final SearchQuery queryTemplate;
+
+    public static final int MAX_NAME_LENGTH = 255;
+    public static final int MAX_DESCRIPTION_LENGTH = 4096;
+
+    public static String validateName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("Batch search name cannot be empty.");
+        }
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new IllegalArgumentException("Batch search name exceeds " + MAX_NAME_LENGTH + " characters.");
+        }
+        return name;
+    }
+
+    public static String validateDescription(String description) {
+        String value = description == null ? "" : description;
+        if (value.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new IllegalArgumentException("Batch search description exceeds " + MAX_DESCRIPTION_LENGTH + " characters.");
+        }
+        return value;
+    }
+
     // batch search creation
 
     public BatchSearch(final List<ProjectProxy> projects, final String name, final String description, User user) {

--- a/datashare-api/src/main/java/org/icij/datashare/batch/BatchSearchRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/batch/BatchSearchRepository.java
@@ -35,6 +35,8 @@ public interface BatchSearchRepository extends Closeable {
 
     boolean publish(User user, String batchId, boolean published);
 
+    boolean setName(User user, String batchId, String name);
+
     BatchSearch get(String id);
     BatchSearch get(User user, String batchId);
     BatchSearch get(User user, String batchId, boolean withQueries);

--- a/datashare-api/src/main/java/org/icij/datashare/batch/BatchSearchRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/batch/BatchSearchRepository.java
@@ -37,6 +37,8 @@ public interface BatchSearchRepository extends Closeable {
 
     boolean setName(User user, String batchId, String name);
 
+    boolean setDescription(User user, String batchId, String description);
+
     BatchSearch get(String id);
     BatchSearch get(User user, String batchId);
     BatchSearch get(User user, String batchId, boolean withQueries);

--- a/datashare-api/src/test/java/org/icij/datashare/batch/BatchSearchTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/batch/BatchSearchTest.java
@@ -89,4 +89,41 @@ public class BatchSearchTest {
         assertThat(copy.name).isEqualTo("new name");
         assertThat(copy.description).isEqualTo("new description");
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_validate_name_rejects_null() {
+        BatchSearch.validateName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_validate_name_rejects_blank() {
+        BatchSearch.validateName("   ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_validate_name_rejects_too_long() {
+        BatchSearch.validateName("x".repeat(BatchSearch.MAX_NAME_LENGTH + 1));
+    }
+
+    @Test
+    public void test_validate_name_accepts_max_length() {
+        String name = "x".repeat(BatchSearch.MAX_NAME_LENGTH);
+        assertThat(BatchSearch.validateName(name)).isEqualTo(name);
+    }
+
+    @Test
+    public void test_validate_description_null_becomes_empty_string() {
+        assertThat(BatchSearch.validateDescription(null)).isEqualTo("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_validate_description_rejects_too_long() {
+        BatchSearch.validateDescription("x".repeat(BatchSearch.MAX_DESCRIPTION_LENGTH + 1));
+    }
+
+    @Test
+    public void test_validate_description_accepts_max_length() {
+        String description = "x".repeat(BatchSearch.MAX_DESCRIPTION_LENGTH);
+        assertThat(BatchSearch.validateDescription(description)).isEqualTo(description);
+    }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -218,7 +218,11 @@ public class BatchSearchResource {
 
         boolean updated = false;
         if (hasPublished) {
-            updated |= batchSearchRepository.publish(user, batchId, data.asBoolean("published"));
+            Object published = body.get("published");
+            if (!(published instanceof Boolean)) {
+                return PayloadFormatter.error("Batch search published must be a boolean.", HttpStatus.BAD_REQUEST);
+            }
+            updated |= batchSearchRepository.publish(user, batchId, (Boolean) published);
         }
         if (hasName) {
             updated |= batchSearchRepository.setName(user, batchId, name);

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -36,9 +36,6 @@ import static org.icij.datashare.function.ThrowingFunctions.parseBoolean;
 public class BatchSearchResource {
     private final BatchSearchRepository batchSearchRepository;
     private final PropertiesProvider propertiesProvider;
-    private static final int MAX_NAME_LENGTH = 255;
-    private static final int MAX_DESCRIPTION_LENGTH = 4096;
-
     @Inject
     public BatchSearchResource(PropertiesProvider propertiesProvider, final BatchSearchRepository batchSearchRepository) {
         this.batchSearchRepository = batchSearchRepository;
@@ -203,8 +200,8 @@ public class BatchSearchResource {
     private boolean applyEdits(User user, String batchId, Map<String, Object> body) {
         // Validate every present field before applying any, so an invalid field never leaves a partial update.
         Boolean published = body.containsKey("published") ? validBoolean(body.get("published"), "published") : null;
-        String name = body.containsKey("name") ? validName(body.get("name")) : null;
-        String description = body.containsKey("description") ? validDescription(body.get("description")) : null;
+        String name = body.containsKey("name") ? BatchSearch.validateName(validString(body.get("name"), "name")) : null;
+        String description = body.containsKey("description") ? BatchSearch.validateDescription(validString(body.get("description"), "description")) : null;
 
         boolean updated = false;
         if (published != null) {
@@ -219,19 +216,6 @@ public class BatchSearchResource {
         return updated;
     }
 
-    private static String validName(Object value) {
-        String name = validString(value, "name");
-        if (name == null || name.trim().isEmpty()) {
-            throw new IllegalArgumentException("Batch search name cannot be empty.");
-        }
-        return withinMaxLength(name, MAX_NAME_LENGTH, "name");
-    }
-
-    private static String validDescription(Object value) {
-        String description = validString(value, "description");
-        return withinMaxLength(description == null ? "" : description, MAX_DESCRIPTION_LENGTH, "description");
-    }
-
     private static String validString(Object value, String field) {
         if (value != null && !(value instanceof String)) {
             throw new IllegalArgumentException("Batch search " + field + " must be a string.");
@@ -244,13 +228,6 @@ public class BatchSearchResource {
             throw new IllegalArgumentException("Batch search " + field + " must be a boolean.");
         }
         return (Boolean) value;
-    }
-
-    private static String withinMaxLength(String value, int maxLength, String field) {
-        if (value.length() > maxLength) {
-            throw new IllegalArgumentException("Batch search " + field + " exceeds " + maxLength + " characters.");
-        }
-        return value;
     }
 
     @Operation( description = """

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -177,8 +177,9 @@ public class BatchSearchResource {
         return new Payload(204);
     }
 
-    @Operation(description = "Updates a batch search with the given id.",
+    @Operation(description = "Updates a batch search with the given id. The JSON body may contain any of `published` (boolean), `name` (string) and `description` (string); only the provided fields are updated.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = JsonData.class))))
+    @ApiResponse(responseCode = "400", description = "If no updatable field is provided, the name is empty, or name/description exceed their maximum length")
     @ApiResponse(responseCode = "404", description = "If the user issuing the request is not the same as the batch owner in database, it will do nothing (thus returning 404)")
     @ApiResponse(responseCode = "200", description = "If the batch has been updated")
     @Patch("/search/:batchid")

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -36,6 +36,8 @@ import static org.icij.datashare.function.ThrowingFunctions.parseBoolean;
 public class BatchSearchResource {
     private final BatchSearchRepository batchSearchRepository;
     private final PropertiesProvider propertiesProvider;
+    private static final int MAX_NAME_LENGTH = 255;
+    private static final int MAX_DESCRIPTION_LENGTH = 4096;
 
     @Inject
     public BatchSearchResource(PropertiesProvider propertiesProvider, final BatchSearchRepository batchSearchRepository) {
@@ -181,10 +183,49 @@ public class BatchSearchResource {
     @ApiResponse(responseCode = "200", description = "If the batch has been updated")
     @Patch("/search/:batchid")
     public Payload updateBatch(String batchId, Context context, JsonData data) {
-        if (batchSearchRepository.publish((User) context.currentUser(), batchId, data.asBoolean("published"))) {
-            return ok();
+        User user = (User) context.currentUser();
+        Map<String, Object> body = data.data;
+        boolean hasPublished = body.containsKey("published");
+        boolean hasName = body.containsKey("name");
+        boolean hasDescription = body.containsKey("description");
+
+        if (!hasPublished && !hasName && !hasDescription) {
+            return PayloadFormatter.error("No updatable field provided (expected published, name or description).", HttpStatus.BAD_REQUEST);
         }
-        return notFound();
+
+        String name = null;
+        if (hasName) {
+            name = (String) body.get("name");
+            if (name == null || name.trim().isEmpty()) {
+                return PayloadFormatter.error("Batch search name cannot be empty.", HttpStatus.BAD_REQUEST);
+            }
+            if (name.length() > MAX_NAME_LENGTH) {
+                return PayloadFormatter.error("Batch search name exceeds " + MAX_NAME_LENGTH + " characters.", HttpStatus.BAD_REQUEST);
+            }
+        }
+
+        String description = null;
+        if (hasDescription) {
+            description = (String) body.get("description");
+            if (description == null) {
+                description = "";
+            }
+            if (description.length() > MAX_DESCRIPTION_LENGTH) {
+                return PayloadFormatter.error("Batch search description exceeds " + MAX_DESCRIPTION_LENGTH + " characters.", HttpStatus.BAD_REQUEST);
+            }
+        }
+
+        boolean updated = false;
+        if (hasPublished) {
+            updated |= batchSearchRepository.publish(user, batchId, data.asBoolean("published"));
+        }
+        if (hasName) {
+            updated |= batchSearchRepository.setName(user, batchId, name);
+        }
+        if (hasDescription) {
+            updated |= batchSearchRepository.setDescription(user, batchId, description);
+        }
+        return updated ? ok() : notFound();
     }
 
     @Operation( description = """

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -186,62 +186,71 @@ public class BatchSearchResource {
     public Payload updateBatch(String batchId, Context context, JsonData data) {
         User user = (User) context.currentUser();
         Map<String, Object> body = data.data;
-        if (body == null) {
-            return PayloadFormatter.error("Request body must contain a data object.", HttpStatus.BAD_REQUEST);
-        }
-        boolean hasPublished = body.containsKey("published");
-        boolean hasName = body.containsKey("name");
-        boolean hasDescription = body.containsKey("description");
-
-        if (!hasPublished && !hasName && !hasDescription) {
+        if (body == null || !hasUpdatableField(body)) {
             return PayloadFormatter.error("No updatable field provided (expected published, name or description).", HttpStatus.BAD_REQUEST);
         }
-
-        String name = null;
-        if (hasName) {
-            Object rawName = body.get("name");
-            if (rawName != null && !(rawName instanceof String)) {
-                return PayloadFormatter.error("Batch search name must be a string.", HttpStatus.BAD_REQUEST);
-            }
-            name = (String) rawName;
-            if (name == null || name.trim().isEmpty()) {
-                return PayloadFormatter.error("Batch search name cannot be empty.", HttpStatus.BAD_REQUEST);
-            }
-            if (name.length() > MAX_NAME_LENGTH) {
-                return PayloadFormatter.error("Batch search name exceeds " + MAX_NAME_LENGTH + " characters.", HttpStatus.BAD_REQUEST);
-            }
+        try {
+            return applyEdits(user, batchId, body) ? ok() : notFound();
+        } catch (IllegalArgumentException invalidField) {
+            return PayloadFormatter.error(invalidField.getMessage(), HttpStatus.BAD_REQUEST);
         }
+    }
 
-        String description = null;
-        if (hasDescription) {
-            Object rawDescription = body.get("description");
-            if (rawDescription != null && !(rawDescription instanceof String)) {
-                return PayloadFormatter.error("Batch search description must be a string.", HttpStatus.BAD_REQUEST);
-            }
-            description = (String) rawDescription;
-            if (description == null) {
-                description = "";
-            }
-            if (description.length() > MAX_DESCRIPTION_LENGTH) {
-                return PayloadFormatter.error("Batch search description exceeds " + MAX_DESCRIPTION_LENGTH + " characters.", HttpStatus.BAD_REQUEST);
-            }
-        }
+    private static boolean hasUpdatableField(Map<String, Object> body) {
+        return body.containsKey("published") || body.containsKey("name") || body.containsKey("description");
+    }
+
+    private boolean applyEdits(User user, String batchId, Map<String, Object> body) {
+        // Validate every present field before applying any, so an invalid field never leaves a partial update.
+        Boolean published = body.containsKey("published") ? validBoolean(body.get("published"), "published") : null;
+        String name = body.containsKey("name") ? validName(body.get("name")) : null;
+        String description = body.containsKey("description") ? validDescription(body.get("description")) : null;
 
         boolean updated = false;
-        if (hasPublished) {
-            Object published = body.get("published");
-            if (!(published instanceof Boolean)) {
-                return PayloadFormatter.error("Batch search published must be a boolean.", HttpStatus.BAD_REQUEST);
-            }
-            updated |= batchSearchRepository.publish(user, batchId, (Boolean) published);
+        if (published != null) {
+            updated |= batchSearchRepository.publish(user, batchId, published);
         }
-        if (hasName) {
+        if (name != null) {
             updated |= batchSearchRepository.setName(user, batchId, name);
         }
-        if (hasDescription) {
+        if (description != null) {
             updated |= batchSearchRepository.setDescription(user, batchId, description);
         }
-        return updated ? ok() : notFound();
+        return updated;
+    }
+
+    private static String validName(Object value) {
+        String name = validString(value, "name");
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("Batch search name cannot be empty.");
+        }
+        return withinMaxLength(name, MAX_NAME_LENGTH, "name");
+    }
+
+    private static String validDescription(Object value) {
+        String description = validString(value, "description");
+        return withinMaxLength(description == null ? "" : description, MAX_DESCRIPTION_LENGTH, "description");
+    }
+
+    private static String validString(Object value, String field) {
+        if (value != null && !(value instanceof String)) {
+            throw new IllegalArgumentException("Batch search " + field + " must be a string.");
+        }
+        return (String) value;
+    }
+
+    private static boolean validBoolean(Object value, String field) {
+        if (!(value instanceof Boolean)) {
+            throw new IllegalArgumentException("Batch search " + field + " must be a boolean.");
+        }
+        return (Boolean) value;
+    }
+
+    private static String withinMaxLength(String value, int maxLength, String field) {
+        if (value.length() > maxLength) {
+            throw new IllegalArgumentException("Batch search " + field + " exceeds " + maxLength + " characters.");
+        }
+        return value;
     }
 
     @Operation( description = """

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -36,6 +36,7 @@ import static org.icij.datashare.function.ThrowingFunctions.parseBoolean;
 public class BatchSearchResource {
     private final BatchSearchRepository batchSearchRepository;
     private final PropertiesProvider propertiesProvider;
+
     @Inject
     public BatchSearchResource(PropertiesProvider propertiesProvider, final BatchSearchRepository batchSearchRepository) {
         this.batchSearchRepository = batchSearchRepository;
@@ -198,32 +199,32 @@ public class BatchSearchResource {
     }
 
     private boolean applyEdits(User user, String batchId, Map<String, Object> body) {
-        // Validate every present field before applying any, so an invalid field never leaves a partial update.
-        Boolean published = body.containsKey("published") ? validBoolean(body.get("published"), "published") : null;
-        String name = body.containsKey("name") ? BatchSearch.validateName(validString(body.get("name"), "name")) : null;
-        String description = body.containsKey("description") ? BatchSearch.validateDescription(validString(body.get("description"), "description")) : null;
-
         boolean updated = false;
-        if (published != null) {
+        if (body.containsKey("published")) {
+            boolean published = asBoolean(body, "published");
             updated |= batchSearchRepository.publish(user, batchId, published);
         }
-        if (name != null) {
+        if (body.containsKey("name")) {
+            String name = BatchSearch.validateName(asString(body, "name"));
             updated |= batchSearchRepository.setName(user, batchId, name);
         }
-        if (description != null) {
+        if (body.containsKey("description")) {
+            String description = BatchSearch.validateDescription(asString(body, "description"));
             updated |= batchSearchRepository.setDescription(user, batchId, description);
         }
         return updated;
     }
 
-    private static String validString(Object value, String field) {
+    private static String asString(Map<String, Object> body, String field) {
+        Object value = body.get(field);
         if (value != null && !(value instanceof String)) {
             throw new IllegalArgumentException("Batch search " + field + " must be a string.");
         }
         return (String) value;
     }
 
-    private static boolean validBoolean(Object value, String field) {
+    private static boolean asBoolean(Map<String, Object> body, String field) {
+        Object value = body.get(field);
         if (!(value instanceof Boolean)) {
             throw new IllegalArgumentException("Batch search " + field + " must be a boolean.");
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/BatchSearchResource.java
@@ -186,6 +186,9 @@ public class BatchSearchResource {
     public Payload updateBatch(String batchId, Context context, JsonData data) {
         User user = (User) context.currentUser();
         Map<String, Object> body = data.data;
+        if (body == null) {
+            return PayloadFormatter.error("Request body must contain a data object.", HttpStatus.BAD_REQUEST);
+        }
         boolean hasPublished = body.containsKey("published");
         boolean hasName = body.containsKey("name");
         boolean hasDescription = body.containsKey("description");
@@ -196,7 +199,11 @@ public class BatchSearchResource {
 
         String name = null;
         if (hasName) {
-            name = (String) body.get("name");
+            Object rawName = body.get("name");
+            if (rawName != null && !(rawName instanceof String)) {
+                return PayloadFormatter.error("Batch search name must be a string.", HttpStatus.BAD_REQUEST);
+            }
+            name = (String) rawName;
             if (name == null || name.trim().isEmpty()) {
                 return PayloadFormatter.error("Batch search name cannot be empty.", HttpStatus.BAD_REQUEST);
             }
@@ -207,7 +214,11 @@ public class BatchSearchResource {
 
         String description = null;
         if (hasDescription) {
-            description = (String) body.get("description");
+            Object rawDescription = body.get("description");
+            if (rawDescription != null && !(rawDescription instanceof String)) {
+                return PayloadFormatter.error("Batch search description must be a string.", HttpStatus.BAD_REQUEST);
+            }
+            description = (String) rawDescription;
             if (description == null) {
                 description = "";
             }

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -244,7 +244,7 @@ public class TaskResource {
                     in = ParameterIn.PATH, examples = @ExampleObject(value = "prj1,prj2"))}
     )
     @ApiResponse(responseCode = "413", description = "if the CSV file is more than 60K lines")
-    @ApiResponse(responseCode = "400", description = "if either name or CSV file is missing")
+    @ApiResponse(responseCode = "400", description = "if name or CSV file is missing, or name/description are empty or exceed their maximum length")
     @Post("/batchSearch/:coma_separated_projects")
     public Payload search(String comaSeparatedProjects, Context context) throws IOException {
         List<Part> parts = context.parts();
@@ -271,7 +271,12 @@ public class TaskResource {
 
         BatchSearch batchSearch = new BatchSearch(stream(comaSeparatedProjects.split(",")).map(Project::project).collect(Collectors.toList()), name, description, queries,uri,
                 (User) context.currentUser(), published, fileTypes, queryTemplate, paths, fuzziness,phraseMatches);
-        boolean isSaved = batchSearchRepository.save(batchSearch);
+        boolean isSaved;
+        try {
+            isSaved = batchSearchRepository.save(batchSearch);
+        } catch (IllegalArgumentException e) {
+            return badRequest();
+        }
         if (isSaved) {
             taskManager.startTask(batchSearch.uuid, BatchSearchRunner.class, (User) context.currentUser(), Map.of("batchRecord", new BatchSearchRecord(batchSearch)));
         }
@@ -301,7 +306,12 @@ public class TaskResource {
             throw new NotFoundException();
         }
         BatchSearch copy = new BatchSearch(sourceBatchSearch, context.extract(HashMap.class));
-        boolean isSaved = batchSearchRepository.save(copy);
+        boolean isSaved;
+        try {
+            isSaved = batchSearchRepository.save(copy);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException();
+        }
         if (isSaved) taskManager.startTask(copy.uuid, BatchSearchRunner.class, (User) context.currentUser(), Map.of("batchRecord", new BatchSearchRecord(copy)));
         return copy.uuid;
     }

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -213,11 +213,70 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_update_batch_search() {
+    public void test_update_batch_search_published() {
         when(batchSearchRepository.publish(User.local(), "batchId", true)).thenReturn(true).thenReturn(false);
 
         patch("/api/batch/search/batchId", "{\"data\": {\"published\": true}}").should().respond(200);
         patch("/api/batch/search/batchId", "{\"data\": {\"published\": true}}").should().respond(404);
+    }
+
+    @Test
+    public void test_update_batch_search_name() {
+        when(batchSearchRepository.setName(User.local(), "batchId", "new name")).thenReturn(true);
+
+        patch("/api/batch/search/batchId", "{\"data\": {\"name\": \"new name\"}}").should().respond(200);
+    }
+
+    @Test
+    public void test_update_batch_search_description() {
+        when(batchSearchRepository.setDescription(User.local(), "batchId", "new description")).thenReturn(true);
+
+        patch("/api/batch/search/batchId", "{\"data\": {\"description\": \"new description\"}}").should().respond(200);
+    }
+
+    @Test
+    public void test_update_batch_search_all_fields() {
+        when(batchSearchRepository.publish(User.local(), "batchId", true)).thenReturn(true);
+        when(batchSearchRepository.setName(User.local(), "batchId", "new name")).thenReturn(true);
+        when(batchSearchRepository.setDescription(User.local(), "batchId", "new description")).thenReturn(true);
+
+        patch("/api/batch/search/batchId",
+                "{\"data\": {\"published\": true, \"name\": \"new name\", \"description\": \"new description\"}}")
+                .should().respond(200);
+    }
+
+    @Test
+    public void test_update_batch_search_unauthorized_returns_404() {
+        when(batchSearchRepository.setName(User.local(), "batchId", "new name")).thenReturn(false);
+
+        patch("/api/batch/search/batchId", "{\"data\": {\"name\": \"new name\"}}").should().respond(404);
+    }
+
+    @Test
+    public void test_update_batch_search_empty_body_returns_400() {
+        patch("/api/batch/search/batchId", "{\"data\": {}}").should().respond(400);
+    }
+
+    @Test
+    public void test_update_batch_search_blank_name_returns_400() {
+        patch("/api/batch/search/batchId", "{\"data\": {\"name\": \"  \"}}").should().respond(400);
+    }
+
+    @Test
+    public void test_update_batch_search_null_name_returns_400() {
+        patch("/api/batch/search/batchId", "{\"data\": {\"name\": null}}").should().respond(400);
+    }
+
+    @Test
+    public void test_update_batch_search_name_too_long_returns_400() {
+        String longName = "x".repeat(256);
+        patch("/api/batch/search/batchId", "{\"data\": {\"name\": \"" + longName + "\"}}").should().respond(400);
+    }
+
+    @Test
+    public void test_update_batch_search_description_too_long_returns_400() {
+        String longDescription = "x".repeat(4097);
+        patch("/api/batch/search/batchId", "{\"data\": {\"description\": \"" + longDescription + "\"}}").should().respond(400);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -285,6 +285,21 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_update_batch_search_non_string_name_returns_400() {
+        patch("/api/batch/search/batchId", "{\"data\": {\"name\": 42}}").should().respond(400);
+    }
+
+    @Test
+    public void test_update_batch_search_non_string_description_returns_400() {
+        patch("/api/batch/search/batchId", "{\"data\": {\"description\": 42}}").should().respond(400);
+    }
+
+    @Test
+    public void test_update_batch_search_missing_data_returns_400() {
+        patch("/api/batch/search/batchId", "{}").should().respond(400);
+    }
+
+    @Test
     public void test_delete_batch_search_by_id() {
         when(batchSearchRepository.delete(User.local(), "myid")).thenReturn(true).thenReturn(false);
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/BatchSearchResourceTest.java
@@ -268,6 +268,11 @@ public class BatchSearchResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_update_batch_search_null_published_returns_400() {
+        patch("/api/batch/search/batchId", "{\"data\": {\"published\": null}}").should().respond(400);
+    }
+
+    @Test
     public void test_update_batch_search_name_too_long_returns_400() {
         String longName = "x".repeat(256);
         patch("/api/batch/search/batchId", "{\"data\": {\"name\": \"" + longName + "\"}}").should().respond(400);

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceBatchSearchTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceBatchSearchTest.java
@@ -170,6 +170,27 @@ public class TaskResourceBatchSearchTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_create_batch_search_with_invalid_name_returns_400() {
+        when(batchSearchRepository.save(any())).thenThrow(new IllegalArgumentException("Batch search name exceeds 255 characters."));
+        postRaw("/api/task/batchSearch/prj", "multipart/form-data;boundary=AaB03x",
+                new MultipartContentBuilder("AaB03x")
+                        .addField("name", "x".repeat(256))
+                        .addFile(new FileUpload("csvFile").withFilename("search.csv").withContentType("text/csv").withContent("query one\r\n"))
+                        .build()).should().respond(400);
+    }
+
+    @Test
+    public void test_copy_batch_search_with_invalid_name_returns_400() {
+        BatchSearch sourceSearch = new BatchSearch(asList(project("prj1"), project("prj2")), "name", "description1",
+                asSet("query 1", "query 2"), "/?q=", User.local());
+        when(batchSearchRepository.get(null, sourceSearch.uuid)).thenReturn(sourceSearch);
+        when(batchSearchRepository.save(any())).thenThrow(new IllegalArgumentException("Batch search name exceeds 255 characters."));
+
+        post("/api/task/batchSearch/copy/" + sourceSearch.uuid,
+                "{\"name\": \"" + "x".repeat(256) + "\"}").should().respond(400);
+    }
+
+    @Test
     public void test_rerun_batch_search_not_found() {
         post("/api/task/batchSearch/copy/bad_uuid", "{}").should().respond(404);
     }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -349,6 +349,14 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
 
     }
 
+    @Override
+    public boolean setName(User user, String batchId, String name) {
+        return DSL.using(dataSource, dialect).update(BATCH_SEARCH).
+                set(BATCH_SEARCH.NAME, name).
+                where(BATCH_SEARCH.UUID.eq(batchId).
+                        and(BATCH_SEARCH.USER_ID.eq(user.id))).execute() > 0;
+    }
+
     private List<BatchSearch> mergeBatchSearches(final List<BatchSearch> flatBatchSearches) {
         Map<String, List<BatchSearch>> collect = flatBatchSearches.stream().collect(groupingBy(bs -> bs.uuid));
         return collect.values().stream().map(batchSearches ->

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -357,6 +357,14 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
                         and(BATCH_SEARCH.USER_ID.eq(user.id))).execute() > 0;
     }
 
+    @Override
+    public boolean setDescription(User user, String batchId, String description) {
+        return DSL.using(dataSource, dialect).update(BATCH_SEARCH).
+                set(BATCH_SEARCH.DESCRIPTION, description).
+                where(BATCH_SEARCH.UUID.eq(batchId).
+                        and(BATCH_SEARCH.USER_ID.eq(user.id))).execute() > 0;
+    }
+
     private List<BatchSearch> mergeBatchSearches(final List<BatchSearch> flatBatchSearches) {
         Map<String, List<BatchSearch>> collect = flatBatchSearches.stream().collect(groupingBy(bs -> bs.uuid));
         return collect.values().stream().map(batchSearches ->

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqBatchSearchRepository.java
@@ -50,6 +50,8 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
 
     @Override
     public boolean save(final BatchSearch batchSearch) {
+        BatchSearch.validateName(batchSearch.name);
+        BatchSearch.validateDescription(batchSearch.description);
         DSLContext context = DSL.using(dataSource, dialect);
         return context.transactionResult(configuration -> {
             DSLContext inner = DSL.using(configuration);
@@ -351,6 +353,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
 
     @Override
     public boolean setName(User user, String batchId, String name) {
+        BatchSearch.validateName(name);
         return DSL.using(dataSource, dialect).update(BATCH_SEARCH).
                 set(BATCH_SEARCH.NAME, name).
                 where(BATCH_SEARCH.UUID.eq(batchId).
@@ -359,6 +362,7 @@ public class JooqBatchSearchRepository implements BatchSearchRepository {
 
     @Override
     public boolean setDescription(User user, String batchId, String description) {
+        BatchSearch.validateDescription(description);
         return DSL.using(dataSource, dialect).update(BATCH_SEARCH).
                 set(BATCH_SEARCH.DESCRIPTION, description).
                 where(BATCH_SEARCH.UUID.eq(batchId).

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -691,6 +691,24 @@ public class JooqBatchSearchRepositoryTest {
     }
 
     @Test
+    public void test_set_name() {
+        repository.save(new BatchSearch("uuid", singletonList(proxy("prj")), "name", "description",
+                asSet("q1", "q2"), new Date(), State.FAILURE, User.local()));
+
+        assertThat(repository.setName(User.local(), "uuid", "new name")).isTrue();
+        assertThat(repository.get(User.local(), "uuid").name).isEqualTo("new name");
+    }
+
+    @Test
+    public void test_set_name_unauthorized_user_does_nothing() {
+        repository.save(new BatchSearch("uuid", singletonList(proxy("prj")), "name1", "description1",
+                asSet("q1", "q2"), new Date(), State.FAILURE, User.local()));
+
+        assertThat(repository.setName(new User("unauthorized"), "uuid", "hacked")).isFalse();
+        assertThat(repository.get(User.local(), "uuid").name).isEqualTo("name1");
+    }
+
+    @Test
     public void test_reset_batch_search() {
         BatchSearch batchSearch = new BatchSearch("uuid", singletonList(proxy("prj")), "name1", "description1",
                 asSet("q1", "q2"), new Date(), State.RUNNING, User.local());

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -920,6 +920,33 @@ public class JooqBatchSearchRepositoryTest {
                 WebQueryBuilder.createWebQuery().queryAll().withSortOrder("(SELECT password FROM users)", "asc").build());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void test_set_name_too_long_throws() {
+        repository.setName(User.local(), "uuid", "x".repeat(BatchSearch.MAX_NAME_LENGTH + 1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_set_name_blank_throws() {
+        repository.setName(User.local(), "uuid", "   ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_set_description_too_long_throws() {
+        repository.setDescription(User.local(), "uuid", "x".repeat(BatchSearch.MAX_DESCRIPTION_LENGTH + 1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_save_with_too_long_name_throws() {
+        repository.save(new BatchSearch(singletonList(proxy("prj")), "x".repeat(BatchSearch.MAX_NAME_LENGTH + 1),
+                "description", asSet("q1", "q2"), null, User.local()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_save_with_too_long_description_throws() {
+        repository.save(new BatchSearch(singletonList(proxy("prj")), "name",
+                "x".repeat(BatchSearch.MAX_DESCRIPTION_LENGTH + 1), asSet("q1", "q2"), null, User.local()));
+    }
+
     private SearchResult resultFrom(Document doc, int docNb, String queryName) {
         return new SearchResult(queryName, doc.getId(), doc.getRootDocument(), doc.getPath(), doc.getCreationDate(), doc.getContentType(), doc.getContentLength(), docNb);
     }

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqBatchSearchRepositoryTest.java
@@ -709,6 +709,24 @@ public class JooqBatchSearchRepositoryTest {
     }
 
     @Test
+    public void test_set_description() {
+        repository.save(new BatchSearch("uuid", singletonList(proxy("prj")), "name", "description",
+                asSet("q1", "q2"), new Date(), State.FAILURE, User.local()));
+
+        assertThat(repository.setDescription(User.local(), "uuid", "new description")).isTrue();
+        assertThat(repository.get(User.local(), "uuid").description).isEqualTo("new description");
+    }
+
+    @Test
+    public void test_set_description_unauthorized_user_does_nothing() {
+        repository.save(new BatchSearch("uuid", singletonList(proxy("prj")), "name1", "description1",
+                asSet("q1", "q2"), new Date(), State.FAILURE, User.local()));
+
+        assertThat(repository.setDescription(new User("unauthorized"), "uuid", "hacked")).isFalse();
+        assertThat(repository.get(User.local(), "uuid").description).isEqualTo("description1");
+    }
+
+    @Test
     public void test_reset_batch_search() {
         BatchSearch batchSearch = new BatchSearch("uuid", singletonList(proxy("prj")), "name1", "description1",
                 asSet("q1", "q2"), new Date(), State.RUNNING, User.local());


### PR DESCRIPTION
As part of #2166, this PR allow users to edit name and description of a batch search through the API.

What began as "let users edit a batch search's title and description over the API" turned out to touch every layer the field validation has to hold at. Editing names/descriptions meant the rules (non-empty name, max lengths) couldn't live only at the endpoint: they had to be enforced consistently wherever those fields are written, so the validators were added to the `BatchSearch` model and then applied not just on update but on the create and copy paths in `JooqBatchSearchRepository`, each returning a proper 400 instead of a 500. 
