### PR TITLE
fix: reconcialiation of tasks with Temporal was not called at startup

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -118,7 +118,7 @@ public class Main {
             Closeable tray = DatashareSystemTray.create(port);
             ofNullable(tray).ifPresent(commonMode::addCloseable);
             WebApp.start(commonMode);
-            if(QueueType.TEMPORAL == commonMode.getCurrentQueueType()) {
+            if(QueueType.TEMPORAL == commonMode.getCurrentBatchQueueType()) {
                 TaskManagerTemporal taskManager = (TaskManagerTemporal) commonMode.get(TaskManager.class);
                 taskManager.reconcileTasks();
             }

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -497,8 +497,8 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
                 get(propertyName).orElse(defaultQueueType.name()).toUpperCase());
     }
 
-    public QueueType getCurrentQueueType() {
-        return getQueueType(propertiesProvider, QUEUE_TYPE_OPT, DEFAULT_QUEUE_TYPE);
+    public QueueType getCurrentBatchQueueType() {
+        return getQueueType(propertiesProvider, BATCH_QUEUE_TYPE_OPT, DEFAULT_BATCH_QUEUE_TYPE);
     }
 
     public void addCloseable(Closeable client) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -108,13 +108,17 @@ public class TaskManagerTemporal implements TaskManager {
      * @throws IOException
      */
     public void reconcileTasks() throws IOException {
+        logger.info("Scanning repository for tasks to reconcile");
         taskRepository.getTasks(TaskFilters.empty().withStates(Set.of(Task.State.RUNNING)))
             .forEach(repoTask -> {
+                logger.info("Reconciling task {} with Temporal", repoTask.getId());
                 try {
                     Task<Serializable> temporalTask = temporal.getTask(repoTask.id);
                     if (temporalTask.isFinished()) {
+                        logger.info("Task {} is finished in Temporal, update the completion information in repository", repoTask.getId());
                         taskRepository.update(temporalTask);
                     } else {
+                        logger.info("Task {} is still running in Temporal, attaching completion listener", repoTask.getId());
                         attachCompletionListener(repoTask.id);
                     }
                 } catch (UnknownTask e) {


### PR DESCRIPTION
This PR fixes the trigger for reconciliation with Temporal. It was the wrong option that was read. Also adds some logs to be able to track reconciliation in prod