### PR TITLE
fix: pin commons-io 2.18.0 and stop throwing on unknown languages

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/text/Language.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/Language.java
@@ -216,7 +216,15 @@ public enum Language implements Serializable {
                 return lang;
             }
         }
-        return valueOf(language.toUpperCase(Locale.ROOT));
+        // Fall back to the enum constant name, but never throw on an unknown code:
+        // the language detector can return ISO codes absent from this enum (e.g. "ast"
+        // for Asturian), and a thrown exception here aborts extraction of the whole
+        // containing file (e.g. every remaining email in a PST).
+        try {
+            return valueOf(language.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
+        }
     }
 
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -143,7 +143,7 @@ public class ElasticsearchSpewerTest {
         );
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_write_with_incorrect_language() throws Exception {
         Path path = get(requireNonNull(getClass().getResource("/docs/a/b/c/doc.txt")).getPath());
 
@@ -152,6 +152,11 @@ public class ElasticsearchSpewerTest {
         }}));
         TikaDocument document = new Extractor(documentFactory).extract(path);
         spewer.write(document);
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(document.getId()), ObjectNode.class);
+        assertThat(nodeToMap(documentFields.source())).includes(
+                entry("language", "UNKNOWN")
+        );
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,16 @@
                 <artifactId>commons-csv</artifactId>
                 <version>1.14.0</version>
             </dependency>
+            <!-- tika-parsers 3.3.0 manages commons-io 2.17.0, which wins Maven mediation, but the
+                 commons-compress 1.28.0 it also pulls calls AbstractStreamBuilder.getInputStream(),
+                 which only became public in commons-io 2.18.0. With 2.17.0 (protected), Tika's
+                 GZipSpecializationDetector throws IllegalAccessError while detecting any gzip-ish
+                 attachment, aborting extraction of the whole containing PST/archive. Pin 2.18.0. -->
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.18.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Two related fixes that keep PST/archive extraction from aborting halfway through:

- **Pin `commons-io` to 2.18.0 in dependency management.**
  Tika 3.3.0 manages `commons-io` 2.17.0, but the `commons-compress` 1.28.0 it ships calls `AbstractStreamBuilder.getInputStream()`, which only became public in 2.18.0. With 2.17.0 (protected), Tika's `GZipSpecializationDetector` throws `IllegalAccessError` when detecting any gzip-ish attachment, aborting extraction of the entire containing PST/archive.
- **Never throw on an unknown detected language code.**
  The language detector can return ISO codes absent from our `Language` enum (e.g. `ast` for Asturian). Previously `Language.parse` threw `IllegalArgumentException`, which aborted extraction of the whole containing file (e.g. every remaining email in a PST). It now falls back to `UNKNOWN`.

## Why

In both cases a single bad attachment or undetectable language would crash extraction of the whole containing PST/archive, silently dropping every remaining document inside it. These changes make extraction resilient so one problematic item no longer takes down its siblings.