### PR TITLE
Reduce the number of connection reset datashare gets

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/BatchDownloadRunner.java
@@ -145,6 +145,7 @@ public class BatchDownloadRunner implements Callable<BatchDownloadRunnerResult>,
                 }
             }
         } catch (ElasticsearchException esEx) {
+            logger.atDebug().log("Unable to query elastic search", esEx);
             throw ElasticSearchAdapterException.createFrom(esEx);
         }
         BatchDownloadRunnerResult.TruncationReason truncationReason = null; //Can stay null if no truncation was made

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -168,6 +168,7 @@ public class DatashareCli {
         DatashareCliOptions.defaultProject(parser);
         DatashareCliOptions.oauthClaimIdAttribute(parser);
         DatashareCliOptions.esHost(parser);
+        DatashareCliOptions.elasticsearchMaxIdleConnectionTime(parser);
         DatashareCliOptions.indexTimeout(parser);
         DatashareCliOptions.queueName(parser);
         DatashareCliOptions.queueType(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -65,6 +65,8 @@ public final class DatashareCliOptions {
     public static final String ELASTICSEARCH_SETTINGS_OPT = "elasticsearchSettings";
     public static final String ELASTICSEARCH_PATH_OPT = "elasticsearchPath";
     public static final String ELASTICSEARCH_DATA_PATH_OPT = "elasticsearchDataPath";
+    // Time in ms after which an idling connection should be considered invalid
+    public static final String ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME_OPT = "elasticsearchMaxIdleConnectionTime";
     public static final String EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT = "embeddedDocumentDownloadMaxSize";
     public static final String EXTENSION_DELETE_OPT = "extensionDelete";
     public static final String EXTENSION_INSTALL_OPT = "extensionInstall";
@@ -254,6 +256,7 @@ public final class DatashareCliOptions {
     public static final String DEFAULT_TEMPORAL_NAMESPACE = "datashare-default";
     public static final String DEFAULT_TEMPORAL_ADDRESS = EnvUtils.resolveUri("temporal", "temporal:7233");
     public static final int DEFAULT_POLICY_RELOAD_INTERVAL = 30_000;
+    public static final int DEFAULT_ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME = 349000;
 
     // A list of aliases for retro-compatibility when an option changed
     public static final Map<String, String> OPT_ALIASES = Map.ofEntries(
@@ -680,6 +683,14 @@ public final class DatashareCliOptions {
                 .withRequiredArg()
                 .ofType(String.class)
                 .defaultsTo(DEFAULT_ELASTICSEARCH_SETTINGS);
+    }
+
+    public static void elasticsearchMaxIdleConnectionTime(OptionParser parser) {
+        parser.acceptsAll(
+                singletonList(ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME_OPT), "Max idling time for a TCP connection to ES to be reused")
+                .withRequiredArg()
+                .ofType(Integer.class)
+                .defaultsTo(DEFAULT_ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME);
     }
 
     public static void reportName(OptionParser parser) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/GlobalOptions.java
@@ -64,6 +64,9 @@ public class GlobalOptions {
     @Option(names = {"--elasticsearchSettings"}, description = "Path to elasticsearch.yml settings", scope = ScopeType.INHERIT)
     String elasticsearchSettings = Paths.get(userHome(), ".local/share/datashare", "elasticsearch.yml").toString();
 
+    @Option(names = {"--elasticsearchMaxIdleConnectionTime"}, defaultValue = "349000", description = "Max idling time for a TCP connection to ES to be reused", scope = ScopeType.INHERIT)
+    int elasticsearchMaxIdleConnectionTime;
+
     @Option(names = {"--redisAddress"}, description = "Redis address", scope = ScopeType.INHERIT)
     String redisAddress = EnvUtils.resolveUri("redis", "redis://redis:6379");
 
@@ -146,6 +149,7 @@ public class GlobalOptions {
         DatashareOptions.putIfNotNull(props, ELASTICSEARCH_PATH_OPT, elasticsearchPath);
         DatashareOptions.putIfNotNull(props, ELASTICSEARCH_DATA_PATH_OPT, elasticsearchDataPath);
         DatashareOptions.putIfNotNull(props, ELASTICSEARCH_SETTINGS_OPT, elasticsearchSettings);
+        DatashareOptions.putIfNotNull(props, ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME_OPT, elasticsearchMaxIdleConnectionTime);
         DatashareOptions.putIfNotNull(props, REDIS_ADDRESS_OPT, redisAddress);
         DatashareOptions.put(props, REDIS_POOL_SIZE_OPT, redisPoolSize);
         DatashareOptions.putIfNotNull(props, MESSAGE_BUS_OPT, messageBusAddress);
@@ -167,7 +171,6 @@ public class GlobalOptions {
         DatashareOptions.putIfNotNull(props, DatashareCliOptions.TEMPORAL_ADDRESS_OPT, temporalAddress);
         DatashareOptions.putIfNotNull(props, DatashareCliOptions.TEMPORAL_NAMESPACE_OPT, temporalNamespace);
         DatashareOptions.putIfNotNull(props, AUTH_USERS_PROVIDER_OPT, authUsersProvider);
-
         return props;
     }
 

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -239,6 +239,12 @@ public class DatashareCliTest {
     }
 
     @Test
+    public void test_elasticsearch_max_idle_time_is_valid() {
+        cli.parseArguments(new String[] {"--elasticsearchMaxIdleConnectionTime", "29"});
+        assertThat(cli.properties).includes(entry("elasticsearchMaxIdleConnectionTime", "29"));
+    }
+
+    @Test
     public void test_extensions_dir_is_based_on_current_user_dir() {
         cli.parseArguments(new String[] {});
         assertThat(cli.properties).includes(entry("extensionsDir", "/home/datashare/.local/share/datashare/extensions"));

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/GlobalOptionsTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/GlobalOptionsTest.java
@@ -1,0 +1,20 @@
+package org.icij.datashare.cli.command;
+
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
+public class GlobalOptionsTest extends AbstractDatashareCommandTest{
+
+    @Test
+    public void test_elasticsearch_max_idle_connection_time_is_taken_into_account() {
+        Properties props = parse(
+                "--elasticsearchMaxIdleConnectionTime", "29");
+        assertThat(props).includes(entry("elasticsearchMaxIdleConnectionTime", "29"));
+    }
+
+}

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
@@ -46,7 +46,6 @@ public class ElasticsearchConfiguration {
     public static final String INDEX_NAME_PROP = "indexName";
     public static final String INDEX_JOIN_FIELD_NAME_PROP = "indexJoinFieldName";
     public static final String INDEX_TYPE_FIELD_NAME_PROP = "indexTypeFieldName";
-    public static final String CLUSTER_PROP = "clusterName";
 
     public static final String DEFAULT_ADDRESS = "http://localhost:9200";
     public static final String ES_CLUSTER_NAME = "datashare";
@@ -100,9 +99,7 @@ public class ElasticsearchConfiguration {
                             .setConnectTimeout(5000)
                             .setSocketTimeout(60000))
                     .setHttpClientConfigCallback(clientConfigCallback).build(), new JacksonJsonpMapper(JsonObjectMapper.getMapper()));
-            ElasticsearchClient client = new ElasticsearchClient(transport);
-            String clusterName = propertiesProvider.get(CLUSTER_PROP).orElse(ES_CLUSTER_NAME);
-            return client;
+            return new ElasticsearchClient(transport);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
@@ -33,6 +33,7 @@ import static com.google.common.io.ByteStreams.toByteArray;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.apache.http.HttpHost.create;
+import static org.icij.datashare.cli.DatashareCliOptions.ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME_OPT;
 
 public class ElasticsearchConfiguration {
     static final String MAPPING_RESOURCE_NAME = "datashare_index_mappings.json";
@@ -49,6 +50,7 @@ public class ElasticsearchConfiguration {
     public static final String INDEX_NAME_PROP = "indexName";
     public static final String INDEX_JOIN_FIELD_NAME_PROP = "indexJoinFieldName";
     public static final String INDEX_TYPE_FIELD_NAME_PROP = "indexTypeFieldName";
+    public static final String ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME_OPT = "elasticsearchMaxIdleConnectionTime";
 
     public static final String DEFAULT_ADDRESS = "http://localhost:9200";
     public static final String ES_CLUSTER_NAME = "datashare";
@@ -87,7 +89,7 @@ public class ElasticsearchConfiguration {
                     // idling for longer.
                     // Else ElasticSearchClient throws an IOException : Connection reset when trying to reuse the
                     // connection after the LB closed it
-                    return 349000;
+                    return propertiesProvider.get(ELASTICSEARCH_MAX_IDLE_CONNECTION_TIME_OPT).map(Long::valueOf).orElse(349000L);
                 });
                 httpAsyncClientBuilder.addInterceptorLast((HttpResponseInterceptor)
                         (response, context) ->

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
@@ -9,11 +9,14 @@ import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ConnectionKeepAliveStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.protocol.HttpContext;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.icij.datashare.PropertiesProvider;
@@ -78,6 +81,14 @@ public class ElasticsearchConfiguration {
 
             RestClientBuilder.HttpClientConfigCallback clientConfigCallback = httpAsyncClientBuilder -> {
                 httpAsyncClientBuilder.disableAuthCaching();
+                httpAsyncClientBuilder.setConnectionReuseStrategy((response, context) -> true);
+                httpAsyncClientBuilder.setKeepAliveStrategy((response, context) -> {
+                    // Load Balancer in production and staging closes TCP connections after 350s, so avoid keeping them
+                    // idling for longer.
+                    // Else ElasticSearchClient throws an IOException : Connection reset when trying to reuse the
+                    // connection after the LB closed it
+                    return 349000;
+                });
                 httpAsyncClientBuilder.addInterceptorLast((HttpResponseInterceptor)
                         (response, context) ->
                                 // This header is expected from the client, versions of ES server below 7.14 don't provide it


### PR DESCRIPTION
With the recent changes in the network configuration (starting around the 13th of may), Datashare started getting `IOException : Connection reset` upon sending requests to ES.
It was due to the fact that there is in DS a connection pooling mechanism in place which kept connections to ES alive for probably 10 minutes (we were never able to find exactly the value, we think there is a chance it is linked to the scroll duration, sent back by ES in an header) BUT in production and staging the load balancer would close connections after 350 seconds.
So Datashare would try to reuse a closed connection, and get a connection reset on its first attempt.
Since they are not handled gracefully (at least in BatchDownload), the Task would fail. 

This PR adds a configuration entry `elasticsearchMaxIdleConnectionTime` which sets the TTL of an idling ES connection, adding the capability to adjust to the network infra. In particular it is recommended to set the TTL of those idling connections lower than the value of the network elements that would shut idling connections (proxy, load balancer etc...)