### PR TITLE
chore(deps): bump extract-lib to 9.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.6.0</extract.version>
+        <extract.version>9.7.1</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>


### PR DESCRIPTION
Bumps `extract-lib` from `9.6.0` to `9.7.1`, driven by the single `extract.version` property in the root `pom.xml` that feeds `datashare-app`, `datashare-index`, `datashare-db`, and `datashare-tasks`.

This release hardens Outlook mailbox extraction and bounds the memory used for embedded-document text. Defaults are sensible, so no datashare config change is required, though two new tuning options are now available to expose if we want them.

## Changes

* chore(deps): bump `extract.version` from `9.6.0` to `9.7.1` in the root `pom.xml`
* feat(pst): `ResilientOutlookPSTParser` replaces Tika's stock `OutlookPSTParser`, isolating per-message failures (including `LinkageError`) so one bad item no longer aborts the whole PST
* feat(pst): add OST 2013 (`.ost` type-36) support
* feat(pst): surface over-emission and unreadable items (e.g. unreadable OST 2013 attachments) as completeness signals instead of silent loss
* fix(pst): include RTF message bodies in size estimates
* feat(extract): add `embedMemoryBudgetMb` option (default 64) to cap embedded-document text held in memory before overflowing to temp files
* feat(extract): add `embedMemoryPressureThreshold` option (default 0.7) to spill embedded text to temp files early under heap pressure
* feat(extract): add `BudgetedEmbedBuffer` and `MemoryPressureGauge` backing the deferred disk spill, with spill-file reclaim
* fix(extract): close embedded-document readers during the spew walk to prevent file-descriptor exhaustion on large jobs
* fix(extract): add `ResourceClosingReader` and make embed-text temp-resource construction exception-safe
* fix(build): bump `central-publishing-maven-plugin` to `0.11.0` so the artifact publishes to Maven Central
