### PR TITLE
fix: enforce project membership on project-scoped endpoints

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -17,6 +17,7 @@ import net.codestory.http.Context;
 import net.codestory.http.annotations.*;
 import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.errors.ForbiddenException;
+import static org.icij.datashare.web.errors.ForbiddenException.forbiddenIfNotGranted;
 import net.codestory.http.payload.Payload;
 import net.codestory.http.types.ContentTypes;
 import org.icij.datashare.PropertiesProvider;
@@ -81,7 +82,8 @@ public class DocumentResource {
     )
     @ApiResponse(responseCode = "200", description = "Datashare Document JSON",  useReturnTypeSchema = true)
     @Get("/:project/documents/:id?routing=:routing")
-    public Document getDoc(String project, String id, String routing) {
+    public Document getDoc(String project, String id, String routing, final Context context) {
+        requireGranted(context, project);
         return notFoundIfNull(indexer.get(project, id, ofNullable(routing).orElse(id)));
     }
 
@@ -161,7 +163,8 @@ public class DocumentResource {
     )
     @ApiResponse(responseCode = "200", description = "JSON containing pages indices parameters",  useReturnTypeSchema = true)
     @Get("/:project/documents/pages/:id?routing=:routing")
-    public PageIndices getPages(final String project, final String id, final String routing) throws IOException {
+    public PageIndices getPages(final String project, final String id, final String routing, final Context context) throws IOException {
+        requireGranted(context, project);
         Document doc = indexer.get(project, id, routing, List.of("content","content_translated"));
         final Extractor extractor = getExtractor(doc);
         if(doc.getOcrParser() == null){
@@ -185,7 +188,8 @@ public class DocumentResource {
     )
     @ApiResponse(responseCode = "200", description = "JSON containing text pages array",  useReturnTypeSchema = true)
     @Get("/:project/documents/content/pages/:id?routing=:routing")
-    public List<String> getContentByPage(final String project, final String id, final String routing) throws IOException {
+    public List<String> getContentByPage(final String project, final String id, final String routing, final Context context) throws IOException {
+        requireGranted(context, project);
         Document doc = indexer.get(project, id, routing, List.of("content","content_translated"));
         final Extractor extractor = getExtractor(doc);
         if(doc.getOcrParser() == null){
@@ -447,6 +451,10 @@ public class DocumentResource {
     @Post("/:project/documents/batchUpdate/unrecommend")
     public Result<Integer> groupUnrecommend(final String projectId, final List<String> docIds, Context context) {
         return new Result<>(repository.unrecommend(project(projectId), (DatashareUser)context.currentUser(), docIds));
+    }
+
+    private void requireGranted(Context context, String project) {
+        forbiddenIfNotGranted(((DatashareUser) context.currentUser()).isGranted(project));
     }
 
     @NotNull

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -248,6 +248,7 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200", description = "returns the number of stared documents")
     @Post("/:project/documents/batchUpdate/star")
     public Result<Integer> groupStarProject(final String projectId, final List<String> docIds, Context context) {
+        requireGranted(context, projectId);
         return new Result<>(repository.star(project(projectId), (DatashareUser)context.currentUser(), docIds));
     }
 
@@ -260,6 +261,7 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200", description = "returns the number of unstared documents")
     @Post("/:project/documents/batchUpdate/unstar")
     public Result<Integer> groupUnstarProject(final String projectId, final List<String> docIds, Context context) {
+        requireGranted(context, projectId);
         return new Result<>(repository.unstar(project(projectId), (DatashareUser)context.currentUser(), docIds));
     }
 
@@ -269,6 +271,7 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     @Get("/:project/documents/starred")
     public List<String> getProjectStarredDocuments(final String projectId, Context context) {
+        requireGranted(context, projectId);
         return repository.getStarredDocuments(project(projectId), (DatashareUser)context.currentUser());
     }
 
@@ -412,7 +415,8 @@ public class DocumentResource {
     )
     @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     @Get("/users/recommendations?project=:project")
-    public AggregateList<User> getProjectRecommendations(final String projectId) {
+    public AggregateList<User> getProjectRecommendations(final String projectId, final Context context) {
+        requireGranted(context, projectId);
         return repository.getRecommendations(project(projectId));
     }
 
@@ -424,7 +428,8 @@ public class DocumentResource {
     )
     @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     @Get("/users/recommendationsby?project=:project&docIds=:coma_separated_docIds")
-    public AggregateList<User> getProjectRecommendations(final String projectId, final String comaSeparatedDocIds) {
+    public AggregateList<User> getProjectRecommendations(final String projectId, final String comaSeparatedDocIds, final Context context) {
+        requireGranted(context, projectId);
         return repository.getRecommendations(project(projectId),stream(comaSeparatedDocIds.split(",")).map(String::new).collect(Collectors.toList()));
     }
 
@@ -435,7 +440,8 @@ public class DocumentResource {
             }
     )
     @Get("/:project/documents/recommendations?userids=:coma_separated_users")
-    public Set<String> getProjectRecommendationsBy(final String projectId, final String comaSeparatedUsers) {
+    public Set<String> getProjectRecommendationsBy(final String projectId, final String comaSeparatedUsers, final Context context) {
+        requireGranted(context, projectId);
         return repository.getRecommendationsBy(project(projectId), stream(comaSeparatedUsers.split(",")).map(User::new).collect(Collectors.toList()));
     }
 
@@ -446,6 +452,7 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200", description = "the number of marked documents", useReturnTypeSchema = true)
     @Post("/:project/documents/batchUpdate/recommend")
     public Result<Integer> groupRecommend(final String projectId, final List<String> docIds, Context context) {
+        requireGranted(context, projectId);
         return new Result<>(repository.recommend(project(projectId), (DatashareUser)context.currentUser(), docIds));
     }
 
@@ -456,6 +463,7 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200", description = "the number of unmarked documents", useReturnTypeSchema = true)
     @Post("/:project/documents/batchUpdate/unrecommend")
     public Result<Integer> groupUnrecommend(final String projectId, final List<String> docIds, Context context) {
+        requireGranted(context, projectId);
         return new Result<>(repository.unrecommend(project(projectId), (DatashareUser)context.currentUser(), docIds));
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -17,7 +17,7 @@ import net.codestory.http.Context;
 import net.codestory.http.annotations.*;
 import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.errors.ForbiddenException;
-import static org.icij.datashare.web.errors.ForbiddenException.forbiddenIfNotGranted;
+import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 import net.codestory.http.payload.Payload;
 import net.codestory.http.types.ContentTypes;
 import org.icij.datashare.PropertiesProvider;
@@ -465,10 +465,6 @@ public class DocumentResource {
     public Result<Integer> groupUnrecommend(final String projectId, final List<String> docIds, Context context) {
         requireGranted(context, projectId);
         return new Result<>(repository.unrecommend(project(projectId), (DatashareUser)context.currentUser(), docIds));
-    }
-
-    private void requireGranted(Context context, String project) {
-        forbiddenIfNotGranted(((DatashareUser) context.currentUser()).isGranted(project));
     }
 
     @NotNull

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -280,7 +280,8 @@ public class DocumentResource {
     )
     @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     @Get("/:projects/documents/tagged/:coma_separated_tags")
-    public List<String> getProjectTaggedDocuments(final String projectId, final String comaSeparatedTags) {
+    public List<String> getProjectTaggedDocuments(final String projectId, final String comaSeparatedTags, final Context context) {
+        requireGranted(context, projectId);
         return repository.getDocuments(project(projectId),
                 stream(comaSeparatedTags.split(",")).map(Tag::tag).toArray(Tag[]::new));
     }
@@ -306,7 +307,8 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200", description = "if tag was already in database")
     @ApiResponse(responseCode = "201", description = "if tag was created")
     @Put("/:project/documents/tags/:docId?routing=:routing")
-    public Payload tagDocument(final String projectId, final String docId, String routing, Tag[] tags) throws IOException {
+    public Payload tagDocument(final String projectId, final String docId, String routing, Tag[] tags, final Context context) throws IOException {
+        requireGranted(context, projectId);
         boolean tagSaved = repository.tag(project(projectId), docId, tags);
         indexer.tag(project(projectId), docId, ofNullable(routing).orElse(docId), tags);
         return tagSaved ? Payload.created(): Payload.ok();
@@ -320,7 +322,8 @@ public class DocumentResource {
     )
     @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     @Get("/:project/documents/tags/:docId")
-    public List<Tag> getDocumentTags(final String projectId, final String docId) {
+    public List<Tag> getDocumentTags(final String projectId, final String docId, final Context context) {
+        requireGranted(context, projectId);
         return repository.getTags(project(projectId), docId);
     }
 
@@ -340,6 +343,7 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200")
     @Post("/:project/documents/batchUpdate/tag")
     public Payload groupTagDocument(final String projectId, BatchTagQuery query, Context context) throws IOException {
+        requireGranted(context, projectId);
         repository.tag(project(projectId), query.docIds, query.tagsAsArray((User)context.currentUser()));
         indexer.tag(project(projectId), query.docIds, query.tagsAsArray((User)context.currentUser()));
         return Payload.ok();
@@ -362,6 +366,7 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200")
     @Post("/:project/documents/batchUpdate/untag")
     public Payload groupUntagDocument(final String projectId, BatchTagQuery query,  Context context) throws IOException {
+        requireGranted(context, projectId);
         repository.untag(project(projectId), query.docIds, query.tagsAsArray((User)context.currentUser()));
         indexer.untag(project(projectId), query.docIds, query.tagsAsArray((User)context.currentUser()));
         return Payload.ok();
@@ -388,7 +393,8 @@ public class DocumentResource {
     @ApiResponse(responseCode = "200", description = "Document untagged")
     @ApiResponse(responseCode = "201", description = "Document had tags; Document tag was deleted")
     @Put("/:project/documents/untag/:docId?routing=:routing")
-    public Payload untagDocument(final String projectId, final String docId, String routing, Tag[] tags) throws IOException {
+    public Payload untagDocument(final String projectId, final String docId, String routing, Tag[] tags, final Context context) throws IOException {
+        requireGranted(context, projectId);
         boolean untagSaved = repository.untag(project(projectId), docId, tags);
         indexer.untag(project(projectId), docId, ofNullable(routing).orElse(docId), tags);
         return untagSaved ? Payload.created(): Payload.ok();

--- a/datashare-app/src/main/java/org/icij/datashare/web/FtmResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/FtmResource.java
@@ -10,11 +10,10 @@ import net.codestory.http.Context;
 import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Prefix;
 import org.icij.datashare.ftm.FtmDocument;
-import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.Indexer;
 
-import static org.icij.datashare.web.errors.ForbiddenException.forbiddenIfNotGranted;
+import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 
 import static java.util.Optional.ofNullable;
 import static net.codestory.http.errors.NotFoundException.notFoundIfNull;
@@ -40,7 +39,4 @@ public class FtmResource {
         return notFoundIfNull(ofNullable(indexer.get(project, docId)).map(d -> new FtmDocument((Document) d)).orElse(null));
     }
 
-    private void requireGranted(Context context, String project) {
-        forbiddenIfNotGranted(((DatashareUser) context.currentUser()).isGranted(project));
-    }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/FtmResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/FtmResource.java
@@ -6,11 +6,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import net.codestory.http.Context;
 import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Prefix;
 import org.icij.datashare.ftm.FtmDocument;
+import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.Indexer;
+
+import static org.icij.datashare.web.errors.ForbiddenException.forbiddenIfNotGranted;
 
 import static java.util.Optional.ofNullable;
 import static net.codestory.http.errors.NotFoundException.notFoundIfNull;
@@ -30,7 +34,13 @@ public class FtmResource {
     @ApiResponse(responseCode = "404", description = "if no document is found with provided id")
     @Get("/:project/:docId")
     public FtmDocument getDocument(@Parameter(name = "project", description = "project identifier", in = ParameterIn.PATH) String project,
-                                   @Parameter(name = "docId", description = "document identifier", in = ParameterIn.PATH) String docId) throws Exception {
+                                   @Parameter(name = "docId", description = "document identifier", in = ParameterIn.PATH) String docId,
+                                   final Context context) throws Exception {
+        requireGranted(context, project);
         return notFoundIfNull(ofNullable(indexer.get(project, docId)).map(d -> new FtmDocument((Document) d)).orElse(null));
+    }
+
+    private void requireGranted(Context context, String project) {
+        forbiddenIfNotGranted(((DatashareUser) context.currentUser()).isGranted(project));
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/NamedEntityResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/NamedEntityResource.java
@@ -6,14 +6,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import net.codestory.http.Context;
 import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Options;
 import net.codestory.http.annotations.Prefix;
 import net.codestory.http.annotations.Put;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.Entity;
+import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.NamedEntity;
 import org.icij.datashare.text.indexing.Indexer;
+
+import static org.icij.datashare.web.errors.ForbiddenException.forbiddenIfNotGranted;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,12 +37,18 @@ public class NamedEntityResource {
         this.indexer = indexer;
     }
 
+    private void requireGranted(Context context, String project) {
+        forbiddenIfNotGranted(((DatashareUser) context.currentUser()).isGranted(project));
+    }
+
     @Operation(description = "Returns the named entity given an id and a document id.")
     @ApiResponse(responseCode = "200", description = "returns the pipeline set", useReturnTypeSchema = true)
     @Get("/:project/namedEntities/:id?routing=:documentId")
     public NamedEntity getById(@Parameter(name = "project", description = "current project", in = ParameterIn.PATH) final String project,
                                @Parameter(name = "id", description = "named entity id", in = ParameterIn.PATH) final String id,
-                               @Parameter(name = "documentId", description = "documentId the root document", in = ParameterIn.PATH) final String documentId) {
+                               @Parameter(name = "documentId", description = "documentId the root document", in = ParameterIn.PATH) final String documentId,
+                               final Context context) {
+        requireGranted(context, project);
         return notFoundIfNull(indexer.get(project, id, documentId));
     }
 
@@ -53,7 +63,9 @@ public class NamedEntityResource {
     @ApiResponse(responseCode = "200", description = "returns 200 OK")
     @Put("/:project/namedEntities/hide/:mentionNorm")
     public Payload hide(@Parameter(name = "project", description = "current project", in = ParameterIn.PATH) final String project,
-                        @Parameter(name = "mentionNorm", description = "normalized mention", in = ParameterIn.PATH) final String mentionNorm) throws IOException {
+                        @Parameter(name = "mentionNorm", description = "normalized mention", in = ParameterIn.PATH) final String mentionNorm,
+                        final Context context) throws IOException {
+        requireGranted(context, project);
         List<? extends Entity> nes = indexer.search(singletonList(project), NamedEntity.class).
                 thatMatchesFieldValue("mentionNorm", mentionNorm).execute().map(ne -> ((NamedEntity)ne).hide()).collect(toList());
         indexer.bulkUpdate(project, nes);

--- a/datashare-app/src/main/java/org/icij/datashare/web/NamedEntityResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/NamedEntityResource.java
@@ -13,11 +13,10 @@ import net.codestory.http.annotations.Prefix;
 import net.codestory.http.annotations.Put;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.Entity;
-import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.NamedEntity;
 import org.icij.datashare.text.indexing.Indexer;
 
-import static org.icij.datashare.web.errors.ForbiddenException.forbiddenIfNotGranted;
+import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 
 import java.io.IOException;
 import java.util.List;
@@ -35,10 +34,6 @@ public class NamedEntityResource {
     @Inject
     public NamedEntityResource(final Indexer indexer) {
         this.indexer = indexer;
-    }
-
-    private void requireGranted(Context context, String project) {
-        forbiddenIfNotGranted(((DatashareUser) context.currentUser()).isGranted(project));
     }
 
     @Operation(description = "Returns the named entity given an id and a document id.")

--- a/datashare-app/src/main/java/org/icij/datashare/web/errors/ForbiddenException.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/errors/ForbiddenException.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.web.errors;
 
+import net.codestory.http.Context;
 import net.codestory.http.errors.HttpException;
+import org.icij.datashare.session.DatashareUser;
 
 public class ForbiddenException extends HttpException {
     public ForbiddenException(final String message) {
@@ -19,5 +21,13 @@ public class ForbiddenException extends HttpException {
             throw new ForbiddenException("Forbidden");
         }
         return true;
+    }
+
+    // Single membership gate shared by every project-scoped endpoint: a user may
+    // only reach a project's data if they are a member of the project named in the
+    // request. Centralised here so the check cannot silently diverge between resources.
+    public static void requireGranted(Context context, String project) {
+        DatashareUser currentUser = (DatashareUser) context.currentUser();
+        forbiddenIfNotGranted(currentUser.isGranted(project));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -526,4 +526,19 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
         assertThat(json.get(1)).contains("");
     }
 
+    @Test
+    public void test_get_document_forbidden_for_non_member_project() {
+        get("/api/foo_index/documents/id_txt").should().respond(403);
+    }
+
+    @Test
+    public void test_get_pages_forbidden_for_non_member_project() {
+        get("/api/foo_index/documents/pages/id_txt").should().respond(403);
+    }
+
+    @Test
+    public void test_get_content_by_page_forbidden_for_non_member_project() {
+        get("/api/foo_index/documents/content/pages/id_txt").should().respond(403);
+    }
+
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -207,46 +207,46 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_tag_document_with_project() throws Exception {
-        when(jooqRepository.tag(eq(project("prj1")), anyString(), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
-        when(indexer.tag(eq(project("prj1")), anyString(), anyString(), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(jooqRepository.tag(eq(project("local-datashare")), anyString(), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(indexer.tag(eq(project("local-datashare")), anyString(), anyString(), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
 
-        put("/api/prj1/documents/tags/doc_id", "[\"tag1\", \"tag2\"]").should().respond(201);
-        put("/api/prj1/documents/tags/doc_id", "[\"tag1\", \"tag2\"]").should().respond(200);
+        put("/api/local-datashare/documents/tags/doc_id", "[\"tag1\", \"tag2\"]").should().respond(201);
+        put("/api/local-datashare/documents/tags/doc_id", "[\"tag1\", \"tag2\"]").should().respond(200);
 
-        verify(indexer, times(2)).tag(eq(project("prj1")), eq("doc_id"), eq("doc_id"), eq(tag("tag1")), eq(tag("tag2")));
+        verify(indexer, times(2)).tag(eq(project("local-datashare")), eq("doc_id"), eq("doc_id"), eq(tag("tag1")), eq(tag("tag2")));
     }
 
     @Test
     public void test_untag_document_with_project() throws Exception {
-        when(jooqRepository.untag(eq(project("prj2")), anyString(), eq(tag("tag3")), eq(tag("tag4")))).thenReturn(true).thenReturn(false);
-        when(indexer.untag(eq(project("prj2")), anyString(), any(), eq(tag("tag3")), eq(tag("tag4")))).thenReturn(true).thenReturn(false);
+        when(jooqRepository.untag(eq(project("local-datashare")), anyString(), eq(tag("tag3")), eq(tag("tag4")))).thenReturn(true).thenReturn(false);
+        when(indexer.untag(eq(project("local-datashare")), anyString(), any(), eq(tag("tag3")), eq(tag("tag4")))).thenReturn(true).thenReturn(false);
 
-        put("/api/prj2/documents/untag/doc_id", "[\"tag3\", \"tag4\"]").should().respond(201);
-        put("/api/prj2/documents/untag/doc_id", "[\"tag3\", \"tag4\"]").should().respond(200);
+        put("/api/local-datashare/documents/untag/doc_id", "[\"tag3\", \"tag4\"]").should().respond(201);
+        put("/api/local-datashare/documents/untag/doc_id", "[\"tag3\", \"tag4\"]").should().respond(200);
 
-        verify(indexer, times(2)).untag(eq(project("prj2")), anyString(), any(), any(), any());
+        verify(indexer, times(2)).untag(eq(project("local-datashare")), anyString(), any(), any(), any());
     }
 
     @Test
     public void test_group_tag_document_with_project() throws Exception {
-        when(jooqRepository.tag(eq(project("prj1")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
-        when(indexer.tag(eq(project("prj1")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(jooqRepository.tag(eq(project("local-datashare")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(indexer.tag(eq(project("local-datashare")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
 
-        post("/api/prj1/documents/batchUpdate/tag", "{\"tags\": [\"tag1\", \"tag2\"], \"docIds\": [\"doc1\", \"doc2\"]}").should().respond(200);
+        post("/api/local-datashare/documents/batchUpdate/tag", "{\"tags\": [\"tag1\", \"tag2\"], \"docIds\": [\"doc1\", \"doc2\"]}").should().respond(200);
     }
 
     @Test
     public void test_group_untag_document_with_project() throws Exception {
-        when(jooqRepository.untag(eq(project("prj1")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
-        when(indexer.untag(eq(project("prj1")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(jooqRepository.untag(eq(project("local-datashare")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(indexer.untag(eq(project("local-datashare")), eq(asList("doc1", "doc2")), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
 
-        post("/api/prj1/documents/batchUpdate/untag", "{\"tags\": [\"tag1\", \"tag2\"], \"docIds\": [\"doc1\", \"doc2\"]}").should().respond(200);
+        post("/api/local-datashare/documents/batchUpdate/untag", "{\"tags\": [\"tag1\", \"tag2\"], \"docIds\": [\"doc1\", \"doc2\"]}").should().respond(200);
     }
 
     @Test
     public void test_get_tagged_documents_with_project() {
-        when(jooqRepository.getDocuments(eq(project("prj3")), eq(tag("foo")), eq(tag("bar")), eq(tag("baz")))).thenReturn(asList("id1", "id2"));
-        get("/api/prj3/documents/tagged/foo,bar,baz").should().respond(200).contain("id1").contain("id2");
+        when(jooqRepository.getDocuments(eq(project("local-datashare")), eq(tag("foo")), eq(tag("bar")), eq(tag("baz")))).thenReturn(asList("id1", "id2"));
+        get("/api/local-datashare/documents/tagged/foo,bar,baz").should().respond(200).contain("id1").contain("id2");
     }
 
     @Test
@@ -257,19 +257,19 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_tags_for_document() {
-        when(jooqRepository.getTags(eq(project("prj")), eq("docId"))).thenReturn(asList(tag("tag1"), tag("tag2")));
-        get("/api/prj/documents/tags/docId").should().respond(200).contain("tag1").contain("tag2");
+        when(jooqRepository.getTags(eq(project("local-datashare")), eq("docId"))).thenReturn(asList(tag("tag1"), tag("tag2")));
+        get("/api/local-datashare/documents/tags/docId").should().respond(200).contain("tag1").contain("tag2");
     }
 
     @Test
     public void test_tag_document_with_project_with_routing() throws Exception {
-        when(jooqRepository.tag(eq(project("prj1")), anyString(), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
-        when(indexer.tag(eq(project("prj1")), any(), eq("routing"), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(jooqRepository.tag(eq(project("local-datashare")), anyString(), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
+        when(indexer.tag(eq(project("local-datashare")), any(), eq("routing"), eq(tag("tag1")), eq(tag("tag2")))).thenReturn(true).thenReturn(false);
 
-        put("/api/prj1/documents/tags/doc_id?routing=routing", "[\"tag1\", \"tag2\"]").should().respond(201);
-        put("/api/prj1/documents/tags/doc_id?routing=routing", "[\"tag1\", \"tag2\"]").should().respond(200);
+        put("/api/local-datashare/documents/tags/doc_id?routing=routing", "[\"tag1\", \"tag2\"]").should().respond(201);
+        put("/api/local-datashare/documents/tags/doc_id?routing=routing", "[\"tag1\", \"tag2\"]").should().respond(200);
 
-        verify(indexer, times(2)).tag(eq(project("prj1")), any(), eq("routing"), eq(tag("tag1")), eq(tag("tag2")));
+        verify(indexer, times(2)).tag(eq(project("local-datashare")), any(), eq("routing"), eq(tag("tag1")), eq(tag("tag2")));
     }
 
 
@@ -539,6 +539,36 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_content_by_page_forbidden_for_non_member_project() {
         get("/api/foo_index/documents/content/pages/id_txt").should().respond(403);
+    }
+
+    @Test
+    public void test_get_tagged_documents_forbidden_for_non_member_project() {
+        get("/api/foo_index/documents/tagged/foo,bar").should().respond(403);
+    }
+
+    @Test
+    public void test_get_document_tags_forbidden_for_non_member_project() {
+        get("/api/foo_index/documents/tags/doc_id").should().respond(403);
+    }
+
+    @Test
+    public void test_tag_document_forbidden_for_non_member_project() {
+        put("/api/foo_index/documents/tags/doc_id", "[\"tag1\"]").should().respond(403);
+    }
+
+    @Test
+    public void test_untag_document_forbidden_for_non_member_project() {
+        put("/api/foo_index/documents/untag/doc_id", "[\"tag1\"]").should().respond(403);
+    }
+
+    @Test
+    public void test_group_tag_forbidden_for_non_member_project() {
+        post("/api/foo_index/documents/batchUpdate/tag", "{\"tags\":[\"t\"],\"docIds\":[\"d\"]}").should().respond(403);
+    }
+
+    @Test
+    public void test_group_untag_forbidden_for_non_member_project() {
+        post("/api/foo_index/documents/batchUpdate/untag", "{\"tags\":[\"t\"],\"docIds\":[\"d\"]}").should().respond(403);
     }
 
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -165,44 +165,44 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_group_star_document_with_project() {
-        when(jooqRepository.star(project("prj1"), User.local(), asList("id1", "id2"))).thenReturn(2);
-        post("/api/prj1/documents/batchUpdate/star", "[\"id1\", \"id2\"]").should().respond(200);
+        when(jooqRepository.star(project("local-datashare"), User.local(), asList("id1", "id2"))).thenReturn(2);
+        post("/api/local-datashare/documents/batchUpdate/star", "[\"id1\", \"id2\"]").should().respond(200);
     }
 
     @Test
     public void test_group_unstar_document_with_project() {
-        when(jooqRepository.unstar(project("prj1"), User.local(), asList("id1", "id2"))).thenReturn(2);
-        post("/api/prj1/documents/batchUpdate/unstar", "[\"id1\", \"id2\"]").should().respond(200);
+        when(jooqRepository.unstar(project("local-datashare"), User.local(), asList("id1", "id2"))).thenReturn(2);
+        post("/api/local-datashare/documents/batchUpdate/unstar", "[\"id1\", \"id2\"]").should().respond(200);
     }
 
     @Test
     public void test_group_recommend_document_with_project() {
-        when(jooqRepository.recommend(project("prj1"), User.local(), asList("id1", "id2"))).thenReturn(2);
-        post("/api/prj1/documents/batchUpdate/recommend", "[\"id1\", \"id2\"]").should().respond(200);
+        when(jooqRepository.recommend(project("local-datashare"), User.local(), asList("id1", "id2"))).thenReturn(2);
+        post("/api/local-datashare/documents/batchUpdate/recommend", "[\"id1\", \"id2\"]").should().respond(200);
     }
 
     @Test
     public void test_group_unrecommend_document_with_project() {
-        when(jooqRepository.unrecommend(project("prj1"), User.local(), asList("id1", "id2"))).thenReturn(2);
-        post("/api/prj1/documents/batchUpdate/unrecommend", "[\"id1\", \"id2\"]").should().respond(200);
+        when(jooqRepository.unrecommend(project("local-datashare"), User.local(), asList("id1", "id2"))).thenReturn(2);
+        post("/api/local-datashare/documents/batchUpdate/unrecommend", "[\"id1\", \"id2\"]").should().respond(200);
     }
 
     @Test
     public void test_get_recommendation_users_of_documents() {
-        when(jooqRepository.getRecommendations(eq(project("prj")), eq(asList("docId1","docId2")))).thenReturn(new Repository.AggregateList<>(of(new Repository.Aggregate<>(new User("user1"), 2), new Repository.Aggregate<>(new User("user2"), 3)).collect(Collectors.toList()), 10));
-        get("/api/users/recommendationsby?project=prj&docIds=docId1,docId2").should().respond(200).contain("user1").contain("user2").contain("\"totalCount\":10");
+        when(jooqRepository.getRecommendations(eq(project("local-datashare")), eq(asList("docId1","docId2")))).thenReturn(new Repository.AggregateList<>(of(new Repository.Aggregate<>(new User("user1"), 2), new Repository.Aggregate<>(new User("user2"), 3)).collect(Collectors.toList()), 10));
+        get("/api/users/recommendationsby?project=local-datashare&docIds=docId1,docId2").should().respond(200).contain("user1").contain("user2").contain("\"totalCount\":10");
     }
 
     @Test
     public void test_get_recommendations_users() {
-        when(jooqRepository.getRecommendations(eq(project("prj")))).thenReturn(new Repository.AggregateList<>(of(new Repository.Aggregate<>(new User("user3"), 3), new Repository.Aggregate<>(new User("user4"), 4)).collect(Collectors.toList()), 8));
-        get("/api/users/recommendations?project=prj").should().respond(200).contain("user3").contain("user4");
+        when(jooqRepository.getRecommendations(eq(project("local-datashare")))).thenReturn(new Repository.AggregateList<>(of(new Repository.Aggregate<>(new User("user3"), 3), new Repository.Aggregate<>(new User("user4"), 4)).collect(Collectors.toList()), 8));
+        get("/api/users/recommendations?project=local-datashare").should().respond(200).contain("user3").contain("user4");
     }
 
     @Test
     public void test_get_recommended_documents() {
-        when(jooqRepository.getRecommendationsBy(eq(project("prj")), eq(asList(new User("user1"), new User("user2"))))).thenReturn(of("doc1", "doc2").collect(Collectors.toSet()));
-        get("/api/prj/documents/recommendations?userids=user1,user2").should().respond(200).contain("doc1").contain("doc2");
+        when(jooqRepository.getRecommendationsBy(eq(project("local-datashare")), eq(asList(new User("user1"), new User("user2"))))).thenReturn(of("doc1", "doc2").collect(Collectors.toSet()));
+        get("/api/local-datashare/documents/recommendations?userids=user1,user2").should().respond(200).contain("doc1").contain("doc2");
     }
 
     @Test
@@ -569,6 +569,46 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_group_untag_forbidden_for_non_member_project() {
         post("/api/foo_index/documents/batchUpdate/untag", "{\"tags\":[\"t\"],\"docIds\":[\"d\"]}").should().respond(403);
+    }
+
+    @Test
+    public void test_get_starred_documents_forbidden_for_non_member_project() {
+        get("/api/foo_index/documents/starred").should().respond(403);
+    }
+
+    @Test
+    public void test_group_star_forbidden_for_non_member_project() {
+        post("/api/foo_index/documents/batchUpdate/star", "[\"id1\"]").should().respond(403);
+    }
+
+    @Test
+    public void test_group_unstar_forbidden_for_non_member_project() {
+        post("/api/foo_index/documents/batchUpdate/unstar", "[\"id1\"]").should().respond(403);
+    }
+
+    @Test
+    public void test_group_recommend_forbidden_for_non_member_project() {
+        post("/api/foo_index/documents/batchUpdate/recommend", "[\"id1\"]").should().respond(403);
+    }
+
+    @Test
+    public void test_group_unrecommend_forbidden_for_non_member_project() {
+        post("/api/foo_index/documents/batchUpdate/unrecommend", "[\"id1\"]").should().respond(403);
+    }
+
+    @Test
+    public void test_get_recommendations_by_forbidden_for_non_member_project() {
+        get("/api/foo_index/documents/recommendations?userids=user1").should().respond(403);
+    }
+
+    @Test
+    public void test_get_recommendations_users_forbidden_for_non_member_project() {
+        get("/api/users/recommendations?project=foo_index").should().respond(403);
+    }
+
+    @Test
+    public void test_get_recommendations_by_docids_forbidden_for_non_member_project() {
+        get("/api/users/recommendationsby?project=foo_index&docIds=d1,d2").should().respond(403);
     }
 
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/FtmResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/FtmResourceTest.java
@@ -1,5 +1,8 @@
 package org.icij.datashare.web;
 
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.db.JooqRepository;
+import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.tasks.MockIndexer;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
@@ -13,25 +16,33 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class FtmResourceTest extends AbstractProdWebServerTest {
     @Mock Indexer mockEs;
+    @Mock JooqRepository jooqRepository;
     MockIndexer mockIndexer;
 
     @Test
     public void test_doc_id() {
-        mockIndexer.indexFile("prj", "doc_id", Path.of("path/to/doc.pdf"), "application/pdf");
-        get("/api/ftm/prj/doc_id").should().respond(200).haveType("application/json")
+        mockIndexer.indexFile("local-datashare", "doc_id", Path.of("path/to/doc.pdf"), "application/pdf");
+        get("/api/ftm/local-datashare/doc_id").should().respond(200).haveType("application/json")
                 .contain("path/to/doc.pdf")
                 .not().contain("null");
     }
 
     @Test
     public void test_doc_id_not_found() {
-        get("/api/ftm/prj/unknown_doc_id").should().respond(404);
+        get("/api/ftm/local-datashare/unknown_doc_id").should().respond(404);
+    }
+
+    @Test
+    public void test_doc_id_forbidden_for_non_member_project() {
+        mockIndexer.indexFile("foo_index", "doc_id", Path.of("path/to/doc.pdf"), "application/pdf");
+        get("/api/ftm/foo_index/doc_id").should().respond(403);
     }
 
     @Before
     public void setUp() {
         initMocks(this);
         this.mockIndexer = new MockIndexer(mockEs);
-        configure(routes -> routes.add(new FtmResource(mockEs)));
+        configure(routes -> routes.add(new FtmResource(mockEs))
+                .filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/NamedEntityResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/NamedEntityResourceTest.java
@@ -36,8 +36,8 @@ public class NamedEntityResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_named_entity() {
         NamedEntity toBeReturned = create(PERSON, "mention", singletonList(123L), "docId", "root", CORENLP, FRENCH);
-        doReturn(toBeReturned).when(indexer).get("index", "my_id", "root_parent");
-        get("/api/index/namedEntities/my_id?routing=root_parent").should().respond(200).haveType("application/json");
+        doReturn(toBeReturned).when(indexer).get("local-datashare", "my_id", "root_parent");
+        get("/api/local-datashare/namedEntities/my_id?routing=root_parent").should().respond(200).haveType("application/json");
     }
 
     @Test
@@ -57,18 +57,28 @@ public class NamedEntityResourceTest extends AbstractProdWebServerTest {
         Indexer.QueryBuilderSearcher searcher = mock(Indexer.QueryBuilderSearcher.class);
         doReturn(Stream.of(toBeHidden)).when(searcher).execute();
         doReturn(searcher).when(searcher).thatMatchesFieldValue(any(), any());
-        doReturn(searcher).when(indexer).search(singletonList("index"), NamedEntity.class);
+        doReturn(searcher).when(indexer).search(singletonList("local-datashare"), NamedEntity.class);
 
-        put("/api/index/namedEntities/hide/to_update").should().respond(200);
+        put("/api/local-datashare/namedEntities/hide/to_update").should().respond(200);
 
-        verify(indexer).bulkUpdate("index", singletonList(toBeHidden));
+        verify(indexer).bulkUpdate("local-datashare", singletonList(toBeHidden));
     }
 
     @Test
     public void test_hide_named_entity_when_failure() {
-        doThrow(new RuntimeException()).when(indexer).search(singletonList("index"), NamedEntity.class);
+        doThrow(new RuntimeException()).when(indexer).search(singletonList("local-datashare"), NamedEntity.class);
 
-        put("/api/index/namedEntities/hide/to_update").should().respond(500);
+        put("/api/local-datashare/namedEntities/hide/to_update").should().respond(500);
+    }
+
+    @Test
+    public void test_get_named_entity_forbidden_for_non_member_project() {
+        get("/api/index/namedEntities/my_id?routing=root_parent").should().respond(403);
+    }
+
+    @Test
+    public void test_hide_named_entity_forbidden_for_non_member_project() {
+        put("/api/index/namedEntities/hide/to_update").should().respond(403);
     }
 
     @Before


### PR DESCRIPTION
Several project-scoped endpoints didn't check that the user is a member of the project in the URL, letting a member of one project read/write another project's data (CWE-862). Adds the membership check the sibling endpoints already use.

## Changes

- fix: enforce project membership on document read endpoints
- fix: enforce project membership on document tag endpoints
- fix: enforce project membership on star/recommend endpoints
- fix: enforce project membership on named entity endpoints
- fix: enforce project membership on FtM document endpoint
- refactor: extract shared requireGranted membership helper

## Notes

- Non-member API-key clients reading cross-project now get 403.
- Non-members probing a missing document now get 403 instead of 404.
