### PR TITLE
feat(ocr): default OMP_THREAD_LIMIT=1 so OCR does not oversubscribe the CPU

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/OpenMpEnvInheritanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/OpenMpEnvInheritanceTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class OpenMpEnvInheritanceTest {
@@ -25,6 +26,8 @@ public class OpenMpEnvInheritanceTest {
     // OMP_THREAD_LIMIT=1 reaches every OCR subprocess.
     @Test(timeout = 10000)
     public void test_spawned_child_inherits_omp_thread_limit() throws IOException, InterruptedException {
+        // Relies on a POSIX `sh`; skip on platforms without one (e.g. Windows dev boxes).
+        Assume.assumeFalse(System.getProperty("os.name", "").toLowerCase().contains("win"));
         Process child = new ProcessBuilder(List.of("sh", "-c", "echo $OMP_THREAD_LIMIT")).start();
         String output;
         try (BufferedReader reader = new BufferedReader(

--- a/datashare-app/src/test/java/org/icij/datashare/OpenMpEnvInheritanceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/OpenMpEnvInheritanceTest.java
@@ -1,0 +1,37 @@
+package org.icij.datashare;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.Test;
+
+public class OpenMpEnvInheritanceTest {
+    // Surefire (root pom) injects OMP_THREAD_LIMIT=1 into the forked test JVM.
+    // This proves Datashare's OCR thread-limit default actually reaches the
+    // test JVM environment. Run via `mvn test`; an IDE run without the maven
+    // env will (correctly) fail this assertion.
+    @Test
+    public void test_surefire_sets_omp_thread_limit_on_jvm() {
+        assertThat(System.getenv("OMP_THREAD_LIMIT")).isEqualTo("1");
+        assertThat(System.getenv("OMP_WAIT_POLICY")).isEqualTo("passive");
+    }
+
+    // A child process spawned by this JVM inherits its environment: this is
+    // exactly how Tika's TesseractOCRParser spawns tesseract, so an inherited
+    // OMP_THREAD_LIMIT=1 reaches every OCR subprocess.
+    @Test(timeout = 10000)
+    public void test_spawned_child_inherits_omp_thread_limit() throws IOException, InterruptedException {
+        Process child = new ProcessBuilder(List.of("sh", "-c", "echo $OMP_THREAD_LIMIT")).start();
+        String output;
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(child.getInputStream(), StandardCharsets.UTF_8))) {
+            output = reader.readLine();
+        }
+        child.waitFor();
+        assertThat(output).isEqualTo("1");
+    }
+}

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -113,6 +113,16 @@ java_flags="
   -Djna.tmpdir=$datashare_jna_tmpdir
   -DDS_SYNC_NLP_MODELS=$datashare_sync_nlp_models
 "
+
+# OCR thread limit: Tesseract is OpenMP-built, so each tesseract child
+# spawned by Tika would otherwise fan out across every core. With the INDEX
+# consumer already running ~vCPUs workers, that oversubscribes the CPU
+# (~vCPUs x vCPUs threads), blows past Tika's 120s OCR timeout, and silently
+# drops documents. Cap each tesseract to one OpenMP thread (one OCR thread
+# per core given parallelism=vCPUs). Override by exporting these yourself.
+export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT:-1}
+export OMP_WAIT_POLICY=${OMP_WAIT_POLICY:-passive}
+
 java_cmd="$java_bin $java_opts $java_flags -cp ./dist:$datashare_jar org.icij.datashare.Main"
 
 if [ "$is_subcommand" = true ]; then

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -114,12 +114,16 @@ java_flags="
   -DDS_SYNC_NLP_MODELS=$datashare_sync_nlp_models
 "
 
-# OCR thread limit: Tesseract is OpenMP-built, so each tesseract child
-# spawned by Tika would otherwise fan out across every core. With the INDEX
-# consumer already running ~vCPUs workers, that oversubscribes the CPU
-# (~vCPUs x vCPUs threads), blows past Tika's 120s OCR timeout, and silently
-# drops documents. Cap each tesseract to one OpenMP thread (one OCR thread
-# per core given parallelism=vCPUs). Override by exporting these yourself.
+# OpenMP thread limit (process-wide). Tesseract is OpenMP-built, so each
+# tesseract child spawned by Tika would otherwise fan out across every core.
+# With the INDEX consumer already running ~vCPUs workers, that oversubscribes
+# the CPU (~vCPUs x vCPUs threads), blows past Tika's 120s OCR timeout, and
+# silently drops documents. Capping to one OpenMP thread gives one OCR thread
+# per core given parallelism=vCPUs. This is exported process-wide, so it also
+# reaches any other OpenMP/BLAS native code in the JVM or its children (e.g.
+# the spaCy NLP worker subprocess); single-thread-per-worker is the intended
+# invariant there too, since those workers also run in parallel. Override by
+# exporting these yourself.
 export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT-1}
 export OMP_WAIT_POLICY=${OMP_WAIT_POLICY-passive}
 

--- a/datashare-dist/src/main/deb/bin/datashare
+++ b/datashare-dist/src/main/deb/bin/datashare
@@ -120,8 +120,8 @@ java_flags="
 # (~vCPUs x vCPUs threads), blows past Tika's 120s OCR timeout, and silently
 # drops documents. Cap each tesseract to one OpenMP thread (one OCR thread
 # per core given parallelism=vCPUs). Override by exporting these yourself.
-export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT:-1}
-export OMP_WAIT_POLICY=${OMP_WAIT_POLICY:-passive}
+export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT-1}
+export OMP_WAIT_POLICY=${OMP_WAIT_POLICY-passive}
 
 java_cmd="$java_bin $java_opts $java_flags -cp ./dist:$datashare_jar org.icij.datashare.Main"
 

--- a/datashare-dist/src/main/docker/entrypoint.sh
+++ b/datashare-dist/src/main/docker/entrypoint.sh
@@ -9,6 +9,12 @@ datashare_jna_tmpdir=${DATASHARE_JNA_TMPDIR:-$datashare_home/index/tmp}
 datashare_sync_nlp_models=${DATASHARE_SYNC_NLP_MODELS:-true}
 datashare_class_path="$datashare_home/dist:$datashare_jars:$datashare_home/extensions/*${CLASSPATH:+:$CLASSPATH}"
 
+# OCR thread limit: cap each Tesseract child to one OpenMP thread so
+# concurrent OCR (one per INDEX worker) does not oversubscribe the CPU and
+# trip Tika's 120s timeout. Override by exporting these yourself.
+export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT:-1}
+export OMP_WAIT_POLICY=${OMP_WAIT_POLICY:-passive}
+
 if [ "$1" = 'sh' ];
 then
     exec "$@"

--- a/datashare-dist/src/main/docker/entrypoint.sh
+++ b/datashare-dist/src/main/docker/entrypoint.sh
@@ -9,9 +9,12 @@ datashare_jna_tmpdir=${DATASHARE_JNA_TMPDIR:-$datashare_home/index/tmp}
 datashare_sync_nlp_models=${DATASHARE_SYNC_NLP_MODELS:-true}
 datashare_class_path="$datashare_home/dist:$datashare_jars:$datashare_home/extensions/*${CLASSPATH:+:$CLASSPATH}"
 
-# OCR thread limit: cap each Tesseract child to one OpenMP thread so
-# concurrent OCR (one per INDEX worker) does not oversubscribe the CPU and
-# trip Tika's 120s timeout. Override by exporting these yourself.
+# OpenMP thread limit (process-wide): cap each Tesseract child to one OpenMP
+# thread so concurrent OCR (one per INDEX worker) does not oversubscribe the
+# CPU and trip Tika's 120s timeout. Exported process-wide, so it also reaches
+# any other OpenMP/BLAS native code in the JVM or its children (e.g. the spaCy
+# NLP worker); single-thread-per-worker is intended there too. Override by
+# exporting these yourself.
 export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT-1}
 export OMP_WAIT_POLICY=${OMP_WAIT_POLICY-passive}
 

--- a/datashare-dist/src/main/docker/entrypoint.sh
+++ b/datashare-dist/src/main/docker/entrypoint.sh
@@ -12,8 +12,8 @@ datashare_class_path="$datashare_home/dist:$datashare_jars:$datashare_home/exten
 # OCR thread limit: cap each Tesseract child to one OpenMP thread so
 # concurrent OCR (one per INDEX worker) does not oversubscribe the CPU and
 # trip Tika's 120s timeout. Override by exporting these yourself.
-export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT:-1}
-export OMP_WAIT_POLICY=${OMP_WAIT_POLICY:-passive}
+export OMP_THREAD_LIMIT=${OMP_THREAD_LIMIT-1}
+export OMP_WAIT_POLICY=${OMP_WAIT_POLICY-passive}
 
 if [ "$1" = 'sh' ];
 then

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,10 @@
                         <systemPropertyVariables>
                             <devenv.file>${devenv.file}</devenv.file>
                         </systemPropertyVariables>
+                        <environmentVariables>
+                            <OMP_THREAD_LIMIT>1</OMP_THREAD_LIMIT>
+                            <OMP_WAIT_POLICY>passive</OMP_WAIT_POLICY>
+                        </environmentVariables>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
OCR is on by default and Tesseract (with its Leptonica dependency) is OpenMP-built, so every `tesseract` subprocess Tika spawns fans out across all CPU cores. The INDEX consumer already runs `parallelism = availableProcessors()` workers, so on an N-core box that is roughly `N x N` OpenMP threads contending for N cores. `OMP_THREAD_LIMIT` was set nowhere, so every default OCR-on run was exposed.

Measured on a 10-vCPU box:
* Oversubscription pushes each OCR's wall-clock past Tika's 120s timeout, which propagates as an `IOException` and drops the whole document. Synthetic stress (60 identical scanned JPEGs): unbounded OpenMP indexed 0/60 (50 timed out, ~10 min); `OMP_THREAD_LIMIT=1` indexed 60/60 in 48s.
* Real corpus (119 scanned PDFs, ~1s OCR each): unbounded **520s** vs `OMP=1` + `parallelism=vCPUs` **16.8s** (31x faster), 119/119 indexed in both.

The cost is asymmetric: oversubscription silently loses documents, undersubscription only leaves cores idle. Benchmark sweeps show `OMP_THREAD_LIMIT=1` is optimal or tied in every loose-file regime, so the safe default is the conservative corner.
