### PR TITLE
feat: Add Content-Length header in endpoint to download original source

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -17,6 +17,8 @@ import net.codestory.http.Context;
 import net.codestory.http.annotations.*;
 import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.errors.ForbiddenException;
+
+import static net.codestory.http.constants.Headers.CONTENT_LENGTH;
 import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 import net.codestory.http.payload.Payload;
 import net.codestory.http.types.ContentTypes;
@@ -513,7 +515,7 @@ public class DocumentResource {
             if (contentType != null && contentType.startsWith("image/ocr-")) {
                 contentType = "image/" + contentType.substring("image/ocr-".length());
             }
-            Payload payload = new Payload(contentType, from);
+            Payload payload = new Payload(contentType, from).withHeader(CONTENT_LENGTH, String.valueOf(doc.getContentLength()));
             String fileName = doc.isRootDocument() ? doc.getName(): doc.getId().substring(0, 10) + "." + FileExtension.get(contentType);
             return inline ? payload: payload.withHeader("Content-Disposition", "attachment;filename=\"" + fileName + "\"");
         } catch (FileNotFoundException | EmbeddedDocumentExtractor.ContentNotFoundException fnf) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -515,7 +515,9 @@ public class DocumentResource {
             if (contentType != null && contentType.startsWith("image/ocr-")) {
                 contentType = "image/" + contentType.substring("image/ocr-".length());
             }
-            Payload payload = new Payload(contentType, from).withHeader(CONTENT_LENGTH, String.valueOf(doc.getContentLength()));
+            Payload payload = filterMetadata
+                    ? new Payload(contentType, from)
+                    : new Payload(contentType, from).withHeader(CONTENT_LENGTH, String.valueOf(doc.getContentLength()));
             String fileName = doc.isRootDocument() ? doc.getName(): doc.getId().substring(0, 10) + "." + FileExtension.get(contentType);
             return inline ? payload: payload.withHeader("Content-Disposition", "attachment;filename=\"" + fileName + "\"");
         } catch (FileNotFoundException | EmbeddedDocumentExtractor.ContentNotFoundException fnf) {

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -84,13 +84,17 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_get_source_file_with_content_type() throws Exception {
+        // Use a content type that is not going to be gzip compressed. See fluent-http documentation
         File txtFile = new File(temp.getRoot(), "/my/path/to/file.ods");
         MockIndexer.write(txtFile, "content");
-        mockIndexer.indexFile("local-datashare", "id_ods", txtFile.toPath(), "application/vnd.oasis.opendocument.spreadsheet", null);
-
-        get("/api/local-datashare/documents/src/id_ods").should().
-                haveType("application/vnd.oasis.opendocument.spreadsheet").
-                haveHeader("Content-Disposition", "attachment;filename=\"file.ods\"");
+        Document aDocWithContentLength = DocumentBuilder.createDoc("id_ods").with(txtFile.toPath()).with(new Project("local-datashare"))
+                .ofContentType("application/vnd.oasis.opendocument.spreadsheet").withContentLength(7).build();
+        mockIndexer.indexFile("local-datashare", aDocWithContentLength);
+        get("/api/local-datashare/documents/src/id_ods").should()
+            .haveType("application/vnd.oasis.opendocument.spreadsheet")
+            .haveHeader("Content-Disposition", "attachment;filename=\"file.ods\"")
+            .haveHeader("Content-Length", "7")
+        ;
     }
 
     @Test
@@ -106,7 +110,9 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     public void test_get_source_file_with_content_type_inline() throws Exception {
         File img = new File(temp.getRoot(), "/my/path/to/image.jpg");
         MockIndexer.write(img, "content");
-        mockIndexer.indexFile("local-datashare", "id_jpg", img.toPath(), "image/jpg", null);
+        Document aDocWithContentLength = DocumentBuilder.createDoc("id_jpg").with(img.toPath()).with(new Project("local-datashare"))
+                .ofContentType("image/jpg").withContentLength(7).build();
+        mockIndexer.indexFile("local-datashare", aDocWithContentLength);
 
         get("/api/local-datashare/documents/src/id_jpg?inline=true").should().
                 haveType("image/jpg").contain("content").

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -103,7 +103,9 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
         MockIndexer.write(txtFile, "content");
         mockIndexer.indexFile("local-datashare", "id_ods", txtFile.toPath(), "application/vnd.oasis.opendocument.spreadsheet", null);
 
-        get("/api/local-datashare/documents/src/id_ods?filter_metadata=true").should().succeed();
+        get("/api/local-datashare/documents/src/id_ods?filter_metadata=true").should()
+                .succeed()
+                .haveHeader("Content-Length", null);
     }
 
     @Test


### PR DESCRIPTION
 It will only be available for content types that are not gzip compressed by the rest server (see recent changes by @bamthomas and I in fluent-http for more details), namely all types but :
     
```txt
    "text/html", "text/plain", "text/css",
    "text/javascript", "text/xml",
    "application/json", "application/javascript",
    "application/x-javascript", "application/xml",
    "image/svg+xml"
 ```