### PR TITLE
feat: register subtypes of loaded extensions

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/extension/ExtensionLoader.java
+++ b/datashare-api/src/main/java/org/icij/datashare/extension/ExtensionLoader.java
@@ -12,6 +12,8 @@ import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.jar.JarEntry;
@@ -42,16 +44,23 @@ public class ExtensionLoader {
         }
     }
 
-    public synchronized <T> void load(Consumer<T> registerFunc, Predicate<Class<?>> predicate) throws FileNotFoundException {
+    public synchronized void load(Consumer<Class<?>> registerFunc, Predicate<Class<?>> predicate) throws FileNotFoundException {
         eagerLoadJars();
         if (jars != null) {
             for (File jar : jars) {
-                registerClassesInJar(registerFunc, predicate, jar);
+                try {
+                    for (Class<?> cls : findAllClassesInJar(predicate, jar)) {
+                        registerFunc.accept(cls);
+                    }
+                } catch (IOException e) {
+                    LOGGER.error("Cannot find classes in jar " + jar, e);
+                }
             }
         }
     }
 
-    synchronized <T> Class<?> findClassesInJar(Predicate<Class<?>> predicate, final File jarFile) throws IOException {
+    synchronized List<Class<?>> findAllClassesInJar(Predicate<Class<?>> predicate, final File jarFile) throws IOException {
+        List<Class<?>> matches = new ArrayList<>();
         URLClassLoader ucl = new URLClassLoader(new URL[]{jarFile.toURI().toURL()}, getClass().getClassLoader());
         JarInputStream jarInputStream = new JarInputStream(new FileInputStream(jarFile));
         for (JarEntry jarEntry = jarInputStream.getNextJarEntry(); jarEntry != null; jarEntry = jarInputStream.getNextJarEntry()) {
@@ -63,7 +72,7 @@ public class ExtensionLoader {
                         final Class<?> myLoadedClass = Class.forName(classname, false, ucl);
                         if (predicate.test(myLoadedClass) &&
                                 !myLoadedClass.isInterface() && !Modifier.isAbstract(myLoadedClass.getModifiers())) {
-                            return myLoadedClass;
+                            matches.add(myLoadedClass);
                         }
                     } catch (ClassNotFoundException | LinkageError e) {
                         LOGGER.warn("cannot load class " + classname, e);
@@ -71,15 +80,7 @@ public class ExtensionLoader {
                 }
             }
         }
-        return null;
-    }
-
-    private <T> void registerClassesInJar(Consumer<T> registerFunc, Predicate<Class<?>> predicate, File jar) {
-        try {
-            ofNullable(findClassesInJar(predicate, jar)).ifPresent(expectedClass -> registerFunc.accept((T) expectedClass));
-        } catch (IOException e) {
-            LOGGER.error("Cannot find class in jar " + jar, e);
-        }
+        return matches;
     }
 
     private void loadJars(DynamicClassLoader classLoader, File[] jars) {

--- a/datashare-api/src/main/java/org/icij/datashare/extension/PipelineRegistry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/extension/PipelineRegistry.java
@@ -47,7 +47,7 @@ public class PipelineRegistry {
     }
 
     public synchronized void load(ExtensionLoader loader) throws FileNotFoundException {
-        loader.load((Consumer<Class<? extends Pipeline>>) this::register, Pipeline.class::isAssignableFrom);
+        loader.load(cls -> register(cls.asSubclass(Pipeline.class)), Pipeline.class::isAssignableFrom);
     }
 }
 

--- a/datashare-api/src/test/java/org/icij/datashare/extension/ExtensionLoaderTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/extension/ExtensionLoaderTest.java
@@ -9,6 +9,8 @@ import org.slf4j.event.Level;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.test.JarUtil.createJar;
@@ -38,15 +40,39 @@ public class ExtensionLoaderTest {
     @Test
     public void test_module_info_should_not_log_errors() throws Exception {
         Path extensionsDir = Paths.get(getClass().getResource("/extensions").toURI());
-        new ExtensionLoader(extensionsDir).findClassesInJar(aClass -> true, extensionsDir.resolve("executable.jar").toFile());
+        new ExtensionLoader(extensionsDir).findAllClassesInJar(aClass -> true, extensionsDir.resolve("executable.jar").toFile());
         assertThat(logWrapper.logs(Level.WARN)).isEmpty();
         assertThat(logWrapper.logs(Level.ERROR)).isEmpty();
+    }
+
+    @Test
+    public void test_load_registers_all_matching_classes() throws Exception {
+        // GIVEN
+        Path extensionsDir = folder.getRoot().toPath();
+        createJar(extensionsDir, "extension", FOO_SOURCE, BAR_SOURCE);
+
+        // WHEN
+        List<Class<?>> loaded = new ArrayList<>();
+        new ExtensionLoader(extensionsDir).load(loaded::add, c -> true);
+
+        // THEN
+        assertThat(loaded).hasSize(2);
+        List<String> names = loaded.stream().map(Class::getSimpleName).toList();
+        assertThat(names).contains("Foo", "Bar");
     }
 
     @After
     public void tearDown() throws Exception {
         logWrapper.reset();
     }
+
+    String FOO_SOURCE = "package org.icij.datashare.extension;\n" +
+            "\n" +
+            "public class Foo implements java.io.Serializable {}\n";
+
+    String BAR_SOURCE = "package org.icij.datashare.extension;\n" +
+            "\n" +
+            "public class Bar implements java.io.Serializable {}\n";
 
     String INFINITE_INITIALIZER_LOOP_SOURCE = "package org.icij.datashare.extension;\n" +
             "\n" +

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.mode;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
@@ -467,11 +468,8 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
          ExtensionLoader extensionLoader = new ExtensionLoader(Paths.get(ofNullable(getExtensionsDir()).orElse("./extensions")));
          if (extensionLoader.extensionsDir != null) {
             try {
-                extensionLoader.load((Consumer<Class<?>>) routes::add, this::isEligibleForLoading);
-                extensionLoader.load(
-                        (Consumer<Class<?>>) cls -> JsonObjectMapper.registerSubtypes(new NamedType(cls)),
-                        cls -> cls.isAnnotationPresent(JsonTypeName.class) && Serializable.class.isAssignableFrom(cls)
-                );
+                extensionLoader.load(routes::add, this::isEligibleForLoading);
+                extensionLoader.load(cls -> JsonObjectMapper.registerSubtypes(new NamedType(cls)), this::isJsonType);
                 get(PipelineRegistry.class).load(extensionLoader);
             } catch (FileNotFoundException e) {
                 logger.warn("Extensions directory not found: {}", extensionLoader.extensionsDir);
@@ -561,6 +559,10 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
 
     private boolean isEligibleForLoading(Class<?> c) {
         return c.isAnnotationPresent(Prefix.class) || c.isAnnotationPresent(Get.class);
+    }
+
+    private boolean isJsonType(Class<?> c) {
+        return (c.isAnnotationPresent(JsonTypeName.class) || c.isAnnotationPresent(JsonTypeInfo.class)) && Serializable.class.isAssignableFrom(c);
     }
 
     @NotNull

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.mode;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.inject.*;
 import com.google.inject.Module;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
@@ -83,6 +85,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
+import java.io.Serializable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -465,6 +468,10 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
          if (extensionLoader.extensionsDir != null) {
             try {
                 extensionLoader.load((Consumer<Class<?>>) routes::add, this::isEligibleForLoading);
+                extensionLoader.load(
+                        (Consumer<Class<?>>) cls -> JsonObjectMapper.registerSubtypes(new NamedType(cls)),
+                        cls -> cls.isAnnotationPresent(JsonTypeName.class) && Serializable.class.isAssignableFrom(cls)
+                );
                 get(PipelineRegistry.class).load(extensionLoader);
             } catch (FileNotFoundException e) {
                 logger.warn("Extensions directory not found: {}", extensionLoader.extensionsDir);


### PR DESCRIPTION
This PR aims to allow extensions to register custom task result subtypes automatically at startup. Datashare now scans extension JARs for classes annotated with @JsonTypeName that implement Serializable, and registers them with the Jackson object mapper.