### PR TITLE
feat: expose --maxEmbedDepth CLI flag

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -113,4 +113,21 @@ public class IndexTaskTest {
         assertThat(extractor.getOcrStrategy()).isEqualTo(PDFParserConfig.OCR_STRATEGY.AUTO);
         assertThat(extractor.isExtractInlineImages()).isFalse();
     }
+
+    @Test
+    public void test_max_embed_depth_reaches_extractor() throws Exception {
+        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
+        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+                new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+                    put("queueName", "test:queue");
+                }}), null);
+
+        Options<String> bound = indexTask.options().createFrom(Options.from(Map.of(
+                "maxEmbedDepth", "3", "queueName", "test:queue")));
+        DocumentFactory documentFactory = new DocumentFactory().configure(bound);
+        Extractor extractor = new Extractor(documentFactory, bound);
+
+        assertThat(extractor.getMaxEmbedDepth()).isEqualTo(3);
+    }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -129,6 +129,7 @@ public class DatashareCli {
         DatashareCliOptions.ocrLanguage(parser);
         DatashareCliOptions.ocrType(parser);
         DatashareCliOptions.ocrStrategy(parser);
+        DatashareCliOptions.maxEmbedDepth(parser);
         DatashareCliOptions.nlpPipeline(parser);
         DatashareCliOptions.nlpMaxTextLength(parser);
         DatashareCliOptions.nlpBatchSize(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -106,6 +106,7 @@ public final class DatashareCliOptions {
     public static final String OCR_OPT = "ocr";
     public static final String OCR_TYPE_OPT = "ocrType";
     public static final String OCR_STRATEGY_OPT = "ocrStrategy";
+    public static final String MAX_EMBED_DEPTH_OPT = "maxEmbedDepth";
     public static final String PARALLELISM_OPT = "parallelism";
     public static final String PARSER_PARALLELISM_ABBR_OPT = "pp";
     public static final String PARSER_PARALLELISM_OPT = "parserParallelism";
@@ -239,6 +240,7 @@ public final class DatashareCliOptions {
     public static final boolean DEFAULT_BROWSER_OPEN_LINK = false;
     public static final boolean DEFAULT_NO_DIGEST_PROJECT = false;
     public static final boolean DEFAULT_OCR = true;
+    public static final int DEFAULT_MAX_EMBED_DEPTH = 20;
     public static final int DEFAULT_BATCH_DOWNLOAD_MAX_NB_FILES = 10000;
     public static final int DEFAULT_BATCH_DOWNLOAD_ZIP_TTL = 24;
     public static final String DEFAULT_PLUGIN_DIR = DEFAULT_DATASHARE_HOME.resolve("plugins").toString();
@@ -758,6 +760,17 @@ public final class DatashareCliOptions {
                 // usage error, matching the picocli stage subcommand, instead of silently degrading
                 // to NO_OCR inside extract. asProperties serializes it back to the enum name.
                 .ofType(OcrStrategy.class);
+    }
+
+    static void maxEmbedDepth(OptionParser parser) {
+        parser.acceptsAll(
+                        List.of(MAX_EMBED_DEPTH_OPT),
+                        "Maximum nesting depth of embedded documents to extract before deeper embeds " +
+                                "are skipped, guarding against decompression-bomb / deeply-nested-archive " +
+                                "inputs. 0 disables the guard. Default: 20.")
+                .withRequiredArg()
+                .ofType(Integer.class)
+                .defaultsTo(DEFAULT_MAX_EMBED_DEPTH);
     }
 
     static void nlpPipeline(OptionParser parser) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -107,6 +107,10 @@ public final class DatashareCliOptions {
     public static final String OCR_TYPE_OPT = "ocrType";
     public static final String OCR_STRATEGY_OPT = "ocrStrategy";
     public static final String MAX_EMBED_DEPTH_OPT = "maxEmbedDepth";
+    public static final String MAX_EMBED_DEPTH_DESC =
+            "Maximum nesting depth of embedded documents to extract before deeper embeds " +
+                    "are skipped, guarding against decompression-bomb / deeply-nested-archive " +
+                    "inputs. 0 disables the guard. Default: 20.";
     public static final String PARALLELISM_OPT = "parallelism";
     public static final String PARSER_PARALLELISM_ABBR_OPT = "pp";
     public static final String PARSER_PARALLELISM_OPT = "parserParallelism";
@@ -765,9 +769,7 @@ public final class DatashareCliOptions {
     static void maxEmbedDepth(OptionParser parser) {
         parser.acceptsAll(
                         List.of(MAX_EMBED_DEPTH_OPT),
-                        "Maximum nesting depth of embedded documents to extract before deeper embeds " +
-                                "are skipped, guarding against decompression-bomb / deeply-nested-archive " +
-                                "inputs. 0 disables the guard. Default: 20.")
+                        MAX_EMBED_DEPTH_DESC)
                 .withRequiredArg()
                 .ofType(Integer.class)
                 .defaultsTo(DEFAULT_MAX_EMBED_DEPTH);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -52,6 +52,9 @@ public class PipelineOptions {
     @Option(names = {"--parserParallelism"}, description = "Number of file parser threads", defaultValue = "1")
     int parserParallelism;
 
+    @Option(names = {"--maxEmbedDepth"}, description = "Maximum nesting depth of embedded documents to extract before deeper embeds are skipped (guards against decompression bombs). 0 disables the guard. Default: 20.", defaultValue = "20")
+    int maxEmbedDepth;
+
     @Option(names = {"-r", "--resume"}, description = "Resume pending operations")
     boolean resume;
 
@@ -81,6 +84,7 @@ public class PipelineOptions {
         DatashareOptions.putIfNotNull(props, OCR_STRATEGY_OPT, ocrStrategy);
         DatashareOptions.putIfNotNull(props, PARALLELISM_OPT, parallelism);
         DatashareOptions.put(props, PARSER_PARALLELISM_OPT, parserParallelism);
+        DatashareOptions.put(props, MAX_EMBED_DEPTH_OPT, maxEmbedDepth);
         DatashareOptions.putIfTrue(props, RESUME_OPT, resume);
         DatashareOptions.put(props, FOLLOW_SYMLINKS_OPT, followSymlinks);
         DatashareOptions.putIfNotNull(props, CREATE_INDEX_OPT, createIndex);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -52,7 +52,7 @@ public class PipelineOptions {
     @Option(names = {"--parserParallelism"}, description = "Number of file parser threads", defaultValue = "1")
     int parserParallelism;
 
-    @Option(names = {"--maxEmbedDepth"}, description = "Maximum nesting depth of embedded documents to extract before deeper embeds are skipped (guards against decompression bombs). 0 disables the guard. Default: 20.", defaultValue = "20")
+    @Option(names = {"--maxEmbedDepth"}, description = MAX_EMBED_DEPTH_DESC, defaultValue = "20")
     int maxEmbedDepth;
 
     @Option(names = {"-r", "--resume"}, description = "Resume pending operations")

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -319,4 +319,16 @@ public class DatashareCliTest {
     public void test_ocr_strategy_opt_rejects_invalid_value() {
         cli.asProperties(cli.createParser().parse("--ocrStrategy", "NOPE"), null);
     }
+
+    @Test
+    public void test_max_embed_depth_opt() {
+        cli.parseArguments(new String[] {"--maxEmbedDepth=5"});
+        assertThat(cli.properties).includes(entry("maxEmbedDepth", "5"));
+    }
+
+    @Test
+    public void test_max_embed_depth_opt_defaults_to_20() {
+        cli.parseArguments(new String[] {""});
+        assertThat(cli.properties).includes(entry("maxEmbedDepth", "20"));
+    }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
@@ -60,4 +60,16 @@ public class StageRunCommandTest extends AbstractDatashareCommandTest {
         Properties props = parse("stage", "run", "--stages", "SCAN,INDEX");
         assertThat(props.containsKey("ocrStrategy")).isFalse();
     }
+
+    @Test
+    public void test_max_embed_depth() {
+        Properties props = parse("stage", "run", "--stages", "SCAN,INDEX", "--maxEmbedDepth", "5");
+        assertThat(props).includes(entry("maxEmbedDepth", "5"));
+    }
+
+    @Test
+    public void test_max_embed_depth_defaults_to_20() {
+        Properties props = parse("stage", "run", "--stages", "SCAN,INDEX");
+        assertThat(props).includes(entry("maxEmbedDepth", "20"));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.13.0</extract.version>
+        <extract.version>9.13.2</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.12.0</extract.version>
+        <extract.version>9.13.0</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>


### PR DESCRIPTION
Exposes extract-lib's decompression-bomb guard (`maxEmbedDepth`) as a first-class `datashare` CLI flag, so operators can set the embedded-document nesting limit at launch. Default is 20 (0 disables the guard); negatives are clamped to 0 by extract-lib.