### PR TITLE
fix(cli): make SCAN,INDEX runs terminate cleanly

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -3,6 +3,8 @@ package org.icij.datashare;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.icij.datashare.cli.CliExtensionService;
 import org.icij.datashare.cli.Prompter;
+import org.icij.datashare.cli.QueueType;
+import org.icij.datashare.cli.TaskRepositoryType;
 import org.icij.datashare.cli.Validators;
 import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.mode.CommonMode;
@@ -187,6 +189,13 @@ class CliApp {
         String runId = randomUUID().toString();
         properties.setProperty(PIPELINE_RUN_ID, runId);
 
+        if (!canTrackSpawnedTasks(properties)) {
+            logger.warn("the {} batch queue runs stages in remote workers but the {} task repository is process-local:"
+                    + " tasks spawned by a stage (e.g. NLP batches) cannot be tracked by this run, which may exit"
+                    + " before they complete. Use a shared task repository (DATABASE or REDIS).",
+                    QueueType.TEMPORAL, TaskRepositoryType.MEMORY);
+        }
+
         if (pipeline.has(Stage.DEDUPLICATE)) {
             taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties));
         }
@@ -239,6 +248,20 @@ class CliApp {
         int exitCode = computeExitCode(taskManager, runScope);
         logger.info("pipeline finished ({} unfinished task(s)), exiting with code {}", unfinished, exitCode);
         System.exit(exitCode);
+    }
+
+    /**
+     * Whether the run-scoped wait can observe every task this run's stages spawn. Under a
+     * TEMPORAL batch queue the stages execute in remote Temporal workers, and a MEMORY task
+     * repository is process-local: child tasks inserted by a worker's repository never
+     * become visible to this process, so the run could exit while spawned work is pending.
+     */
+    static boolean canTrackSpawnedTasks(Properties properties) {
+        QueueType batchQueueType = QueueType.valueOf(
+                properties.getProperty(BATCH_QUEUE_TYPE_OPT, DEFAULT_BATCH_QUEUE_TYPE.name()).toUpperCase());
+        TaskRepositoryType taskRepositoryType = TaskRepositoryType.valueOf(
+                properties.getProperty(TASK_REPOSITORY_OPT, TaskRepositoryType.DATABASE.name()));
+        return batchQueueType != QueueType.TEMPORAL || taskRepositoryType != TaskRepositoryType.MEMORY;
     }
 
     /**

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -24,7 +24,6 @@ import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskManager;
-import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
@@ -44,13 +43,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
 
+import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.icij.datashare.PropertiesProvider.propertiesToMap;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
@@ -179,83 +178,87 @@ class CliApp {
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
 
-        // Reconcile tasks left non-final by previously interrupted CLI runs before
-        // enqueuing our own. In CLI mode this process is the only worker and it has
-        // not enqueued anything yet, so any non-final task owned by the CLI user
-        // (nullUser) provably belongs to a dead run and is safe to cancel. Scoping to
-        // nullUser keeps a concurrent web server's real-user tasks untouched.
-        List<String> reconciled = taskManager.reconcileStaleTasks(TaskFilters.empty().withUser(nullUser()));
-        if (!reconciled.isEmpty()) {
-            logger.warn("reconciled {} orphaned task(s) from previous runs: {}", reconciled.size(), reconciled);
-        }
+        // Stamp every task this run starts (and, through CreateNlpBatchesFromIndex, every
+        // task they spawn) with a unique run id. That id is what lets us wait on exactly
+        // this run's work below, including spawned descendants whose ids we never see here,
+        // without being blocked by, or ever cancelling, tasks owned by other CLI runs or a
+        // concurrent server sharing the same (persistent) task store. All task users are the
+        // shared nullUser, so the user alone cannot tell this run's tasks from a peer's.
+        String runId = randomUUID().toString();
+        properties.setProperty(PIPELINE_RUN_ID, runId);
 
-        List<String> startedTaskIds = new ArrayList<>();
         if (pipeline.has(Stage.DEDUPLICATE)) {
-            startedTaskIds.add(taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.SCANIDX)) {
-            startedTaskIds.add(taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.SCAN)) {
-            startedTaskIds.add(taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.INDEX)) {
-            startedTaskIds.add(taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.ENQUEUEIDX)) {
-            startedTaskIds.add(taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.CATEGORIZE)) {
-            startedTaskIds.add(taskManager.startTask(CategorizeTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(CategorizeTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.CREATENLPBATCHESFROMIDX)) {
-            startedTaskIds.add(taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.NLP)) {
-            startedTaskIds.add(taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties));
         }
 
         if (pipeline.has(Stage.ARTIFACT)) {
-            startedTaskIds.add(taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties)));
+            taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties));
         }
-        // Wait only on the tasks this run started, not the global non-final count:
-        // the repository is shared and persistent, so unrelated non-final rows must
-        // never keep a finished run alive.
-        long unfinished = taskManager.waitTasksToBeDone(startedTaskIds, Integer.MAX_VALUE, SECONDS);
+        // Wait on every non-final task carrying this run id, not just the ids we started:
+        // stages such as CreateNlpBatchesFromIndex enqueue child BatchNlpTask tasks that
+        // must reach a final state before we shut the worker down, otherwise their still
+        // QUEUED work is silently dropped on System.exit. Scoping to the run id (rather
+        // than the global non-final count) also means unrelated rows left by other runs
+        // never keep this finished run alive.
+        TaskFilters runScope = TaskFilters.empty()
+                .withArgs(new TaskFilters.ArgsFilter(PIPELINE_RUN_ID, runId));
+        long unfinished = taskManager.waitTasksToBeDone(runScope, Integer.MAX_VALUE, SECONDS);
         taskManager.shutdown();
 
         // The JVM would otherwise stay alive on non-daemon threads (a second
         // TaskManager worker pool created by the unused CommonMode in Main, Redisson
         // netty threads). Force the exit, non-zero if any of this run's tasks errored.
-        int exitCode = computeExitCode(taskManager, startedTaskIds);
+        int exitCode = computeExitCode(taskManager, runScope);
         logger.info("pipeline finished ({} unfinished task(s)), exiting with code {}", unfinished, exitCode);
         System.exit(exitCode);
     }
 
     /**
-     * Success (0) unless one of this run's tasks ended in ERROR, or its final state
-     * could not be read (treated as a failure so a broken run never reports success).
+     * Success (0) unless one of this run's tasks (a stage we started, or a task one of
+     * them spawned) ended in ERROR, or their states could not be read (treated as a
+     * failure so a broken run never reports success).
      */
-    private static int computeExitCode(TaskManager taskManager, List<String> startedTaskIds) {
-        for (String taskId : startedTaskIds) {
-            try {
-                if (taskManager.getTask(taskId).getState() == Task.State.ERROR) {
-                    logger.error("task {} ended in ERROR", taskId);
+    private static int computeExitCode(TaskManager taskManager, TaskFilters runScope) {
+        try {
+            for (Task<?> task : taskManager.getTasks(runScope).toList()) {
+                if (task.getState() == Task.State.ERROR) {
+                    logger.error("task {} ended in ERROR", task.id);
                     return EXIT_RUNTIME;
                 }
-            } catch (IOException | UnknownTask e) {
-                logger.error("could not read final state of task {}; treating run as failed", taskId, e);
-                return EXIT_RUNTIME;
             }
+            return EXIT_SUCCESS;
+        } catch (IOException e) {
+            logger.error("could not read final task states; treating run as failed", e);
+            return EXIT_RUNTIME;
         }
-        return EXIT_SUCCESS;
     }
 
     static int handleUserCreate(UserAdminService service, Properties properties) {

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -26,6 +26,7 @@ import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.asynctasks.TaskManagerMemory;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
@@ -240,7 +241,7 @@ class CliApp {
         TaskFilters runScope = TaskFilters.empty()
                 .withArgs(new TaskFilters.ArgsFilter(PIPELINE_RUN_ID, runId));
         long unfinished = taskManager.waitTasksToBeDone(runScope, Integer.MAX_VALUE, SECONDS);
-        taskManager.shutdown();
+        shutdownLocalWorkers(taskManager);
 
         // The JVM would otherwise stay alive on non-daemon threads (a second
         // TaskManager worker pool created by the unused CommonMode in Main, Redisson
@@ -248,6 +249,19 @@ class CliApp {
         int exitCode = computeExitCode(taskManager, runScope);
         logger.info("pipeline finished ({} unfinished task(s)), exiting with code {}", unfinished, exitCode);
         System.exit(exitCode);
+    }
+
+    /**
+     * Only the in-process worker pool is ours to stop. For distributed batch queues,
+     * {@link TaskManager#shutdown()} broadcasts a ShutdownEvent on the shared Redis
+     * event topic or AMQP WORKER_EVENT queue, which would close every worker listening
+     * on the bus, including workers executing a concurrent server's or another run's
+     * still QUEUED/RUNNING tasks. Temporal owns its workers' lifecycle entirely.
+     */
+    static void shutdownLocalWorkers(TaskManager taskManager) throws IOException {
+        if (taskManager instanceof TaskManagerMemory) {
+            taskManager.shutdown();
+        }
     }
 
     /**

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -21,7 +21,10 @@ import org.icij.datashare.tasks.ArtifactTask;
 import org.icij.datashare.tasks.CreateNlpBatchesFromIndex;
 import org.icij.datashare.tasks.CategorizeTask;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskFilters;
 import org.icij.datashare.asynctasks.TaskManager;
+import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
@@ -41,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -174,43 +178,84 @@ class CliApp {
 
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
+
+        // Reconcile tasks left non-final by previously interrupted CLI runs before
+        // enqueuing our own. In CLI mode this process is the only worker and it has
+        // not enqueued anything yet, so any non-final task owned by the CLI user
+        // (nullUser) provably belongs to a dead run and is safe to cancel. Scoping to
+        // nullUser keeps a concurrent web server's real-user tasks untouched.
+        List<String> reconciled = taskManager.reconcileStaleTasks(TaskFilters.empty().withUser(nullUser()));
+        if (!reconciled.isEmpty()) {
+            logger.warn("reconciled {} orphaned task(s) from previous runs: {}", reconciled.size(), reconciled);
+        }
+
+        List<String> startedTaskIds = new ArrayList<>();
         if (pipeline.has(Stage.DEDUPLICATE)) {
-            taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.SCANIDX)) {
-            taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.SCAN)) {
-            taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.INDEX)) {
-            taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.ENQUEUEIDX)) {
-            taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.CATEGORIZE)) {
-            taskManager.startTask(CategorizeTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(CategorizeTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.CREATENLPBATCHESFROMIDX)) {
-            taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.NLP)) {
-            taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.ARTIFACT)) {
-            taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties));
+            startedTaskIds.add(taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties)));
         }
-        taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS);
+        // Wait only on the tasks this run started, not the global non-final count:
+        // the repository is shared and persistent, so unrelated non-final rows must
+        // never keep a finished run alive.
+        long unfinished = taskManager.waitTasksToBeDone(startedTaskIds, Integer.MAX_VALUE, SECONDS);
         taskManager.shutdown();
+
+        // The JVM would otherwise stay alive on non-daemon threads (a second
+        // TaskManager worker pool created by the unused CommonMode in Main, Redisson
+        // netty threads). Force the exit, non-zero if any of this run's tasks errored.
+        int exitCode = computeExitCode(taskManager, startedTaskIds);
+        logger.info("pipeline finished ({} unfinished task(s)), exiting with code {}", unfinished, exitCode);
+        System.exit(exitCode);
+    }
+
+    /**
+     * Success (0) unless one of this run's tasks ended in ERROR, or its final state
+     * could not be read (treated as a failure so a broken run never reports success).
+     */
+    private static int computeExitCode(TaskManager taskManager, List<String> startedTaskIds) {
+        for (String taskId : startedTaskIds) {
+            try {
+                if (taskManager.getTask(taskId).getState() == Task.State.ERROR) {
+                    logger.error("task {} ended in ERROR", taskId);
+                    return EXIT_RUNTIME;
+                }
+            } catch (IOException | UnknownTask e) {
+                logger.error("could not read final state of task {}; treating run as failed", taskId, e);
+                return EXIT_RUNTIME;
+            }
+        }
+        return EXIT_SUCCESS;
     }
 
     static int handleUserCreate(UserAdminService service, Properties properties) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -24,9 +24,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import static java.lang.String.valueOf;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_POLLING_INTERVAL_SEC;
+import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 
 /**
  * Computes the contentTypeCategory field of documents based on their contentType in Elasticsearch.
@@ -40,7 +43,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT
 public class CategorizeTask extends PipelineTask<String> implements Monitorable {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private static final int NB_MAX_POLLS = 3;
-    private static final int POLLING_INTERVAL_SECONDS = 60;
+    private final float pollingIntervalSeconds;
     private final AtomicInteger processed = new AtomicInteger(0);
     private final Function<Double, Void> progressCallback;
     private final Indexer indexer;
@@ -51,6 +54,7 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
         this.progressCallback = progressCallback;
         this.indexer = indexer;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
+        pollingIntervalSeconds = Float.parseFloat(ofNullable((String) taskView.args.get(POLLING_INTERVAL_SECONDS_OPT)).orElse(DEFAULT_POLLING_INTERVAL_SEC));
     }
 
     @Override
@@ -60,14 +64,19 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
         String docId;
         long nbMessages = 0;
         int nbMaxPolls = NB_MAX_POLLS;
-        int pollingIntervalSeconds = POLLING_INTERVAL_SECONDS;
 
-        while (!(STRING_POISON.equals(docId = inputQueue.poll( (pollingIntervalSeconds * 1000L), TimeUnit.MILLISECONDS)))
-                && nbMaxPolls > 0) {
+        while (nbMaxPolls > 0) {
+            long pollTimeoutMs = Math.max(1L, (long) (pollingIntervalSeconds * 1000));
+            docId = inputQueue.poll(pollTimeoutMs, TimeUnit.MILLISECONDS);
             try {
-                if (docId != null) {
+                if (docId == null) {
+                    logger.info("will poll document queue again for pollingInterval={} seconds ({}/{})", pollingIntervalSeconds, nbMaxPolls, NB_MAX_POLLS);
+                    nbMaxPolls--;
+                } else if (isPoison(docId)) {
+                    logger.debug("skipping legacy POISON entry in queue {}", inputQueue.getName());
+                } else {
                     Document retrievedFromIndexer = indexer.get(project.getName(), docId);
-                    if(retrievedFromIndexer == null) {
+                    if (retrievedFromIndexer == null) {
                         logger.warn("Unable to retrieve document {} from indexer. Cannot add it's contentTypeCategory", docId);
                     } else {
                         enrichWithType(retrievedFromIndexer);
@@ -75,19 +84,13 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
                     nbMessages++;
                     processed.incrementAndGet();
                     progressCallback.apply(getProgressRate());
-                    if(!outputQueue.offer(docId)){
+                    if (!outputQueue.offer(docId)) {
                         logger.warn("unable to offer {} to queue {}", docId, outputQueue.getName());
                     }
-                } else {
-                    logger.info("will poll document queue again for pollingInterval={} seconds ({}/{})", pollingIntervalSeconds, nbMaxPolls, NB_MAX_POLLS);
-                    nbMaxPolls--;
                 }
             } catch (Exception e) {
                 logger.error("error in CategorizeTask loop", e);
             }
-        }
-        if(!outputQueue.offer(STRING_POISON)){
-            logger.warn("unable to offer POISON to queue {}", outputQueue.getName());
         }
         logger.info("exiting CategorizeTask loop after {} messages.", nbMessages);
         return nbMessages;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import static java.lang.String.valueOf;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndex.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndex.java
@@ -12,6 +12,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_SCROLL_SIZE;
 import static org.icij.datashare.cli.DatashareCliOptions.NLP_BATCH_SIZE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.NLP_MAX_TEXT_LENGTH_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.NLP_PIPELINE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.PIPELINE_RUN_ID;
 import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_DURATION_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.SCROLL_SIZE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.SEARCH_QUERY_OPT;
@@ -65,6 +66,9 @@ public class CreateNlpBatchesFromIndex extends DefaultTask<List<String>> impleme
     private final Indexer indexer;
     private final String scrollDuration;
     private final int scrollSize;
+    // Correlation id of the CLI run that started us, propagated to the child BatchNlpTask
+    // tasks so that run can wait on them before exiting. Null outside CLI (e.g. web mode).
+    private final String runId;
     private Language currentLanguage = null;
 
     public record BatchDocument(String id, String rootDocument, String project, Language language) {
@@ -89,6 +93,7 @@ public class CreateNlpBatchesFromIndex extends DefaultTask<List<String>> impleme
         this.scrollDuration = (String) taskView.args.getOrDefault(SCROLL_DURATION_OPT, DEFAULT_SCROLL_DURATION);
         this.scrollSize = (int) taskView.args.getOrDefault(SCROLL_SIZE_OPT, DEFAULT_SCROLL_SIZE);
         this.searchQuery = (String) taskView.args.get(SEARCH_QUERY_OPT);
+        this.runId = (String) taskView.args.get(PIPELINE_RUN_ID);
     }
 
     @Override
@@ -169,6 +174,8 @@ public class CreateNlpBatchesFromIndex extends DefaultTask<List<String>> impleme
         String taskId;
         HashMap<String, Object> args = new HashMap<>(this.batchTaskArgs);
         args.put("docs", batch.stream().map(BatchDocument::fromDocument).toList());
+        // Carry the run id onto the child so the CLI run that owns us waits for it too.
+        ofNullable(runId).ifPresent(id -> args.put(PIPELINE_RUN_ID, id));
         // TODO: here we bind the task name to the Java class name which is not ideal since it leaks Java inners
         //  bolts to Python, it could be nice to decouple task names from class names since they can change and
         //  are bound to languages

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -50,7 +50,7 @@ public class DeduplicateTask extends PipelineTask<Path> {
 
     long transferToOutputQueue(Predicate<Path> filter) throws Exception {
         long originalSize = inputQueue.size();
-        long pollMillis = pipelineQueuePoll(propertiesProvider).toMillis();
+        long pollMillis = Math.max(1L, pipelineQueuePoll(propertiesProvider).toMillis());
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
             Path path;
             while ((path = inputQueue.poll(pollMillis, TimeUnit.MILLISECONDS)) != null) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -49,14 +50,18 @@ public class DeduplicateTask extends PipelineTask<Path> {
 
     long transferToOutputQueue(Predicate<Path> filter) throws Exception {
         long originalSize = inputQueue.size();
+        long pollMillis = pipelineQueuePoll(propertiesProvider).toMillis();
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
             Path path;
-            while (!(path = inputQueue.take()).equals(PATH_POISON)) {
+            while ((path = inputQueue.poll(pollMillis, TimeUnit.MILLISECONDS)) != null) {
+                if (isPoison(path)) {
+                    logger.debug("skipping legacy POISON entry in queue {}", inputQueue.getName());
+                    continue;
+                }
                 if (filter.test(path)) {
                     outputQueue.add(path);
                 }
             }
-            outputQueue.add(PATH_POISON);
             return originalSize - outputQueue.size();
         }
     }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -77,7 +77,8 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
         long nbMessages = 0;
         int nbMaxPolls = NB_MAX_POLLS;
         while (nbMaxPolls > 0) {
-            docId = inputQueue.poll((long) (pollingIntervalSeconds * 1000), TimeUnit.MILLISECONDS);
+            long pollTimeoutMs = Math.max(1L, (long) (pollingIntervalSeconds * 1000));
+            docId = inputQueue.poll(pollTimeoutMs, TimeUnit.MILLISECONDS);
             try {
                 if (docId == null) {
                     logger.info("will poll document queue again for pollingInterval={} seconds ({}/{})", pollingIntervalSeconds, nbMaxPolls, NB_MAX_POLLS);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -76,17 +76,19 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
         String docId;
         long nbMessages = 0;
         int nbMaxPolls = NB_MAX_POLLS;
-        while (!(STRING_POISON.equals(docId = inputQueue.poll((long) (pollingIntervalSeconds * 1000), TimeUnit.MILLISECONDS)))
-                && nbMaxPolls > 0) {
+        while (nbMaxPolls > 0) {
+            docId = inputQueue.poll((long) (pollingIntervalSeconds * 1000), TimeUnit.MILLISECONDS);
             try {
-                if (docId != null) {
+                if (docId == null) {
+                    logger.info("will poll document queue again for pollingInterval={} seconds ({}/{})", pollingIntervalSeconds, nbMaxPolls, NB_MAX_POLLS);
+                    nbMaxPolls--;
+                } else if (isPoison(docId)) {
+                    logger.debug("skipping legacy POISON entry in queue {}", inputQueue.getName());
+                } else {
                     findNamedEntities(project, docId);
                     nbMessages++;
                     processed.incrementAndGet();
                     progressCallback.apply(getProgressRate());
-                } else {
-                    logger.info("will poll document queue again for pollingInterval={} seconds ({}/{})", pollingIntervalSeconds, nbMaxPolls, NB_MAX_POLLS);
-                    nbMaxPolls--;
                 }
             } catch (Throwable e) {
                 logger.error("error in ExtractNlpTask loop", e);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 
 import static java.lang.Math.max;
 import static java.lang.String.valueOf;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import static java.lang.Math.max;
 import static java.lang.String.valueOf;
@@ -71,6 +72,10 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
 
         consumer = new DocumentConsumer(spewer, this.extractor, this.parallelism);
         progressTrackConsumer = path -> {
+            if (isPoison(path)) {
+                logger.debug("skipping legacy POISON entry from queue {}", inputQueue.getName());
+                return;
+            }
             consumer.accept(path);
             processed.incrementAndGet();
             if (progressCallback != null) {
@@ -82,6 +87,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
             consumer.setReporter(new Reporter(factory.createMap(propertiesProvider.getProperties().get(REPORT_NAME_OPT).toString())));
         }
         drainer = new DocumentQueueDrainer<>(inputQueue, progressTrackConsumer).configure(allTaskOptions);
+        drainer.setPollTimeout(pipelineQueuePoll(propertiesProvider));
     }
 
     @Override
@@ -89,7 +95,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         super.call();
         logger.info("Processing up to {} file(s) in parallel", parallelism);
         try {
-            totalToProcess = drainer.drain(PATH_POISON).get();
+            totalToProcess = drainer.drain().get();
             drainer.shutdown();
             drainer.awaitTermination(10, SECONDS); // drain is finished
             logger.info("drained {} documents. Waiting for consumer to shutdown", totalToProcess);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import static java.lang.Math.max;
 import static java.lang.String.valueOf;
@@ -85,8 +86,13 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
             logger.info("report map enabled with name set to {}", propertiesProvider.getProperties().get(REPORT_NAME_OPT));
             consumer.setReporter(new Reporter(factory.createMap(propertiesProvider.getProperties().get(REPORT_NAME_OPT).toString())));
         }
-        drainer = new DocumentQueueDrainer<>(inputQueue, progressTrackConsumer).configure(allTaskOptions);
-        drainer.setPollTimeout(pipelineQueuePoll(propertiesProvider));
+        drainer = new DocumentQueueDrainer<>(inputQueue, progressTrackConsumer);
+        Duration queuePoll = pipelineQueuePoll(propertiesProvider);
+        if (!queuePoll.isZero() && queuePoll.getSeconds() == 0) {
+            // the drainer only honors whole-second poll timeouts; round sub-second up so INDEX still blocks
+            queuePoll = Duration.ofSeconds(1);
+        }
+        drainer.setPollTimeout(queuePoll);
     }
 
     @Override

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -9,11 +9,15 @@ import org.icij.datashare.user.User;
 import org.icij.datashare.user.UserTask;
 import org.icij.extract.queue.DocumentQueue;
 import org.icij.task.DefaultTask;
+import org.icij.time.HumanDuration;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 
 import static java.util.Optional.ofNullable;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_QUEUE_POLL;
+import static org.icij.datashare.cli.DatashareCliOptions.QUEUE_POLL_OPT;
 
 public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserTask, CancellableTask {
     protected final DocumentQueue<T> inputQueue;
@@ -25,6 +29,18 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
     public static Path PATH_POISON = Paths.get("POISON");
     public static String STRING_POISON = "POISON";
     private volatile Thread taskThread;
+
+    public static boolean isPoison(Path path) {
+        return PATH_POISON.equals(path);
+    }
+
+    public static boolean isPoison(String id) {
+        return STRING_POISON.equals(id);
+    }
+
+    public static Duration pipelineQueuePoll(PropertiesProvider propertiesProvider) {
+        return HumanDuration.parse(propertiesProvider.get(QUEUE_POLL_OPT).orElse(DEFAULT_QUEUE_POLL));
+    }
 
     public PipelineTask(Stage stage, User user, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz) {
         this.propertiesProvider = propertiesProvider;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
@@ -41,7 +41,6 @@ public class ScanTask extends PipelineTask<Path> {
         super.call();
         ScannerVisitor scannerVisitor = scanner.createScannerVisitor(path);
         Long scanned = scannerVisitor.call();
-        outputQueue.add(PATH_POISON);
         return scanned;
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTaskTrackingTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTaskTrackingTest.java
@@ -1,5 +1,9 @@
 package org.icij.datashare;
 
+import org.icij.datashare.asynctasks.TaskManagerAmqp;
+import org.icij.datashare.asynctasks.TaskManagerMemory;
+import org.icij.datashare.asynctasks.TaskManagerRedis;
+import org.icij.datashare.asynctasks.TaskManagerTemporal;
 import org.junit.Test;
 
 import java.util.Properties;
@@ -7,8 +11,53 @@ import java.util.Properties;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.cli.DatashareCliOptions.BATCH_QUEUE_TYPE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.TASK_REPOSITORY_OPT;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 public class CliAppTaskTrackingTest {
+    @Test
+    public void test_shutdown_stops_the_in_process_worker_pool() throws Exception {
+        // The MEMORY task manager's worker pool lives in this JVM and belongs to
+        // this run only: it must be shut down so the pool stops cleanly.
+        TaskManagerMemory taskManager = mock(TaskManagerMemory.class);
+
+        CliApp.shutdownLocalWorkers(taskManager);
+
+        verify(taskManager).shutdown();
+    }
+
+    @Test
+    public void test_shutdown_does_not_broadcast_to_a_shared_redis_bus() throws Exception {
+        // TaskManagerRedis.shutdown() publishes a ShutdownEvent on the shared event
+        // topic: every worker on the bus would close, including a concurrent server's
+        // or another run's workers with QUEUED/RUNNING tasks.
+        TaskManagerRedis taskManager = mock(TaskManagerRedis.class);
+
+        CliApp.shutdownLocalWorkers(taskManager);
+
+        verify(taskManager, never()).shutdown();
+    }
+
+    @Test
+    public void test_shutdown_does_not_broadcast_to_a_shared_amqp_bus() throws Exception {
+        TaskManagerAmqp taskManager = mock(TaskManagerAmqp.class);
+
+        CliApp.shutdownLocalWorkers(taskManager);
+
+        verify(taskManager, never()).shutdown();
+    }
+
+    @Test
+    public void test_shutdown_leaves_temporal_workers_alone() throws Exception {
+        // Temporal owns worker lifecycle; the CLI has nothing to stop.
+        TaskManagerTemporal taskManager = mock(TaskManagerTemporal.class);
+
+        CliApp.shutdownLocalWorkers(taskManager);
+
+        verify(taskManager, never()).shutdown();
+    }
+
     @Test
     public void test_cannot_track_spawned_tasks_with_temporal_queue_and_memory_repository() {
         // Remote Temporal workers insert the tasks they spawn into THEIR repository;

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTaskTrackingTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTaskTrackingTest.java
@@ -1,0 +1,40 @@
+package org.icij.datashare;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.cli.DatashareCliOptions.BATCH_QUEUE_TYPE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_REPOSITORY_OPT;
+
+public class CliAppTaskTrackingTest {
+    @Test
+    public void test_cannot_track_spawned_tasks_with_temporal_queue_and_memory_repository() {
+        // Remote Temporal workers insert the tasks they spawn into THEIR repository;
+        // with a process-local MEMORY repository this run can never see them.
+        Properties properties = new Properties();
+        properties.setProperty(BATCH_QUEUE_TYPE_OPT, "TEMPORAL");
+        properties.setProperty(TASK_REPOSITORY_OPT, "MEMORY");
+
+        assertThat(CliApp.canTrackSpawnedTasks(properties)).isFalse();
+    }
+
+    @Test
+    public void test_can_track_spawned_tasks_with_temporal_queue_and_default_database_repository() {
+        Properties properties = new Properties();
+        properties.setProperty(BATCH_QUEUE_TYPE_OPT, "TEMPORAL");
+
+        assertThat(CliApp.canTrackSpawnedTasks(properties)).isTrue();
+    }
+
+    @Test
+    public void test_can_track_spawned_tasks_with_default_memory_queue() {
+        // The default MEMORY batch queue executes everything in-process, so even a
+        // MEMORY repository observes every spawned task.
+        Properties properties = new Properties();
+        properties.setProperty(TASK_REPOSITORY_OPT, "MEMORY");
+
+        assertThat(CliApp.canTrackSpawnedTasks(properties)).isTrue();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
@@ -53,7 +53,7 @@ public class CategorizeTaskIntTest {
 
         indexAndEnqueueWithPoison(videoDoc, pdfDoc, unknownTypeDoc);
         CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
-                "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
+                "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName(), "pollingInterval", "0.1")), NO_OP_PROGRESS);
 
         //WHEN
         long res = categorizeTask.call();
@@ -61,7 +61,7 @@ public class CategorizeTaskIntTest {
         //THEN
         assertThat(res).isEqualTo(3);
         DocumentQueue<String> outPutQueue = documentCollectionFactory.createQueue("extract:queue:nlp", String.class);
-        assertThat(outPutQueue.size()).isEqualTo(4); // with POISON
+        assertThat(outPutQueue.size()).isEqualTo(3); // no POISON
 
         assertThat(((Document) indexer.get(es.getIndexName(), videoDoc.getId())).getContentTypeCategory()).isEqualTo(ContentTypeCategory.VIDEO);
         assertThat(((Document) indexer.get(es.getIndexName(), pdfDoc.getId())).getContentTypeCategory()).isEqualTo(ContentTypeCategory.DOCUMENT);
@@ -74,14 +74,14 @@ public class CategorizeTaskIntTest {
         //GIVEN
         indexAndEnqueueTwoDocuments("foo:categorize");
         CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
-                "categorizeTask1", User.local(), Map.of(QUEUE_NAME_OPT, "foo", DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
+                "categorizeTask1", User.local(), Map.of(QUEUE_NAME_OPT, "foo", DEFAULT_PROJECT_OPT, es.getIndexName(), "pollingInterval", "0.1")), NO_OP_PROGRESS);
 
         //WHEN
         categorizeTask.call();
 
         //THEN
         DocumentQueue<String> outputQueue = documentCollectionFactory.createQueue("foo:nlp", String.class);
-        assertThat(outputQueue.size()).isEqualTo(3); // with POISON
+        assertThat(outputQueue.size()).isEqualTo(2); // no POISON
     }
 
     @Test
@@ -94,7 +94,7 @@ public class CategorizeTaskIntTest {
             return null;
         };
         CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
-                "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), callback);
+                "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName(), "pollingInterval", "0.1")), callback);
 
         //WHEN
         categorizeTask.call();
@@ -110,7 +110,7 @@ public class CategorizeTaskIntTest {
         // A document that will not be in the index
         enqueueWithPoison(aDoc());
         CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
-                "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
+                "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName(), "pollingInterval", "0.1")), NO_OP_PROGRESS);
 
         // WHEN
         long res = categorizeTask.call();
@@ -118,7 +118,20 @@ public class CategorizeTaskIntTest {
         // THEN
         assertThat(res).isEqualTo(1);
         DocumentQueue<String> outPutQueue = documentCollectionFactory.createQueue("extract:queue:nlp", String.class);
-        assertThat(outPutQueue.size()).isEqualTo(2); // with POISON
+        assertThat(outPutQueue.size()).isEqualTo(1); // no POISON
+    }
+
+    @Test(timeout = 6000)
+    public void test_terminates_with_zero_polling_interval_on_empty_queue() throws Exception {
+        // GIVEN a quiet input queue and a pollingInterval of 0 (should be clamped, not block forever)
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
+                "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName(), "pollingInterval", "0")), NO_OP_PROGRESS);
+
+        // WHEN
+        long res = categorizeTask.call();
+
+        // THEN
+        assertThat(res).isEqualTo(0);
     }
 
     @Test
@@ -132,7 +145,8 @@ public class CategorizeTaskIntTest {
 
         Map<String, Object> args = Map.of(
                 DEFAULT_PROJECT_OPT, es.getIndexName(),
-                "stages", "ENQUEUEIDX,CATEGORIZE");
+                "stages", "ENQUEUEIDX,CATEGORIZE",
+                "pollingInterval", "0.1");
 
         // WHEN
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,
@@ -161,7 +175,8 @@ public class CategorizeTaskIntTest {
 
         Map<String, Object> args = Map.of(
                 DEFAULT_PROJECT_OPT, es.getIndexName(),
-                "stages", "ENQUEUEIDX,CATEGORIZE");
+                "stages", "ENQUEUEIDX,CATEGORIZE",
+                "pollingInterval", "0.1");
 
         // WHEN
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CreateNlpBatchesFromIndexTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.tasks;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
 import static org.icij.datashare.text.Project.project;
+import static org.icij.datashare.cli.DatashareCliOptions.PIPELINE_RUN_ID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -87,5 +88,27 @@ public class CreateNlpBatchesFromIndexTest {
         // Then
         List<List<String>> expected = List.of(List.of("my_id"));
         assertThat(queued).isEqualTo(expected);
+    }
+
+    @Test
+    public void test_child_batches_inherit_the_run_id() throws Exception {
+        // Given a run id stamped on the parent task (as the CLI does)
+        indexer.add(es.getIndexName(), createDoc("my_id").with("this is my precious doc")
+            .with(Pipeline.Type.CORENLP).with(project(es.getIndexName())).build());
+        Map<String, Object> properties = Map.of(
+            "defaultProject", es.getIndexName(),
+            "nlpPipeline", "OPENNLP",
+            "batchSize", 3,
+            "scrollSize", 5,
+            PIPELINE_RUN_ID, "run-123"
+        );
+        CreateNlpBatchesFromIndex enqueueFromIndex = new CreateNlpBatchesFromIndex(taskManager, indexer,
+            new Task<>(CreateNlpBatchesFromIndex.class.getName(), new User("test"), properties), null);
+        // When
+        enqueueFromIndex.call();
+        // Then every spawned child batch carries the run id, so the CLI run waits on them
+        List<Object> childRunIds = taskManager.getTasks().map(t -> t.args.get(PIPELINE_RUN_ID)).toList();
+        assertThat(childRunIds).isNotEmpty();
+        assertThat(childRunIds).containsOnly("run-123");
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -16,12 +16,11 @@ import static org.icij.datashare.tasks.PipelineTask.PATH_POISON;
 
 public class DeduplicateTaskTest {
     DocumentCollectionFactory<Path> docCollectionFactory = new MemoryDocumentCollectionFactory<>();
-    Map<String, Object> defaultOpts = Map.of("queueName", "test:queue", "stages", "DEDUPLICATE");
+    Map<String, Object> defaultOpts = Map.of("queueName", "test:queue", "stages", "DEDUPLICATE", "queuePoll", "10ms");
     DeduplicateTask task = new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null);
 
     @Test(timeout = 2000)
     public void test_filter_empty() throws Exception {
-        docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).add(PATH_POISON);
         assertThat(new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
     }
 
@@ -29,41 +28,50 @@ public class DeduplicateTaskTest {
     public void test_filter_queue_removes_duplicates() throws Exception {
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
-        docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).add(PATH_POISON);
 
-        assertThat(new DeduplicateTask(docCollectionFactory,  new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
+        assertThat(new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
 
-        assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(2); // with POISON
+        assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(1); // no POISON
     }
 
     @Test(timeout = 2000)
-    public void test_pipeline_task_transfer_to_output_queue() throws Exception {
+    public void test_transfer_terminates_on_quiet_queue_without_poison() throws Exception {
         task.inputQueue.put(get("/path/to/doc1"));
         task.inputQueue.put(get("/path/to/doc2"));
-        task.inputQueue.put(PATH_POISON);
 
         task.transferToOutputQueue();
 
         assertThat(task.inputQueue.isEmpty()).isTrue();
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
-        assertThat(outputQueue.size()).isEqualTo(3);
+        assertThat(outputQueue.size()).isEqualTo(2);
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc2");
-        assertThat(outputQueue.poll().toString()).isEqualTo(PATH_POISON.toString());
     }
 
     @Test(timeout = 2000)
-    public void test_pipeline_task_conditional_transfer_to_output_queue() throws Exception {
+    public void test_skips_legacy_poison_without_forwarding_it() throws Exception {
+        task.inputQueue.put(get("/path/to/doc1"));
+        task.inputQueue.put(PATH_POISON);
+        task.inputQueue.put(get("/path/to/doc2"));
+
+        task.transferToOutputQueue();
+
+        DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
+        assertThat(outputQueue.size()).isEqualTo(2); // POISON skipped, not forwarded
+        assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");
+        assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc2");
+    }
+
+    @Test(timeout = 2000)
+    public void test_conditional_transfer_to_output_queue() throws Exception {
         task.inputQueue.put(get("/path/to/doc1"));
         task.inputQueue.put(get("/path/to/doc2"));
-        task.inputQueue.put(PATH_POISON);
 
         task.transferToOutputQueue(p -> p.toString().contains("1"));
 
         assertThat(task.inputQueue.isEmpty()).isTrue();
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
-        assertThat(outputQueue.size()).isEqualTo(2);
+        assertThat(outputQueue.size()).isEqualTo(1);
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");
-        assertThat(outputQueue.poll().toString()).isEqualTo(PATH_POISON.toString());
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -63,6 +63,22 @@ public class DeduplicateTaskTest {
     }
 
     @Test(timeout = 2000)
+    public void test_transfer_terminates_with_zero_queue_poll() throws Exception {
+        // NB: queuePoll="0" clamps the internal poll timeout to 1ms (see Math.max(1L, ...) in
+        // DeduplicateTask#transferToOutputQueue). MemoryDocumentCollectionFactory's ArrayBlockingQueue
+        // returns immediately on poll(0, MS) regardless of the clamp, so this test cannot reproduce the
+        // real Redis BLPOP-with-timeout-0 hang (which blocks forever). It only guards that the clamped
+        // value is still accepted and the loop terminates on a quiet queue.
+        Map<String, Object> zeroPollOpts = Map.of("queueName", "test:queue:zero", "stages", "DEDUPLICATE", "queuePoll", "0");
+        DeduplicateTask zeroPollTask = new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), zeroPollOpts), null);
+
+        zeroPollTask.transferToOutputQueue();
+
+        DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(zeroPollTask.getOutputQueueName(), Path.class);
+        assertThat(outputQueue.isEmpty()).isTrue();
+    }
+
+    @Test(timeout = 2000)
     public void test_conditional_transfer_to_output_queue() throws Exception {
         task.inputQueue.put(get("/path/to/doc1"));
         task.inputQueue.put(get("/path/to/doc2"));

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
@@ -50,7 +50,7 @@ public class ExtractNlpTaskIntTest {
         this.factory = injector.getInstance(new Key<>(){});
     }
 
-    @Test(timeout = 2000)
+    @Test(timeout = 6000)
     public void test_loop_consume_two_documents() throws Exception {
         when(pipeline.getType()).thenReturn(Pipeline.Type.CORENLP);
         when(pipeline.initialize(any())).thenReturn(true);
@@ -66,9 +66,28 @@ public class ExtractNlpTaskIntTest {
 
         verify(pipeline).initialize(ENGLISH);
         verify(pipeline).process(doc);
+        verify(indexer, never()).get(anyString(), eq("POISON"));
     }
 
-    @Test(timeout = 2000)
+    @Test(timeout = 6000)
+    public void test_skips_legacy_poison_and_keeps_consuming() throws Exception {
+        when(pipeline.getType()).thenReturn(Pipeline.Type.CORENLP);
+        when(pipeline.initialize(any())).thenReturn(true);
+        Document doc = createDoc("content").build();
+        when(indexer.get(anyString(), eq("docId"))).thenReturn(doc);
+
+        String queueName = new PipelineHelper(new PropertiesProvider()).getQueueNameFor(Stage.NLP);
+        DocumentQueue<String> queue = factory.createQueue(queueName, String.class);
+        queue.add(PipelineTask.STRING_POISON); // legacy poison BEFORE the real doc
+        queue.add("docId");
+
+        nlpTask.call();
+
+        verify(pipeline).process(doc); // reached the doc that sat behind the poison
+        verify(indexer, never()).get(anyString(), eq("POISON"));
+    }
+
+    @Test(timeout = 6000)
     public void test_progress() throws Exception {
         List<Double> progressValues = Collections.synchronizedList(new ArrayList<>());
         Function<Double, Void> callback = progress -> {
@@ -95,6 +114,7 @@ public class ExtractNlpTaskIntTest {
 
         new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>() {{
             put("maxContentLength", "32");
+            put("pollingInterval", "1");
         }}), callback).call();
 
         verify(pipeline, times(3)).initialize(ENGLISH);
@@ -130,6 +150,7 @@ public class ExtractNlpTaskIntTest {
         initMocks(this);
         nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
             put("maxContentLength", "32");
+            put("pollingInterval", "1");
         }}), null);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
@@ -123,6 +123,20 @@ public class ExtractNlpTaskIntTest {
         assertThat(progressValues).contains(0.5);
     }
 
+    @Test(timeout = 6000)
+    public void test_zero_polling_interval_terminates_via_nb_max_polls() throws Exception {
+        when(pipeline.getType()).thenReturn(Pipeline.Type.CORENLP);
+
+        ExtractNlpTask zeroIntervalTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>() {{
+            put("maxContentLength", "32");
+            put("pollingInterval", "0");
+        }}), null);
+
+        long nbMessages = zeroIntervalTask.call();
+
+        assertThat(nbMessages).isEqualTo(0);
+    }
+
     @Parameterized.Parameters
     public static Collection<Object[]> factories() {
         return asList(new Object[][]{

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -28,7 +28,6 @@ import java.util.*;
 import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.tasks.PipelineTask.STRING_POISON;
 import static org.mockito.Mockito.verify;
 
 public class IndexTaskIntTest {
@@ -54,13 +53,14 @@ public class IndexTaskIntTest {
     private Map<String, Object> map = new HashMap<>() {{
         put("defaultProject", es.getIndexName());
         put("queueName", "test:queue");
+        put("queuePoll", "0"); // pre-populated queue: drain then stop immediately
     }};
     private final PropertiesProvider propertiesProvider = new PropertiesProvider(map);
     private final ElasticsearchSpewer spewer = new ElasticsearchSpewer(new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True),
             outputQueueFactory, text -> Language.ENGLISH, new FieldNames(), propertiesProvider);
 
     @Test
-    public void index_task_should_enqueue_poison_pill() throws Exception {
+    public void index_task_forwards_only_document_ids_without_poison() throws Exception {
         DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
@@ -68,9 +68,38 @@ public class IndexTaskIntTest {
 
         assertThat(nbDocs).isEqualTo(1);
         DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);
-        assertThat(outputQueue).hasSize(2);
+        assertThat(outputQueue).hasSize(1);
         assertThat(outputQueue.poll()).isEqualTo("bc6852541ef5200206a7a9740f3d2d62178a1f53b1aa5417ab426c6ec1f7cbc7");
-        assertThat(outputQueue.poll()).isEqualTo(STRING_POISON);
+    }
+
+    @Test
+    public void index_task_skips_legacy_poison_in_input_queue() throws Exception {
+        DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
+        queue.add(PipelineTask.PATH_POISON);
+        queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
+        queue.add(PipelineTask.PATH_POISON);
+
+        new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+
+        DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);
+        assertThat(outputQueue).hasSize(1); // only the real document id, POISON skipped
+        assertThat(outputQueue.poll()).isEqualTo("bc6852541ef5200206a7a9740f3d2d62178a1f53b1aa5417ab426c6ec1f7cbc7");
+    }
+
+    @Test(timeout = 20000)
+    public void index_task_waits_for_quiet_queue_with_positive_queue_poll() throws Exception {
+        Map<String, Object> waitMap = new HashMap<>(map) {{
+            put("queuePoll", "1s"); // block up to 1s on an empty queue before concluding drained
+        }};
+        DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
+        queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
+
+        long start = System.currentTimeMillis();
+        Long nbDocs = new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), waitMap), null).call();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(nbDocs).isEqualTo(1);
+        assertThat(elapsed).isGreaterThanOrEqualTo(900); // proves it blocked on the empty queue instead of exiting instantly
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -102,6 +102,26 @@ public class IndexTaskIntTest {
         assertThat(elapsed).isGreaterThanOrEqualTo(900); // proves it blocked on the empty queue instead of exiting instantly
     }
 
+    @Test(timeout = 20000)
+    public void index_task_waits_for_quiet_queue_with_sub_second_queue_poll() throws Exception {
+        Map<String, Object> waitMap = new HashMap<>(map) {{
+            put("queuePoll", "500ms"); // sub-second poll must still block (rounded up to 1s) on an empty queue
+        }};
+        DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
+        queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
+
+        // construct outside of the timed window: cold-start ES/index/extractor setup can itself take
+        // close to a second, which would otherwise mask whether the drain loop actually blocked
+        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), waitMap), null);
+
+        long start = System.currentTimeMillis();
+        Long nbDocs = indexTask.call();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(nbDocs).isEqualTo(1);
+        assertThat(elapsed).isGreaterThanOrEqualTo(900); // proves the sub-second poll was rounded up and blocked, instead of exiting instantly
+    }
+
     @Test
     public void index_task_update_progress() throws Exception {
         List<Double> progressValues = Collections.synchronizedList(new ArrayList<>());

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/PipelineTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/PipelineTaskTest.java
@@ -26,9 +26,9 @@ public class PipelineTaskTest {
     }
 
     @Test
-    public void test_pipeline_queue_poll_defaults_to_120s() {
+    public void test_pipeline_queue_poll_defaults_to_30s() {
         assertThat(PipelineTask.pipelineQueuePoll(new PropertiesProvider()))
-                .isEqualTo(Duration.ofSeconds(120));
+                .isEqualTo(Duration.ofSeconds(30));
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/PipelineTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/PipelineTaskTest.java
@@ -1,0 +1,45 @@
+package org.icij.datashare.tasks;
+
+import org.icij.datashare.PropertiesProvider;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class PipelineTaskTest {
+    @Test
+    public void test_isPoison_path() {
+        assertThat(PipelineTask.isPoison(Paths.get("POISON"))).isTrue();
+        assertThat(PipelineTask.isPoison(Paths.get("/real/doc.txt"))).isFalse();
+        assertThat(PipelineTask.isPoison((Path) null)).isFalse();
+    }
+
+    @Test
+    public void test_isPoison_string() {
+        assertThat(PipelineTask.isPoison("POISON")).isTrue();
+        assertThat(PipelineTask.isPoison("realId")).isFalse();
+        assertThat(PipelineTask.isPoison((String) null)).isFalse();
+    }
+
+    @Test
+    public void test_pipeline_queue_poll_defaults_to_120s() {
+        assertThat(PipelineTask.pipelineQueuePoll(new PropertiesProvider()))
+                .isEqualTo(Duration.ofSeconds(120));
+    }
+
+    @Test
+    public void test_pipeline_queue_poll_honors_explicit_value() {
+        PropertiesProvider pp = new PropertiesProvider(Map.of("queuePoll", "5s"));
+        assertThat(PipelineTask.pipelineQueuePoll(pp)).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    @Test
+    public void test_pipeline_queue_poll_honors_explicit_zero() {
+        PropertiesProvider pp = new PropertiesProvider(Map.of("queuePoll", "0"));
+        assertThat(PipelineTask.pipelineQueuePoll(pp)).isEqualTo(Duration.ZERO);
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ScanTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ScanTaskTest.java
@@ -21,7 +21,7 @@ public class ScanTaskTest extends TestCase {
         assertThat(new ScanTask(documentCollectionFactory, new Task<>("org.icij.datashare.tasks.ScanTask", User.local(),
                 Map.of(DATA_DIR_OPT, Paths.get(ClassLoader.getSystemResource("docs").getPath()).toString())), null).call()).isEqualTo(3);
         DocumentQueue<Path> queue = documentCollectionFactory.createQueue("extract:queue:index", Path.class);
-        assertThat(queue.size()).isEqualTo(4); // with POISON
+        assertThat(queue.size()).isEqualTo(3); // no POISON
     }
 
     public void test_scan_with_queue_name() throws Exception {
@@ -29,6 +29,6 @@ public class ScanTaskTest extends TestCase {
                 Map.of(DATA_DIR_OPT, Paths.get(ClassLoader.getSystemResource("docs").getPath()).toString(),
                         QUEUE_NAME_OPT, "foo")), null).call()).isEqualTo(3);
         DocumentQueue<Path> queue = documentCollectionFactory.createQueue("foo:index", Path.class);
-        assertThat(queue.size()).isEqualTo(4); // with POISON
+        assertThat(queue.size()).isEqualTo(3); // no POISON
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -207,6 +207,7 @@ public class DatashareCli {
         DatashareCliOptions.taskRoutingStrategy(parser);
         DatashareCliOptions.taskRoutingKey(parser);
         DatashareCliOptions.pollingInterval(parser);
+        DatashareCliOptions.queuePoll(parser);
         DatashareCliOptions.taskRepositoryType(parser);
         DatashareCliOptions.taskManagerPollingInterval(parser);
         DatashareCliOptions.taskProgressUpdateInterval(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -262,7 +262,7 @@ public final class DatashareCliOptions {
     public static final String DEFAULT_MAX_CONTENT_LENGTH = "20000000";
     public static final RoutingStrategy DEFAULT_TASK_ROUTING_STRATEGY = RoutingStrategy.UNIQUE;
     public static final String DEFAULT_POLLING_INTERVAL_SEC = "60";
-    public static final String DEFAULT_QUEUE_POLL = "120s";
+    public static final String DEFAULT_QUEUE_POLL = "30s";
     public static final int DEFAULT_TASK_MANAGER_POLLING_INTERVAL = 5000;
     public static final String DEFAULT_TASK_WORKERS = "1";
     public static final double DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS = 10;
@@ -1052,7 +1052,7 @@ public final class DatashareCliOptions {
     public static void queuePoll(OptionParser parser) {
         parser.acceptsAll(singletonList(QUEUE_POLL_OPT),
                         "Time INDEX/DEDUPLICATE wait for new documents on the shared queue before " +
-                        "concluding it is drained (e.g. \"120s\"). Raise it above your worst-case gap " +
+                        "concluding it is drained (e.g. \"30s\"). Raise it above your worst-case gap " +
                         "between SCAN producing and INDEX consuming when running SCAN and INDEX on " +
                         "separate instances. Defaults to " + DEFAULT_QUEUE_POLL + " for pipeline draining.")
                 .withRequiredArg()

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -91,6 +91,10 @@ public final class DatashareCliOptions {
     public static final String NLP_PARALLELISM_OPT = "nlpParallelism";
     public static final String NLP_PIPELINE_ABBR_OPT = "nlpp";
     public static final String NLP_PIPELINE_OPT = "nlpPipeline";
+    // Internal correlation key (not a user-facing option): the CLI stamps every task it
+    // starts, and every task those tasks spawn, with a per-run id so it can wait on exactly
+    // its own run's tasks (spawned descendants included) and never touch other runs' work.
+    public static final String PIPELINE_RUN_ID = "pipelineRunId";
     public static final String NO_DIGEST_PROJECT_OPT = "noDigestProject";
     public static final String OAUTH_API_URL_OPT = "oauthApiUrl";
     public static final String OAUTH_AUTHORIZE_URL_OPT = "oauthAuthorizeUrl";

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -144,6 +144,7 @@ public final class DatashareCliOptions {
     public static final String VERSION_OPT = "version";
     public static final String ARTIFACT_DIR_OPT = "artifactDir";
     public static final String SEARCH_QUERY_OPT = "searchQuery";
+    public static final String QUEUE_POLL_OPT = "queuePoll";
     public static final String TASK_ROUTING_STRATEGY_OPT = "taskRoutingStrategy";
     public static final String TASK_ROUTING_KEY_OPT = "taskRoutingKey";
     public static final String OAUTH_USER_PROJECTS_KEY_OPT = "oauthUserProjectsAttribute";
@@ -261,6 +262,7 @@ public final class DatashareCliOptions {
     public static final String DEFAULT_MAX_CONTENT_LENGTH = "20000000";
     public static final RoutingStrategy DEFAULT_TASK_ROUTING_STRATEGY = RoutingStrategy.UNIQUE;
     public static final String DEFAULT_POLLING_INTERVAL_SEC = "60";
+    public static final String DEFAULT_QUEUE_POLL = "120s";
     public static final int DEFAULT_TASK_MANAGER_POLLING_INTERVAL = 5000;
     public static final String DEFAULT_TASK_WORKERS = "1";
     public static final double DEFAULT_TASK_PROGRESS_INTERVAL_SECONDS = 10;
@@ -1045,6 +1047,16 @@ public final class DatashareCliOptions {
         parser.acceptsAll(singletonList(POLLING_INTERVAL_SECONDS_OPT), "Queue polling interval.")
                 .withRequiredArg()
                 .ofType(String.class).defaultsTo(DEFAULT_POLLING_INTERVAL_SEC);
+    }
+
+    public static void queuePoll(OptionParser parser) {
+        parser.acceptsAll(singletonList(QUEUE_POLL_OPT),
+                        "Time INDEX/DEDUPLICATE wait for new documents on the shared queue before " +
+                        "concluding it is drained (e.g. \"120s\"). Raise it above your worst-case gap " +
+                        "between SCAN producing and INDEX consuming when running SCAN and INDEX on " +
+                        "separate instances. Defaults to " + DEFAULT_QUEUE_POLL + " for pipeline draining.")
+                .withRequiredArg()
+                .ofType(String.class);
     }
 
     public static void taskRepositoryType(OptionParser parser) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -317,7 +317,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
 
     @Override
     public void close() throws Exception {
-        outputQueue.put("POISON");
+        // end-of-stream is signalled by a quiet queue (poll timeout), not a POISON pill
     }
 
     private void setIndex(String indexName) {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManagerImpl.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManagerImpl.java
@@ -2,11 +2,17 @@ package org.icij.datashare.asynctasks;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.icij.datashare.asynctasks.bus.amqp.CancelledEvent;
 import org.icij.datashare.asynctasks.bus.amqp.ErrorEvent;
 import org.icij.datashare.asynctasks.bus.amqp.ProgressEvent;
 import org.icij.datashare.asynctasks.bus.amqp.ResultEvent;
 import org.icij.datashare.asynctasks.bus.amqp.TaskEvent;
+
+import static org.icij.datashare.asynctasks.Task.State.NON_FINAL_STATES;
 
 /**
  * Task manager back by a queueing system and a persistent storay
@@ -33,6 +39,27 @@ abstract class StoreAndQueueTaskManagerImpl implements StoreAndQueueTaskManager 
         taskView.queue();
         enqueue(taskView);
         return taskView.id;
+    }
+
+    @Override
+    public List<String> reconcileStaleTasks(TaskFilters filters) throws IOException {
+        Set<Task.State> states = new HashSet<>(NON_FINAL_STATES);
+        if (filters.hasStates()) {
+            states.retainAll(filters.getStates());
+        }
+        List<String> reconciled = new ArrayList<>();
+        for (String taskId : getTaskIds(filters.withStates(states)).toList()) {
+            try {
+                Task<?> task = getTask(taskId);
+                task.cancel();
+                update(task);
+                reconciled.add(taskId);
+                logger.info("reconciled stale task {} to CANCELLED", taskId);
+            } catch (UnknownTask e) {
+                logger.warn("stale task {} vanished before reconciliation", taskId, e);
+            }
+        }
+        return reconciled;
     }
 
     private <V extends Serializable> Task<V> setResult(ResultEvent<V> e) throws IOException, UnknownTask {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManagerImpl.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/StoreAndQueueTaskManagerImpl.java
@@ -2,17 +2,11 @@ package org.icij.datashare.asynctasks;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import org.icij.datashare.asynctasks.bus.amqp.CancelledEvent;
 import org.icij.datashare.asynctasks.bus.amqp.ErrorEvent;
 import org.icij.datashare.asynctasks.bus.amqp.ProgressEvent;
 import org.icij.datashare.asynctasks.bus.amqp.ResultEvent;
 import org.icij.datashare.asynctasks.bus.amqp.TaskEvent;
-
-import static org.icij.datashare.asynctasks.Task.State.NON_FINAL_STATES;
 
 /**
  * Task manager back by a queueing system and a persistent storay
@@ -39,27 +33,6 @@ abstract class StoreAndQueueTaskManagerImpl implements StoreAndQueueTaskManager 
         taskView.queue();
         enqueue(taskView);
         return taskView.id;
-    }
-
-    @Override
-    public List<String> reconcileStaleTasks(TaskFilters filters) throws IOException {
-        Set<Task.State> states = new HashSet<>(NON_FINAL_STATES);
-        if (filters.hasStates()) {
-            states.retainAll(filters.getStates());
-        }
-        List<String> reconciled = new ArrayList<>();
-        for (String taskId : getTaskIds(filters.withStates(states)).toList()) {
-            try {
-                Task<?> task = getTask(taskId);
-                task.cancel();
-                update(task);
-                reconciled.add(taskId);
-                logger.info("reconciled stale task {} to CANCELLED", taskId);
-            } catch (UnknownTask e) {
-                logger.warn("stale task {} vanished before reconciliation", taskId, e);
-            }
-        }
-        return reconciled;
     }
 
     private <V extends Serializable> Task<V> setResult(ResultEvent<V> e) throws IOException, UnknownTask {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -116,61 +115,41 @@ public interface TaskManager extends Closeable {
      * @throws IOException if the task list cannot be retrieved because of a network failure.
      */
     default long waitTasksToBeDone(int timeout, TimeUnit timeUnit) throws IOException {
-        return pollUntilDone(timeout, timeUnit, null);
+        return waitTasksToBeDone(TaskFilters.empty(), timeout, timeUnit);
     }
 
     /**
-     * Same as {@link #waitTasksToBeDone(int, TimeUnit)} but only waits on the given
-     * task ids instead of every non-final task in the (possibly shared and persistent)
-     * repository. This lets a caller that owns a known set of tasks (e.g. a CLI run)
-     * return as soon as its own tasks are done, without being blocked forever by
-     * unrelated non-final rows left over from other or interrupted runs.
+     * Same as {@link #waitTasksToBeDone(int, TimeUnit)} but only waits on the non-final
+     * tasks matching {@code scope} instead of every non-final task in the (possibly shared
+     * and persistent) repository.
      *
-     * @param taskIds the ids to wait on. An empty or null collection returns immediately.
+     * <p>This lets a caller that tags a recognizable set of tasks (e.g. a CLI run stamping
+     * every task it starts, and every task those tasks spawn, with a per-run id) wait on
+     * exactly its own run. It returns as soon as that set is done, without being blocked by
+     * unrelated non-final rows left by other or interrupted runs, and without having to
+     * enumerate the ids of descendants that only come into existence while the run executes.
+     * Any states carried by {@code scope} are ignored: only non-final tasks are ever counted.
+     *
+     * @param scope filters selecting the tasks to wait on (user, name, args...).
      * @param timeout amount for the timeout
      * @param timeUnit unit of the timeout
-     * @return the number of the given tasks still unfinished
+     * @return the number of matching tasks still unfinished
      * @throws IOException if the task list cannot be retrieved because of a network failure.
      */
-    default long waitTasksToBeDone(Collection<String> taskIds, int timeout, TimeUnit timeUnit) throws IOException {
-        if (taskIds == null || taskIds.isEmpty()) {
-            return 0L;
-        }
-        return pollUntilDone(timeout, timeUnit, new HashSet<>(taskIds));
-    }
-
-    private long pollUntilDone(int timeout, TimeUnit timeUnit, Set<String> scope) throws IOException {
+    default long waitTasksToBeDone(TaskFilters scope, int timeout, TimeUnit timeUnit) throws IOException {
         long startTime = System.currentTimeMillis();
         long maxDuration = timeUnit.toMillis(timeout);
-        TaskFilters filterNotCompleted = TaskFilters.empty().withStates(NON_FINAL_STATES);
-        long nUnfinished = countUnfinished(filterNotCompleted, scope);
+        TaskFilters filterNotCompleted = scope.withStates(NON_FINAL_STATES);
+        long nUnfinished = getTaskIds(filterNotCompleted).count();
         while (System.currentTimeMillis() - startTime < maxDuration && nUnfinished > 0) {
             try {
                 Thread.sleep(Math.min(getTerminationPollingInterval(), maxDuration));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            nUnfinished = countUnfinished(filterNotCompleted, scope);
+            nUnfinished = getTaskIds(filterNotCompleted).count();
         }
         return nUnfinished;
-    }
-
-    private long countUnfinished(TaskFilters filterNotCompleted, Set<String> scope) throws IOException {
-        Stream<String> taskIds = getTaskIds(filterNotCompleted);
-        return (scope == null ? taskIds : taskIds.filter(scope::contains)).count();
-    }
-
-    /**
-     * Mark as CANCELLED the non-final tasks matching {@code filters}, persisting the
-     * transition to the backing repository, and return the ids that were reconciled.
-     *
-     * <p>Managers that delegate reconciliation to their backing engine (e.g. Temporal)
-     * leave this a no-op. Callers must only pass filters that cannot match a live
-     * worker's tasks: this is meant for cleaning up rows orphaned by dead runs, not
-     * for stopping running work (see {@link #stopTasks(TaskFilters)} for that).
-     */
-    default List<String> reconcileStaleTasks(TaskFilters filters) throws IOException {
-        return List.of();
     }
 
     // for tests

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -115,20 +116,61 @@ public interface TaskManager extends Closeable {
      * @throws IOException if the task list cannot be retrieved because of a network failure.
      */
     default long waitTasksToBeDone(int timeout, TimeUnit timeUnit) throws IOException {
+        return pollUntilDone(timeout, timeUnit, null);
+    }
+
+    /**
+     * Same as {@link #waitTasksToBeDone(int, TimeUnit)} but only waits on the given
+     * task ids instead of every non-final task in the (possibly shared and persistent)
+     * repository. This lets a caller that owns a known set of tasks (e.g. a CLI run)
+     * return as soon as its own tasks are done, without being blocked forever by
+     * unrelated non-final rows left over from other or interrupted runs.
+     *
+     * @param taskIds the ids to wait on. An empty or null collection returns immediately.
+     * @param timeout amount for the timeout
+     * @param timeUnit unit of the timeout
+     * @return the number of the given tasks still unfinished
+     * @throws IOException if the task list cannot be retrieved because of a network failure.
+     */
+    default long waitTasksToBeDone(Collection<String> taskIds, int timeout, TimeUnit timeUnit) throws IOException {
+        if (taskIds == null || taskIds.isEmpty()) {
+            return 0L;
+        }
+        return pollUntilDone(timeout, timeUnit, new HashSet<>(taskIds));
+    }
+
+    private long pollUntilDone(int timeout, TimeUnit timeUnit, Set<String> scope) throws IOException {
         long startTime = System.currentTimeMillis();
         long maxDuration = timeUnit.toMillis(timeout);
         TaskFilters filterNotCompleted = TaskFilters.empty().withStates(NON_FINAL_STATES);
-        long nUnfinished = getTaskIds(filterNotCompleted).count();
+        long nUnfinished = countUnfinished(filterNotCompleted, scope);
         while (System.currentTimeMillis() - startTime < maxDuration && nUnfinished > 0) {
             try {
                 Thread.sleep(Math.min(getTerminationPollingInterval(), maxDuration));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            Stream<String> taskIds = getTaskIds(filterNotCompleted);
-            nUnfinished = taskIds.count();
+            nUnfinished = countUnfinished(filterNotCompleted, scope);
         }
         return nUnfinished;
+    }
+
+    private long countUnfinished(TaskFilters filterNotCompleted, Set<String> scope) throws IOException {
+        Stream<String> taskIds = getTaskIds(filterNotCompleted);
+        return (scope == null ? taskIds : taskIds.filter(scope::contains)).count();
+    }
+
+    /**
+     * Mark as CANCELLED the non-final tasks matching {@code filters}, persisting the
+     * transition to the backing repository, and return the ids that were reconciled.
+     *
+     * <p>Managers that delegate reconciliation to their backing engine (e.g. Temporal)
+     * leave this a no-op. Callers must only pass filters that cannot match a live
+     * worker's tasks: this is meant for cleaning up rows orphaned by dead runs, not
+     * for stopping running work (see {@link #stopTasks(TaskFilters)} for that).
+     */
+    default List<String> reconcileStaleTasks(TaskFilters filters) throws IOException {
+        return List.of();
     }
 
     // for tests

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManagerTemporal.java
@@ -12,11 +12,13 @@ import java.util.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.icij.datashare.LambdaExceptionUtils.rethrowConsumer;
 import static org.icij.datashare.asynctasks.Task.State.FINAL_STATES;
+import static org.icij.datashare.asynctasks.Task.State.NON_FINAL_STATES;
 import static org.icij.datashare.asynctasks.temporal.TemporalInterlocutor.*;
 
 public class TaskManagerTemporal implements TaskManager {
@@ -101,6 +103,53 @@ public class TaskManagerTemporal implements TaskManager {
             taskRepository.delete(id);
         }));
         return tasks;
+    }
+
+    /**
+     * Same contract as the default implementation, but each poll first reconciles the
+     * matching RUNNING tasks that have no completion listener in this JVM against
+     * Temporal, the source of truth. Repository rows only reach a final state through
+     * the completion listener of the process that started the workflow: a task started
+     * by another process (e.g. a child spawned by a remote Temporal worker) or orphaned
+     * by a worker restart would otherwise stay RUNNING in the repository forever and
+     * block the caller, even though its workflow is long finished in Temporal.
+     */
+    @Override
+    public long waitTasksToBeDone(TaskFilters scope, int timeout, TimeUnit timeUnit) throws IOException {
+        long startTime = System.currentTimeMillis();
+        long maxDuration = timeUnit.toMillis(timeout);
+        TaskFilters filterNotCompleted = scope.withStates(NON_FINAL_STATES);
+        long nUnfinished = reconcileAndCount(filterNotCompleted);
+        while (System.currentTimeMillis() - startTime < maxDuration && nUnfinished > 0) {
+            try {
+                Thread.sleep(Math.min(getTerminationPollingInterval(), maxDuration));
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            nUnfinished = reconcileAndCount(filterNotCompleted);
+        }
+        return nUnfinished;
+    }
+
+    private long reconcileAndCount(TaskFilters filterNotCompleted) throws IOException {
+        getTasks(filterNotCompleted)
+            .filter(t -> t.getState() == Task.State.RUNNING)
+            .filter(t -> !pendingListeners.containsKey(t.id))
+            .forEach(this::reconcileListenerlessTask);
+        return getTaskIds(filterNotCompleted).count();
+    }
+
+    private void reconcileListenerlessTask(Task<?> repoTask) {
+        try {
+            Task<Serializable> inTemporal = temporal.getTask(repoTask.id);
+            if (inTemporal != null && inTemporal.isFinished()) {
+                taskRepository.update(inTemporal);
+            }
+        } catch (UnknownTask e) {
+            logger.warn("task {} is RUNNING in repository but not found in Temporal, it will never complete", repoTask.id);
+        } catch (IOException e) {
+            logger.warn("failed to reconcile task {} while waiting for completion", repoTask.id, e);
+        }
     }
 
     /**

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskWorkerLoop.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskWorkerLoop.java
@@ -138,7 +138,20 @@ public class TaskWorkerLoop implements Callable<Integer>, Closeable {
                     taskSupplier.error(currentTask.get().id, new TaskError(ex));
                 }
             } catch (ReflectiveOperationException unknownTask) {
-                throw new NackException(unknownTask, true);
+                // Task construction/instantiation failed: unknown task class or a
+                // constructor that threw. On AMQP we nack+requeue and let the broker
+                // layer decide what to do with the message. On the local (MEMORY/REDIS)
+                // loop there is no broker to requeue to, so the NackException would only
+                // be logged in mainLoop() and the task would stay non-final forever,
+                // blocking any run that waits on it. Record it as an ERROR instead so it
+                // reaches a final state.
+                if (taskSupplier instanceof TaskSupplierAmqp) {
+                    throw new NackException(unknownTask, true);
+                }
+                logger.error("task {} could not be created, marking it as error", currentTask.get(), unknownTask);
+                if (currentTask.get() != null && !currentTask.get().isNull()) {
+                    taskSupplier.error(currentTask.get().id, new TaskError(unknownTask));
+                }
             } catch (Error | Exception ex) {
                 throw new NackException(ex, false);
             } finally {

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskWorkerLoop.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskWorkerLoop.java
@@ -153,7 +153,17 @@ public class TaskWorkerLoop implements Callable<Integer>, Closeable {
                     taskSupplier.error(currentTask.get().id, new TaskError(unknownTask));
                 }
             } catch (Error | Exception ex) {
-                throw new NackException(ex, false);
+                // Same constraint as above for checked exceptions thrown by the task
+                // itself (call() is declared 'throws Exception'): on the local loop the
+                // NackException is only logged by mainLoop() and the task would stay
+                // non-final forever, blocking any run that waits on it.
+                if (taskSupplier instanceof TaskSupplierAmqp) {
+                    throw new NackException(ex, false);
+                }
+                logger.error("error running task {}, marking it as error", currentTask.get(), ex);
+                if (currentTask.get() != null && !currentTask.get().isNull()) {
+                    taskSupplier.error(currentTask.get().id, new TaskError(ex));
+                }
             } finally {
                 currentTaskReference.set(null);
                 currentTask.set(null);

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -182,62 +182,51 @@ public class TaskManagerMemoryTest {
         assert unfinished == 1L;
     }
 
-    @Test
-    public void test_wait_scoped_to_own_ids_ignores_foreign_non_final_task() throws Exception {
-        // a task left non-final by a prior interrupted run: inserted but never enqueued
-        Task<String> stale = new Task<>("sleep", User.local(), Map.of("intParameter", 12));
-        taskManager.insert(stale, new Group(TaskGroupType.Test));
-        stale.queue();
-        taskManager.update(stale);
+    // Well-known args key a CLI run stamps on its tasks; the wait scopes on it via an
+    // args filter. Duplicated as a literal here because datashare-tasks does not depend on
+    // datashare-cli where DatashareCliOptions.PIPELINE_RUN_ID lives.
+    private static final String RUN_ID = "pipelineRunId";
 
-        // our own quick task
-        Task<String> own = new Task<>(TestFactory.HelloWorld.class.getName(), User.local(), Map.of("greeted", "world"));
+    @Test
+    public void test_wait_scoped_to_run_id_leaves_a_peers_non_final_task_untouched() throws Exception {
+        // A concurrent peer's task on the shared store: non-final, same (null) user, tagged
+        // with a DIFFERENT run id. It is never enqueued to our loop so it stays QUEUED.
+        Task<String> peer = new Task<>("sleep", User.nullUser(), Map.of("intParameter", 12, RUN_ID, "other-run"));
+        taskManager.insert(peer, new Group(TaskGroupType.Test));
+        peer.queue();
+        taskManager.update(peer);
+
+        // our own quick task, tagged with our run id
+        Task<String> own = new Task<>(TestFactory.HelloWorld.class.getName(), User.nullUser(), Map.of("greeted", "world", RUN_ID, "my-run"));
         String ownId = taskManager.startTask(own, new Group(TaskGroupType.Test));
 
-        long unfinished = taskManager.waitTasksToBeDone(java.util.List.of(ownId), 2, TimeUnit.SECONDS);
+        long unfinished = taskManager.waitTasksToBeDone(
+            TaskFilters.empty().withArgs(new TaskFilters.ArgsFilter(RUN_ID, "my-run")), 2, TimeUnit.SECONDS);
 
         assertThat(unfinished).isEqualTo(0L);
         assertThat(taskManager.getTask(ownId).getState()).isEqualTo(Task.State.DONE);
-        // the stale task is still non-final and would have blocked the global wait
-        assertThat(taskManager.getTask(stale.id).getState()).isEqualTo(Task.State.QUEUED);
+        // the peer's task was neither waited on nor cancelled: exactly where it was left
+        assertThat(taskManager.getTask(peer.id).getState()).isEqualTo(Task.State.QUEUED);
     }
 
     @Test
-    public void test_wait_on_empty_ids_returns_immediately() throws Exception {
-        assertThat(taskManager.waitTasksToBeDone(java.util.List.of(), 1, TimeUnit.SECONDS)).isEqualTo(0L);
-    }
+    public void test_wait_scoped_to_run_id_covers_descendant_not_among_started_ids() throws Exception {
+        // A descendant a running stage would spawn mid-flight (e.g. CreateNlpBatchesFromIndex
+        // enqueuing a BatchNlpTask): tagged with our run id but never handed to the caller as
+        // a "started" id. It stays non-final (not enqueued to our loop here).
+        Task<String> descendant = new Task<>("sleep", User.nullUser(), Map.of("intParameter", 12, RUN_ID, "my-run"));
+        taskManager.insert(descendant, new Group(TaskGroupType.Test));
+        descendant.queue();
+        taskManager.update(descendant);
 
-    @Test
-    public void test_reconcile_cancels_scoped_non_final_tasks() throws Exception {
-        Task<String> stale = new Task<>("sleep", User.local(), Map.of("intParameter", 12));
-        taskManager.insert(stale, new Group(TaskGroupType.Test));
-        stale.queue();
-        taskManager.update(stale);
+        // Waiting on the run id (not on a fixed set of ids) keeps the run alive: the
+        // descendant is still non-final, so the scoped wait reports it rather than returning
+        // 0 and letting the caller shut the worker down on still-queued work.
+        long unfinished = taskManager.waitTasksToBeDone(
+            TaskFilters.empty().withArgs(new TaskFilters.ArgsFilter(RUN_ID, "my-run")), 500, TimeUnit.MILLISECONDS);
 
-        java.util.List<String> reconciled = taskManager.reconcileStaleTasks(TaskFilters.empty().withUser(User.local()));
-
-        assertThat(reconciled).containsExactly(stale.id);
-        assertThat(taskManager.getTask(stale.id).getState()).isEqualTo(Task.State.CANCELLED);
-    }
-
-    @Test
-    public void test_reconcile_leaves_final_and_out_of_scope_tasks_untouched() throws Exception {
-        // final task: never reconciled
-        Task<String> done = new Task<>("sleep", User.local(), Map.of("intParameter", 0));
-        taskManager.insert(done, new Group(TaskGroupType.Test));
-        done.setResult(new TaskResult<>("ok"));
-        taskManager.update(done);
-        // non-final but owned by another user: out of the reconcile scope
-        Task<String> otherUser = new Task<>("sleep", new User("bob"), Map.of("intParameter", 5));
-        taskManager.insert(otherUser, new Group(TaskGroupType.Test));
-        otherUser.queue();
-        taskManager.update(otherUser);
-
-        java.util.List<String> reconciled = taskManager.reconcileStaleTasks(TaskFilters.empty().withUser(User.local()));
-
-        assertThat(reconciled).isEmpty();
-        assertThat(taskManager.getTask(done.id).getState()).isEqualTo(Task.State.DONE);
-        assertThat(taskManager.getTask(otherUser.id).getState()).isEqualTo(Task.State.QUEUED);
+        assertThat(unfinished).isEqualTo(1L);
+        assertThat(taskManager.getTask(descendant.id).getState()).isEqualTo(Task.State.QUEUED);
     }
 
     @Test

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerMemoryTest.java
@@ -183,6 +183,64 @@ public class TaskManagerMemoryTest {
     }
 
     @Test
+    public void test_wait_scoped_to_own_ids_ignores_foreign_non_final_task() throws Exception {
+        // a task left non-final by a prior interrupted run: inserted but never enqueued
+        Task<String> stale = new Task<>("sleep", User.local(), Map.of("intParameter", 12));
+        taskManager.insert(stale, new Group(TaskGroupType.Test));
+        stale.queue();
+        taskManager.update(stale);
+
+        // our own quick task
+        Task<String> own = new Task<>(TestFactory.HelloWorld.class.getName(), User.local(), Map.of("greeted", "world"));
+        String ownId = taskManager.startTask(own, new Group(TaskGroupType.Test));
+
+        long unfinished = taskManager.waitTasksToBeDone(java.util.List.of(ownId), 2, TimeUnit.SECONDS);
+
+        assertThat(unfinished).isEqualTo(0L);
+        assertThat(taskManager.getTask(ownId).getState()).isEqualTo(Task.State.DONE);
+        // the stale task is still non-final and would have blocked the global wait
+        assertThat(taskManager.getTask(stale.id).getState()).isEqualTo(Task.State.QUEUED);
+    }
+
+    @Test
+    public void test_wait_on_empty_ids_returns_immediately() throws Exception {
+        assertThat(taskManager.waitTasksToBeDone(java.util.List.of(), 1, TimeUnit.SECONDS)).isEqualTo(0L);
+    }
+
+    @Test
+    public void test_reconcile_cancels_scoped_non_final_tasks() throws Exception {
+        Task<String> stale = new Task<>("sleep", User.local(), Map.of("intParameter", 12));
+        taskManager.insert(stale, new Group(TaskGroupType.Test));
+        stale.queue();
+        taskManager.update(stale);
+
+        java.util.List<String> reconciled = taskManager.reconcileStaleTasks(TaskFilters.empty().withUser(User.local()));
+
+        assertThat(reconciled).containsExactly(stale.id);
+        assertThat(taskManager.getTask(stale.id).getState()).isEqualTo(Task.State.CANCELLED);
+    }
+
+    @Test
+    public void test_reconcile_leaves_final_and_out_of_scope_tasks_untouched() throws Exception {
+        // final task: never reconciled
+        Task<String> done = new Task<>("sleep", User.local(), Map.of("intParameter", 0));
+        taskManager.insert(done, new Group(TaskGroupType.Test));
+        done.setResult(new TaskResult<>("ok"));
+        taskManager.update(done);
+        // non-final but owned by another user: out of the reconcile scope
+        Task<String> otherUser = new Task<>("sleep", new User("bob"), Map.of("intParameter", 5));
+        taskManager.insert(otherUser, new Group(TaskGroupType.Test));
+        otherUser.queue();
+        taskManager.update(otherUser);
+
+        java.util.List<String> reconciled = taskManager.reconcileStaleTasks(TaskFilters.empty().withUser(User.local()));
+
+        assertThat(reconciled).isEmpty();
+        assertThat(taskManager.getTask(done.id).getState()).isEqualTo(Task.State.DONE);
+        assertThat(taskManager.getTask(otherUser.id).getState()).isEqualTo(Task.State.QUEUED);
+    }
+
+    @Test
     public void test_health_ok() {
         assertThat(taskManager.getHealth()).isTrue();
     }

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskManagerTemporalTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
@@ -32,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 
 public class TaskManagerTemporalTest {
@@ -120,6 +122,47 @@ public class TaskManagerTemporalTest {
         taskManager.reconcileTasks();
 
         verify(taskRepository).update(argThat(t -> t.getState() == Task.State.DONE));
+    }
+
+    @Test(timeout = 10000)
+    public void test_scoped_wait_reconciles_orphaned_running_task_with_temporal() throws Exception {
+        // A task RUNNING in the repository with no completion listener in this JVM
+        // (a child spawned by a remote Temporal worker, or orphaned by a worker
+        // restart): the scoped wait must ask Temporal for the truth instead of
+        // polling the stale repository row forever.
+        TaskRepositoryMemory repository = new TaskRepositoryMemory();
+        try (TaskManagerTemporal manager = new TaskManagerTemporal(temporal, repository, RoutingStrategy.UNIQUE)) {
+            Task<String> orphan = new Task<>("taskName", User.local(), Map.of("pipelineRunId", "my-run"));
+            repository.insert(orphan, new Group(TaskGroupType.Test));
+            orphan.setState(Task.State.RUNNING);
+            repository.update(orphan);
+            Task<String> doneInTemporal = new Task<>(orphan.id, orphan.name, Task.State.DONE, 1.0, orphan.createdAt, 0, null, orphan.args, new TaskResult<>("result"), null);
+            doReturn(doneInTemporal).when(temporal).getTask(orphan.id);
+
+            long unfinished = manager.waitTasksToBeDone(
+                TaskFilters.empty().withArgs(new TaskFilters.ArgsFilter("pipelineRunId", "my-run")), 3, TimeUnit.SECONDS);
+
+            assertThat(unfinished).isEqualTo(0L);
+            assertThat(repository.getTask(orphan.id).getState()).isEqualTo(Task.State.DONE);
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void test_scoped_wait_does_not_reconcile_tasks_with_local_completion_listener() throws Exception {
+        // Tasks started by this JVM already have a completion listener updating the
+        // repository on workflow completion: the wait must not query Temporal again
+        // for those on every poll.
+        TaskRepositoryMemory repository = new TaskRepositoryMemory();
+        try (TaskManagerTemporal manager = new TaskManagerTemporal(temporal, repository, RoutingStrategy.UNIQUE)) {
+            Task<String> own = new Task<>("taskName", User.local(), Map.of("pipelineRunId", "my-run"));
+            manager.startTask(own, new Group(TaskGroupType.Test));
+
+            long unfinished = manager.waitTasksToBeDone(
+                TaskFilters.empty().withArgs(new TaskFilters.ArgsFilter("pipelineRunId", "my-run")), 1, TimeUnit.SECONDS);
+
+            assertThat(unfinished).isEqualTo(1L);
+            verify(temporal, Mockito.never()).getTask(own.id);
+        }
     }
 
     @Test

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
@@ -74,6 +74,36 @@ public class TaskWorkerLoopTest {
     }
 
     @Test(timeout = 2000)
+    public void test_checked_exception_on_local_loop_is_marked_error() throws Exception {
+        // A task whose call() throws a checked exception (e.g. an IOException from
+        // IndexTask) must reach a final ERROR state on the local (non-AMQP) loop,
+        // otherwise it stays non-final forever and blocks any run waiting on it.
+        TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
+        Task<Serializable> taskView = new Task<>(TestFactory.CheckedFailure.class.getName(), User.local(), Map.of());
+
+        app.handle(taskView);
+
+        verify(supplier).error(eq(taskView.id), Mockito.any(TaskError.class));
+    }
+
+    @Test(timeout = 2000)
+    public void test_checked_exception_on_amqp_loop_is_nacked_without_requeue() throws Exception {
+        // On AMQP the broker owns retry semantics, so a checked execution failure is
+        // still surfaced as a nack (no requeue) and not recorded as an error here.
+        TaskSupplierAmqp amqpSupplier = Mockito.mock(TaskSupplierAmqp.class);
+        TaskWorkerLoop app = new TaskWorkerLoop(registry, amqpSupplier);
+        Task<Serializable> taskView = new Task<>(TestFactory.CheckedFailure.class.getName(), User.local(), Map.of());
+
+        try {
+            app.handle(taskView);
+            fail("NackException should be raised");
+        } catch (NackException ne) {
+            assertThat(ne.requeue).isFalse();
+        }
+        verify(amqpSupplier, Mockito.never()).error(Mockito.any(), Mockito.any());
+    }
+
+    @Test(timeout = 2000)
     public void test_cancel_task() throws Exception {
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
         Task<Serializable> taskView = new Task<>(TestFactory.SleepForever.class.getName(), User.local(), Map.of());

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TaskWorkerLoopTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.asynctasks;
 
+import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.user.User;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,8 +44,24 @@ public class TaskWorkerLoopTest {
     }
 
     @Test(timeout = 2000)
-    public void test_unknown_task() throws Exception {
+    public void test_unknown_task_on_local_loop_is_marked_error() throws Exception {
+        // On the local (non-AMQP) loop a construction failure must end the task in
+        // ERROR rather than being nacked-and-dropped, otherwise it stays non-final
+        // forever and blocks any run waiting on it.
         TaskWorkerLoop app = new TaskWorkerLoop(registry, supplier);
+        Task<Serializable> taskView = new Task<>("unknown_task", User.local(), Map.of());
+
+        app.handle(taskView);
+
+        verify(supplier).error(eq(taskView.id), Mockito.any(TaskError.class));
+    }
+
+    @Test(timeout = 2000)
+    public void test_unknown_task_on_amqp_loop_is_nacked_for_requeue() throws Exception {
+        // On AMQP the broker owns requeue semantics, so a construction failure is
+        // still surfaced as a nack-with-requeue and not recorded as an error here.
+        TaskSupplierAmqp amqpSupplier = Mockito.mock(TaskSupplierAmqp.class);
+        TaskWorkerLoop app = new TaskWorkerLoop(registry, amqpSupplier);
         Task<Serializable> taskView = new Task<>("unknown_task", User.local(), Map.of());
 
         try {
@@ -53,6 +70,7 @@ public class TaskWorkerLoopTest {
         } catch (NackException ne) {
             assertThat(ne.requeue).isTrue();
         }
+        verify(amqpSupplier, Mockito.never()).error(Mockito.any(), Mockito.any());
     }
 
     @Test(timeout = 2000)

--- a/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TestFactory.java
+++ b/datashare-tasks/src/test/java/org/icij/datashare/asynctasks/TestFactory.java
@@ -25,6 +25,10 @@ public class TestFactory implements TaskFactory {
         return new Sleep(taskView, progress);
     }
 
+    public CheckedFailure createCheckedFailure(Task<String> taskView, Function<Double, String> progress) {
+        return new CheckedFailure(taskView, progress);
+    }
+
     public static class HelloWorld implements Callable<String> {
         private final Function<Double, String> progress;
         private String greeted;
@@ -89,6 +93,17 @@ public class TestFactory implements TaskFactory {
                 }
                 Thread.sleep(100);
             }
+        }
+    }
+
+    @TaskGroup(TaskGroupType.Test)
+    public static class CheckedFailure implements Callable<String> {
+        CheckedFailure(Task<String> taskView, Function<Double, String> progress) {
+        }
+
+        @Override
+        public String call() throws Exception {
+            throw new java.io.IOException("checked failure");
         }
     }
 


### PR DESCRIPTION
CLI `SCAN,INDEX` runs (and the wider ingest pipeline) now terminate on their own once the work is done, instead of hanging until someone kills the process. That hang was the cause of the repeated manual restarts on the last production run. Two independent root causes are fixed:

1. **Run lifecycle**: a run waited on the *global* set of unfinished tasks in the shared, persistent task repository, so any row left `RUNNING`/`QUEUED` by a previously killed run blocked every later run forever.
2. **Queue end-of-stream**: the pipeline relied on manually injected `POISON` sentinel entries to signal "no more work", which does not scale when `INDEX` is fanned out across many instances sharing one Redis queue.

Because end-of-stream is now inferred from a quiet queue rather than an explicit marker, an `INDEX`/`DEDUPLICATE` stage will idle up to `queuePoll` (30s) after the last document before completing, and will conclude "drained" if a producer stalls longer than `queuePoll`. Tune `--queuePoll` for deployments where `SCAN` can pause for extended periods.

```mermaid
flowchart TB
  A["poll(queue, queuePoll)"] --> B{"poll result?"}
  B -->|document| C["process it"] --> A
  B -->|"legacy POISON"| D["skip, log at debug"] --> A
  B -->|"null (queue quiet for queuePoll)"| E["conclude drained, exit"]
```

`INDEX`/`DEDUPLICATE` conclude "drained" after one `queuePoll` window of silence; `NER`/`CATEGORIZE` use their existing `pollingInterval x NB_MAX_POLLS` empty-poll budget. All four skip legacy `POISON` the same way.

## Changes

- feat: scope run completion to the run's own tasks, reconcile orphaned tasks, and exit with a status code derived from those tasks
- fix: record task construction/checked failures as errors on non-AMQP worker loops
- fix: reconcile listenerless running tasks with Temporal during scoped waits
- fix: wait on spawned child tasks, stop cancelling peer-owned tasks, and stop broadcasting worker shutdown to shared task buses on exit
- feat: stop producing `POISON` (SCAN, DEDUPLICATE, CATEGORIZE, and the Elasticsearch spewer)
- feat: terminate INDEX/DEDUPLICATE on a quiet queue via `queuePoll` and NER/CATEGORIZE via their empty-poll budget
- feat: silently skip legacy `POISON` entries in every consumer
- feat: add `--queuePoll` option (default `30s`) with help text
- fix: clamp poll timeouts so a `0`/sub-second interval cannot block a Redis `BLPOP` forever (INDEX, DEDUPLICATE, NER, CATEGORIZE)
