### PR TITLE
fix(index): bound extracted-text read to avoid OOM

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +33,12 @@ import static org.icij.datashare.text.Hasher.shorten;
 public class ElasticsearchSpewer extends Spewer implements Serializable {
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchSpewer.class);
     public static final String DEFAULT_VALUE_UNKNOWN = "unknown";
+    // Largest char[] a String can be backed by (Integer.MAX_VALUE - 8). Used as the hard ceiling
+    // when maxContentLength is disabled (-1): it is exactly the length at which the previous
+    // toString(reader) call blew up with "Required array length 2147483639 + 9 is too large", so
+    // stopping here avoids that OOM while never dropping content that could otherwise be indexed.
+    private static final int MAX_CONTENT_LENGTH = Integer.MAX_VALUE - 8;
+    private static final int READ_CHUNK_SIZE = 8192;
 
     static final String PST_ATTACHMENT_RECOVERY = "tika:pst_attachment_recovery";
     static final String PST_EXPECTED = "tika:pst_expected";
@@ -168,11 +175,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
                 .withOcrParser(document.getMetadata().get(OCRParser.OCR_PARSER))
                 .with(parseChildRecoveryStatus(document));
 
-        String content = toString(document.getReader()).trim();
-        if (maxContentLength != -1 && content.length() > maxContentLength) {
-            logger.warn("document id {} extracted text will be truncated to {} bytes", document.getId(), maxContentLength);
-            content = content.substring(0, maxContentLength).trim();
-        }
+        String content = readContent(document);
         if (document.getLanguage() == null) {
             builder.with(languageGuesser.guess(content));
         } else  {
@@ -186,6 +189,53 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         }
         applyParentRollup(builder, document);
         return builder.build();
+    }
+
+    // Reads the extracted text bounded to maxContentLength characters. The previous
+    // toString(document.getReader()) copied the whole reader into an unbounded StringWriter and
+    // only truncated afterwards, so multi-GB extracted text (e.g. a zip bomb's contents) overran
+    // the 2^31-1 char-array cap and threw OutOfMemoryError before the cap could ever apply. Here
+    // we never buffer more than the cap: reading stops as soon as the limit is reached.
+    String readContent(TikaDocument document) throws IOException {
+        // maxContentLength == -1 disables the configured cap, but we still refuse to buffer past
+        // the largest array a String can hold to avoid the OOM that toString used to hit.
+        final int limit = maxContentLength == -1 ? MAX_CONTENT_LENGTH : maxContentLength;
+        final StringBuilder content = new StringBuilder();
+        final char[] chunk = new char[READ_CHUNK_SIZE];
+        // The reader is owned and closed by Spewer.write/writeTree (see closeReaderQuietly), so we
+        // only read from it here; leaving it partially consumed on truncation is fine, close still
+        // releases any spilled temp files.
+        final Reader reader = document.getReader();
+        boolean truncated = false;
+        int read;
+        while ((read = reader.read(chunk)) != -1) {
+            final int remaining = limit - content.length();
+            if (read <= remaining) {
+                content.append(chunk, 0, read);
+            } else {
+                content.append(chunk, 0, remaining);
+                truncated = true;
+                break;
+            }
+        }
+        if (truncated) {
+            logger.warn("document id {} extracted text will be truncated to {} bytes", document.getId(), limit);
+        }
+        return trim(content);
+    }
+
+    // Reproduces String.trim() semantics (strips code points <= U+0020 from both ends) directly on
+    // the bounded buffer, so we don't allocate a second copy of the whole extracted text.
+    private static String trim(StringBuilder content) {
+        int start = 0;
+        int end = content.length();
+        while (start < end && content.charAt(start) <= ' ') {
+            start++;
+        }
+        while (end > start && content.charAt(end - 1) <= ' ') {
+            end--;
+        }
+        return content.substring(start, end);
     }
 
     int getMaxContentLength(PropertiesProvider propertiesProvider) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -206,14 +206,37 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         // only read from it here; leaving it partially consumed on truncation is fine, close still
         // releases any spilled temp files.
         final Reader reader = document.getReader();
+        // The old code did toString(reader).trim() *before* applying the cap, so leading whitespace
+        // never counted against maxContentLength. We reproduce that: leading whitespace (blank
+        // pages, OCR page breaks preceding the body) is skipped without buffering and without
+        // eating into `limit`, so a document that starts with a limit-long run of blank lines still
+        // gets its real text indexed instead of an all-whitespace buffer that trims to empty. The
+        // skip is itself bounded by `limit` so a reader that only ever yields whitespace terminates.
+        boolean bodyStarted = false;
+        long skippedLeadingWhitespace = 0;
         boolean truncated = false;
         int read;
         while ((read = reader.read(chunk)) != -1) {
+            int offset = 0;
+            if (!bodyStarted) {
+                while (offset < read && chunk[offset] <= ' ') {
+                    offset++;
+                }
+                skippedLeadingWhitespace += offset;
+                if (offset == read) {
+                    if (skippedLeadingWhitespace >= limit) {
+                        break;
+                    }
+                    continue;
+                }
+                bodyStarted = true;
+            }
+            final int available = read - offset;
             final int remaining = limit - content.length();
-            if (read <= remaining) {
-                content.append(chunk, 0, read);
+            if (available <= remaining) {
+                content.append(chunk, offset, available);
             } else {
-                content.append(chunk, 0, remaining);
+                content.append(chunk, offset, remaining);
                 truncated = true;
                 break;
             }

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -197,9 +197,13 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
     // the 2^31-1 char-array cap and threw OutOfMemoryError before the cap could ever apply. Here
     // we never buffer more than the cap: reading stops as soon as the limit is reached.
     String readContent(TikaDocument document) throws IOException {
-        // maxContentLength == -1 disables the configured cap, but we still refuse to buffer past
-        // the largest array a String can hold to avoid the OOM that toString used to hit.
-        final int limit = maxContentLength == -1 ? MAX_CONTENT_LENGTH : maxContentLength;
+        // A configured maxContentLength can be as high as Integer.MAX_VALUE (see getMaxContentLength),
+        // and maxContentLength == -1 disables the configured cap entirely, but in both cases we still
+        // refuse to buffer past the largest array a String can hold, so clamp the effective limit in
+        // every branch rather than only guarding -1. (-1 stays "index everything up to that array
+        // cap": with no configured limit a single multi-GB document is bounded only by the heap, by
+        // design; operators cap memory by setting a finite maxContentLength.)
+        final int limit = Math.min(maxContentLength == -1 ? MAX_CONTENT_LENGTH : maxContentLength, MAX_CONTENT_LENGTH);
         final StringBuilder content = new StringBuilder();
         final char[] chunk = new char[READ_CHUNK_SIZE];
         // The reader is owned and closed by Spewer.write/writeTree (see closeReaderQuietly), so we
@@ -207,11 +211,12 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         // releases any spilled temp files.
         final Reader reader = document.getReader();
         // The old code did toString(reader).trim() *before* applying the cap, so leading whitespace
-        // never counted against maxContentLength. We reproduce that: leading whitespace (blank
-        // pages, OCR page breaks preceding the body) is skipped without buffering and without
-        // eating into `limit`, so a document that starts with a limit-long run of blank lines still
-        // gets its real text indexed instead of an all-whitespace buffer that trims to empty. The
-        // skip is itself bounded by `limit` so a reader that only ever yields whitespace terminates.
+        // never counted against maxContentLength. We reproduce that: leading whitespace (blank pages,
+        // OCR page breaks preceding the body) is skipped without buffering, however many chunks it
+        // spans, until the body appears -- so a document that opens with a run of blank lines longer
+        // than the cap still gets its real text indexed instead of an all-whitespace buffer that
+        // trims to empty. The skip is bounded by the same array cap as the buffer, so a reader that
+        // only ever yields whitespace still terminates.
         boolean bodyStarted = false;
         long skippedLeadingWhitespace = 0;
         boolean truncated = false;
@@ -222,9 +227,9 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
                 while (offset < read && chunk[offset] <= ' ') {
                     offset++;
                 }
-                skippedLeadingWhitespace += offset;
                 if (offset == read) {
-                    if (skippedLeadingWhitespace >= limit) {
+                    skippedLeadingWhitespace += offset;
+                    if (skippedLeadingWhitespace >= MAX_CONTENT_LENGTH) {
                         break;
                     }
                     continue;
@@ -237,14 +242,38 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
                 content.append(chunk, offset, available);
             } else {
                 content.append(chunk, offset, remaining);
-                truncated = true;
+                // The cap is reached, but only report truncation if real (non-whitespace) content
+                // still follows: trailing whitespace that merely overflows the window is stripped by
+                // trim() and did not count as truncation in the old toString(reader).trim() path.
+                truncated = hasNonWhitespaceRemaining(chunk, offset + remaining, read, reader);
                 break;
             }
         }
         if (truncated) {
-            logger.warn("document id {} extracted text will be truncated to {} bytes", document.getId(), limit);
+            logger.warn("document id {} extracted text will be truncated to {} characters", document.getId(), limit);
         }
         return trim(content);
+    }
+
+    // After the content cap has been reached, reports whether any non-whitespace character remains in
+    // the unread tail of the current chunk or the rest of the reader. It stops at the first
+    // non-whitespace character (so a genuinely oversized document returns immediately) or at end of
+    // input, and buffers nothing, so it never reintroduces the unbounded read this class avoids.
+    private static boolean hasNonWhitespaceRemaining(char[] chunk, int from, int read, Reader reader) throws IOException {
+        for (int i = from; i < read; i++) {
+            if (chunk[i] > ' ') {
+                return true;
+            }
+        }
+        int n;
+        while ((n = reader.read(chunk)) != -1) {
+            for (int i = 0; i < n; i++) {
+                if (chunk[i] > ' ') {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     // Reproduces String.trim() semantics (strips code points <= U+0020 from both ends) directly on

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerContentTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerContentTest.java
@@ -63,7 +63,7 @@ public class ElasticsearchSpewerContentTest {
     @Test
     public void test_bounded_read_stops_without_consuming_the_whole_reader() throws Exception {
         ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
-        CountingInfiniteReader reader = new CountingInfiniteReader();
+        CountingInfiniteReader reader = new CountingInfiniteReader('a');
 
         String content = spewer.readContent(documentReading(reader));
 
@@ -74,15 +74,45 @@ public class ElasticsearchSpewerContentTest {
         assertThat(reader.charsProduced).isLessThan(1_000_000L);
     }
 
-    // A reader that hands out an effectively infinite stream of 'a' and counts how many chars it
-    // produced, so a test can prove the bounded read stops early instead of draining it.
+    @Test
+    public void test_leading_whitespace_does_not_consume_the_content_budget() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
+        // A document whose extracted text begins with more than maxContentLength worth of blank
+        // lines (blank pages, OCR page breaks before the body) must still index its real text.
+        // The old toString(reader).trim() stripped that leading whitespace before capping; a
+        // regression that caps the raw stream first would fill the budget with whitespace and trim
+        // to an empty, unsearchable document.
+        String text = " ".repeat(50) + "this content should be truncated";
+        assertThat(spewer.readContent(documentReading(new StringReader(text)))).isEqualTo("this content should");
+    }
+
+    @Test
+    public void test_whitespace_only_reader_terminates_with_empty_content() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
+        CountingInfiniteReader reader = new CountingInfiniteReader(' ');
+
+        String content = spewer.readContent(documentReading(reader));
+
+        // An infinite run of pure whitespace never starts a body: it must terminate (the leading
+        // whitespace skip is bounded) and yield empty content without buffering the whole stream.
+        assertThat(content).isEmpty();
+        assertThat(reader.charsProduced).isLessThan(1_000_000L);
+    }
+
+    // A reader that hands out an effectively infinite stream of a single char and counts how many
+    // chars it produced, so a test can prove the bounded read stops early instead of draining it.
     private static class CountingInfiniteReader extends Reader {
+        private final char fill;
         private long charsProduced = 0;
+
+        private CountingInfiniteReader(char fill) {
+            this.fill = fill;
+        }
 
         @Override
         public int read(char[] cbuf, int off, int len) {
             for (int i = 0; i < len; i++) {
-                cbuf[off + i] = 'a';
+                cbuf[off + i] = fill;
             }
             charsProduced += len;
             return len;

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerContentTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerContentTest.java
@@ -63,7 +63,7 @@ public class ElasticsearchSpewerContentTest {
     @Test
     public void test_bounded_read_stops_without_consuming_the_whole_reader() throws Exception {
         ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
-        CountingInfiniteReader reader = new CountingInfiniteReader('a');
+        CountingReader reader = new CountingReader('a', Long.MAX_VALUE);
 
         String content = spewer.readContent(documentReading(reader));
 
@@ -87,35 +87,63 @@ public class ElasticsearchSpewerContentTest {
     }
 
     @Test
+    public void test_leading_whitespace_spanning_multiple_chunks_is_still_indexed() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
+        // Regression: when the leading whitespace fills one or more whole read chunks (> 8192 chars)
+        // the body arrives in a later chunk. The skip must keep reading across chunks instead of
+        // giving up once it has skipped `limit` whitespace, otherwise the real text is dropped and an
+        // empty document is indexed.
+        String text = " ".repeat(20_000) + "this content should be truncated";
+        assertThat(spewer.readContent(documentReading(new StringReader(text)))).isEqualTo("this content should");
+    }
+
+    @Test
+    public void test_trailing_whitespace_beyond_the_cap_is_not_treated_as_content() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
+        // The real text is exactly the cap; only trailing whitespace overflows the read window. That
+        // is not a truncation (the old toString(reader).trim() dropped the trailing whitespace and
+        // saw the content fit), so the body must be indexed whole.
+        String text = "12345678901234567890" + " ".repeat(5_000);
+        assertThat(spewer.readContent(documentReading(new StringReader(text)))).isEqualTo("12345678901234567890");
+    }
+
+    @Test
     public void test_whitespace_only_reader_terminates_with_empty_content() throws Exception {
         ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
-        CountingInfiniteReader reader = new CountingInfiniteReader(' ');
+        CountingReader reader = new CountingReader(' ', 5_000_000L);
 
         String content = spewer.readContent(documentReading(reader));
 
-        // An infinite run of pure whitespace never starts a body: it must terminate (the leading
-        // whitespace skip is bounded) and yield empty content without buffering the whole stream.
+        // A run of pure whitespace never starts a body: it terminates at end of input and yields
+        // empty content without ever buffering the stream.
         assertThat(content).isEmpty();
-        assertThat(reader.charsProduced).isLessThan(1_000_000L);
+        assertThat(reader.charsProduced).isEqualTo(5_000_000L);
     }
 
-    // A reader that hands out an effectively infinite stream of a single char and counts how many
-    // chars it produced, so a test can prove the bounded read stops early instead of draining it.
-    private static class CountingInfiniteReader extends Reader {
+    // A reader that hands out a stream of a single char up to `total` chars then reports end of
+    // input, counting how many chars it produced so a test can prove how much the read touched. Pass
+    // Long.MAX_VALUE for an effectively infinite stream.
+    private static class CountingReader extends Reader {
         private final char fill;
+        private final long total;
         private long charsProduced = 0;
 
-        private CountingInfiniteReader(char fill) {
+        private CountingReader(char fill, long total) {
             this.fill = fill;
+            this.total = total;
         }
 
         @Override
         public int read(char[] cbuf, int off, int len) {
-            for (int i = 0; i < len; i++) {
+            if (charsProduced >= total) {
+                return -1;
+            }
+            int n = (int) Math.min(len, total - charsProduced);
+            for (int i = 0; i < n; i++) {
                 cbuf[off + i] = fill;
             }
-            charsProduced += len;
-            return len;
+            charsProduced += n;
+            return n;
         }
 
         @Override

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerContentTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerContentTest.java
@@ -1,0 +1,94 @@
+package org.icij.datashare.text.indexing.elasticsearch;
+
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
+import org.icij.datashare.text.Language;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.document.PathIdentifier;
+import org.icij.extract.document.TikaDocument;
+import org.icij.spewer.FieldNames;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Map;
+
+import static java.nio.file.Paths.get;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+// Unit tests for the bounded reader in ElasticsearchSpewer.readContent. These do not need
+// Elasticsearch: they exercise the read/cap/trim path directly with in-memory readers.
+public class ElasticsearchSpewerContentTest {
+    private ElasticsearchSpewer spewerWithMaxContentLength(String maxContentLength) {
+        return new ElasticsearchSpewer(mock(Indexer.class), new MemoryDocumentCollectionFactory<>(),
+                text -> Language.ENGLISH, new FieldNames(),
+                new PropertiesProvider(Map.of("maxContentLength", maxContentLength)));
+    }
+
+    private TikaDocument documentReading(Reader reader) {
+        TikaDocument document = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("content.txt"));
+        document.setReader(reader);
+        return document;
+    }
+
+    @Test
+    public void test_reads_whole_content_when_shorter_than_limit() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
+        assertThat(spewer.readContent(documentReading(new StringReader("short content")))).isEqualTo("short content");
+    }
+
+    @Test
+    public void test_caps_content_to_max_content_length_and_trims() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
+        // The first 20 chars are "this content should " and the trailing space is trimmed off.
+        assertThat(spewer.readContent(documentReading(new StringReader("this content should be truncated"))))
+                .isEqualTo("this content should");
+    }
+
+    @Test
+    public void test_trims_leading_and_trailing_whitespace() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("-1");
+        assertThat(spewer.readContent(documentReading(new StringReader("  \n hello world \t ")))).isEqualTo("hello world");
+    }
+
+    @Test
+    public void test_unbounded_reads_full_content_for_normal_document() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("-1");
+        String text = "a".repeat(5_000_000);
+        assertThat(spewer.readContent(documentReading(new StringReader(text))).length()).isEqualTo(5_000_000);
+    }
+
+    @Test
+    public void test_bounded_read_stops_without_consuming_the_whole_reader() throws Exception {
+        ElasticsearchSpewer spewer = spewerWithMaxContentLength("20");
+        CountingInfiniteReader reader = new CountingInfiniteReader();
+
+        String content = spewer.readContent(documentReading(reader));
+
+        assertThat(content.length()).isEqualTo(20);
+        // The reader yields an effectively infinite stream, yet the bounded read touches only a
+        // handful of chars before stopping. The old toString(reader) would have read until it hit
+        // the 2^31-1 array cap and thrown OutOfMemoryError.
+        assertThat(reader.charsProduced).isLessThan(1_000_000L);
+    }
+
+    // A reader that hands out an effectively infinite stream of 'a' and counts how many chars it
+    // produced, so a test can prove the bounded read stops early instead of draining it.
+    private static class CountingInfiniteReader extends Reader {
+        private long charsProduced = 0;
+
+        @Override
+        public int read(char[] cbuf, int off, int len) {
+            for (int i = 0; i < len; i++) {
+                cbuf[off + i] = 'a';
+            }
+            charsProduced += len;
+            return len;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
Very large extracted text no longer triggers the OutOfMemoryError that aborted indexing; content is capped at the configured maximum length instead of being fully loaded into memory first.