### PR TITLE
chore(logging): filter benign PDFBox log noise

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/log/PdfBoxNoiseFilter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/log/PdfBoxNoiseFilter.java
@@ -1,0 +1,48 @@
+package org.icij.datashare.log;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+/**
+ * Drops PDFBox/FontBox's high-volume, benign warnings (font fallback, xref auto-repair and
+ * missing-Unicode-mapping messages) that dominate ~85% of datashare's WARN volume even though text
+ * still extracts correctly. Only WARN-and-below events on the org.apache.pdfbox / org.apache.fontbox
+ * loggers are considered, so genuine ERRORs and unrelated warnings always pass through. The noise
+ * originates inside PDFBox, so message-level filtering is the only way to separate it from real
+ * warnings on the same logger. This mirrors extract-cli's filter of the same name, which is absent
+ * from datashare's runtime jar because datashare depends on extract-lib rather than extract-cli.
+ * Extend NOISE_SUBSTRINGS as further dominant benign messages are measured.
+ */
+public class PdfBoxNoiseFilter extends Filter<ILoggingEvent> {
+
+    private static final String[] NOISE_SUBSTRINGS = {
+            "No current font",
+            "Using fallback font",
+            "No Unicode mapping",
+            "found wrong object number",
+    };
+
+    @Override
+    public FilterReply decide(final ILoggingEvent event) {
+        final String loggerName = event.getLoggerName();
+        if (loggerName == null
+                || (!loggerName.startsWith("org.apache.pdfbox") && !loggerName.startsWith("org.apache.fontbox"))) {
+            return FilterReply.NEUTRAL;
+        }
+        if (event.getLevel().isGreaterOrEqual(Level.ERROR)) {
+            return FilterReply.NEUTRAL;
+        }
+        final String message = event.getFormattedMessage();
+        if (message == null) {
+            return FilterReply.NEUTRAL;
+        }
+        for (final String noise : NOISE_SUBSTRINGS) {
+            if (message.contains(noise)) {
+                return FilterReply.DENY;
+            }
+        }
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/datashare-app/src/main/resources/logback-prod.xml
+++ b/datashare-app/src/main/resources/logback-prod.xml
@@ -2,6 +2,9 @@
 <configuration>
     <contextName>production</contextName>
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- Drop benign, high-volume PDFBox/FontBox font-fallback, xref-repair and no-Unicode-mapping
+             warnings (~85% of WARN volume) while keeping genuine PDF/font errors visible. -->
+        <filter class="org.icij.datashare.log.PdfBoxNoiseFilter"/>
         <encoder>
             <pattern>%d [%thread] %-5level %logger{0} - %msg%n</pattern>
         </encoder>

--- a/datashare-app/src/test/java/org/icij/datashare/log/PdfBoxNoiseFilterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/log/PdfBoxNoiseFilterTest.java
@@ -1,0 +1,70 @@
+package org.icij.datashare.log;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.spi.FilterReply;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class PdfBoxNoiseFilterTest {
+
+    private final PdfBoxNoiseFilter filter = new PdfBoxNoiseFilter();
+    private final LoggerContext context = new LoggerContext();
+
+    private LoggingEvent event(final String loggerName, final Level level, final String message) {
+        final Logger logger = context.getLogger(loggerName);
+        return new LoggingEvent(Logger.class.getName(), logger, level, message, null, null);
+    }
+
+    @Test
+    public void denies_fontFallbackNoise() {
+        assertThat(filter.decide(event("org.apache.pdfbox.pdmodel.font.PDTrueTypeFont", Level.WARN,
+                "Using fallback font LiberationSans for Arial")))
+                .isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void denies_xrefRepairNoise() {
+        assertThat(filter.decide(event("org.apache.pdfbox.pdfparser.COSParser", Level.WARN,
+                "found wrong object number. expected [12] found [13]")))
+                .isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void denies_noUnicodeMappingNoise() {
+        assertThat(filter.decide(event("org.apache.fontbox.ttf.CmapSubtable", Level.WARN,
+                "No Unicode mapping for glyph 42")))
+                .isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void denies_noCurrentFontNoise() {
+        assertThat(filter.decide(event("org.apache.pdfbox.contentstream.PDFStreamEngine", Level.WARN,
+                "No current font, will use default")))
+                .isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void keeps_pdfBoxError() {
+        assertThat(filter.decide(event("org.apache.pdfbox.pdmodel.font.PDTrueTypeFont", Level.ERROR,
+                "Using fallback font LiberationSans for Arial")))
+                .isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    @Test
+    public void keeps_otherPdfBoxWarning() {
+        assertThat(filter.decide(event("org.apache.pdfbox.pdmodel.PDDocument", Level.WARN,
+                "This PDF is malformed")))
+                .isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    @Test
+    public void ignores_nonPdfBoxEvent() {
+        assertThat(filter.decide(event("org.icij.datashare.SomethingElse", Level.WARN,
+                "Using fallback font LiberationSans for Arial")))
+                .isEqualTo(FilterReply.NEUTRAL);
+    }
+}


### PR DESCRIPTION
Cuts roughly 85% of production WARN volume (benign PDFBox font-fallback and xref-repair messages) so genuine warnings are actually visible. No behavior change.