### PR TITLE
feat: make ENQUEUEIDX NLP-exclusion stage-aware

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
+++ b/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
@@ -33,7 +33,7 @@ public class PipelineHelper {
         return stage.isLastEnum() ? null: getQueueName(propertiesProvider, getNextStage(stage));
     }
 
-    private Stage getNextStage(Stage stage) {
+    public Stage getNextStage(Stage stage) {
         if (stage == stages.get(stages.size() - 1)) return stage.getDefaultNextStage();
         if (!stages.contains(stage)) return stage.getDefaultNextStage();
         return stages.get(stages.indexOf(stage) + 1);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
@@ -80,8 +80,9 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
         searcher.sort("language", Indexer.Searcher.SortOrder.ASC);
         List<? extends Entity> docsToProcess = searcher.scroll(scrollDuration).collect(toList());
         long totalHits = searcher.totalHits();
-        logger.info("enqueuing doc ids for index {} and {} with {} scroll and size of {} : {} documents found", projectName, nlpPipeline,
-                scrollDuration, scrollSize, totalHits);
+        String pipelineInfo = (nextStage == Stage.NLP) ? " excluding already processed by " + nlpPipeline : "";
+        logger.info("enqueuing doc ids for index {} targeting {}{} with {} scroll and size of {} : {} documents found",
+                projectName, nextStage, pipelineInfo, scrollDuration, scrollSize, totalHits);
 
         try (DocumentQueue<String> outputQueue = factory.createQueue(getOutputQueueName(), String.class)) {
             do {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
@@ -5,6 +5,7 @@ import com.google.inject.assistedinject.Assisted;
 
 import java.util.function.Function;
 import org.icij.datashare.Entity;
+import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
@@ -46,6 +47,7 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
     private final Indexer indexer;
     private final String scrollDuration;
     private final int scrollSize;
+    private final Stage nextStage;
 
     @Inject
     public EnqueueFromIndexTask(final DocumentCollectionFactory<String> factory, final Indexer indexer,
@@ -58,6 +60,7 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
         this.scrollDuration = propertiesProvider.get(SCROLL_DURATION_OPT).orElse(DEFAULT_SCROLL_DURATION);
         this.scrollSize = parseInt(propertiesProvider.get(SCROLL_SIZE_OPT).orElse(String.valueOf(DEFAULT_SCROLL_SIZE)));
         this.searchQuery = propertiesProvider.get(SEARCH_QUERY_OPT).orElse(null);
+        this.nextStage = new PipelineHelper(propertiesProvider).getNextStage(Stage.ENQUEUEIDX);
     }
 
     @Override
@@ -65,8 +68,11 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
         super.call();
         Indexer.Searcher searcher;
         if (searchQuery == null) {
-            searcher = indexer.search(singletonList(projectName), Document.class)
-                    .without(nlpPipeline).withSource("rootDocument").limit(scrollSize);
+            Indexer.QueryBuilderSearcher builder = indexer.search(singletonList(projectName), Document.class);
+            if (nextStage == Stage.NLP) {
+                builder = builder.without(nlpPipeline);
+            }
+            searcher = builder.withSource("rootDocument").limit(scrollSize);
         } else {
             searcher = indexer.search(singletonList(projectName), Document.class, new SearchQuery(searchQuery))
                     .withoutSource("content", "contentTranslated").limit(scrollSize);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
@@ -84,6 +84,41 @@ public class EnqueueFromIndexTaskTest {
     }
 
     @Test
+    public void test_no_query_targeting_artifact_ignores_nlp_pipeline_filter() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            indexer.add(es.getIndexName(), createDoc("doc" + i)
+                    .with(Pipeline.Type.CORENLP).with(project(es.getIndexName())).build());
+        }
+        Map<String, Object> properties = Map.of(
+                "defaultProject", es.getIndexName(),
+                "stages", "ARTIFACT,ENQUEUEIDX",
+                "queueName", "test:queue");
+        MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
+        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer,
+                new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
+        enqueueFromIndex.call();
+        assertThat(factory.queues.get("test:queue:artifact")).hasSize(5);
+    }
+
+    @Test
+    public void test_no_query_targeting_nlp_still_excludes_already_processed() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            indexer.add(es.getIndexName(), createDoc("doc" + i)
+                    .with(Pipeline.Type.CORENLP).with(project(es.getIndexName())).build());
+        }
+        Map<String, Object> properties = Map.of(
+                "defaultProject", es.getIndexName(),
+                "stages", "ENQUEUEIDX",
+                "queueName", "test:queue",
+                NLP_PIPELINE_OPT, Pipeline.Type.CORENLP.name());
+        MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
+        EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer,
+                new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
+        enqueueFromIndex.call();
+        assertThat(factory.queues.get("test:queue:nlp")).isNullOrEmpty();
+    }
+
+    @Test
     public void test_log_displays_correct_document_count() throws Exception {
         LogbackAppenderWrapper logWrapper = new LogbackAppenderWrapper();
         for (int i = 0; i < 3; i++) {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
@@ -92,7 +92,8 @@ public class EnqueueFromIndexTaskTest {
         Map<String, Object> properties = Map.of(
                 "defaultProject", es.getIndexName(),
                 "stages", "ARTIFACT,ENQUEUEIDX",
-                "queueName", "test:queue");
+                "queueName", "test:queue",
+                NLP_PIPELINE_OPT, Pipeline.Type.CORENLP.name());
         MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
         EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);


### PR DESCRIPTION
The `ENQUEUEIDX` stage (`EnqueueFromIndexTask`) applied a `.without(nlpPipeline)` filter (skipping documents already processed by the NLP pipeline) whenever no `--searchQuery` was given, regardless of which stage consumed its output.

This filter only makes sense when the destination is NLP. When running `--stages ARTIFACT,ENQUEUEIDX`, it silently excluded already-NLP'd documents and enqueued a too-small subset for artifact extraction.
