### PR TITLE
feat: ARTIFACT parallelism

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -94,8 +94,8 @@ public class ArtifactTask extends PipelineTask<String> {
                     nbFailures++;
                 }
             }
-            if (!futures.isEmpty() && nbFailures == futures.size()) {
-                throw new IllegalStateException(String.format("all %d artifact worker(s) terminated abnormally", futures.size()), firstCause);
+            if (nbFailures > 0) {
+                throw new IllegalStateException(String.format("%d of %d artifact worker(s) terminated abnormally", nbFailures, futures.size()), firstCause);
             }
         } catch (InterruptedException e) {
             // task was cancelled: force-stop the workers, give them a short grace period to
@@ -158,7 +158,6 @@ public class ArtifactTask extends PipelineTask<String> {
         return runnable -> {
             Thread thread = new Thread(runnable);
             thread.setName(prefix + "-" + counter.incrementAndGet());
-            thread.setDaemon(true);
             return thread;
         };
     }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -48,6 +48,7 @@ public class ArtifactTask extends PipelineTask<String> {
     private final Path artifactDir;
     private final int pollingInterval;
     private final int parallelism;
+    private final ExecutorService executor;
 
     @Inject
     public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
@@ -57,6 +58,16 @@ public class ArtifactTask extends PipelineTask<String> {
         pollingInterval = Integer.parseInt(propertiesProvider.get(POLLING_INTERVAL_SECONDS_OPT).orElse(DEFAULT_POLLING_INTERVAL_SEC));
         parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
+        executor = Executors.newFixedThreadPool(parallelism, namedThreadFactory("artifact-worker"));
+    }
+
+    @Override
+    public void cancel(boolean requeue) {
+        // interrupt the task thread first (PipelineTask): that is what makes the blocking
+        // future.get() in call() throw InterruptedException and surface the cancellation.
+        // Then stop the worker pool so the workers themselves wind down promptly.
+        super.cancel(requeue);
+        executor.shutdownNow();
     }
 
     @Override
@@ -65,7 +76,6 @@ public class ArtifactTask extends PipelineTask<String> {
         logger.info("creating artifact cache in {} for project {} from queue {} with {} worker(s) and polling interval {}s", artifactDir, project, inputQueue.getName(), parallelism, pollingInterval);
         AtomicLong nbDocs = new AtomicLong(0);
         AtomicLong nbSkipped = new AtomicLong(0);
-        ExecutorService executor = Executors.newFixedThreadPool(parallelism, namedThreadFactory("artifact-worker"));
         try {
             List<Future<?>> futures = new ArrayList<>();
             for (int i = 0; i < parallelism; i++) {
@@ -92,7 +102,7 @@ public class ArtifactTask extends PipelineTask<String> {
             // actually stop (so we don't read counters/logs while they're still writing), then
             // rethrow so TaskWorkerLoop records this as a cancellation instead of a success.
             executor.shutdownNow();
-            awaitWorkersTermination(executor);
+            awaitWorkersTermination();
             Thread.currentThread().interrupt();
             throw e;
         } finally {
@@ -133,7 +143,7 @@ public class ArtifactTask extends PipelineTask<String> {
         return new SourceExtractor(propertiesProvider);
     }
 
-    private void awaitWorkersTermination(ExecutorService executor) {
+    private void awaitWorkersTermination() {
         try {
             if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
                 logger.warn("artifact worker(s) did not terminate within the grace period after cancellation");

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -41,6 +41,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECOND
 @TemporalSingleActivityWorkflow(name = "artifact", activityOptions = @ActivityOpts(timeout = "P1D"))
 @TaskGroup(TaskGroupType.Java)
 public class ArtifactTask extends PipelineTask<String> {
+    private static final List<String> SOURCE_EXCLUDES = List.of("content", "content_translated");
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Indexer indexer;
     private final Project project;
@@ -54,7 +55,7 @@ public class ArtifactTask extends PipelineTask<String> {
         this.indexer = indexer;
         project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
         pollingInterval = Integer.parseInt(propertiesProvider.get(POLLING_INTERVAL_SECONDS_OPT).orElse(DEFAULT_POLLING_INTERVAL_SEC));
-        parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1);
+        parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
     }
 
@@ -108,12 +109,11 @@ public class ArtifactTask extends PipelineTask<String> {
 
     private void runWorker(AtomicLong nbDocs, AtomicLong nbSkipped) {
         SourceExtractor extractor = createSourceExtractor();
-        List<String> sourceExcludes = List.of("content", "content_translated");
         try {
             String queueEntry;
             while ((queueEntry = inputQueue.poll(pollingInterval, TimeUnit.SECONDS)) != null) {
                 try {
-                    Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), sourceExcludes);
+                    Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), SOURCE_EXCLUDES);
                     if (doc == null) {
                         nbSkipped.incrementAndGet();
                         continue;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -87,10 +87,17 @@ public class ArtifactTask extends PipelineTask<String> {
                 throw new IllegalStateException(String.format("all %d artifact worker(s) terminated abnormally", futures.size()), firstCause);
             }
         } catch (InterruptedException e) {
+            // task was cancelled: force-stop the workers, give them a short grace period to
+            // actually stop (so we don't read counters/logs while they're still writing), then
+            // rethrow so TaskWorkerLoop records this as a cancellation instead of a success.
             executor.shutdownNow();
+            awaitWorkersTermination(executor);
             Thread.currentThread().interrupt();
+            throw e;
         } finally {
-            executor.shutdownNow();
+            // graceful here: on the happy/partial-failure paths all work is already done;
+            // the cancel path above has already force-stopped workers via shutdownNow().
+            executor.shutdown();
         }
         if (nbSkipped.get() > 0) {
             logger.error("{} document(s) could not be retrieved from index {} and got no artifact cache, re-run the ARTIFACT stage for them", nbSkipped.get(), project.name);
@@ -126,11 +133,22 @@ public class ArtifactTask extends PipelineTask<String> {
         return new SourceExtractor(propertiesProvider);
     }
 
+    private void awaitWorkersTermination(ExecutorService executor) {
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.warn("artifact worker(s) did not terminate within the grace period after cancellation");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     private static ThreadFactory namedThreadFactory(String prefix) {
         AtomicInteger counter = new AtomicInteger(0);
         return runnable -> {
             Thread thread = new Thread(runnable);
             thread.setName(prefix + "-" + counter.incrementAndGet());
+            thread.setDaemon(true);
             return thread;
         };
     }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -19,14 +19,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_POLLING_INTERVAL_SEC;
+import static org.icij.datashare.cli.DatashareCliOptions.PARALLELISM_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 
 @TemporalSingleActivityWorkflow(name = "artifact", activityOptions = @ActivityOpts(timeout = "P1D"))
@@ -37,6 +46,7 @@ public class ArtifactTask extends PipelineTask<String> {
     private final Project project;
     private final Path artifactDir;
     private final int pollingInterval;
+    private final int parallelism;
 
     @Inject
     public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
@@ -44,35 +54,75 @@ public class ArtifactTask extends PipelineTask<String> {
         this.indexer = indexer;
         project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
         pollingInterval = Integer.parseInt(propertiesProvider.get(POLLING_INTERVAL_SECONDS_OPT).orElse(DEFAULT_POLLING_INTERVAL_SEC));
+        parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1);
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
     }
 
     @Override
     public Long call() throws Exception {
         super.call();
-        logger.info("creating artifact cache in {} for project {} from queue {} with polling interval {}s", artifactDir, project, inputQueue.getName(), pollingInterval);
-        SourceExtractor extractor = new SourceExtractor(propertiesProvider);
-        List<String> sourceExcludes = List.of("content", "content_translated");
-        String queueEntry;
-        long nbDocs = 0;
-        long nbSkipped = 0;
-        while ((queueEntry = inputQueue.poll(pollingInterval, TimeUnit.SECONDS)) != null) {
-            try {
-                Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), sourceExcludes);
-                if (doc == null) {
-                    nbSkipped++;
-                    continue;
-                }
-                extractor.extractEmbeddedSources(project, doc);
-                nbDocs++;
-            } catch (Throwable e) {
-                logger.error("error in ArtifactTask loop", e);
+        logger.info("creating artifact cache in {} for project {} from queue {} with {} worker(s) and polling interval {}s", artifactDir, project, inputQueue.getName(), parallelism, pollingInterval);
+        AtomicLong nbDocs = new AtomicLong(0);
+        AtomicLong nbSkipped = new AtomicLong(0);
+        ExecutorService executor = Executors.newFixedThreadPool(parallelism, namedThreadFactory("artifact-worker"));
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < parallelism; i++) {
+                futures.add(executor.submit(() -> runWorker(nbDocs, nbSkipped)));
             }
+            for (Future<?> future : futures) {
+                try {
+                    future.get();
+                } catch (ExecutionException e) {
+                    logger.error("artifact worker terminated abnormally", e.getCause());
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        } finally {
+            executor.shutdownNow();
         }
-        if (nbSkipped > 0) {
-            logger.error("{} document(s) could not be retrieved from index {} and got no artifact cache, re-run the ARTIFACT stage for them", nbSkipped, project.name);
+        if (nbSkipped.get() > 0) {
+            logger.error("{} document(s) could not be retrieved from index {} and got no artifact cache, re-run the ARTIFACT stage for them", nbSkipped.get(), project.name);
         }
-        logger.info("exiting ArtifactTask loop after processing {} document(s).", nbDocs);
-        return nbDocs;
+        logger.info("exiting ArtifactTask loop after processing {} document(s).", nbDocs.get());
+        return nbDocs.get();
+    }
+
+    private void runWorker(AtomicLong nbDocs, AtomicLong nbSkipped) {
+        SourceExtractor extractor = createSourceExtractor();
+        List<String> sourceExcludes = List.of("content", "content_translated");
+        try {
+            String queueEntry;
+            while ((queueEntry = inputQueue.poll(pollingInterval, TimeUnit.SECONDS)) != null) {
+                try {
+                    Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), sourceExcludes);
+                    if (doc == null) {
+                        nbSkipped.incrementAndGet();
+                        continue;
+                    }
+                    extractor.extractEmbeddedSources(project, doc);
+                    nbDocs.incrementAndGet();
+                } catch (Throwable e) {
+                    logger.error("error in ArtifactTask loop", e);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    protected SourceExtractor createSourceExtractor() {
+        return new SourceExtractor(propertiesProvider);
+    }
+
+    private static ThreadFactory namedThreadFactory(String prefix) {
+        AtomicInteger counter = new AtomicInteger(0);
+        return runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName(prefix + "-" + counter.incrementAndGet());
+            return thread;
+        };
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -70,12 +70,21 @@ public class ArtifactTask extends PipelineTask<String> {
             for (int i = 0; i < parallelism; i++) {
                 futures.add(executor.submit(() -> runWorker(nbDocs, nbSkipped)));
             }
+            int nbFailures = 0;
+            Throwable firstCause = null;
             for (Future<?> future : futures) {
                 try {
                     future.get();
                 } catch (ExecutionException e) {
                     logger.error("artifact worker terminated abnormally", e.getCause());
+                    if (nbFailures == 0) {
+                        firstCause = e.getCause();
+                    }
+                    nbFailures++;
                 }
+            }
+            if (!futures.isEmpty() && nbFailures == futures.size()) {
+                throw new IllegalStateException(String.format("all %d artifact worker(s) terminated abnormally", futures.size()), firstCause);
             }
         } catch (InterruptedException e) {
             executor.shutdownNow();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -97,18 +97,11 @@ public class ArtifactTask extends PipelineTask<String> {
             if (nbFailures > 0) {
                 throw new IllegalStateException(String.format("%d of %d artifact worker(s) terminated abnormally", nbFailures, futures.size()), firstCause);
             }
-        } catch (InterruptedException e) {
-            // task was cancelled: force-stop the workers, give them a short grace period to
-            // actually stop (so we don't read counters/logs while they're still writing), then
-            // rethrow so TaskWorkerLoop records this as a cancellation instead of a success.
-            executor.shutdownNow();
-            awaitWorkersTermination();
-            Thread.currentThread().interrupt();
-            throw e;
         } finally {
-            // graceful here: on the happy/partial-failure paths all work is already done;
-            // the cancel path above has already force-stopped workers via shutdownNow().
-            executor.shutdown();
+            // single cleanup point for every path: normal completion, worker failure, and
+            // cancellation (where the InterruptedException from future.get() propagates out and
+            // TaskWorkerLoop records the run as cancelled).
+            executor.shutdownNow();
         }
         if (nbSkipped.get() > 0) {
             logger.error("{} document(s) could not be retrieved from index {} and got no artifact cache, re-run the ARTIFACT stage for them", nbSkipped.get(), project.name);
@@ -141,16 +134,6 @@ public class ArtifactTask extends PipelineTask<String> {
 
     protected SourceExtractor createSourceExtractor() {
         return new SourceExtractor(propertiesProvider);
-    }
-
-    private void awaitWorkersTermination() {
-        try {
-            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-                logger.warn("artifact worker(s) did not terminate within the grace period after cancellation");
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
     }
 
     private static ThreadFactory namedThreadFactory(String prefix) {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -3,10 +3,15 @@ package org.icij.datashare.tasks;
 
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.LogbackCapturingRule;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 import org.icij.datashare.user.User;
+import org.icij.extract.document.TikaDocument;
 import org.icij.extract.queue.DocumentQueue;
 import org.junit.Before;
 import org.junit.Rule;
@@ -21,6 +26,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -78,6 +86,51 @@ public class ArtifactTaskTest {
 
         verify(mockEs).get("prj", EMBEDDED_DOC_SHA256, "rootId", List.of("content", "content_translated"));
         assertThat(numberOfDocuments).isEqualTo(1);
+    }
+
+    @Test(timeout = 10000)
+    public void test_workers_run_concurrently() throws Exception {
+        indexEmbeddedDoc();
+        String secondId = "1111111111111111111111111111111111111111111111111111111111111111";
+        mockIndexer.indexFile("prj", secondId,
+                Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).toURI()),
+                "message/rfc822");
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_DOC_SHA256);
+        queue.add(secondId);
+
+        CountDownLatch bothInFlight = new CountDownLatch(2);
+        PropertiesProvider props = new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1",
+                "parallelism", "2"));
+        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+            @Override
+            protected SourceExtractor createSourceExtractor() {
+                return new SourceExtractor(props) {
+                    @Override
+                    public TikaDocument extractEmbeddedSources(Project project, Document document) {
+                        bothInFlight.countDown();
+                        try {
+                            // both workers must arrive before either proceeds;
+                            // with a single worker the second countDown never happens -> timeout
+                            if (!bothInFlight.await(5, TimeUnit.SECONDS)) {
+                                throw new AssertionError("workers did not run concurrently");
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return null;
+                    }
+                };
+            }
+        };
+
+        Long processed = artifactTask.call();
+        assertThat(processed).isEqualTo(2);
     }
 
     private void indexEmbeddedDoc() throws URISyntaxException {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -210,6 +211,56 @@ public class ArtifactTaskTest {
 
         assertThat(numberOfDocuments).isEqualTo(1);
         assertThat(logback.logs(Level.ERROR)).contains("error in ArtifactTask loop");
+    }
+
+    @Test(timeout = 10000)
+    public void test_cancellation_throws_instead_of_returning_success() throws Exception {
+        indexEmbeddedDoc();
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_DOC_SHA256);
+
+        CountDownLatch started = new CountDownLatch(1);
+        PropertiesProvider props = new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1",
+                "parallelism", "1"));
+        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+            @Override
+            protected SourceExtractor createSourceExtractor() {
+                return new SourceExtractor(props) {
+                    @Override
+                    public TikaDocument extractEmbeddedSources(Project project, Document document) {
+                        started.countDown();
+                        try {
+                            Thread.sleep(10_000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return null;
+                    }
+                };
+            }
+        };
+
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread callerThread = new Thread(() -> {
+            try {
+                artifactTask.call();
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        });
+        callerThread.start();
+
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+        callerThread.interrupt();
+        callerThread.join(5000);
+
+        assertThat(thrown.get()).isNotNull();
+        assertThat(thrown.get()).isInstanceOf(InterruptedException.class);
     }
 
     @Test(timeout = 10000)

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -3,7 +3,6 @@ package org.icij.datashare.tasks;
 
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.LogbackCapturingRule;
 import org.icij.datashare.text.Document;
@@ -131,6 +130,34 @@ public class ArtifactTaskTest {
 
         Long processed = artifactTask.call();
         assertThat(processed).isEqualTo(2);
+    }
+
+    @Test(timeout = 10000, expected = IllegalStateException.class)
+    public void test_all_workers_dying_fails_the_task() throws Exception {
+        indexEmbeddedDoc();
+        String secondId = "1111111111111111111111111111111111111111111111111111111111111111";
+        mockIndexer.indexFile("prj", secondId,
+                Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).toURI()),
+                "message/rfc822");
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_DOC_SHA256);
+        queue.add(secondId);
+
+        PropertiesProvider props = new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1",
+                "parallelism", "2"));
+        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+            @Override
+            protected SourceExtractor createSourceExtractor() {
+                throw new IllegalStateException("no extractor");
+            }
+        };
+
+        artifactTask.call();
     }
 
     private void indexEmbeddedDoc() throws URISyntaxException {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -160,6 +160,76 @@ public class ArtifactTaskTest {
         artifactTask.call();
     }
 
+    @Test(timeout = 10000)
+    public void test_skip_counted_under_parallelism() throws Exception {
+        indexEmbeddedDoc();
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add("unknownId");
+        queue.add(EMBEDDED_DOC_SHA256);
+
+        Long numberOfDocuments = runArtifactTask(2);
+
+        assertThat(numberOfDocuments).isEqualTo(1);
+        assertThat(logback.logs(Level.WARN)).contains("document <unknownId> could not be retrieved from index prj (missing document or index fetch error), skipping");
+        assertThat(logback.logs(Level.ERROR)).contains("1 document(s) could not be retrieved from index prj and got no artifact cache, re-run the ARTIFACT stage for them");
+    }
+
+    @Test(timeout = 10000)
+    public void test_per_document_failure_is_non_fatal() throws Exception {
+        indexEmbeddedDoc();
+        String failingId = "2222222222222222222222222222222222222222222222222222222222222222";
+        mockIndexer.indexFile("prj", failingId,
+                Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).toURI()),
+                "message/rfc822");
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(failingId);
+        queue.add(EMBEDDED_DOC_SHA256);
+
+        PropertiesProvider props = new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1",
+                "parallelism", "2"));
+        ArtifactTask task = new ArtifactTask(factory, mockEs, props,
+                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null) {
+            @Override
+            protected SourceExtractor createSourceExtractor() {
+                return new SourceExtractor(props) {
+                    @Override
+                    public TikaDocument extractEmbeddedSources(Project project, Document document) throws org.apache.tika.exception.TikaException {
+                        if (document.getId().equals(failingId)) {
+                            throw new org.apache.tika.exception.TikaException("boom");
+                        }
+                        return null;
+                    }
+                };
+            }
+        };
+
+        Long numberOfDocuments = task.call();
+
+        assertThat(numberOfDocuments).isEqualTo(1);
+        assertThat(logback.logs(Level.ERROR)).contains("error in ArtifactTask loop");
+    }
+
+    @Test(timeout = 10000)
+    public void test_default_is_single_threaded_and_still_drains() throws Exception {
+        indexEmbeddedDoc();
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_DOC_SHA256);
+
+        // no "parallelism" key -> ArtifactTask resolves .orElse(1)
+        Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1")),
+                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                .call();
+
+        assertThat(numberOfDocuments).isEqualTo(1);
+        assertThat(artifactDir.getRoot().toPath().resolve("prj/6a/bb/6abb96950946b62bb993307c8945c0c096982783bab7fa24901522426840ca3e/raw").toFile()).isFile();
+    }
+
     private void indexEmbeddedDoc() throws URISyntaxException {
         indexEmbeddedDoc(EMBEDDED_DOC_SHA256);
     }
@@ -175,6 +245,16 @@ public class ArtifactTaskTest {
                 "defaultProject", "prj",
                 "pollingInterval", "1"
                 )),
+                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                .call();
+    }
+
+    private Long runArtifactTask(int parallelism) throws Exception {
+        return new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1",
+                "parallelism", String.valueOf(parallelism))),
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -264,6 +264,57 @@ public class ArtifactTaskTest {
     }
 
     @Test(timeout = 10000)
+    public void test_cancel_stops_an_in_flight_run() throws Exception {
+        indexEmbeddedDoc();
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_DOC_SHA256);
+
+        CountDownLatch started = new CountDownLatch(1);
+        PropertiesProvider props = new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1",
+                "parallelism", "1"));
+        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+            @Override
+            protected SourceExtractor createSourceExtractor() {
+                return new SourceExtractor(props) {
+                    @Override
+                    public TikaDocument extractEmbeddedSources(Project project, Document document) {
+                        started.countDown();
+                        try {
+                            Thread.sleep(10_000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return null;
+                    }
+                };
+            }
+        };
+
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread callerThread = new Thread(() -> {
+            try {
+                artifactTask.call();
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        });
+        callerThread.start();
+
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+        // cancel() must stop the worker pool and end the run, without interrupting this test thread
+        artifactTask.cancel(false);
+        callerThread.join(5000);
+
+        assertThat(callerThread.isAlive()).isFalse();
+        assertThat(thrown.get()).isInstanceOf(InterruptedException.class);
+    }
+
+    @Test(timeout = 10000)
     public void test_default_is_single_threaded_and_still_drains() throws Exception {
         indexEmbeddedDoc();
         DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -155,6 +156,45 @@ public class ArtifactTaskTest {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 throw new IllegalStateException("no extractor");
+            }
+        };
+
+        artifactTask.call();
+    }
+
+    @Test(timeout = 10000, expected = IllegalStateException.class)
+    public void test_a_single_worker_death_fails_the_task() throws Exception {
+        indexEmbeddedDoc();
+        String secondId = "1111111111111111111111111111111111111111111111111111111111111111";
+        mockIndexer.indexFile("prj", secondId,
+                Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).toURI()),
+                "message/rfc822");
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_DOC_SHA256);
+        queue.add(secondId);
+
+        PropertiesProvider props = new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "pollingInterval", "1",
+                "parallelism", "2"));
+        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+
+        // exactly one of the two workers fails to build its extractor and dies; the other survives.
+        // the task must still fail, independently of the parallelism.
+        AtomicInteger extractorCalls = new AtomicInteger(0);
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+            @Override
+            protected SourceExtractor createSourceExtractor() {
+                if (extractorCalls.getAndIncrement() == 0) {
+                    throw new IllegalStateException("one worker has no extractor");
+                }
+                return new SourceExtractor(props) {
+                    @Override
+                    public TikaDocument extractEmbeddedSources(Project project, Document document) {
+                        return null;
+                    }
+                };
             }
         };
 


### PR DESCRIPTION
The ARTIFACT stage drained its document queue on a single thread and ignored `--parallelism`, so a large pre-caching run (e.g. 50k documents) used one core while the rest of the box sat idle. This makes `ArtifactTask` drain the queue across a `--parallelism`-sized worker pool, matching how `IndexTask` and `ExtractNlpTask` already scale.

Behavior is unchanged for the on-demand path: `--parallelism` defaults to 1 when the option is absent (server/on-demand tasks), while CLI batch runs pick up the value passed on the command line.

## Changes

- feat: drain the ARTIFACT queue across a `--parallelism`-sized worker pool
- fix: fail loudly when every worker dies, instead of returning a partial count as success
- fix: propagate cancellation so an interrupted run is recorded as cancelled rather than successful
- refactor: clamp `--parallelism` to a minimum of 1 and hoist `sourceExcludes` to a shared constant

## Notes

- Reuses the existing `--parallelism` option; no new CLI flag.
- Worker threads are daemons so a wedged native OCR call cannot block JVM exit.
- Per-document extraction cost is unchanged (OCR-produced documents are still re-parsed with OCR); the win is running those extractions in parallel.