### PR TITLE
chore(log): drop more benign POI parser noise in PoiNoiseTurboFilter

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/log/PoiNoiseTurboFilter.java
+++ b/datashare-app/src/main/java/org/icij/datashare/log/PoiNoiseTurboFilter.java
@@ -8,9 +8,13 @@ import org.slf4j.Marker;
 
 /**
  * Drops benign, high-volume Apache POI parsing messages emitted for many legacy Office
- * files (WMF text metrics, PowerPoint text atoms and style runs). Message-targeted — like
- * extract's PdfBoxNoiseFilter — rather than logger-level, so genuine POI corruption
- * diagnostics keep flowing and nothing at ERROR is ever dropped.
+ * files (WMF text metrics, PowerPoint text atoms and style runs, Visio chunk offsets, Word
+ * paragraph tables, Outlook attachment chunks, HPSF code pages and spreadsheet number formats).
+ * Message-targeted (like extract's PdfBoxNoiseFilter) rather than logger-level, so genuine POI
+ * corruption diagnostics keep flowing and nothing at ERROR is ever dropped.
+ *
+ * <p>Each prefix matches the stable text before POI's first {@code {}} placeholder, so it works
+ * whether logback receives the raw pattern or the already-formatted message from the log4j bridge.
  */
 public class PoiNoiseTurboFilter extends TurboFilter {
     @Override
@@ -27,6 +31,18 @@ public class PoiNoiseTurboFilter extends TurboFilter {
             case "org.apache.poi.hslf.record.Record" ->
                     deny(format.startsWith("Problem reading paragraph style runs")
                             || format.startsWith("Problem reading character style runs"));
+            case "org.apache.poi.hdgf.chunks.Chunk" ->
+                    deny(format.startsWith("Command offset"));
+            case "org.apache.poi.hslf.model.textproperties.BitMaskTextProp" ->
+                    deny(format.startsWith("Style properties of"));
+            case "org.apache.poi.hwpf.model.PAPBinTable" ->
+                    deny(format.startsWith("Paragraph ["));
+            case "org.apache.poi.hsmf.datatypes.AttachmentChunks" ->
+                    deny(format.startsWith("Currently unsupported attachment chunk property"));
+            case "org.apache.poi.hpsf.CodePageString" ->
+                    deny(format.startsWith("CodePageString started at offset"));
+            case "org.apache.poi.ss.usermodel.DataFormatter" ->
+                    deny(format.startsWith("Formatting failed for format"));
             default -> FilterReply.NEUTRAL;
         };
     }

--- a/datashare-app/src/test/java/org/icij/datashare/log/PoiNoiseTurboFilterTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/log/PoiNoiseTurboFilterTest.java
@@ -31,6 +31,44 @@ public class PoiNoiseTurboFilterTest {
     }
 
     @Test
+    public void test_denies_hdgf_chunk_command_offset_noise() {
+        assertThat(decide("org.apache.poi.hdgf.chunks.Chunk", Level.WARN, "Command offset 4919 past end of data at 4919")).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void test_denies_bitmask_textprop_sanitized_noise() {
+        assertThat(decide("org.apache.poi.hslf.model.textproperties.BitMaskTextProp", Level.WARN, "Style properties of 'paragraph_flags' don't match mask - output will be sanitized")).isEqualTo(FilterReply.DENY);
+        assertThat(decide("org.apache.poi.hslf.model.textproperties.BitMaskTextProp", Level.WARN, "Style properties of 'char_flags' don't match mask - output will be sanitized")).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void test_denies_papbintable_no_papx_noise() {
+        assertThat(decide("org.apache.poi.hwpf.model.PAPBinTable", Level.WARN, "Paragraph [1234; 5678) has no PAPX. Creating new one.")).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void test_denies_attachment_chunks_unsupported_property_noise() {
+        assertThat(decide("org.apache.poi.hsmf.datatypes.AttachmentChunks", Level.WARN, "Currently unsupported attachment chunk property will be ignored. __properties_version1.0")).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void test_denies_codepagestring_not_null_terminated_noise() {
+        assertThat(decide("org.apache.poi.hpsf.CodePageString", Level.WARN, "CodePageString started at offset #12 is not NULL-terminated")).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void test_denies_dataformatter_formatting_failed_noise() {
+        assertThat(decide("org.apache.poi.ss.usermodel.DataFormatter", Level.WARN, "Formatting failed for format _-* #,##0_-;\\-* #,##0_-;_-* \"-\"??_-;_-@_-, falling back")).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    public void test_keeps_other_messages_of_newly_filtered_loggers() {
+        assertThat(decide("org.apache.poi.hdgf.chunks.Chunk", Level.WARN, "some other Visio chunk warning")).isEqualTo(FilterReply.NEUTRAL);
+        assertThat(decide("org.apache.poi.ss.usermodel.DataFormatter", Level.ERROR, "Formatting failed for format x, falling back")).isEqualTo(FilterReply.NEUTRAL);
+        assertThat(decide("org.apache.poi.hsmf.datatypes.AttachmentChunks", Level.WARN, "genuine attachment corruption")).isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    @Test
     public void test_keeps_other_messages_of_filtered_loggers() {
         assertThat(decide("org.apache.poi.hslf.record.Record", Level.WARN, "Warning: Skipping record of unknown type")).isEqualTo(FilterReply.NEUTRAL);
         assertThat(decide("org.apache.poi.hslf.usermodel.HSLFTextParagraph", Level.DEBUG, "some debug diagnostic")).isEqualTo(FilterReply.NEUTRAL);


### PR DESCRIPTION
Analysing a recent ARTIFACT run showed several high-volume but benign Apache POI parser warnings that the current `PoiNoiseTurboFilter` does not yet cover (tens of thousands of lines from legacy Office/Visio/Outlook files). These are message-targeted, matched on the stable prefix before POI's `{}` placeholder, so genuine POI corruption diagnostics keep flowing and nothing at ERROR is ever dropped.

- chore: drop `hdgf.chunks.Chunk` "Command offset ..." noise
- chore: drop `BitMaskTextProp` "Style properties of ..." noise
- chore: drop `hwpf.PAPBinTable` "Paragraph [...] has no PAPX" noise
- chore: drop `hsmf.AttachmentChunks` unsupported-property noise
- chore: drop `hpsf.CodePageString` "not NULL-terminated" noise
- chore: drop `ss.usermodel.DataFormatter` "Formatting failed for format ..." noise
- test: cover each new denied logger and confirm other messages / ERROR still pass through