### PR TITLE
feat(index): mark aborted container roots PARTIAL with indexed-child count

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/text/Document.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/Document.java
@@ -112,6 +112,10 @@ public class Document implements Entity, DocumentMetadataConstants {
     private final Integer pstExpected;
     private final Integer pstEmitted;
     private final Integer pstUnrecovered;
+    // Number of embedded children actually indexed under this container root. Set on a root when the
+    // streaming parse aborted mid-way (with recoveryStatus PARTIAL) so it is visible how much of the
+    // container was recovered; null on non-container documents.
+    private final Integer nbChildrenEmitted;
 
     @JsonDeserialize(using = CharsetDeserializer.class)
     private final Charset contentEncoding;
@@ -128,18 +132,19 @@ public class Document implements Entity, DocumentMetadataConstants {
 
 
     Document(Project project, String id, Path filePath, String content, Language language, Charset charset, String mimetype, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags, Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel, Long contentLength) {
-        this(project, id, filePath, content, null, language, extractionDate, charset, mimetype, extractionLevel, metadata, status, nerTags, parentDocument, rootDocument, contentLength, new HashSet<>(), null, null, null, null, null);
+        this(project, id, filePath, content, null, language, extractionDate, charset, mimetype, extractionLevel, metadata, status, nerTags, parentDocument, rootDocument, contentLength, new HashSet<>(), null, null, null, null, null, null);
     }
 
     Document(Project project, String id, Path filePath, String content, List<Map<String,String>> content_translated, Language language, Charset charset,
                     String contentType, Map<String, Object> metadata, Status status, Set<Pipeline.Type> nerTags,
                     Date extractionDate, String parentDocument, String rootDocument, Short extractionLevel,
                     Long contentLength, Set<Tag> tags, ContentTypeCategory contentTypeCategory,
-                    RecoveryStatus recoveryStatus, Integer pstExpected, Integer pstEmitted, Integer pstUnrecovered) {
+                    RecoveryStatus recoveryStatus, Integer pstExpected, Integer pstEmitted, Integer pstUnrecovered,
+                    Integer nbChildrenEmitted) {
         this(project, id, filePath, content, content_translated, language, extractionDate, charset,
                 contentType, extractionLevel, metadata, status, nerTags,
                 parentDocument, rootDocument, contentLength,
-                tags, contentTypeCategory, recoveryStatus, pstExpected, pstEmitted, pstUnrecovered);
+                tags, contentTypeCategory, recoveryStatus, pstExpected, pstEmitted, pstUnrecovered, nbChildrenEmitted);
     }
 
     @JsonCreator
@@ -160,7 +165,8 @@ public class Document implements Entity, DocumentMetadataConstants {
                      @JsonProperty("recoveryStatus") RecoveryStatus recoveryStatus,
                      @JsonProperty("pstExpected") Integer pstExpected,
                      @JsonProperty("pstEmitted") Integer pstEmitted,
-                     @JsonProperty("pstUnrecovered") Integer pstUnrecovered
+                     @JsonProperty("pstUnrecovered") Integer pstUnrecovered,
+                     @JsonProperty("nbChildrenEmitted") Integer nbChildrenEmitted
     ) {
         this.id = id;
         this.project = project;
@@ -185,6 +191,7 @@ public class Document implements Entity, DocumentMetadataConstants {
         this.pstExpected = pstExpected;
         this.pstEmitted = pstEmitted;
         this.pstUnrecovered = pstUnrecovered;
+        this.nbChildrenEmitted = nbChildrenEmitted;
     }
 
     static String getHash(Project project, Path path) {
@@ -215,6 +222,8 @@ public class Document implements Entity, DocumentMetadataConstants {
     public Integer getPstEmitted() { return pstEmitted; }
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Integer getPstUnrecovered() { return pstUnrecovered; }
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getNbChildrenEmitted() { return nbChildrenEmitted; }
     public String getContentTypeOrDefault() { return ofNullable(getContentType()).orElse(DEFAULT_VALUE_UNKNOWN); }
     public Language getLanguage() { return language; }
     public short getExtractionLevel() { return extractionLevel;}

--- a/datashare-api/src/main/java/org/icij/datashare/text/DocumentBuilder.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/DocumentBuilder.java
@@ -34,6 +34,7 @@ public class DocumentBuilder {
     private Integer pstExpected = null;
     private Integer pstEmitted = null;
     private Integer pstUnrecovered = null;
+    private Integer nbChildrenEmitted = null;
 
     private DocumentBuilder() {}
     public static DocumentBuilder createDoc() {
@@ -69,7 +70,8 @@ public class DocumentBuilder {
                 .withTags(doc.getTags())
                 .with(doc.getContentTypeCategory())
                 .with(doc.getRecoveryStatus())
-                .withPstCounts(doc.getPstExpected(), doc.getPstEmitted(), doc.getPstUnrecovered());
+                .withPstCounts(doc.getPstExpected(), doc.getPstEmitted(), doc.getPstUnrecovered())
+                .withNbChildrenEmitted(doc.getNbChildrenEmitted());
     }
 
     public DocumentBuilder withDefaultValues(String id){
@@ -199,6 +201,11 @@ public class DocumentBuilder {
         return this;
     }
 
+    public DocumentBuilder withNbChildrenEmitted(Integer nbChildrenEmitted) {
+        this.nbChildrenEmitted = nbChildrenEmitted;
+        return this;
+    }
+
     public Document build() {
         if(id == null && project == null && path == null && content == null){
             throw new NullPointerException("Id, Project, Path or content are missing.");
@@ -206,7 +213,8 @@ public class DocumentBuilder {
         return new Document(project, id, path, content, content_translated, language,
                 charset, contentType, metadata, documentStatus,
                 pipelines, extractionDate, parentId, rootId, extractionLevel,
-                contentLength, tags, contentTypeCategory, recoveryStatus, pstExpected, pstEmitted, pstUnrecovered);
+                contentLength, tags, contentTypeCategory, recoveryStatus, pstExpected, pstEmitted, pstUnrecovered,
+                nbChildrenEmitted);
     }
 
 }

--- a/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
@@ -43,6 +43,10 @@ public interface Indexer extends Closeable {
     <T extends Entity> boolean bulkUpdate(String indexName, List<T> entities) throws IOException;
     <T extends Entity> void add(String indexName, T obj) throws IOException;
     <T extends Entity> void update(String indexName, T obj) throws IOException;
+    // Partial (doc-merge) update of specific fields on an existing document, leaving all other fields
+    // untouched. Unlike update(indexName, T obj), which serializes the whole entity (and would reset
+    // unset fields to their defaults), this merges only the supplied fields.
+    void update(String indexName, String id, Map<String, Object> fields) throws IOException;
 
     boolean exists(String indexName) throws IOException;
     boolean exists(String indexName, String id) throws IOException;

--- a/datashare-api/src/test/java/org/icij/datashare/text/DocumentBuilderTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/DocumentBuilderTest.java
@@ -14,6 +14,15 @@ import org.junit.Test;
 
 public class DocumentBuilderTest {
     @Test
+    public void test_nb_children_emitted_round_trips() {
+        assertThat(DocumentBuilder.createDoc("id").withNbChildrenEmitted(42).build().getNbChildrenEmitted()).isEqualTo(42);
+        assertThat(DocumentBuilder.createDoc("id").build().getNbChildrenEmitted()).isNull();
+        // from() preserves it (index read-back path)
+        Document src = DocumentBuilder.createDoc("id").withNbChildrenEmitted(7).build();
+        assertThat(DocumentBuilder.from(src).build().getNbChildrenEmitted()).isEqualTo(7);
+    }
+
+    @Test
     public void test_build() {
         // Given
         String docId = "someId";
@@ -114,6 +123,7 @@ public class DocumentBuilderTest {
                 .with(contentTypeCategory)
                 .with(recoveryStatus)
                 .withPstCounts(5, 5, 0)
+                .withNbChildrenEmitted(5)
                 .withOcrParser(ocrParser).build();
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -191,6 +191,16 @@ public class ElasticsearchIndexer implements Indexer {
     }
 
     @Override
+    public void update(String indexName, String id, Map<String, Object> fields) throws IOException {
+        UpdateRequest.Builder<Map<String, Object>, Object> req = new UpdateRequest.Builder<Map<String, Object>, Object>()
+                .index(indexName)
+                .id(id)
+                .refresh(esCfg.refreshPolicy)
+                .doc(fields);
+        client.update(req.build(), Object.class);
+    }
+
+    @Override
     public boolean exists(String indexName) throws IOException {
         co.elastic.clients.elasticsearch.indices.ExistsRequest request =
                 new co.elastic.clients.elasticsearch.indices.ExistsRequest.Builder()

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -159,14 +159,23 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         if (root.isDuplicate()) {
             return;
         }
+        // Never clobber an already-indexed root: a prior successful run may have indexed this container
+        // fully (content, search text, its real recovery status), and overwriting it with a contentless
+        // PARTIAL stub would be data loss. If the root already exists, its children are not orphaned, so
+        // there is nothing to do. (A stub left by an earlier aborted run is likewise kept as-is.)
+        if (isDuplicate(root.getId())) {
+            logger.debug("aborted parse: root {} already indexed, keeping it; not writing PARTIAL stub", shorten(root.getId(), 4));
+            return;
+        }
         String contentType = ofNullable(root.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN).split(";")[0];
         Document document = DocumentBuilder.createDoc(root.getId())
                 .with(root.getPath())
                 .with(Document.Status.INDEXED)
                 .with(getMetadata(root))
+                .with("") // contentless: the parse aborted, no body text was extracted for the root
                 .ofContentType(contentType)
                 .with(ContentTypeCategory.fromContentType(contentType))
-                .withContentLength(Long.parseLong(ofNullable(root.getMetadata().get(CONTENT_LENGTH)).orElse("-1")))
+                .withContentLength(parseContentLength(root))
                 .withExtractionLevel((short) 0)
                 .with(Document.RecoveryStatus.PARTIAL)
                 .withNbChildrenEmitted((int) Math.min(writtenChildren, Integer.MAX_VALUE))
@@ -174,6 +183,16 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         indexer.add(indexName, document);
         logger.warn("aborted parse: wrote PARTIAL root stub {} with {} indexed child(ren): {}",
                 shorten(root.getId(), 4), writtenChildren, root);
+    }
+
+    // Defensive parse: a non-numeric Content-Length must not abort the stub write (that would leave the
+    // already-indexed children orphaned, which is exactly what the stub prevents). Unknown length -> -1.
+    private static long parseContentLength(TikaDocument document) {
+        try {
+            return Long.parseLong(ofNullable(document.getMetadata().get(CONTENT_LENGTH)).orElse("-1"));
+        } catch (NumberFormatException e) {
+            return -1L;
+        }
     }
 
     private boolean isDuplicate(String docId) throws IOException {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -24,6 +24,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
 import static java.lang.System.currentTimeMillis;
+import java.util.HashMap;
+import java.util.Map;
+
 import static java.util.Optional.ofNullable;
 import static org.apache.tika.metadata.HttpHeaders.*;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
@@ -182,6 +185,24 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
                 .build();
         indexer.add(indexName, document);
         logger.warn("aborted parse: wrote PARTIAL root stub {} with {} indexed child(ren): {}",
+                shorten(root.getId(), 4), writtenChildren, root);
+    }
+
+    @Override
+    public void finalizeRoot(TikaDocument root, long writtenChildren) throws IOException {
+        // The container parsed to completion; its root was already indexed with content during the parse.
+        // Now that the child count is final, record it and (for non-PST containers) mark the root
+        // complete. A partial update preserves the already-indexed content/language/status. PST roots
+        // already carry their COMPLETE/PARTIAL/LOSSY rollup from the initial write (applyParentRollup),
+        // so their recoveryStatus is left untouched here.
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("nbChildrenEmitted", (int) Math.min(writtenChildren, Integer.MAX_VALUE));
+        boolean isPstRoot = root.getMetadata().get(PST_EXPECTED) != null || root.getMetadata().get(PST_EMITTED) != null;
+        if (!isPstRoot) {
+            fields.put("recoveryStatus", Document.RecoveryStatus.COMPLETE.toString());
+        }
+        indexer.update(indexName, root.getId(), fields);
+        logger.info("finalized container root {} as complete with {} indexed child(ren): {}",
                 shorten(root.getId(), 4), writtenChildren, root);
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -148,6 +148,34 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
                 shorten(doc.getId(), 4), currentTimeMillis() - before, doc);
     }
 
+    @Override
+    public void writeRootStub(TikaDocument root, long writtenChildren) throws IOException {
+        // The streaming parse aborted (timeout/cancel/OOM) after some embedded children had already
+        // been indexed, but before the real root was written. Index a minimal, contentless root so
+        // those children are not orphaned under a missing root; mark it PARTIAL and record how many
+        // children were indexed. A later re-run of the ARTIFACT/INDEX stage replaces this stub with
+        // the fully-parsed root. No content is read here: the parse is gone and its reader/temp files
+        // may already be torn down.
+        if (root.isDuplicate()) {
+            return;
+        }
+        String contentType = ofNullable(root.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN).split(";")[0];
+        Document document = DocumentBuilder.createDoc(root.getId())
+                .with(root.getPath())
+                .with(Document.Status.INDEXED)
+                .with(getMetadata(root))
+                .ofContentType(contentType)
+                .with(ContentTypeCategory.fromContentType(contentType))
+                .withContentLength(Long.parseLong(ofNullable(root.getMetadata().get(CONTENT_LENGTH)).orElse("-1")))
+                .withExtractionLevel((short) 0)
+                .with(Document.RecoveryStatus.PARTIAL)
+                .withNbChildrenEmitted((int) Math.min(writtenChildren, Integer.MAX_VALUE))
+                .build();
+        indexer.add(indexName, document);
+        logger.warn("aborted parse: wrote PARTIAL root stub {} with {} indexed child(ren): {}",
+                shorten(root.getId(), 4), writtenChildren, root);
+    }
+
     private boolean isDuplicate(String docId) throws IOException {
         return indexer.exists(indexName, docId);
     }

--- a/datashare-index/src/main/resources/datashare_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_index_mappings.json
@@ -97,6 +97,7 @@
     "pstExpected": { "type": "integer" },
     "pstEmitted": { "type": "integer" },
     "pstUnrecovered": { "type": "integer" },
+    "nbChildrenEmitted": { "type": "integer" },
     "nerTags": {
       "type": "keyword"
     },

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -78,6 +78,22 @@ public class ElasticsearchSpewerTest {
     }
 
     @Test
+    public void test_write_root_stub_marks_partial_with_child_count() throws Exception {
+        // A streaming parse aborted after some children were indexed but before the root was written.
+        // The stub must index a contentless root marked PARTIAL, recording how many children got in.
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("aborted-container.ost"));
+
+        spewer.writeRootStub(root, 55363L);
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(root.getId()), ObjectNode.class);
+        assertThat(documentFields.found()).isTrue();
+        Map<String, Object> source = nodeToMap(documentFields.source());
+        assertThat(source.get("recoveryStatus")).isEqualTo("PARTIAL");
+        assertThat(((Number) source.get("nbChildrenEmitted")).intValue()).isEqualTo(55363);
+        assertThat(((Map<?, ?>) source.get("join")).get("name")).isEqualTo("Document");
+    }
+
+    @Test
     public void test_write_with_correct_iso1_language() throws Exception {
         Path path = get(requireNonNull(getClass().getResource("/docs/a/b/c/zho.txt")).getPath());
         DocumentFactory documentFactory = new DocumentFactory().configure(Options.from(new HashMap<>() {{

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -91,6 +91,39 @@ public class ElasticsearchSpewerTest {
         assertThat(source.get("recoveryStatus")).isEqualTo("PARTIAL");
         assertThat(((Number) source.get("nbChildrenEmitted")).intValue()).isEqualTo(55363);
         assertThat(((Map<?, ?>) source.get("join")).get("name")).isEqualTo("Document");
+        // Contentless: the stub must not carry the document hash (createDoc's default) as its body text.
+        assertThat(source.get("content")).isEqualTo("");
+    }
+
+    @Test
+    public void test_write_root_stub_does_not_overwrite_an_already_indexed_root() throws Exception {
+        // A prior run indexed this container fully (content + real status).
+        final TikaDocument existing = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("prior-complete.ost"));
+        existing.setReader(new ParsingReader(new ByteArrayInputStream("real container body text".getBytes())));
+        spewer.write(existing);
+
+        // A later re-run's streaming parse aborts before the root is written, for the same id.
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("prior-complete.ost"));
+        spewer.writeRootStub(root, 99L);
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(root.getId()), ObjectNode.class);
+        Map<String, Object> source = nodeToMap(documentFields.source());
+        // The complete root is preserved: not clobbered by a contentless PARTIAL stub.
+        assertThat((String) source.get("content")).contains("real container body text");
+        assertThat(source.get("recoveryStatus")).isNull();
+        assertThat(source.get("nbChildrenEmitted")).isNull();
+    }
+
+    @Test
+    public void test_write_root_stub_tolerates_non_numeric_content_length() throws Exception {
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("weird-length.ost"));
+        root.getMetadata().set("Content-Length", "not-a-number");
+
+        spewer.writeRootStub(root, 3L); // must not throw and orphan the children
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(root.getId()), ObjectNode.class);
+        assertThat(documentFields.found()).isTrue();
+        assertThat(nodeToMap(documentFields.source()).get("recoveryStatus")).isEqualTo("PARTIAL");
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -127,6 +127,41 @@ public class ElasticsearchSpewerTest {
     }
 
     @Test
+    public void test_finalize_root_marks_complete_with_child_count_preserving_content() throws Exception {
+        // A container parsed to completion: its root was indexed with content during the parse.
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("finished-container.zip"));
+        root.setReader(new ParsingReader(new ByteArrayInputStream("container listing body text".getBytes())));
+        spewer.write(root);
+
+        spewer.finalizeRoot(root, 128004L);
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(root.getId()), ObjectNode.class);
+        Map<String, Object> source = nodeToMap(documentFields.source());
+        assertThat(source.get("recoveryStatus")).isEqualTo("COMPLETE");
+        assertThat(((Number) source.get("nbChildrenEmitted")).intValue()).isEqualTo(128004);
+        // The partial update must preserve the content already indexed by the normal root write.
+        assertThat((String) source.get("content")).contains("container listing body text");
+    }
+
+    @Test
+    public void test_finalize_root_does_not_override_pst_recovery_status() throws Exception {
+        // A PST/OST root already carries its message-loss rollup (LOSSY here) from the initial write;
+        // finalize must record the child count without clobbering that status.
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("mailbox.ost"));
+        root.getMetadata().set("tika:pst_expected", "10");
+        root.getMetadata().set("tika:pst_emitted", "5"); // expected > emitted -> LOSSY rollup on write
+        root.setReader(new ParsingReader(new ByteArrayInputStream("mailbox".getBytes())));
+        spewer.write(root);
+
+        spewer.finalizeRoot(root, 5L);
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(root.getId()), ObjectNode.class);
+        Map<String, Object> source = nodeToMap(documentFields.source());
+        assertThat(source.get("recoveryStatus")).isEqualTo("LOSSY");
+        assertThat(((Number) source.get("nbChildrenEmitted")).intValue()).isEqualTo(5);
+    }
+
+    @Test
     public void test_write_with_correct_iso1_language() throws Exception {
         Path path = get(requireNonNull(getClass().getResource("/docs/a/b/c/zho.txt")).getPath());
         DocumentFactory documentFactory = new DocumentFactory().configure(Options.from(new HashMap<>() {{

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.15.1</extract.version>
+        <extract.version>9.15.2</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.14.0</extract.version>
+        <extract.version>9.15.1</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>


### PR DESCRIPTION
Builds on the extract 9.15.1 streaming fixes. When a streaming parse aborts (parse-timeout, cancellation, OOM) after some embedded children were already indexed but before the container root was written, extract's StreamingSpewCoordinator now calls back with the number of children written. This wires that into the index so those children are no longer orphaned under a missing root: a minimal, contentless root is indexed, marked PARTIAL, recording how many children were recovered. A later re-run of the stage replaces the stub with the fully-parsed root.

- chore: bump extract-lib to 9.15.1 (streaming embed-retention, cancellation, and root-stub fixes)
- feat: add nbChildrenEmitted (integer) to Document + DocumentBuilder + index mapping
- feat: override ElasticsearchSpewer.writeRootStub to index a contentless root with recoveryStatus=PARTIAL and nbChildrenEmitted=<children indexed>
- test: writeRootStub indexes a PARTIAL root with the child count; builder round-trips the field

Follow-up (needs a further extract change): also stamp COMPLETE + nbChildrenEmitted on normally-finished container roots (uniform). The finished-root total-descendant count is only known after the spew worker drains, which is after the root is written today, so it requires a post-drain finalize in extract's coordinator. Finished PST roots already get COMPLETE via the existing parent rollup.