### PR TITLE
feat(cli): add first-class --parseTimeout option

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.time.format.DateTimeParseException;
 import org.icij.time.HumanDuration;
 
 import static java.lang.Math.max;
@@ -133,12 +132,13 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
                     logger.warn("parseTimeout is set to {}: the parse timeout is DISABLED. " +
                             "A pathological document can hang a worker indefinitely.", value);
                 }
-            } catch (DateTimeParseException e) {
-                // Leave duration validation to the extractor; do not fail task construction here.
+            } catch (RuntimeException e) {
+                // Any parse failure (DateTimeParseException, NumberFormatException, ...) is intentionally
+                // ignored here: this is a diagnostic-only check and must never fail task construction.
+                // Leave duration validation to the extractor.
             }
         });
     }
-
 
     @Override
     public double getProgressRate() {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -29,6 +29,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import org.icij.time.HumanDuration;
 
 import static java.lang.Math.max;
 import static java.lang.String.valueOf;
@@ -62,6 +65,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         super(Stage.INDEX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
         parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(Runtime.getRuntime().availableProcessors());
         indexTimeout = getIndexTimeout();
+        warnIfParseTimeoutDisabled();
 
         Options<String> allTaskOptions = options().createFrom(Options.from(taskView.args));
         ((ElasticsearchSpewer) spewer.configure(allTaskOptions)).createIndexIfNotExists();
@@ -119,6 +123,20 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
      */
     private int getIndexTimeout() {
         return Integer.parseInt(propertiesProvider.get(INDEX_TIMEOUT_OPT).orElse(valueOf(DEFAULT_INDEX_TIMEOUT)));
+    }
+
+    private void warnIfParseTimeoutDisabled() {
+        propertiesProvider.get(PARSE_TIMEOUT_OPT).ifPresent(value -> {
+            try {
+                Duration parseTimeout = HumanDuration.parse(value);
+                if (parseTimeout.isZero() || parseTimeout.isNegative()) {
+                    logger.warn("parseTimeout is set to {}: the parse timeout is DISABLED. " +
+                            "A pathological document can hang a worker indefinitely.", value);
+                }
+            } catch (DateTimeParseException e) {
+                // Leave duration validation to the extractor; do not fail task construction here.
+            }
+        });
     }
 
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -10,6 +10,7 @@ import org.icij.extract.extractor.Extractor;
 import org.icij.task.Option;
 import org.icij.task.Options;
 import org.icij.task.StringOptionParser;
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class IndexTaskTest {
+    private final LogbackAppenderWrapper logWrapper = new LogbackAppenderWrapper();
 
     @Test
     public void test_options_include_ocr() throws Exception {
@@ -151,7 +153,6 @@ public class IndexTaskTest {
 
     @Test
     public void test_warns_when_parse_timeout_disabled() throws Exception {
-        LogbackAppenderWrapper logWrapper = new LogbackAppenderWrapper();
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
@@ -165,7 +166,6 @@ public class IndexTaskTest {
 
     @Test
     public void test_does_not_warn_when_parse_timeout_enabled() throws Exception {
-        LogbackAppenderWrapper logWrapper = new LogbackAppenderWrapper();
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
@@ -175,5 +175,10 @@ public class IndexTaskTest {
 
         assertThat(logWrapper.logs(Level.WARN).stream()
                 .anyMatch(l -> l.contains("parseTimeout"))).isFalse();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        logWrapper.reset();
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.tasks;
 import org.apache.tika.parser.pdf.PDFParserConfig;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.extract.DocumentCollectionFactory;
+import org.icij.datashare.test.LogbackAppenderWrapper;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSpewer;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.Extractor;
@@ -12,11 +13,13 @@ import org.icij.task.StringOptionParser;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.slf4j.event.Level;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.cli.DatashareCliOptions.PARSE_TIMEOUT_OPT;
 import static org.icij.datashare.user.User.nullUser;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -129,5 +132,48 @@ public class IndexTaskTest {
         Extractor extractor = new Extractor(documentFactory, bound);
 
         assertThat(extractor.getMaxEmbedDepth()).isEqualTo(3);
+    }
+
+    @Test
+    public void test_parse_timeout_value_reaches_extractor_options() throws Exception {
+        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
+        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
+
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+                new Task<>(IndexTask.class.getName(), nullUser(),
+                        Map.of(PARSE_TIMEOUT_OPT, "48h", "queueName", "test:queue")), null);
+
+        ArgumentCaptor<Options> captor = ArgumentCaptor.forClass(Options.class);
+        verify(spewer).configure(captor.capture());
+        Option<String> option = new Option<>(PARSE_TIMEOUT_OPT, StringOptionParser::new).update("48h");
+        assertThat(captor.getValue()).contains(option);
+    }
+
+    @Test
+    public void test_warns_when_parse_timeout_disabled() throws Exception {
+        LogbackAppenderWrapper logWrapper = new LogbackAppenderWrapper();
+        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
+        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
+
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+                new Task<>(IndexTask.class.getName(), nullUser(),
+                        Map.of(PARSE_TIMEOUT_OPT, "0", "queueName", "test:queue")), null);
+
+        assertThat(logWrapper.logs(Level.WARN).stream()
+                .anyMatch(l -> l.contains("parseTimeout") && l.contains("DISABLED"))).isTrue();
+    }
+
+    @Test
+    public void test_does_not_warn_when_parse_timeout_enabled() throws Exception {
+        LogbackAppenderWrapper logWrapper = new LogbackAppenderWrapper();
+        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
+        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
+
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+                new Task<>(IndexTask.class.getName(), nullUser(),
+                        Map.of(PARSE_TIMEOUT_OPT, "48h", "queueName", "test:queue")), null);
+
+        assertThat(logWrapper.logs(Level.WARN).stream()
+                .anyMatch(l -> l.contains("parseTimeout"))).isFalse();
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -130,6 +130,7 @@ public class DatashareCli {
         DatashareCliOptions.ocrType(parser);
         DatashareCliOptions.ocrStrategy(parser);
         DatashareCliOptions.ocrTimeout(parser);
+        DatashareCliOptions.parseTimeout(parser);
         DatashareCliOptions.maxEmbedDepth(parser);
         DatashareCliOptions.nlpPipeline(parser);
         DatashareCliOptions.nlpMaxTextLength(parser);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -115,6 +115,7 @@ public final class DatashareCliOptions {
     public static final String PARALLELISM_OPT = "parallelism";
     public static final String PARSER_PARALLELISM_ABBR_OPT = "pp";
     public static final String PARSER_PARALLELISM_OPT = "parserParallelism";
+    public static final String PARSE_TIMEOUT_OPT = "parseTimeout";
     public static final String PLUGIN_DELETE_OPT = "pluginDelete";
     public static final String PLUGIN_INSTALL_OPT = "pluginInstall";
     public static final String PLUGIN_LIST_OPT = "pluginList";
@@ -250,6 +251,7 @@ public final class DatashareCliOptions {
     public static final boolean DEFAULT_NO_DIGEST_PROJECT = false;
     public static final boolean DEFAULT_OCR = true;
     public static final String DEFAULT_OCR_TIMEOUT = "12h";
+    public static final String DEFAULT_PARSE_TIMEOUT = "24h";
     public static final int DEFAULT_MAX_EMBED_DEPTH = 20;
     public static final int DEFAULT_BATCH_DOWNLOAD_MAX_NB_FILES = 10000;
     public static final int DEFAULT_BATCH_DOWNLOAD_ZIP_TTL = 24;
@@ -759,6 +761,15 @@ public final class DatashareCliOptions {
             .withRequiredArg()
             .ofType(String.class)
             .defaultsTo(DEFAULT_OCR_TIMEOUT);
+    }
+
+    static void parseTimeout(OptionParser parser) {
+        parser.acceptsAll(List.of(PARSE_TIMEOUT_OPT),
+                "Wall-clock timeout for a single document's parse and output, e.g. \"30m\" or \"24h\". " +
+                        "Set to 0 to disable. Defaults to 24h.")
+            .withRequiredArg()
+            .ofType(String.class)
+            .defaultsTo(DEFAULT_PARSE_TIMEOUT);
     }
 
     static void ocrStrategy(OptionParser parser) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -43,6 +43,9 @@ public class PipelineOptions {
     @Option(names = {"--ocrTimeout"}, description = "OCR timeout", defaultValue = DEFAULT_OCR_TIMEOUT)
     String ocrTimeout;
 
+    @Option(names = {"--parseTimeout"}, description = "Wall-clock timeout for a single document's parse and output, e.g. \"30m\" or \"24h\". Set to 0 to disable. Defaults to 24h.", defaultValue = DEFAULT_PARSE_TIMEOUT)
+    String parseTimeout;
+
     // No defaultValue on purpose: when unset the field stays null and putIfNotNull omits the key,
     // so extract applies its own NO_OCR default. A default here would emit the key for every run
     // and silently change OCR behavior for all users.
@@ -108,6 +111,7 @@ public class PipelineOptions {
         DatashareOptions.putIfNotNull(props, CREATE_INDEX_OPT, createIndex);
         DatashareOptions.put(props, INDEX_TIMEOUT_OPT, indexTimeout);
         DatashareOptions.put(props, OCR_TIMEOUT, ocrTimeout);
+        DatashareOptions.put(props, PARSE_TIMEOUT_OPT, parseTimeout);
         DatashareOptions.putIfNotNull(props, SEARCH_QUERY_OPT, searchQuery);
         DatashareOptions.putIfNotNull(props, SCROLL_DURATION_OPT, scroll);
         DatashareOptions.put(props, SCROLL_SIZE_OPT, scrollSize);

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -331,4 +331,16 @@ public class DatashareCliTest {
         cli.parseArguments(new String[] {""});
         assertThat(cli.properties).includes(entry("maxEmbedDepth", "20"));
     }
+
+    @Test
+    public void test_parse_timeout_opt() {
+        cli.parseArguments(new String[] {"--parseTimeout", "48h"});
+        assertThat(cli.properties).includes(entry("parseTimeout", "48h"));
+    }
+
+    @Test
+    public void test_parse_timeout_opt_defaults_to_24h() {
+        cli.parseArguments(new String[] {""});
+        assertThat(cli.properties).includes(entry("parseTimeout", "24h"));
+    }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
@@ -113,4 +113,16 @@ public class StageRunCommandTest extends AbstractDatashareCommandTest {
         Properties props = parse("stage", "run", "--stages", "SCAN,INDEX");
         assertThat(props).includes(entry("maxContentLength", "20000000"));
     }
+
+    @Test
+    public void test_stage_run_parse_timeout() {
+        Properties props = parse("stage", "run", "--stages", "SCAN,INDEX", "--parseTimeout", "48h");
+        assertThat(props).includes(entry("parseTimeout", "48h"));
+    }
+
+    @Test
+    public void test_stage_run_parse_timeout_defaults_to_24h() {
+        Properties props = parse("stage", "run", "--stages", "SCAN,INDEX");
+        assertThat(props).includes(entry("parseTimeout", "24h"));
+    }
 }


### PR DESCRIPTION
Promotes the extractor's `parseTimeout` (wall-clock timeout for parsing a single document) to a first-class CLI flag. Indexing a genuinely huge OST/PST can legitimately outlast the default 24h timeout, after which the parse is cancelled and the document is only partially indexed. Operators previously could only raise or disable it through the `-s`/`--settings` properties file; now it is a real flag on both CLI surfaces, mirroring the existing `ocrTimeout` option.

## Changes

- feat(cli): add first-class `--parseTimeout` option to the JOpt parser (`DatashareCliOptions`/`DatashareCli`), defaulting to `24h`
- feat(cli): add `--parseTimeout` to the picocli pipeline options (`stage run` / server mode)
- feat(index): warn at startup when the resolved `parseTimeout` is `0`/disabled (no safety cap: a pathological document can hang a worker indefinitely)
- fix(index): keep the disabled-check diagnostic-only so it never aborts index task construction; the extractor remains the sole validator of the value (parity with `ocrTimeout`)
- test: cover flag parsing on both surfaces, value propagation into the `Extractor`, and the warn-on-0 behavior

## Notes

- Value is an unvalidated duration string (e.g. `48h`, `30m`, `0` to disable), exactly like `ocrTimeout`; garbage is rejected by the extractor at task construction, same as the sibling option.
- Behavior change for existing settings-file users: because the flag defaults to `24h` and CLI properties override the `-s` settings file, a CLI run without `--parseTimeout` now applies `24h` even if the settings file set a different `parseTimeout`. Operators relying on a settings-file value should move it to the flag.
- datashare-side only; extract-lib (>= 9.15.2) is unchanged.
