### PR TITLE
feat(index): root-stub-first, make the container root visible during a long parse

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -152,7 +152,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
     }
 
     @Override
-    public void writeRootStub(TikaDocument root, long writtenChildren) throws IOException {
+    public boolean writeRootStub(TikaDocument root, long writtenChildren) throws IOException {
         // The streaming parse aborted (timeout/cancel/OOM) after some embedded children had already
         // been indexed, but before the real root was written. Index a minimal, contentless root so
         // those children are not orphaned under a missing root; mark it PARTIAL and record how many
@@ -160,7 +160,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         // the fully-parsed root. No content is read here: the parse is gone and its reader/temp files
         // may already be torn down.
         if (root.isDuplicate()) {
-            return;
+            return false;
         }
         // Never clobber an already-indexed root: a prior successful run may have indexed this container
         // fully (content, search text, its real recovery status), and overwriting it with a contentless
@@ -168,7 +168,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         // there is nothing to do. (A stub left by an earlier aborted run is likewise kept as-is.)
         if (isDuplicate(root.getId())) {
             logger.debug("aborted parse: root {} already indexed, keeping it; not writing PARTIAL stub", shorten(root.getId(), 4));
-            return;
+            return false;
         }
         String contentType = ofNullable(root.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN).split(";")[0];
         Document document = DocumentBuilder.createDoc(root.getId())
@@ -186,6 +186,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         indexer.add(indexName, document);
         logger.warn("aborted parse: wrote PARTIAL root stub {} with {} indexed child(ren): {}",
                 shorten(root.getId(), 4), writtenChildren, root);
+        return true;
     }
 
     @Override
@@ -203,6 +204,19 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         }
         indexer.update(indexName, root.getId(), fields);
         logger.info("finalized container root {} as complete with {} indexed child(ren): {}",
+                shorten(root.getId(), 4), writtenChildren, root);
+    }
+
+    @Override
+    public void finalizeAbortedRoot(TikaDocument root, long writtenChildren) throws IOException {
+        // The parse aborted after the early stub was written but before the real root write. Refresh the
+        // child count on the still-PARTIAL stub via a partial update, WITHOUT touching recoveryStatus, so
+        // the root stays PARTIAL (the container was not fully processed). A later re-run replaces the stub
+        // with the fully-parsed root.
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("nbChildrenEmitted", (int) Math.min(writtenChildren, Integer.MAX_VALUE));
+        indexer.update(indexName, root.getId(), fields);
+        logger.warn("aborted parse: refreshed PARTIAL root stub {} child count to {}: {}",
                 shorten(root.getId(), 4), writtenChildren, root);
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -170,7 +170,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
             logger.debug("aborted parse: root {} already indexed, keeping it; not writing PARTIAL stub", shorten(root.getId(), 4));
             return false;
         }
-        String contentType = ofNullable(root.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN).split(";")[0];
+        String contentType = baseContentType(ofNullable(root.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN));
         Document document = DocumentBuilder.createDoc(root.getId())
                 .with(root.getPath())
                 .with(Document.Status.INDEXED)
@@ -196,13 +196,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         // complete. A partial update preserves the already-indexed content/language/status. PST roots
         // already carry their COMPLETE/PARTIAL/LOSSY rollup from the initial write (applyParentRollup),
         // so their recoveryStatus is left untouched here.
-        Map<String, Object> fields = new HashMap<>();
-        fields.put("nbChildrenEmitted", (int) Math.min(writtenChildren, Integer.MAX_VALUE));
-        boolean isPstRoot = root.getMetadata().get(PST_EXPECTED) != null || root.getMetadata().get(PST_EMITTED) != null;
-        if (!isPstRoot) {
-            fields.put("recoveryStatus", Document.RecoveryStatus.COMPLETE.toString());
-        }
-        indexer.update(indexName, root.getId(), fields);
+        updateRootChildCount(root, writtenChildren, true);
         logger.info("finalized container root {} as complete with {} indexed child(ren): {}",
                 shorten(root.getId(), 4), writtenChildren, root);
     }
@@ -213,11 +207,34 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         // child count on the still-PARTIAL stub via a partial update, WITHOUT touching recoveryStatus, so
         // the root stays PARTIAL (the container was not fully processed). A later re-run replaces the stub
         // with the fully-parsed root.
-        Map<String, Object> fields = new HashMap<>();
-        fields.put("nbChildrenEmitted", (int) Math.min(writtenChildren, Integer.MAX_VALUE));
-        indexer.update(indexName, root.getId(), fields);
+        updateRootChildCount(root, writtenChildren, false);
         logger.warn("aborted parse: refreshed PARTIAL root stub {} child count to {}: {}",
                 shorten(root.getId(), 4), writtenChildren, root);
+    }
+
+    // Partial (doc-merge) update of the container root's child count, int-clamped, preserving the
+    // already-indexed content/language/status. markComplete flips a non-PST root to COMPLETE (PST roots
+    // keep their applyParentRollup rollup either way); the aborted path passes false so the root stays
+    // PARTIAL.
+    private void updateRootChildCount(TikaDocument root, long writtenChildren, boolean markComplete) throws IOException {
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("nbChildrenEmitted", (int) Math.min(writtenChildren, Integer.MAX_VALUE));
+        if (markComplete) {
+            boolean isPstRoot = root.getMetadata().get(PST_EXPECTED) != null || root.getMetadata().get(PST_EMITTED) != null;
+            if (!isPstRoot) {
+                fields.put("recoveryStatus", Document.RecoveryStatus.COMPLETE.toString());
+            }
+        }
+        indexer.update(indexName, root.getId(), fields);
+    }
+
+    // Tika's Content-Type may carry parameters after ';' (e.g. "text/plain;charset=utf-8"); keep the
+    // media-type prefix. Uses substring rather than split(";")[0] because a value of only ";" splits to
+    // an empty array and [0] would throw -- and a crash here would abort the (stub or real) root write
+    // and orphan already-streamed children, exactly what these writes exist to prevent.
+    private static String baseContentType(String rawContentType) {
+        int semicolon = rawContentType.indexOf(';');
+        return semicolon >= 0 ? rawContentType.substring(0, semicolon) : rawContentType;
     }
 
     // Defensive parse: a non-numeric Content-Length must not abort the stub write (that would leave the
@@ -245,7 +262,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
     Document getDocument(TikaDocument document, TikaDocument root, TikaDocument parent, short level) throws IOException {
         Charset charset = Charset.isSupported(ofNullable(document.getMetadata().get(CONTENT_ENCODING)).orElse(DEFAULT_VALUE_UNKNOWN)) ?
                 Charset.forName(document.getMetadata().get(CONTENT_ENCODING)) : StandardCharsets.US_ASCII;
-        String contentType = ofNullable(document.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN).split(";")[0];
+        String contentType = baseContentType(ofNullable(document.getMetadata().get(CONTENT_TYPE)).orElse(DEFAULT_VALUE_UNKNOWN));
         DocumentBuilder builder = DocumentBuilder.createDoc(document.getId())
                 .with(document.getPath())
                 .with(Document.Status.INDEXED)

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -96,6 +96,29 @@ public class ElasticsearchSpewerTest {
     }
 
     @Test
+    public void test_write_root_stub_returns_true_on_first_write_and_false_when_root_exists() throws Exception {
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("early-stub.ost"));
+
+        assertThat(spewer.writeRootStub(root, 1L)).isTrue();  // first write: a stub row was indexed
+        assertThat(spewer.writeRootStub(root, 2L)).isFalse(); // root now exists: no-op, no clobber
+    }
+
+    @Test
+    public void test_finalize_aborted_root_refreshes_count_and_keeps_partial() throws Exception {
+        // The early stub was written PARTIAL with an initial count; the parse then aborted.
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("aborted-after-stub.ost"));
+        spewer.writeRootStub(root, 0L);
+
+        spewer.finalizeAbortedRoot(root, 4210L);
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(root.getId()), ObjectNode.class);
+        Map<String, Object> source = nodeToMap(documentFields.source());
+        assertThat(source.get("recoveryStatus")).isEqualTo("PARTIAL"); // NOT complete: the parse did not finish
+        assertThat(((Number) source.get("nbChildrenEmitted")).intValue()).isEqualTo(4210);
+        assertThat(source.get("content")).isEqualTo(""); // still contentless
+    }
+
+    @Test
     public void test_write_root_stub_does_not_overwrite_an_already_indexed_root() throws Exception {
         // A prior run indexed this container fully (content + real status).
         final TikaDocument existing = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("prior-complete.ost"));

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -150,6 +150,18 @@ public class ElasticsearchSpewerTest {
     }
 
     @Test
+    public void test_write_root_stub_tolerates_semicolon_only_content_type() throws Exception {
+        final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("weird-ctype.ost"));
+        root.getMetadata().set("Content-Type", ";"); // all-semicolon: split(";")[0] would throw and orphan the children
+
+        spewer.writeRootStub(root, 7L); // must not throw
+
+        GetResponse<ObjectNode> documentFields = es.client.get(doc -> doc.index(es.getIndexName()).id(root.getId()), ObjectNode.class);
+        assertThat(documentFields.found()).isTrue();
+        assertThat(nodeToMap(documentFields.source()).get("recoveryStatus")).isEqualTo("PARTIAL");
+    }
+
+    @Test
     public void test_finalize_root_marks_complete_with_child_count_preserving_content() throws Exception {
         // A container parsed to completion: its root was indexed with content during the parse.
         final TikaDocument root = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("finished-container.zip"));

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <amazon.version>1.12.411</amazon.version>
 
         <aws-s3.version>2.35.10</aws-s3.version>
-        <extract.version>9.15.2</extract.version>
+        <extract.version>9.15.3</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>


### PR DESCRIPTION
Datashare side of root-stub-first (extract-lib half is ICIJ/extract#67). With streaming spew the container root now becomes visible in the index as a contentless PARTIAL stub while a long OST/PST/archive parse is still running, instead of only appearing at completion.

- build: bump extract.version to 9.15.3
- feat(index): `writeRootStub` returns whether a stub was actually indexed, so a prior COMPLETE root is never clobbered on reindex
- feat(index): add `finalizeAbortedRoot`, which refreshes the root's child count on abort while keeping it PARTIAL
- fix(index): guard an all-semicolon Content-Type that could throw and orphan already-streamed children (also hardens the existing root write path)
