### PR TITLE
feat(artifacts): --artifacts generation in INDEX + ARTIFACT stages

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
@@ -33,6 +33,18 @@ public record ManifestEntry(
         return new ManifestEntry(status, taskInput, pagination, contentType, filename, confidence, label);
     }
 
+    /** Producers return EMPTY as-is; any other (status-less) entry becomes COMPLETE. Callers stamp
+     *  only once the payload is written, so a crash mid-produce never leaves a "ready" lie. */
+    public ManifestEntry withTerminalStatus() {
+        return isTerminal() ? this : withStatus(ManifestEntryStatus.COMPLETE);
+    }
+
+    /** Whether this entry makes regeneration unnecessary: terminal, and produced with the exact same
+     *  task input (config + version). Compares from the argument side so an absent taskInput does not NPE. */
+    public boolean isCurrentFor(Map<String, Object> taskInput) {
+        return isTerminal() && taskInput.equals(this.taskInput);
+    }
+
     public boolean isComplete() {
         return status != null && status.isServable();
     }

--- a/datashare-api/src/test/java/org/icij/datashare/text/artifact/ManifestEntryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/artifact/ManifestEntryTest.java
@@ -45,6 +45,42 @@ public class ManifestEntryTest {
     }
 
     @Test
+    public void test_with_terminal_status_stamps_complete_when_status_absent() {
+        ManifestEntry entry = ManifestEntry.singleFile(Map.of("type", "raw", "version", 1), "text/plain", "a.txt");
+        assertThat(entry.withTerminalStatus().status()).isEqualTo(ManifestEntryStatus.COMPLETE);
+    }
+
+    @Test
+    public void test_with_terminal_status_keeps_an_already_terminal_status() {
+        ManifestEntry entry = ManifestEntry.empty(Map.of("type", "raw", "version", 1));
+        assertThat(entry.withTerminalStatus().status()).isEqualTo(ManifestEntryStatus.EMPTY);
+    }
+
+    @Test
+    public void test_is_current_for_same_task_input() {
+        ManifestEntry entry = ManifestEntry.empty(Map.of("type", "raw", "version", 1));
+        assertThat(entry.isCurrentFor(Map.of("type", "raw", "version", 1))).isTrue();
+    }
+
+    @Test
+    public void test_is_not_current_for_another_task_input() {
+        ManifestEntry entry = ManifestEntry.empty(Map.of("type", "raw", "version", 1));
+        assertThat(entry.isCurrentFor(Map.of("type", "raw", "version", 2))).isFalse();
+    }
+
+    @Test
+    public void test_is_not_current_when_status_absent() {
+        ManifestEntry entry = ManifestEntry.singleFile(Map.of("type", "raw", "version", 1), "text/plain", "a.txt");
+        assertThat(entry.isCurrentFor(Map.of("type", "raw", "version", 1))).isFalse();
+    }
+
+    @Test
+    public void test_is_not_current_when_task_input_absent() {
+        ManifestEntry entry = ManifestEntry.singleFile(null, "text/plain", "a.txt").withStatus(ManifestEntryStatus.COMPLETE);
+        assertThat(entry.isCurrentFor(Map.of("type", "raw", "version", 1))).isFalse();
+    }
+
+    @Test
     public void test_paginated_entry_carries_pagination() {
         ManifestEntry entry = ManifestEntry.paginated(Map.of("type", "structure", "version", 1),
                 Pagination.filesystem(12));

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactStages.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactStages.java
@@ -1,0 +1,44 @@
+package org.icij.datashare.tasks;
+
+import org.icij.datashare.PropertiesProvider;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_FORCE_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
+
+/** Shared artifact-stage configuration for the INDEX and ARTIFACT stages, so the two stages resolve
+ *  the project, the force flag, and the artifact directory the same way and cannot drift. */
+public final class ArtifactStages {
+    private ArtifactStages() {}
+
+    /** Resolve the project name the same way ElasticsearchSpewer.configure resolves the ES index
+     *  name: prefer the task-level projectName, then defaultProject, then the built-in default. Keeps
+     *  the manifest dir, the embedded raw bytes, and the ES index under one project name. */
+    public static String resolveProjectName(PropertiesProvider properties) {
+        return properties.get("projectName")
+                .orElse(properties.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
+    }
+
+    /** Whether artifacts should be reprocessed even when an up-to-date manifest entry exists. */
+    public static boolean force(PropertiesProvider properties) {
+        return Boolean.parseBoolean(properties.get(ARTIFACTS_FORCE_OPT).orElse("false"));
+    }
+
+    /** The artifact project root for a stage that opted in via --artifacts, or empty when the stage did
+     *  not opt in. Throws IllegalArgumentException when --artifacts is set without --artifactDir. Call
+     *  from a stage's RUN path (not its constructor): a throw here is reported as a clean task error,
+     *  whereas a throw from a reflectively-constructed task becomes a requeue-forever NackException. */
+    public static Optional<Path> artifactProjectRoot(PropertiesProvider properties) {
+        if (properties.get(ARTIFACTS_OPT).isEmpty()) {
+            return Optional.empty();
+        }
+        String dir = properties.get(ARTIFACT_DIR_OPT)
+                .orElseThrow(() -> new IllegalArgumentException("--artifacts requires --artifactDir"));
+        return Optional.of(Path.of(dir).resolve(resolveProjectName(properties)));
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactStages.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactStages.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.tasks;
 
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -39,6 +40,6 @@ public final class ArtifactStages {
         }
         String dir = properties.get(ARTIFACT_DIR_OPT)
                 .orElseThrow(() -> new IllegalArgumentException("--artifacts requires --artifactDir"));
-        return Optional.of(Path.of(dir).resolve(resolveProjectName(properties)));
+        return Optional.of(ArtifactPath.projectRoot(Path.of(dir), resolveProjectName(properties)));
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -133,7 +133,7 @@ public class ArtifactTask extends PipelineTask<String> {
         List<Artifact> selected = registry.select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
         boolean force = ArtifactStages.force(propertiesProvider);
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository());
-        Path projectRoot = artifactDir.resolve(project.name);
+        Path projectRoot = ArtifactPath.projectRoot(artifactDir, project.name);
         // The interrupt check keeps cancellation prompt, since cancel() calls executor.shutdownNow()
         // while a worker may sit between two non-blocking polls.
         while (!Thread.currentThread().isInterrupted()) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -18,7 +18,6 @@ import org.icij.datashare.text.artifact.ArtifactContext;
 import org.icij.datashare.text.artifact.ArtifactProducer;
 import org.icij.datashare.text.artifact.ArtifactRegistry;
 import org.icij.datashare.text.artifact.FilesystemManifestRepository;
-import org.icij.datashare.text.artifact.RawArtifact;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
@@ -133,7 +132,7 @@ public class ArtifactTask extends PipelineTask<String> {
         SourceExtractor extractor = createSourceExtractor();
         // Decide once per worker which artifact types to produce: an absent --artifacts flag
         // means all registered types (raw is the only one wired in this foundation).
-        ArtifactRegistry registry = new ArtifactRegistry(List.of(new RawArtifact()));
+        ArtifactRegistry registry = ArtifactRegistry.withDefaults();
         List<Artifact> selected = registry.select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
         boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository());

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -36,11 +36,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
-import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_FORCE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_OPT;
-import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
 import static org.icij.datashare.cli.DatashareCliOptions.PARALLELISM_OPT;
 
 @TemporalSingleActivityWorkflow(name = "artifact", activityOptions = @ActivityOpts(timeout = "P1D"))
@@ -58,7 +55,7 @@ public class ArtifactTask extends PipelineTask<String> {
     public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
         super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class, gateFactory.forTask(taskView));
         this.indexer = indexer;
-        project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
+        project = Project.project(ArtifactStages.resolveProjectName(propertiesProvider));
         parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
         executor = Executors.newFixedThreadPool(parallelism, namedThreadFactory("artifact-worker"));
@@ -134,7 +131,7 @@ public class ArtifactTask extends PipelineTask<String> {
         // means all registered types (raw is the only one wired in this foundation).
         ArtifactRegistry registry = ArtifactRegistry.withDefaults();
         List<Artifact> selected = registry.select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
-        boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
+        boolean force = ArtifactStages.force(propertiesProvider);
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository());
         Path projectRoot = artifactDir.resolve(project.name);
         // The interrupt check keeps cancellation prompt, since cancel() calls executor.shutdownNow()

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -15,6 +15,12 @@ import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.monitoring.Monitorable;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.artifact.Artifact;
+import org.icij.datashare.text.artifact.ArtifactRegistry;
+import org.icij.datashare.text.artifact.FilesystemManifestRepository;
+import org.icij.datashare.text.artifact.ManifestRecorder;
+import org.icij.datashare.text.artifact.RawArtifact;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSpewer;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.DocumentConsumer;
@@ -31,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
 import org.icij.time.HumanDuration;
 
 import static java.lang.Math.max;
@@ -69,6 +76,16 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(Runtime.getRuntime().availableProcessors());
         indexTimeout = getIndexTimeout();
         warnIfParseTimeoutDisabled();
+
+        propertiesProvider.get(ARTIFACTS_OPT).ifPresent(artifactsValue -> {
+            String dir = propertiesProvider.get(ARTIFACT_DIR_OPT)
+                    .orElseThrow(() -> new IllegalArgumentException("--artifacts requires --artifactDir"));
+            Project project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
+            Path projectRoot = Path.of(dir).resolve(project.name);
+            List<Artifact> selected = new ArtifactRegistry(List.of(new RawArtifact())).select(artifactsValue);
+            boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
+            spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, force));
+        });
 
         Options<String> allTaskOptions = options().createFrom(Options.from(taskView.args));
         ((ElasticsearchSpewer) spewer.configure(allTaskOptions)).createIndexIfNotExists();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -15,7 +15,6 @@ import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.monitoring.Monitorable;
-import org.icij.datashare.text.Project;
 import org.icij.datashare.text.artifact.Artifact;
 import org.icij.datashare.text.artifact.ArtifactRegistry;
 import org.icij.datashare.text.artifact.FilesystemManifestRepository;
@@ -77,21 +76,32 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         indexTimeout = getIndexTimeout();
         warnIfParseTimeoutDisabled();
 
-        propertiesProvider.get(ARTIFACTS_OPT).ifPresent(artifactsValue -> {
+        // --artifacts is opt-in and requires a place to write. Resolve the project the same way
+        // ElasticsearchSpewer.configure resolves the ES index name (prefer projectName, then
+        // defaultProject) so the manifest dir, the embedded raw bytes, and the ES index all agree.
+        Path artifactProjectRoot = null;
+        if (propertiesProvider.get(ARTIFACTS_OPT).isPresent()) {
             String dir = propertiesProvider.get(ARTIFACT_DIR_OPT)
                     .orElseThrow(() -> new IllegalArgumentException("--artifacts requires --artifactDir"));
-            Project project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
-            Path projectRoot = Path.of(dir).resolve(project.name);
-            List<Artifact> selected = new ArtifactRegistry(List.of(new RawArtifact())).select(artifactsValue);
+            String projectName = propertiesProvider.get("projectName")
+                    .orElse(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
+            artifactProjectRoot = Path.of(dir).resolve(projectName);
+            List<Artifact> selected = new ArtifactRegistry(List.of(new RawArtifact())).select(propertiesProvider.get(ARTIFACTS_OPT).get());
             boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
-            spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, force));
-        });
+            spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), artifactProjectRoot, selected, force));
+        }
 
         Options<String> allTaskOptions = options().createFrom(Options.from(taskView.args));
         ((ElasticsearchSpewer) spewer.configure(allTaskOptions)).createIndexIfNotExists();
 
         DocumentFactory documentFactory = new DocumentFactory().configure(allTaskOptions);
         this.extractor = createExtractor(documentFactory, allTaskOptions);
+        if (artifactProjectRoot != null) {
+            // extract-lib writes embedded raw bytes only when embedOutput is set; the INDEX path
+            // never sets it otherwise. Point it at the same project root as the manifest recorder so
+            // --artifacts actually produces the payloads the manifest entries reference.
+            this.extractor.setEmbedOutputPath(artifactProjectRoot);
+        }
 
         consumer = new DocumentConsumer(spewer, this.extractor, this.parallelism);
         progressTrackConsumer = path -> {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -56,6 +56,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.*;
 public class IndexTask extends PipelineTask<Path> implements Monitorable{
     private static final Path PATH_POISON = Paths.get("POISON");
     private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ElasticsearchSpewer spewer;
     private final Extractor extractor;
     private final DocumentQueueDrainer<Path> drainer;
     private final DocumentConsumer consumer;
@@ -71,36 +72,16 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
     @Inject
     public IndexTask(final ElasticsearchSpewer spewer, final DocumentCollectionFactory<Path> factory, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) throws IOException {
         super(Stage.INDEX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class, gateFactory.forTask(taskView));
+        this.spewer = spewer;
         parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(Runtime.getRuntime().availableProcessors());
         indexTimeout = getIndexTimeout();
         warnIfParseTimeoutDisabled();
-
-        // --artifacts is opt-in and requires a place to write. Resolve the project the same way
-        // ElasticsearchSpewer.configure resolves the ES index name (prefer projectName, then
-        // defaultProject) so the manifest dir, the embedded raw bytes, and the ES index all agree.
-        Path artifactProjectRoot = null;
-        if (propertiesProvider.get(ARTIFACTS_OPT).isPresent()) {
-            String dir = propertiesProvider.get(ARTIFACT_DIR_OPT)
-                    .orElseThrow(() -> new IllegalArgumentException("--artifacts requires --artifactDir"));
-            String projectName = propertiesProvider.get("projectName")
-                    .orElse(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
-            artifactProjectRoot = Path.of(dir).resolve(projectName);
-            List<Artifact> selected = ArtifactRegistry.withDefaults().select(propertiesProvider.get(ARTIFACTS_OPT).get());
-            boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
-            spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), artifactProjectRoot, selected, force));
-        }
 
         Options<String> allTaskOptions = options().createFrom(Options.from(taskView.args));
         ((ElasticsearchSpewer) spewer.configure(allTaskOptions)).createIndexIfNotExists();
 
         DocumentFactory documentFactory = new DocumentFactory().configure(allTaskOptions);
         this.extractor = createExtractor(documentFactory, allTaskOptions);
-        if (artifactProjectRoot != null) {
-            // extract-lib writes embedded raw bytes only when embedOutput is set; the INDEX path
-            // never sets it otherwise. Point it at the same project root as the manifest recorder so
-            // --artifacts actually produces the payloads the manifest entries reference.
-            this.extractor.setEmbedOutputPath(artifactProjectRoot);
-        }
 
         consumer = new DocumentConsumer(spewer, this.extractor, this.parallelism);
         progressTrackConsumer = path -> {
@@ -134,6 +115,15 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
     @Override
     public Long call() throws Exception {
         super.call();
+        // Opt-in artifact generation is wired here (not in the constructor) so a bad --artifacts
+        // config surfaces as a clean task error rather than a reflective-construction NackException
+        // that requeues forever. When set, extract-lib writes embed bytes to the same project root the
+        // ManifestRecorder writes manifests to.
+        ArtifactStages.artifactProjectRoot(propertiesProvider).ifPresent(projectRoot -> {
+            List<Artifact> selected = ArtifactRegistry.withDefaults().select(propertiesProvider.get(ARTIFACTS_OPT).get());
+            extractor.setEmbedOutputPath(projectRoot);
+            spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, ArtifactStages.force(propertiesProvider)));
+        });
         logger.info("Processing up to {} file(s) in parallel", parallelism);
         try {
             totalToProcess = drainer.drain().get() - skipped.get();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -19,7 +19,6 @@ import org.icij.datashare.text.artifact.Artifact;
 import org.icij.datashare.text.artifact.ArtifactRegistry;
 import org.icij.datashare.text.artifact.FilesystemManifestRepository;
 import org.icij.datashare.text.artifact.ManifestRecorder;
-import org.icij.datashare.text.artifact.RawArtifact;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSpewer;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.DocumentConsumer;
@@ -86,7 +85,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
             String projectName = propertiesProvider.get("projectName")
                     .orElse(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
             artifactProjectRoot = Path.of(dir).resolve(projectName);
-            List<Artifact> selected = new ArtifactRegistry(List.of(new RawArtifact())).select(propertiesProvider.get(ARTIFACTS_OPT).get());
+            List<Artifact> selected = ArtifactRegistry.withDefaults().select(propertiesProvider.get(ARTIFACTS_OPT).get());
             boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
             spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), artifactProjectRoot, selected, force));
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -120,7 +120,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         // that requeues forever. When set, extract-lib writes embed bytes to the same project root the
         // ManifestRecorder writes manifests to.
         ArtifactStages.artifactProjectRoot(propertiesProvider).ifPresent(projectRoot -> {
-            List<Artifact> selected = ArtifactRegistry.withDefaults().select(propertiesProvider.get(ARTIFACTS_OPT).get());
+            List<Artifact> selected = ArtifactRegistry.withDefaults().select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
             extractor.setEmbedOutputPath(projectRoot);
             spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, ArtifactStages.force(propertiesProvider)));
         });

--- a/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
+++ b/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
@@ -18,6 +18,12 @@ public class ArtifactRegistry {
         }
     }
 
+    /** The app's default catalog of Java-produced artifact types. Shared by the INDEX and ARTIFACT
+     *  stages so a newly registered producer cannot be honored by one stage and missed by the other. */
+    public static ArtifactRegistry withDefaults() {
+        return new ArtifactRegistry(List.of(new RawArtifact()));
+    }
+
     public List<Artifact> select(String flagValue) {
         if (flagValue == null || flagValue.isBlank() || "true".equals(flagValue)) {
             return new ArrayList<>(byType.values());

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactStagesTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactStagesTest.java
@@ -29,18 +29,6 @@ public class ArtifactStagesTest {
     }
 
     @Test
-    public void test_force_true() {
-        PropertiesProvider properties = new PropertiesProvider(Map.of("artifactsForce", "true"));
-        assertThat(ArtifactStages.force(properties)).isTrue();
-    }
-
-    @Test
-    public void test_force_false() {
-        PropertiesProvider properties = new PropertiesProvider(Map.of("artifactsForce", "false"));
-        assertThat(ArtifactStages.force(properties)).isFalse();
-    }
-
-    @Test
     public void test_force_absent_defaults_to_false() {
         PropertiesProvider properties = new PropertiesProvider(Map.of());
         assertThat(ArtifactStages.force(properties)).isFalse();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactStagesTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactStagesTest.java
@@ -1,0 +1,66 @@
+package org.icij.datashare.tasks;
+
+import org.icij.datashare.PropertiesProvider;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ArtifactStagesTest {
+    @Test
+    public void test_resolve_project_name_prefers_project_name() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of("projectName", "bar", "defaultProject", "foo"));
+        assertThat(ArtifactStages.resolveProjectName(properties)).isEqualTo("bar");
+    }
+
+    @Test
+    public void test_resolve_project_name_falls_back_to_default_project() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of("defaultProject", "foo"));
+        assertThat(ArtifactStages.resolveProjectName(properties)).isEqualTo("foo");
+    }
+
+    @Test
+    public void test_resolve_project_name_falls_back_to_default_default_project() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of());
+        assertThat(ArtifactStages.resolveProjectName(properties)).isEqualTo("local-datashare");
+    }
+
+    @Test
+    public void test_force_true() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of("artifactsForce", "true"));
+        assertThat(ArtifactStages.force(properties)).isTrue();
+    }
+
+    @Test
+    public void test_force_false() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of("artifactsForce", "false"));
+        assertThat(ArtifactStages.force(properties)).isFalse();
+    }
+
+    @Test
+    public void test_force_absent_defaults_to_false() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of());
+        assertThat(ArtifactStages.force(properties)).isFalse();
+    }
+
+    @Test
+    public void test_artifact_project_root_absent_when_artifacts_not_set() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of());
+        assertThat(ArtifactStages.artifactProjectRoot(properties)).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void test_artifact_project_root_resolved_when_artifacts_and_artifact_dir_set() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of("artifacts", "true", "artifactDir", "/tmp/art", "projectName", "bar"));
+        assertThat(ArtifactStages.artifactProjectRoot(properties)).isEqualTo(Optional.of(Path.of("/tmp/art").resolve("bar")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_artifact_project_root_throws_when_artifacts_set_without_artifact_dir() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of("artifacts", "true"));
+        ArtifactStages.artifactProjectRoot(properties);
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -56,12 +56,6 @@ public class ArtifactTaskTest {
         new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void test_artifacts_without_artifact_dir_fails() {
-        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of("artifacts", "true")),
-                new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
-    }
-
     @Test(timeout = 10000)
     public void test_create_artifact_cache_one_file() throws Exception {
         indexEmbeddedDoc();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -56,6 +56,12 @@ public class ArtifactTaskTest {
         new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void test_artifacts_without_artifact_dir_fails() {
+        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of("artifacts", "true")),
+                new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
+    }
+
     @Test(timeout = 10000)
     public void test_create_artifact_cache_one_file() throws Exception {
         indexEmbeddedDoc();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -17,6 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -188,6 +189,47 @@ public class IndexTaskTest {
                     put("queueName", "test:queue");
                     put("artifacts", "true");
                 }}), null);
+    }
+
+    // Captures the Extractor built during construction so tests can assert embedOutput wiring.
+    static class CapturingIndexTask extends IndexTask {
+        Extractor captured;
+        CapturingIndexTask(ElasticsearchSpewer spewer, DocumentCollectionFactory<Path> factory, Task<Long> taskView) throws Exception {
+            super(spewer, factory, taskView, null);
+        }
+        @Override
+        protected Extractor createExtractor(DocumentFactory documentFactory, Options<String> options) {
+            captured = super.createExtractor(documentFactory, options);
+            return captured;
+        }
+    }
+
+    @Test
+    public void test_artifacts_sets_embed_output_to_artifact_project_root_preferring_project_name() throws Exception {
+        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
+        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
+        CapturingIndexTask task = new CapturingIndexTask(spewer, mock(DocumentCollectionFactory.class),
+                new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>() {{
+                    put("queueName", "test:queue");
+                    put("artifacts", "true");
+                    put("artifactDir", "/tmp/art");
+                    put("defaultProject", "foo");
+                    put("projectName", "bar");
+                }}));
+
+        assertThat((Object) task.captured.getEmbedOutputPath()).isEqualTo(Path.of("/tmp/art").resolve("bar"));
+    }
+
+    @Test
+    public void test_no_artifacts_leaves_embed_output_null() throws Exception {
+        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
+        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
+        CapturingIndexTask task = new CapturingIndexTask(spewer, mock(DocumentCollectionFactory.class),
+                new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>() {{
+                    put("queueName", "test:queue");
+                }}));
+
+        assertThat(task.captured.getEmbedOutputPath()).isNull();
     }
 
     @After

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -179,6 +179,17 @@ public class IndexTaskTest {
                 .anyMatch(l -> l.contains("parseTimeout"))).isFalse();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void test_artifacts_without_artifact_dir_fails() throws Exception {
+        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
+        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+                new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>() {{
+                    put("queueName", "test:queue");
+                    put("artifacts", "true");
+                }}), null);
+    }
+
     @After
     public void tearDown() throws Exception {
         logWrapper.reset();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -17,7 +17,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.event.Level;
 
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -180,56 +179,17 @@ public class IndexTaskTest {
                 .anyMatch(l -> l.contains("parseTimeout"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void test_artifacts_without_artifact_dir_fails() throws Exception {
+    @Test
+    public void test_artifacts_without_artifact_dir_does_not_throw_at_construction() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+        // Must not throw: --artifacts validation is deferred to call() so a bad config is a clean
+        // task error, not a reflective-construction NackException that requeues forever.
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository),
                 new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>() {{
                     put("queueName", "test:queue");
                     put("artifacts", "true");
                 }}), null);
-    }
-
-    // Captures the Extractor built during construction so tests can assert embedOutput wiring.
-    static class CapturingIndexTask extends IndexTask {
-        Extractor captured;
-        CapturingIndexTask(ElasticsearchSpewer spewer, DocumentCollectionFactory<Path> factory, Task<Long> taskView) throws Exception {
-            super(spewer, factory, taskView, null);
-        }
-        @Override
-        protected Extractor createExtractor(DocumentFactory documentFactory, Options<String> options) {
-            captured = super.createExtractor(documentFactory, options);
-            return captured;
-        }
-    }
-
-    @Test
-    public void test_artifacts_sets_embed_output_to_artifact_project_root_preferring_project_name() throws Exception {
-        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
-        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        CapturingIndexTask task = new CapturingIndexTask(spewer, mock(DocumentCollectionFactory.class),
-                new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>() {{
-                    put("queueName", "test:queue");
-                    put("artifacts", "true");
-                    put("artifactDir", "/tmp/art");
-                    put("defaultProject", "foo");
-                    put("projectName", "bar");
-                }}));
-
-        assertThat((Object) task.captured.getEmbedOutputPath()).isEqualTo(Path.of("/tmp/art").resolve("bar"));
-    }
-
-    @Test
-    public void test_no_artifacts_leaves_embed_output_null() throws Exception {
-        ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
-        Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        CapturingIndexTask task = new CapturingIndexTask(spewer, mock(DocumentCollectionFactory.class),
-                new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>() {{
-                    put("queueName", "test:queue");
-                }}));
-
-        assertThat(task.captured.getEmbedOutputPath()).isNull();
     }
 
     @After

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -505,7 +505,10 @@ public final class DatashareCliOptions {
         parser.acceptsAll(
                 List.of(ARTIFACTS_FORCE_OPT),
                 "Reprocess artifacts even when an up-to-date manifest entry exists (bypasses caching)." )
-                .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
+                // No defaultsTo: JOpt would always emit the default into the CLI properties, and
+                // mergeWith(putIfAbsent) would then silently clobber an artifactsForce=true set in a
+                // settings file. Absent key -> false via ArtifactStages.force.
+                .withRequiredArg().ofType(Boolean.class);
     }
 
     static void rootHost(OptionParser parser) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -505,7 +505,7 @@ public final class DatashareCliOptions {
         parser.acceptsAll(
                 List.of(ARTIFACTS_FORCE_OPT),
                 "Reprocess artifacts even when an up-to-date manifest entry exists (bypasses caching)." )
-                .withOptionalArg().ofType(Boolean.class).defaultsTo(false);
+                .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
     }
 
     static void rootHost(OptionParser parser) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -489,7 +489,9 @@ public final class DatashareCliOptions {
 
     static void artifactDir(OptionParser parser) {
         parser.acceptsAll(
-                List.of(ARTIFACT_DIR_OPT),
+                // ARTIFACT_DIR_OPT stays first: asPropertyKey uses the first long flag, so the plural
+                // alias (consistent with --artifacts) still writes the historical artifactDir key.
+                List.of(ARTIFACT_DIR_OPT, "artifactsDir"),
                 "Artifact directory for embedded caching. If not provided datashare will use memory." )
                 .withRequiredArg();
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -505,9 +505,9 @@ public final class DatashareCliOptions {
         parser.acceptsAll(
                 List.of(ARTIFACTS_FORCE_OPT),
                 "Reprocess artifacts even when an up-to-date manifest entry exists (bypasses caching)." )
-                // No defaultsTo: JOpt would always emit the default into the CLI properties, and
-                // mergeWith(putIfAbsent) would then silently clobber an artifactsForce=true set in a
-                // settings file. Absent key -> false via ArtifactStages.force.
+                // No defaultsTo: JOpt would always emit the default into the CLI properties, which
+                // CommonMode then applies over the settings file (overrideWith is a putAll), silently
+                // clobbering an artifactsForce=true set there. Absent key -> false via ArtifactStages.force.
                 .withRequiredArg().ofType(Boolean.class);
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -19,6 +19,17 @@ public class PipelineOptions {
     @Option(names = {"--artifactDir"}, description = "Artifact directory for embedded caching")
     String artifactDir;
 
+    // arity = "0..1" + fallbackValue = "true" mirrors the JOpt withOptionalArg semantics: a bare
+    // --artifacts means "all types", --artifacts=raw,structure selects a subset. Left null when
+    // absent so toProperties omits the key and INDEX produces no artifacts.
+    @Option(names = {"--artifacts"}, arity = "0..1", fallbackValue = "true",
+            description = "Artifact types to produce, comma-separated (bare flag = all types); unknown types are rejected.")
+    String artifacts;
+
+    @Option(names = {"--artifactsForce"}, arity = "0..1", fallbackValue = "true", defaultValue = "false",
+            description = "Reprocess artifacts even when an up-to-date manifest entry exists (bypasses caching).")
+    boolean artifactsForce;
+
     @Option(names = {"--nlpPipeline"}, description = "NLP pipeline to be run", defaultValue = "CORENLP")
     Pipeline.Type nlpPipeline;
 
@@ -95,6 +106,8 @@ public class PipelineOptions {
     public Properties toProperties() {
         Properties props = new Properties();
         DatashareOptions.putIfNotNull(props, ARTIFACT_DIR_OPT, artifactDir);
+        DatashareOptions.putIfNotNull(props, ARTIFACTS_OPT, artifacts);
+        DatashareOptions.put(props, ARTIFACTS_FORCE_OPT, artifactsForce);
         DatashareOptions.putIfNotNull(props, NLP_PIPELINE_OPT, nlpPipeline);
         DatashareOptions.put(props, NLP_PARALLELISM_OPT, nlpParallelism);
         DatashareOptions.put(props, NLP_BATCH_SIZE_OPT, batchSize);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -26,7 +26,11 @@ public class PipelineOptions {
             description = "Artifact types to produce, comma-separated (bare flag = all types); unknown types are rejected.")
     String artifacts;
 
-    @Option(names = {"--artifactsForce"}, arity = "0..1", fallbackValue = "true", defaultValue = "false",
+    // Requires an explicit true/false (like --ocr / --followSymlinks) rather than a bare flag, so the
+    // JOpt (withRequiredArg) and picocli surfaces agree: absent -> false, --artifactsForce=false -> false,
+    // --artifactsForce=true -> reprocess. A bare flag is intentionally not allowed to avoid the two
+    // surfaces disagreeing on what "bare" means.
+    @Option(names = {"--artifactsForce"}, arity = "1", defaultValue = "false",
             description = "Reprocess artifacts even when an up-to-date manifest entry exists (bypasses caching).")
     boolean artifactsForce;
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -16,7 +16,9 @@ import static org.icij.datashare.cli.DatashareCliOptions.*;
  */
 public class PipelineOptions {
 
-    @Option(names = {"--artifactDir"}, description = "Artifact directory for embedded caching")
+    // --artifactsDir is an alias: the singular name is public since 21814dfa6 and set in prod
+    // settings files, so it stays the property key while the plural matches --artifacts.
+    @Option(names = {"--artifactDir", "--artifactsDir"}, description = "Artifact directory for embedded caching")
     String artifactDir;
 
     // Mirrors the JOpt withOptionalArg semantics. Left null when absent so toProperties omits the

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -19,17 +19,14 @@ public class PipelineOptions {
     @Option(names = {"--artifactDir"}, description = "Artifact directory for embedded caching")
     String artifactDir;
 
-    // arity = "0..1" + fallbackValue = "true" mirrors the JOpt withOptionalArg semantics: a bare
-    // --artifacts means "all types", --artifacts=raw,structure selects a subset. Left null when
-    // absent so toProperties omits the key and INDEX produces no artifacts.
+    // Mirrors the JOpt withOptionalArg semantics. Left null when absent so toProperties omits the
+    // key and INDEX produces no artifacts.
     @Option(names = {"--artifacts"}, arity = "0..1", fallbackValue = "true",
             description = "Artifact types to produce, comma-separated (bare flag = all types); unknown types are rejected.")
     String artifacts;
 
-    // Requires an explicit true/false (like --ocr / --followSymlinks) rather than a bare flag, so the
-    // JOpt (withRequiredArg) and picocli surfaces agree: absent -> false, --artifactsForce=false -> false,
-    // --artifactsForce=true -> reprocess. A bare flag is intentionally not allowed to avoid the two
-    // surfaces disagreeing on what "bare" means.
+    // Explicit true/false like --ocr, no bare flag: the JOpt surface uses withRequiredArg, and a bare
+    // flag here would make the two surfaces disagree on what "bare" means.
     @Option(names = {"--artifactsForce"}, arity = "1", defaultValue = "false",
             description = "Reprocess artifacts even when an up-to-date manifest entry exists (bypasses caching).")
     boolean artifactsForce;

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -26,10 +26,13 @@ public class PipelineOptions {
     String artifacts;
 
     // Explicit true/false like --ocr, no bare flag: the JOpt surface uses withRequiredArg, and a bare
-    // flag here would make the two surfaces disagree on what "bare" means.
-    @Option(names = {"--artifactsForce"}, arity = "1", defaultValue = "false",
+    // flag here would make the two surfaces disagree on what "bare" means. No defaultValue and a
+    // nullable Boolean, so an absent flag emits no key: CommonMode applies these properties over the
+    // settings file (overrideWith is a putAll), and a default would clobber an artifactsForce=true
+    // set there. Absent key -> false via ArtifactStages.force.
+    @Option(names = {"--artifactsForce"}, arity = "1",
             description = "Reprocess artifacts even when an up-to-date manifest entry exists (bypasses caching).")
-    boolean artifactsForce;
+    Boolean artifactsForce;
 
     @Option(names = {"--nlpPipeline"}, description = "NLP pipeline to be run", defaultValue = "CORENLP")
     Pipeline.Type nlpPipeline;
@@ -108,7 +111,7 @@ public class PipelineOptions {
         Properties props = new Properties();
         DatashareOptions.putIfNotNull(props, ARTIFACT_DIR_OPT, artifactDir);
         DatashareOptions.putIfNotNull(props, ARTIFACTS_OPT, artifacts);
-        DatashareOptions.put(props, ARTIFACTS_FORCE_OPT, artifactsForce);
+        DatashareOptions.putIfNotNull(props, ARTIFACTS_FORCE_OPT, artifactsForce);
         DatashareOptions.putIfNotNull(props, NLP_PIPELINE_OPT, nlpPipeline);
         DatashareOptions.put(props, NLP_PARALLELISM_OPT, nlpParallelism);
         DatashareOptions.put(props, NLP_BATCH_SIZE_OPT, batchSize);

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -149,6 +149,13 @@ public class DatashareCliTest {
     }
 
     @Test
+    public void test_artifacts_dir_alias_writes_the_artifact_dir_key() {
+        cli.parseArguments(new String[] {"--artifactsDir", "/tmp/art"});
+        assertThat(cli.properties).includes(entry("artifactDir", "/tmp/art"));
+        assertThat(cli.properties.containsKey("artifactsDir")).isFalse();
+    }
+
+    @Test
     public void test_has_english_indexing_language_value() {
         cli.parseArguments(new String[] {"--language", "ENGLISH"});
         assertThat(cli.properties).includes(entry("language", "ENGLISH"));

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
@@ -151,8 +151,14 @@ public class StageRunCommandTest extends AbstractDatashareCommandTest {
     }
 
     @Test
-    public void test_artifacts_force_bare_flag_is_true() {
-        Properties props = parse("stage", "run", "--stages", "INDEX", "--artifactsForce");
+    public void test_artifacts_force_explicit_true() {
+        Properties props = parse("stage", "run", "--stages", "INDEX", "--artifactsForce", "true");
         assertThat(props).includes(entry("artifactsForce", "true"));
+    }
+
+    @Test
+    public void test_artifacts_force_explicit_false() {
+        Properties props = parse("stage", "run", "--stages", "INDEX", "--artifactsForce", "false");
+        assertThat(props).includes(entry("artifactsForce", "false"));
     }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
@@ -125,4 +125,34 @@ public class StageRunCommandTest extends AbstractDatashareCommandTest {
         Properties props = parse("stage", "run", "--stages", "SCAN,INDEX");
         assertThat(props).includes(entry("parseTimeout", "24h"));
     }
+
+    @Test
+    public void test_artifacts_bare_flag_selects_all() {
+        Properties props = parse("stage", "run", "--stages", "INDEX", "--artifacts");
+        assertThat(props).includes(entry("artifacts", "true"));
+    }
+
+    @Test
+    public void test_artifacts_csv_subset() {
+        Properties props = parse("stage", "run", "--stages", "INDEX", "--artifacts", "raw,structure");
+        assertThat(props).includes(entry("artifacts", "raw,structure"));
+    }
+
+    @Test
+    public void test_artifacts_absent_by_default() {
+        Properties props = parse("stage", "run", "--stages", "INDEX");
+        assertThat(props.containsKey("artifacts")).isFalse();
+    }
+
+    @Test
+    public void test_artifacts_force_defaults_to_false() {
+        Properties props = parse("stage", "run", "--stages", "INDEX");
+        assertThat(props).includes(entry("artifactsForce", "false"));
+    }
+
+    @Test
+    public void test_artifacts_force_bare_flag_is_true() {
+        Properties props = parse("stage", "run", "--stages", "INDEX", "--artifactsForce");
+        assertThat(props).includes(entry("artifactsForce", "true"));
+    }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
@@ -151,6 +151,13 @@ public class StageRunCommandTest extends AbstractDatashareCommandTest {
     }
 
     @Test
+    public void test_artifacts_dir_alias_writes_the_artifact_dir_key() {
+        Properties props = parse("stage", "run", "--stages", "INDEX", "--artifactsDir", "/tmp/art");
+        assertThat(props).includes(entry("artifactDir", "/tmp/art"));
+        assertThat(props.containsKey("artifactsDir")).isFalse();
+    }
+
+    @Test
     public void test_artifacts_force_explicit_true() {
         Properties props = parse("stage", "run", "--stages", "INDEX", "--artifactsForce", "true");
         assertThat(props).includes(entry("artifactsForce", "true"));

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/StageRunCommandTest.java
@@ -145,9 +145,9 @@ public class StageRunCommandTest extends AbstractDatashareCommandTest {
     }
 
     @Test
-    public void test_artifacts_force_defaults_to_false() {
+    public void test_artifacts_force_absent_by_default() {
         Properties props = parse("stage", "run", "--stages", "INDEX");
-        assertThat(props).includes(entry("artifactsForce", "false"));
+        assertThat(props.containsKey("artifactsForce")).isFalse();
     }
 
     @Test

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -68,6 +68,13 @@ public class ArtifactProducer {
     // regeneration skipped.
     private boolean isCurrent(ArtifactType type, Artifact artifact, ArtifactContext context) throws IOException {
         ManifestEntry existing = repository.get(context.docArtifactDir(), type.token());
-        return existing != null && existing.isTerminal() && existing.taskInput().equals(artifact.taskInput());
+        return entryIsCurrent(existing, artifact.taskInput());
+    }
+
+    // Skip-if-current predicate, shared with the INDEX-time ManifestRecorder so both stages agree on
+    // when a cached entry is reused. Compares from the always-non-null taskInput side so a manifest
+    // entry with an absent (null) taskInput does not NPE.
+    static boolean entryIsCurrent(ManifestEntry existing, Map<String, Object> taskInput) {
+        return existing != null && existing.isTerminal() && taskInput.equals(existing.taskInput());
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -59,7 +59,7 @@ public class ArtifactProducer {
 
     // Producers return EMPTY as-is; any other (status-less) entry is stamped COMPLETE only after
     // its payload has been written, so a crash mid-produce never leaves a "ready" lie.
-    private ManifestEntry stampTerminal(ManifestEntry produced) {
+    static ManifestEntry stampTerminal(ManifestEntry produced) {
         return produced.isTerminal() ? produced : produced.withStatus(ManifestEntryStatus.COMPLETE);
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -71,9 +71,8 @@ public class ArtifactProducer {
         return entryIsCurrent(existing, artifact.taskInput());
     }
 
-    // Skip-if-current predicate, shared with the INDEX-time ManifestRecorder so both stages agree on
-    // when a cached entry is reused. Compares from the always-non-null taskInput side so a manifest
-    // entry with an absent (null) taskInput does not NPE.
+    // Shared with the INDEX-time ManifestRecorder. Compares from the always-non-null taskInput side so
+    // an entry with an absent taskInput does not NPE.
     static boolean entryIsCurrent(ManifestEntry existing, Map<String, Object> taskInput) {
         return existing != null && existing.isTerminal() && taskInput.equals(existing.taskInput());
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -49,7 +49,7 @@ public class ArtifactProducer {
             ManifestEntry produced = artifact.produce(context);
             // put() holds the per-doc write lock while it merges the entry, so the recorded manifest
             // stays consistent (and cross-process/host safe) with the payload just written.
-            repository.put(context.docArtifactDir(), type.token(), stampTerminal(produced));
+            repository.put(context.docArtifactDir(), type.token(), produced.withTerminalStatus());
             return true;
         } catch (ArtifactException | IOException failure) {
             LOGGER.error("failed to produce artifact '{}' for document {}", type.token(), context.document().getId(), failure);
@@ -57,23 +57,8 @@ public class ArtifactProducer {
         }
     }
 
-    // Producers return EMPTY as-is; any other (status-less) entry is stamped COMPLETE only after
-    // its payload has been written, so a crash mid-produce never leaves a "ready" lie.
-    static ManifestEntry stampTerminal(ManifestEntry produced) {
-        return produced.isTerminal() ? produced : produced.withStatus(ManifestEntryStatus.COMPLETE);
-    }
-
-    // An artifact is current when a terminal entry (COMPLETE or EMPTY) already exists and was
-    // produced with the exact same task input (config + version) as this run; only then is
-    // regeneration skipped.
     private boolean isCurrent(ArtifactType type, Artifact artifact, ArtifactContext context) throws IOException {
         ManifestEntry existing = repository.get(context.docArtifactDir(), type.token());
-        return entryIsCurrent(existing, artifact.taskInput());
-    }
-
-    // Shared with the INDEX-time ManifestRecorder. Compares from the always-non-null taskInput side so
-    // an entry with an absent taskInput does not NPE.
-    static boolean entryIsCurrent(ManifestEntry existing, Map<String, Object> taskInput) {
-        return existing != null && existing.isTerminal() && taskInput.equals(existing.taskInput());
+        return existing != null && existing.isCurrentFor(artifact.taskInput());
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
@@ -2,6 +2,7 @@ package org.icij.datashare.text.artifact;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.MapMaker;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 
@@ -12,7 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
@@ -27,7 +28,11 @@ public class FilesystemManifestRepository implements ManifestRepository {
     private static final long LOCK_TIMEOUT_MS = 30_000;
     private static final ObjectMapper MAPPER = JsonObjectMapper.getMapper();
     private static final TypeReference<LinkedHashMap<String, ManifestEntry>> MANIFEST_TYPE = new TypeReference<>() {};
-    private static final ConcurrentHashMap<String, ReentrantLock> JVM_LOCKS = new ConcurrentHashMap<>();
+    // Weak values, because this is keyed per document and hit once per indexed document: a strong map
+    // would keep one entry per document ever processed for the life of the JVM. A lock a thread holds
+    // is kept alive by that thread's own reference to it, so one dir still maps to one lock for as long
+    // as it is in use, which is what the FileLock non-overlap guarantee below relies on.
+    private static final ConcurrentMap<String, ReentrantLock> JVM_LOCKS = new MapMaker().weakValues().makeMap();
 
     @Override
     public ManifestEntry get(Path docArtifactDir, String type) throws IOException {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -56,7 +56,7 @@ public class ManifestRecorder {
         // actually on disk (written by extract-lib during the parse). Otherwise skip, so a later
         // ARTIFACT-stage run produces it rather than leaving a permanent false-COMPLETE. A root has
         // no payload in its own dir, so it always records its EMPTY entry.
-        if (document.getExtractionLevel() > 0 && !Files.exists(docArtifactDir.resolve("raw"))) {
+        if (document.getExtractionLevel() > 0 && !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))) {
             return;
         }
         repository.put(docArtifactDir, ArtifactType.RAW.token(), ArtifactProducer.stampTerminal(raw.entryFor(document)));

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -1,0 +1,43 @@
+package org.icij.datashare.text.artifact;
+
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/** Records the raw manifest entry for a document indexed during the INDEX stage, without
+ *  re-extracting: extract-lib already wrote the raw bytes during the parse, so this only writes
+ *  or updates manifest.json. It produces the same entry the ARTIFACT stage would, because both go
+ *  through {@link RawArtifact#entryFor} and {@link ArtifactProducer#stampTerminal}. */
+public class ManifestRecorder {
+    private final ManifestRepository repository;
+    private final Path projectRoot;
+    private final boolean force;
+    private final boolean rawSelected;
+    private final RawArtifact raw = new RawArtifact();
+
+    public ManifestRecorder(ManifestRepository repository, Path projectRoot, List<Artifact> selected, boolean force) {
+        this.repository = repository;
+        this.projectRoot = projectRoot;
+        this.force = force;
+        this.rawSelected = selected.stream().anyMatch(artifact -> artifact.type() == ArtifactType.RAW);
+    }
+
+    /** Record the raw entry for a document written during indexing. No-op when raw was not among the
+     *  selected types, or when a matching terminal entry already exists (unless force). */
+    public void record(Document document) throws IOException {
+        if (!rawSelected) {
+            return;
+        }
+        Path docArtifactDir = ArtifactPath.dir(projectRoot, document.getId());
+        if (!force) {
+            ManifestEntry existing = repository.get(docArtifactDir, ArtifactType.RAW.token());
+            if (existing != null && existing.isTerminal() && existing.taskInput().equals(raw.taskInput())) {
+                return;
+            }
+        }
+        repository.put(docArtifactDir, ArtifactType.RAW.token(), ArtifactProducer.stampTerminal(raw.entryFor(document)));
+    }
+}

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -2,8 +2,6 @@ package org.icij.datashare.text.artifact;
 
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,7 +17,6 @@ import java.util.List;
  *  during the streaming parse, which today is {@link ArtifactType#RAW}. Any other selected type is
  *  produced by the ARTIFACT stage, not here. */
 public class ManifestRecorder {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ManifestRecorder.class);
     private final ManifestRepository repository;
     private final Path projectRoot;
     private final boolean force;
@@ -31,15 +28,6 @@ public class ManifestRecorder {
         this.projectRoot = projectRoot;
         this.force = force;
         this.rawSelected = selected.stream().anyMatch(artifact -> artifact.type() == ArtifactType.RAW);
-        List<String> deferredToArtifactStage = selected.stream()
-                .map(Artifact::type)
-                .filter(type -> type != ArtifactType.RAW)
-                .map(ArtifactType::token)
-                .distinct()
-                .toList();
-        if (!deferredToArtifactStage.isEmpty()) {
-            LOGGER.info("INDEX-time recording handles only 'raw'; {} will be produced by the ARTIFACT stage", deferredToArtifactStage);
-        }
     }
 
     /** Record the raw entry for a document written during indexing. No-op when raw was not among the

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -4,6 +4,7 @@ import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -32,11 +33,15 @@ public class ManifestRecorder {
             return;
         }
         Path docArtifactDir = ArtifactPath.dir(projectRoot, document.getId());
-        if (!force) {
-            ManifestEntry existing = repository.get(docArtifactDir, ArtifactType.RAW.token());
-            if (existing != null && existing.isTerminal() && existing.taskInput().equals(raw.taskInput())) {
-                return;
-            }
+        if (!force && ArtifactProducer.entryIsCurrent(repository.get(docArtifactDir, ArtifactType.RAW.token()), raw.taskInput())) {
+            return;
+        }
+        // Fix C (#2): for an embedded node, only record a COMPLETE entry once its raw payload is
+        // actually on disk (written by extract-lib during the parse). Otherwise skip, so a later
+        // ARTIFACT-stage run produces it rather than leaving a permanent false-COMPLETE. A root has
+        // no payload in its own dir, so it always records its EMPTY entry.
+        if (document.getExtractionLevel() > 0 && !Files.exists(docArtifactDir.resolve("raw"))) {
+            return;
         }
         repository.put(docArtifactDir, ArtifactType.RAW.token(), ArtifactProducer.stampTerminal(raw.entryFor(document)));
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -2,6 +2,8 @@ package org.icij.datashare.text.artifact;
 
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,7 +19,7 @@ import java.util.List;
  *  during the streaming parse, which today is {@link ArtifactType#RAW}. Any other selected type is
  *  produced by the ARTIFACT stage, not here. */
 public class ManifestRecorder {
-    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ManifestRecorder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManifestRecorder.class);
     private final ManifestRepository repository;
     private final Path projectRoot;
     private final boolean force;
@@ -29,7 +31,7 @@ public class ManifestRecorder {
         this.projectRoot = projectRoot;
         this.force = force;
         this.rawSelected = selected.stream().anyMatch(artifact -> artifact.type() == ArtifactType.RAW);
-        java.util.List<String> deferredToArtifactStage = selected.stream()
+        List<String> deferredToArtifactStage = selected.stream()
                 .map(Artifact::type)
                 .filter(type -> type != ArtifactType.RAW)
                 .map(ArtifactType::token)

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -11,8 +11,13 @@ import java.util.List;
 /** Records the raw manifest entry for a document indexed during the INDEX stage, without
  *  re-extracting: extract-lib already wrote the raw bytes during the parse, so this only writes
  *  or updates manifest.json. It produces the same entry the ARTIFACT stage would, because both go
- *  through {@link RawArtifact#entryFor} and {@link ArtifactProducer#stampTerminal}. */
+ *  through {@link RawArtifact#entryFor} and {@link ArtifactProducer#stampTerminal}.
+ *
+ *  <p>INDEX-time recording only records artifact types whose payload extract-lib materializes
+ *  during the streaming parse, which today is {@link ArtifactType#RAW}. Any other selected type is
+ *  produced by the ARTIFACT stage, not here. */
 public class ManifestRecorder {
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(ManifestRecorder.class);
     private final ManifestRepository repository;
     private final Path projectRoot;
     private final boolean force;
@@ -24,6 +29,15 @@ public class ManifestRecorder {
         this.projectRoot = projectRoot;
         this.force = force;
         this.rawSelected = selected.stream().anyMatch(artifact -> artifact.type() == ArtifactType.RAW);
+        java.util.List<String> deferredToArtifactStage = selected.stream()
+                .map(Artifact::type)
+                .filter(type -> type != ArtifactType.RAW)
+                .map(ArtifactType::token)
+                .distinct()
+                .toList();
+        if (!deferredToArtifactStage.isEmpty()) {
+            LOGGER.info("INDEX-time recording handles only 'raw'; {} will be produced by the ARTIFACT stage", deferredToArtifactStage);
+        }
     }
 
     /** Record the raw entry for a document written during indexing. No-op when raw was not among the

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -40,7 +40,7 @@ public class ManifestRecorder {
         if (!force && ArtifactProducer.entryIsCurrent(repository.get(docArtifactDir, ArtifactType.RAW.token()), raw.taskInput())) {
             return;
         }
-        // Fix C (#2): for an embedded node, only record a COMPLETE entry once its raw payload is
+        // For an embedded node, only record a COMPLETE entry once its raw payload is
         // actually on disk (written by extract-lib during the parse). Otherwise skip, so a later
         // ARTIFACT-stage run produces it rather than leaving a permanent false-COMPLETE. A root has
         // no payload in its own dir, so it always records its EMPTY entry.

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -11,7 +11,7 @@ import java.util.List;
 /** Records the raw manifest entry for a document indexed during the INDEX stage, without
  *  re-extracting: extract-lib already wrote the raw bytes during the parse, so this only writes
  *  or updates manifest.json. It produces the same entry the ARTIFACT stage would, because both go
- *  through {@link RawArtifact#entryFor} and {@link ArtifactProducer#stampTerminal}.
+ *  through {@link RawArtifact#entryFor} and {@link ManifestEntry#withTerminalStatus}.
  *
  *  <p>INDEX-time recording only records artifact types whose payload extract-lib materializes
  *  during the streaming parse, which today is {@link ArtifactType#RAW}. Any other selected type is
@@ -37,8 +37,11 @@ public class ManifestRecorder {
             return;
         }
         Path docArtifactDir = ArtifactPath.dir(projectRoot, document.getId());
-        if (!force && ArtifactProducer.entryIsCurrent(repository.get(docArtifactDir, ArtifactType.RAW.token()), raw.taskInput())) {
-            return;
+        if (!force) {
+            ManifestEntry existing = repository.get(docArtifactDir, ArtifactType.RAW.token());
+            if (existing != null && existing.isCurrentFor(raw.taskInput())) {
+                return;
+            }
         }
         // For an embedded node, only record a COMPLETE entry once its raw payload is
         // actually on disk (written by extract-lib during the parse). Otherwise skip, so a later
@@ -47,6 +50,6 @@ public class ManifestRecorder {
         if (document.getExtractionLevel() > 0 && !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))) {
             return;
         }
-        repository.put(docArtifactDir, ArtifactType.RAW.token(), ArtifactProducer.stampTerminal(raw.entryFor(document)));
+        repository.put(docArtifactDir, ArtifactType.RAW.token(), raw.entryFor(document).withTerminalStatus());
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
@@ -31,18 +31,15 @@ public class RawArtifact implements Artifact {
         try {
             // extract-lib writes the raw/raw.json bytes for the embedded subtree as a side effect.
             context.sources().extractEmbeddedSources(context.project(), document);
-            // A root's source is the on-disk original, served directly and never copied here, so there is
-            // no payload in this dir. Record an empty entry so the root is not reprocessed on every run.
-            if (document.getExtractionLevel() <= 0) {
-                return ManifestEntry.empty(taskInput());
-            }
-            ManifestEntry entry = ManifestEntry.singleFile(taskInput(), document.getContentType(), document.getName());
+            ManifestEntry entry = entryFor(document);
+            // A root has no payload in this dir, so there is nothing to verify. For an embedded node,
             // extractAll can return normally without ever writing THIS polled document's bytes: a
             // per-message parse failure the resilient parser swallows, a mid-walk abort, a corrupt
             // entry, an OCR-off image... Verify the raw payload actually landed before handing back
             // a terminal-able entry, so a silent miss fails loudly (nbFailed, re-runnable) instead of
             // being recorded as produced.
-            if (Files.notExists(context.docArtifactDir().resolve(ArtifactPath.RAW_FILE))) {
+            if (document.getExtractionLevel() > 0
+                    && Files.notExists(context.docArtifactDir().resolve(ArtifactPath.RAW_FILE))) {
                 throw new ArtifactException("raw extraction produced no bytes for " + document.getId(), null);
             }
             return entry;
@@ -51,5 +48,16 @@ public class RawArtifact implements Artifact {
         } catch (Exception extractionFailure) {
             throw new ArtifactException("raw extraction failed for " + document.getId(), extractionFailure);
         }
+    }
+
+    /** Build the raw manifest entry for an already-extracted document, without touching the
+     *  filesystem. Shared by produce() and the INDEX-time ManifestRecorder so both stages emit
+     *  the same entry. A root's source is the on-disk original (no payload here), so it records
+     *  an empty entry; an embedded node records its single-file payload. */
+    public ManifestEntry entryFor(Document document) {
+        if (document.getExtractionLevel() <= 0) {
+            return ManifestEntry.empty(taskInput());
+        }
+        return ManifestEntry.singleFile(taskInput(), document.getContentType(), document.getName());
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
@@ -5,8 +5,7 @@ import java.nio.file.Path;
 /** Content-addressed on-disk layout for per-document artifacts under artifactDir. */
 public class ArtifactPath {
     public static final String MANIFEST_FILE = "manifest.json";
-    // extract-lib's EmbeddedArtifactWriter owns these names: the raw payload and its sidecar. RAW_FILE
-    // is not to be confused with ArtifactType.RAW.token() (the manifest key, coincidentally also "raw").
+    // extract-lib's EmbeddedArtifactWriter owns these names: the raw payload and its sidecar.
     public static final String RAW_FILE = "raw";
     public static final String RAW_SIDECAR_FILE = "raw.json";
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
@@ -5,11 +5,18 @@ import java.nio.file.Path;
 /** Content-addressed on-disk layout for per-document artifacts under artifactDir. */
 public class ArtifactPath {
     public static final String MANIFEST_FILE = "manifest.json";
-    // extract-lib's EmbeddedArtifactWriter owns these names: the raw payload and its sidecar.
+    // extract-lib's EmbeddedArtifactWriter owns these names: the raw payload and its sidecar. RAW_FILE
+    // is not to be confused with ArtifactType.RAW.token() (the manifest key, coincidentally also "raw").
     public static final String RAW_FILE = "raw";
     public static final String RAW_SIDECAR_FILE = "raw.json";
 
     private ArtifactPath() {}
+
+    /** The per-project artifact root under artifactDir. Single home for the dir+project join so the
+     *  INDEX stage, the ARTIFACT stage, and the source-extraction read path cannot drift. */
+    public static Path projectRoot(Path artifactDir, String projectName) {
+        return artifactDir.resolve(projectName);
+    }
 
     /** Content-addressed directory for a digest, mirroring extract-lib's raw layout. */
     public static Path dir(Path projectRoot, String digest) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import org.icij.datashare.*;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.text.*;
+import org.icij.datashare.text.artifact.ManifestRecorder;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.LanguageGuesser;
 import org.icij.extract.document.TikaDocument;
@@ -112,6 +113,7 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
     private final Hasher digestAlgorithm;
     private final DocumentQueue<String> outputQueue;
     public String indexName;
+    private ManifestRecorder manifestRecorder;
 
     @Inject
     public ElasticsearchSpewer(final Indexer indexer, DocumentCollectionFactory<String> outputQueueFactory, LanguageGuesser languageGuesser, final FieldNames fields,
@@ -142,6 +144,9 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         } else {
             Document document = getDocument(doc, root, parent, (short) level);
             indexer.add(indexName, document);
+            if (manifestRecorder != null) {
+                manifestRecorder.record(document);
+            }
             String queueEntry = DocReference.fromDocument(document).toQueueEntry();
             if (!outputQueue.offer(queueEntry)) {
                 logger.warn("cannot offer {} to queue {}", queueEntry, outputQueue.getName());
@@ -401,6 +406,13 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
     public Spewer configure(Options<String> options) {
         super.configure(options);
         setIndex(options.valueIfPresent("projectName").orElse(options.get(DEFAULT_PROJECT_OPT).value().get()));
+        return this;
+    }
+
+    /** Opt-in: when set, records the raw manifest entry for each indexed document (INDEX-time
+     *  artifact generation). Null by default, so indexing is unchanged unless --artifacts is set. */
+    public ElasticsearchSpewer setManifestRecorder(ManifestRecorder manifestRecorder) {
+        this.manifestRecorder = manifestRecorder;
         return this;
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -145,7 +145,14 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
             Document document = getDocument(doc, root, parent, (short) level);
             indexer.add(indexName, document);
             if (manifestRecorder != null) {
-                manifestRecorder.record(document);
+                try {
+                    manifestRecorder.record(document);
+                } catch (Exception e) {
+                    // Mirror the ARTIFACT stage (ArtifactProducer.produce): a manifest-write failure
+                    // must not abort indexing of an already-indexed document, which would orphan a
+                    // container's children. Log and continue.
+                    logger.error("failed to record artifact manifest for {}", document.getId(), e);
+                }
             }
             String queueEntry = DocReference.fromDocument(document).toQueueEntry();
             if (!outputQueue.offer(queueEntry)) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -113,7 +113,8 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
     private final Hasher digestAlgorithm;
     private final DocumentQueue<String> outputQueue;
     public String indexName;
-    private ManifestRecorder manifestRecorder;
+    // volatile: set by the task thread before the pipeline starts, read by every consumer thread
+    private volatile ManifestRecorder manifestRecorder;
 
     @Inject
     public ElasticsearchSpewer(final Indexer indexer, DocumentCollectionFactory<String> outputQueueFactory, LanguageGuesser languageGuesser, final FieldNames fields,

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -187,7 +187,7 @@ public class SourceExtractor {
     }
 
     private Path getArtifactPath(Project project) {
-        return propertiesProvider.get(DatashareCliOptions.ARTIFACT_DIR_OPT).map(dir -> Path.of(dir).resolve(project.name)).orElse(null);
+        return propertiesProvider.get(DatashareCliOptions.ARTIFACT_DIR_OPT).map(dir -> ArtifactPath.projectRoot(Path.of(dir), project.name)).orElse(null);
     }
 
     private boolean noDigestProject() {

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
@@ -1,0 +1,90 @@
+package org.icij.datashare.text.artifact;
+
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.text.DocumentBuilder.createDoc;
+
+public class ManifestRecorderTest {
+    private static final String EMBEDDED_ID = "eeee1111222233334444555566667777";
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+    private final ManifestRepository repository = new FilesystemManifestRepository();
+    private final RawArtifact raw = new RawArtifact();
+
+    private Path projectRoot() {
+        return tmp.getRoot().toPath().resolve("prj");
+    }
+
+    private ManifestRecorder recorder(boolean force) {
+        return new ManifestRecorder(repository, projectRoot(), List.of(raw), force);
+    }
+
+    private Document embedded(String id) {
+        return createDoc(id).with(Path.of("/tmp/image2.jpg"))
+                .ofContentType("image/jpeg").withExtractionLevel((short) 1).build();
+    }
+
+    @Test
+    public void test_records_single_file_entry_for_embedded() throws Exception {
+        Document doc = embedded(EMBEDDED_ID);
+
+        recorder(false).record(doc);
+
+        ManifestEntry entry = repository.get(ArtifactPath.dir(projectRoot(), doc.getId()), "raw");
+        assertThat(entry).isNotNull();
+        assertThat(entry.isComplete()).isTrue();
+        assertThat(entry.contentType()).isEqualTo("image/jpeg");
+        assertThat(entry.filename()).isEqualTo("image2.jpg");
+    }
+
+    @Test
+    public void test_records_empty_entry_for_root() throws Exception {
+        Document root = createDoc("rootrootrootroot").with(Path.of("/tmp/root.pdf"))
+                .ofContentType("application/pdf").withExtractionLevel((short) 0).build();
+
+        recorder(false).record(root);
+
+        ManifestEntry entry = repository.get(ArtifactPath.dir(projectRoot(), root.getId()), "raw");
+        assertThat(entry.status()).isEqualTo(ManifestEntryStatus.EMPTY);
+    }
+
+    @Test
+    public void test_skip_if_current_leaves_existing_entry() throws Exception {
+        Document doc = embedded(EMBEDDED_ID);
+        Path dir = ArtifactPath.dir(projectRoot(), doc.getId());
+        // A terminal entry with the same taskInput already exists -> record(force=false) must skip.
+        repository.put(dir, "raw", ManifestEntry.empty(raw.taskInput()));
+
+        recorder(false).record(doc);
+
+        assertThat(repository.get(dir, "raw").status()).isEqualTo(ManifestEntryStatus.EMPTY);
+    }
+
+    @Test
+    public void test_force_overwrites_current_entry() throws Exception {
+        Document doc = embedded(EMBEDDED_ID);
+        Path dir = ArtifactPath.dir(projectRoot(), doc.getId());
+        repository.put(dir, "raw", ManifestEntry.empty(raw.taskInput()));
+
+        recorder(true).record(doc);
+
+        assertThat(repository.get(dir, "raw").filename()).isEqualTo("image2.jpg");
+    }
+
+    @Test
+    public void test_no_op_when_raw_not_selected() throws Exception {
+        Document doc = embedded(EMBEDDED_ID);
+        ManifestRecorder recorder = new ManifestRecorder(repository, projectRoot(), List.of(), false);
+
+        recorder.record(doc);
+
+        assertThat(repository.get(ArtifactPath.dir(projectRoot(), doc.getId()), "raw")).isNull();
+    }
+}

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -31,9 +32,15 @@ public class ManifestRecorderTest {
                 .ofContentType("image/jpeg").withExtractionLevel((short) 1).build();
     }
 
+    private void writePayload(String docId) throws Exception {
+        Files.createDirectories(ArtifactPath.dir(projectRoot(), docId));
+        Files.write(ArtifactPath.dir(projectRoot(), docId).resolve("raw"), new byte[]{1, 2, 3});
+    }
+
     @Test
     public void test_records_single_file_entry_for_embedded() throws Exception {
         Document doc = embedded(EMBEDDED_ID);
+        writePayload(doc.getId());
 
         recorder(false).record(doc);
 
@@ -41,6 +48,29 @@ public class ManifestRecorderTest {
         assertThat(entry).isNotNull();
         assertThat(entry.isComplete()).isTrue();
         assertThat(entry.contentType()).isEqualTo("image/jpeg");
+        assertThat(entry.filename()).isEqualTo("image2.jpg");
+    }
+
+    @Test
+    public void test_skips_embedded_when_payload_missing() throws Exception {
+        Document doc = embedded(EMBEDDED_ID);
+
+        recorder(false).record(doc);
+
+        assertThat(repository.get(ArtifactPath.dir(projectRoot(), doc.getId()), "raw")).isNull();
+    }
+
+    @Test
+    public void test_null_task_input_entry_is_not_current() throws Exception {
+        Document doc = embedded(EMBEDDED_ID);
+        Path dir = ArtifactPath.dir(projectRoot(), doc.getId());
+        repository.put(dir, "raw", new ManifestEntry(ManifestEntryStatus.COMPLETE, null, null, null, null, null, null));
+        writePayload(doc.getId());
+
+        recorder(false).record(doc);
+
+        ManifestEntry entry = repository.get(dir, "raw");
+        assertThat(entry).isNotNull();
         assertThat(entry.filename()).isEqualTo("image2.jpg");
     }
 
@@ -61,6 +91,7 @@ public class ManifestRecorderTest {
         Path dir = ArtifactPath.dir(projectRoot(), doc.getId());
         // A terminal entry with the same taskInput already exists -> record(force=false) must skip.
         repository.put(dir, "raw", ManifestEntry.empty(raw.taskInput()));
+        writePayload(doc.getId());
 
         recorder(false).record(doc);
 
@@ -72,6 +103,7 @@ public class ManifestRecorderTest {
         Document doc = embedded(EMBEDDED_ID);
         Path dir = ArtifactPath.dir(projectRoot(), doc.getId());
         repository.put(dir, "raw", ManifestEntry.empty(raw.taskInput()));
+        writePayload(doc.getId());
 
         recorder(true).record(doc);
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
@@ -21,9 +21,34 @@ import static org.mockito.Mockito.when;
 public class RawArtifactTest {
     @Rule public TemporaryFolder dir = new TemporaryFolder();
 
+    private final RawArtifact raw = new RawArtifact();
+
+    @Test
+    public void test_entry_for_root_is_empty() {
+        Document root = createDoc("rootrootrootroot").with(Path.of("/tmp/root.pdf"))
+                .ofContentType("application/pdf").withExtractionLevel((short) 0).build();
+
+        ManifestEntry entry = raw.entryFor(root);
+
+        assertThat(entry.status()).isEqualTo(ManifestEntryStatus.EMPTY);
+        assertThat(entry.filename()).isNull();
+    }
+
+    @Test
+    public void test_entry_for_embedded_is_single_file() {
+        Document embedded = createDoc("embeddedembedded").with(Path.of("/tmp/image2.jpg"))
+                .ofContentType("image/jpeg").withExtractionLevel((short) 1).build();
+
+        ManifestEntry entry = raw.entryFor(embedded);
+
+        assertThat(entry.status()).isNull();
+        assertThat(entry.contentType()).isEqualTo("image/jpeg");
+        assertThat(entry.filename()).isEqualTo("image2.jpg");
+        assertThat(entry.taskInput()).isEqualTo(raw.taskInput());
+    }
+
     @Test
     public void test_type_and_task_input() {
-        RawArtifact raw = new RawArtifact();
         assertThat(raw.type()).isEqualTo(ArtifactType.RAW);
         assertThat(raw.taskInput()).isEqualTo(Map.of("type", "raw", "version", 1));
     }

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -19,6 +19,7 @@ import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.*;
+import org.icij.datashare.text.artifact.*;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.LanguageGuesser;
 import org.icij.extract.document.DocumentFactory;
@@ -29,6 +30,8 @@ import org.icij.spewer.FieldNames;
 import org.icij.task.Options;
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -59,6 +62,24 @@ public class ElasticsearchSpewerTest {
             documentQueueFactory, text -> Language.ENGLISH, new FieldNames(), new PropertiesProvider(new HashMap<>() {{
                 put("defaultProject", es.getIndexName());
     }}));
+
+    @Rule public TemporaryFolder artifactDir = new TemporaryFolder();
+
+    @Test
+    public void test_write_records_raw_manifest_when_recorder_set() throws Exception {
+        Path projectRoot = artifactDir.getRoot().toPath().resolve("prj");
+        ManifestRepository repository = new FilesystemManifestRepository();
+        spewer.setManifestRecorder(new ManifestRecorder(repository, projectRoot, List.of(new RawArtifact()), false));
+        final TikaDocument document = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("recorded-file.txt"));
+        document.setReader(new ParsingReader(new ByteArrayInputStream("test".getBytes())));
+
+        spewer.write(document);
+
+        // A root document (level 0) has no payload in its own dir, so an EMPTY entry is recorded.
+        ManifestEntry entry = repository.get(ArtifactPath.dir(projectRoot, document.getId()), "raw");
+        assertThat(entry).isNotNull();
+        assertThat(entry.status()).isEqualTo(ManifestEntryStatus.EMPTY);
+    }
 
     @Test
     public void test_simple_write() throws Exception {


### PR DESCRIPTION
Opt-in per-document artifact generation (`raw`), gated by `--artifacts`, on both CLI surfaces and both the INDEX and ARTIFACT stages. Closes #2225.

- feat: `--artifacts` / `--artifactsForce` on the JOpt and picocli CLI surfaces
- feat: INDEX-stage inline manifest recording via `ManifestRecorder`, wired from `ElasticsearchSpewer`
- feat: fail-fast guard, `--artifacts` requires `--artifactDir`
- fix: no `--artifactsForce` default, so a settings-file value is not clobbered
- refactor: shared `RawArtifact.entryFor`, `ArtifactProducer.entryIsCurrent`, `ArtifactRegistry.withDefaults`, and `ArtifactStages` project/force resolution so INDEX and ARTIFACT stay in parity
- refactor: on-disk layout knowledge centralized in `ArtifactPath`
