### PR TITLE
fix(security): require INSTANCE_ADMIN for global user-inventory endpoints

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/UserResource.java
@@ -187,7 +187,7 @@ public class UserResource {
     @ApiResponse(responseCode = "201", description = "user created")
     @ApiResponse(responseCode = "400", description = "validation error")
     @ApiResponse(responseCode = "409", description = "user already exists")
-    @Policy(role = Role.PROJECT_ADMIN)
+    @Policy(role = Role.INSTANCE_ADMIN)
     @Post
     public Payload createUser(UserCreateRequest request) {
         try {
@@ -203,7 +203,7 @@ public class UserResource {
             parameters = @Parameter(name = "userId", in = ParameterIn.PATH))
     @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     @ApiResponse(responseCode = "404", description = "user not found")
-    @Policy(role = Role.PROJECT_ADMIN)
+    @Policy(role = Role.INSTANCE_ADMIN)
     @Get("/:userId")
     public Payload getUserByUid(String userId) {
         try {
@@ -218,7 +218,7 @@ public class UserResource {
     @ApiResponse(responseCode = "200", useReturnTypeSchema = true)
     @ApiResponse(responseCode = "400", description = "validation error")
     @ApiResponse(responseCode = "404", description = "user not found")
-    @Policy(role = Role.PROJECT_ADMIN)
+    @Policy(role = Role.INSTANCE_ADMIN)
     @Put("/:userId")
     public Payload updateUser(String userId, UserUpdateRequest request) {
         try {
@@ -233,7 +233,7 @@ public class UserResource {
     @Operation(description = "Deletes a user by userId. Idempotent: returns 204 even when the user does not exist.",
             parameters = @Parameter(name = "uid", in = ParameterIn.PATH))
     @ApiResponse(responseCode = "204", description = "user deleted or did not exist")
-    @Policy(role = Role.PROJECT_ADMIN)
+    @Policy(role = Role.INSTANCE_ADMIN)
     @Delete("/:userId")
     public Payload deleteUser(String userId) {
         userAdminService.deleteIfExists(userId);

--- a/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/UserResourceTest.java
@@ -65,7 +65,9 @@ public class UserResourceTest extends AbstractProdWebServerTest {
     public void setUp() throws IOException {
         initMocks(this);
         authorizer = new Authorizer(casbinRuleAdapter);
-        authorizer.addRoleForUserInDomain(User.local(), Role.PROJECT_ADMIN, Domain.DEFAULT);
+        // INSTANCE_ADMIN inherits PROJECT_ADMIN, so the local user can both manage the global
+        // user inventory (create/get/update/delete require INSTANCE_ADMIN) and list users.
+        authorizer.addRoleForUserInInstance(User.local(), Role.INSTANCE_ADMIN);
         PolicyAnnotation policyAnnotation = new PolicyAnnotation(authorizer);
         configure(routes -> routes
                 .registerAroundAnnotation(Policy.class, policyAnnotation)
@@ -515,11 +517,64 @@ public class UserResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_list_users_returns_200_for_admin() {
-        // setUp() grants PROJECT_ADMIN to User.local(), so admin can list users
+        // setUp() grants INSTANCE_ADMIN (which inherits PROJECT_ADMIN) to User.local(), so admin can list users
         when(userAdminService.list(new UserFilter(null), null, 0, Integer.MAX_VALUE))
                 .thenReturn(new WebResponse<>(List.of(), 0, Integer.MAX_VALUE, 0));
 
         get("/api/users").should().respond(200);
+    }
+
+    // Security regression: the global user-inventory endpoints (create/get/update/delete) require
+    // INSTANCE_ADMIN. A user who is only PROJECT_ADMIN of a single project must NOT be able to reach
+    // them, even by supplying an ?index= (or JSON body "index") they control — otherwise a project
+    // admin could take over, read, or delete arbitrary users globally.
+
+    private void configureWithSingleProjectAdmin() throws IOException {
+        Authorizer projectAdmin = new Authorizer(casbinRuleAdapter);
+        // local is PROJECT_ADMIN of a single project only — no instance/domain-wide role
+        projectAdmin.addRoleForUserInProject(User.local(), Role.PROJECT_ADMIN, Domain.DEFAULT, new Project("cantina"));
+        PolicyAnnotation policyAnnotation = new PolicyAnnotation(projectAdmin);
+        configure(routes -> routes
+                .registerAroundAnnotation(Policy.class, policyAnnotation)
+                .add(new UserResource(jooqRepository, projectAdmin, userAdminService, projectAdminService))
+                .filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
+    }
+
+    @Test
+    public void test_create_user_returns_403_for_single_project_admin_even_with_index() throws IOException {
+        configureWithSingleProjectAdmin();
+
+        post("/api/users?index=cantina", "{\"uid\":\"victim\",\"provider\":\"local\",\"password\":\"pw\",\"groups\":[]}")
+                .should().respond(403);
+    }
+
+    @Test
+    public void test_create_user_returns_403_for_single_project_admin_even_with_index_in_body() throws IOException {
+        configureWithSingleProjectAdmin();
+
+        post("/api/users", "{\"uid\":\"victim\",\"provider\":\"local\",\"password\":\"pw\",\"groups\":[],\"index\":\"cantina\"}")
+                .should().respond(403);
+    }
+
+    @Test
+    public void test_get_user_returns_403_for_single_project_admin_even_with_index() throws IOException {
+        configureWithSingleProjectAdmin();
+
+        get("/api/users/victim?index=cantina").should().respond(403);
+    }
+
+    @Test
+    public void test_update_user_returns_403_for_single_project_admin_even_with_index() throws IOException {
+        configureWithSingleProjectAdmin();
+
+        put("/api/users/victim?index=cantina", "{\"password\":\"newpass\"}").should().respond(403);
+    }
+
+    @Test
+    public void test_delete_user_returns_403_for_single_project_admin_even_with_index() throws IOException {
+        configureWithSingleProjectAdmin();
+
+        delete("/api/users/victim?index=cantina").should().respond(403);
     }
 
     @Test


### PR DESCRIPTION
## Problem
related to #2259 and #2096 

The global user endpoints (`POST /api/users`, `GET/PUT/DELETE /api/users/:userId`) act on any user account, but were gated by `@Policy(role = PROJECT_ADMIN)` with `idParam = "index"`. `PolicyAnnotation.resolveProjectId` derives the authorization scope from caller-controlled input (the `index` query param, JSON body field, or a `"*"` fallback). As a result, a user who is `PROJECT_ADMIN` of a single project could authorize against a project they control and then act on arbitrary users: reset any password (account takeover), mass-assign groups, delete or create users, and read any user's data.

## Fix

Switch those four endpoints to `@Policy(role = INSTANCE_ADMIN)`, which `PolicyAnnotation` forces to `domain=*`/`project=*` and never sources from request input. This restores the pre-`b8d449ece` behavior.

Left as `PROJECT_ADMIN` on purpose:
- `listUsers`: results are scope-filtered to the authorized project, and the project users UI needs it.
- grant/revoke role (`/api/users/:userId/index/:index`): scope comes from the `:index` path segment, not caller input.

## Tests

`UserResourceTest` setup now grants the test user `INSTANCE_ADMIN` (inherits `PROJECT_ADMIN` via the role hierarchy, so existing tests stay valid). Added 5 regression tests asserting a single-project `PROJECT_ADMIN` gets 403 on create/get/update/delete, including the `?index=` and JSON-body `index` vectors. 80 tests pass.

## Related

Frontend branch `fix/user-crud-sec` (https://github.com/ICIJ/datashare-client/pull/464) hides the Create/Delete user controls from non-instance-admins. Merge together to avoid project admins hitting 403s.