### PR TITLE
fix(batch-search): JSON-escape query when substituting into query template

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/BatchSearchRunnerIntTest.java
@@ -202,6 +202,21 @@ public class BatchSearchRunnerIntTest {
     }
 
     @Test
+    public void test_search_with_query_template_and_double_quotes_in_query() throws Exception {
+        String queryBody = "{\"bool\":{\"must\":[{\"match_all\":{}},{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"<query>\"}}]}},{\"match\":{\"type\":\"Document\"}}]}}";
+        Document mydoc = createDoc("docId").with("mydoc to find").build();
+        indexer.add(es.getIndexName(), mydoc);
+        // query with double quotes used to break JSON substitution into the template (see #query_string bug)
+        BatchSearch searchOk = new BatchSearch(singletonList(project(es.getIndexName())), "name", "desc", asSet("content:\"mydoc to find\""), null, User.local(), false, null, queryBody,
+                null, 0);
+        when(repository.get(local(), searchOk.uuid)).thenReturn(searchOk);
+
+        new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(searchOk), progressCb).call();
+
+        verify(repository).saveResults(searchOk.uuid, "content:\"mydoc to find\"", singletonList(mydoc), true);
+    }
+
+    @Test
     public void test_search_without_query_template() throws Exception {
         Document mydoc = createDoc("docId").with("mydoc to find").build();
         indexer.add(es.getIndexName(), mydoc);
@@ -236,7 +251,7 @@ public class BatchSearchRunnerIntTest {
         when(repository.get(local(), search.uuid)).thenReturn(search);
 
         Exception exception = assertThrows(SearchException.class, () -> new BatchSearchRunner(indexer, new PropertiesProvider(), repository, taskView(search), progressCb).call());
-        assertThat(exception.getMessage()).contains("Unexpected char");
+        assertThat(exception.getMessage()).contains("Failed to parse query [\"mydoc]");
         verify(repository).setState(eq(search.uuid), any(SearchException.class));
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchQueryBuilderSearcher.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchQueryBuilderSearcher.java
@@ -58,7 +58,7 @@ class ElasticsearchQueryBuilderSearcher extends ElasticsearchSearcher implements
     @Override
     protected BoolQuery.Builder getBoolQueryBuilder(String query) {
         return query != null ? boolQueryBuilder.must(m -> m.matchAll(ma -> ma))
-                .must(m -> m.queryString(qs -> qs.query(buildQueryString(query, fuzziness, phraseMatches, "\"")))):
+                .must(m -> m.queryString(qs -> qs.query(buildQueryString(query, fuzziness, phraseMatches)))):
                 boolQueryBuilder;
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSearcher.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSearcher.java
@@ -9,6 +9,7 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.json.JsonException;
@@ -74,9 +75,7 @@ class ElasticsearchSearcher implements Indexer.Searcher {
 
     @Override
     public Stream<? extends Entity> execute(String stringQuery) throws IOException {
-        String queryString = buildQueryString(stringQuery, fuzziness, phraseMatches, "\\\\\"");
-        final String queryBody = jsonBoolQuery.toString().replaceAll(TEMPLATE_QUERY,queryString);
-        return getStream(queryBody);
+        return getStream(substituteQuery(stringQuery));
     }
 
     protected Stream<? extends Entity> getStream(String queryBody) throws IOException {
@@ -101,11 +100,20 @@ class ElasticsearchSearcher implements Indexer.Searcher {
 
     protected String queryAsString(String queryString) {
         if (isTemplate() && queryString != null) {
-            String replacement = buildQueryString(queryString, fuzziness, phraseMatches, "\\\\\"");
-            return jsonBoolQuery.toString().replaceAll(TEMPLATE_QUERY, replacement);
+            return substituteQuery(queryString);
         } else {
             return jsonBoolQuery.toString();
         }
+    }
+
+    // Substitutes the user query into the JSON template. The <query> placeholder sits inside a JSON
+    // string literal ("query":"<query>"), so the query must be JSON-escaped or any double quote it
+    // contains (e.g. title:"source.zip") would break the surrounding JSON. Uses literal replace()
+    // rather than replaceAll() so backslashes and $ in the query aren't treated as regex replacements.
+    private String substituteQuery(String queryString) {
+        String replacement = buildQueryString(queryString, fuzziness, phraseMatches);
+        String jsonEscaped = new String(JsonStringEncoder.getInstance().quoteAsString(replacement));
+        return jsonBoolQuery.toString().replace(TEMPLATE_QUERY, jsonEscaped);
     }
 
     private boolean isTemplate() {
@@ -159,10 +167,10 @@ class ElasticsearchSearcher implements Indexer.Searcher {
         return this;
     }
 
-    protected static String buildQueryString(String query, int fuzziness, boolean phraseMatches, String phraseMatchDoubleQuotes) {
+    protected static String buildQueryString(String query, int fuzziness, boolean phraseMatches) {
         String queryString;
         if (phraseMatches) {
-            queryString = phraseMatchDoubleQuotes + query + phraseMatchDoubleQuotes + (fuzziness == 0 ? "" : "~" + fuzziness);
+            queryString = "\"" + query + "\"" + (fuzziness == 0 ? "" : "~" + fuzziness);
         } else if (fuzziness > 0) {
             queryString = Stream.of(query.split(" ")).map(s -> s + "~" + fuzziness).collect(Collectors.joining(" "));
         } else {

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
@@ -5,7 +5,6 @@ import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch.core.GetRequest;
 import co.elastic.clients.elasticsearch.core.UpdateRequest;
-import jakarta.json.JsonException;
 import org.apache.http.ConnectionClosedException;
 import org.icij.datashare.Entity;
 import org.icij.datashare.PropertiesProvider;
@@ -325,6 +324,33 @@ public class ElasticsearchIndexerTest {
     }
 
     @Test
+    public void test_search_with_a_template_json_query_containing_double_quotes() throws IOException {
+        Document doc = createDoc("id").with("content with john doe").build();
+        indexer.add(es.getIndexName(), doc);
+        String queryBody = "{\"bool\":{\"must\":[{\"match_all\":{}},{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"<query>\"}}]}},{\"match\":{\"type\":\"Document\"}}]}}";
+
+        // a query containing double quotes must not break JSON substitution into the template
+        List<? extends Entity> results = indexer.search(singletonList(es.getIndexName()), Document.class, new SearchQuery(queryBody))
+                .execute("content:\"john doe\"").toList();
+
+        assertThat(results.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void test_scroll_with_a_template_json_query_containing_double_quotes() throws IOException {
+        Document doc = createDoc("id").with("content with john doe").build();
+        indexer.add(es.getIndexName(), doc);
+        String queryBody = "{\"bool\":{\"must\":[{\"match_all\":{}},{\"bool\":{\"should\":[{\"query_string\":{\"query\":\"<query>\"}}]}},{\"match\":{\"type\":\"Document\"}}]}}";
+
+        // batch search goes through the scroll path with a raw query string (here containing double quotes)
+        Indexer.Searcher searcher = indexer.search(singletonList(es.getIndexName()), Document.class, new SearchQuery(queryBody));
+        List<? extends Entity> results = searcher.scroll("1m", "content:\"john doe\"").toList();
+        searcher.clearScroll();
+
+        assertThat(results.size()).isEqualTo(1);
+    }
+
+    @Test
     public void test_update_tagged_document_does_not_push_tag_objects_into_keyword_field() throws IOException {
         Document doc = createDoc("id").build();
         indexer.add(es.getIndexName(), doc);
@@ -517,7 +543,7 @@ public class ElasticsearchIndexerTest {
         searcher.clearScroll();
     }
 
-    @Test(expected = JsonException.class)
+    @Test(expected = ElasticsearchException.class)
     public void test_scroll_with_json_query_template_and_wrong_query() throws IOException {
         Document doc = createDoc("id").build();
         indexer.add(es.getIndexName(), doc);
@@ -525,6 +551,8 @@ public class ElasticsearchIndexerTest {
         Indexer.Searcher searcher = indexer.search(singletonList(es.getIndexName()), Document.class,
                         new SearchQuery("{\"bool\":{\"must\":[{\"query_string\":{\"query\":\"<query>\"}}, {\"match\":{\"type\":\"Document\"}}]}}"));
 
+        // the query is now JSON-escaped into the template, so a malformed Lucene query (unbalanced
+        // quote) no longer breaks JSON parsing but is rejected by Elasticsearch's query parser
         searcher.scroll(KEEP_ALIVE, "\"id*");
 
         searcher.clearScroll();


### PR DESCRIPTION
Batch search substituted the raw query into a JSON template (`"query":"<query>"`) without escaping, so a query containing a double quote (e.g. `title:"source.zip"`) broke the JSON and failed with a `JsonParsingException`. Interactive search was unaffected. This JSON-escapes the query before substitution.

- fix: JSON-escape the query and use literal `replace()` instead of regex `replaceAll()` when filling the query template
- test: cover template queries containing double quotes (execute + scroll + batch paths)