### PR TITLE
fix: Ensure striclty positive content length value in the HTTP header

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -515,9 +515,10 @@ public class DocumentResource {
             if (contentType != null && contentType.startsWith("image/ocr-")) {
                 contentType = "image/" + contentType.substring("image/ocr-".length());
             }
-            Payload payload = filterMetadata
-                    ? new Payload(contentType, from)
-                    : new Payload(contentType, from).withHeader(CONTENT_LENGTH, String.valueOf(doc.getContentLength()));
+            Payload payload =  new Payload(contentType, from);
+            if(!filterMetadata && doc.getContentLength() > 0) {
+                payload.withHeader(CONTENT_LENGTH, String.valueOf(doc.getContentLength()));
+            }
             String fileName = doc.isRootDocument() ? doc.getName(): doc.getId().substring(0, 10) + "." + FileExtension.get(contentType);
             return inline ? payload: payload.withHeader("Content-Disposition", "attachment;filename=\"" + fileName + "\"");
         } catch (FileNotFoundException | EmbeddedDocumentExtractor.ContentNotFoundException fnf) {

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -98,6 +98,20 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_get_source_file_without_indexed_content_length() throws Exception {
+        // embedded documents don't have their contentLength indexed (it defaults to -1):
+        // Content-Length must not be sent with a bogus "-1" value while real content is written
+        File txtFile = new File(temp.getRoot(), "/my/path/to/file.ods");
+        MockIndexer.write(txtFile, "content");
+        Document docWithoutContentLength = DocumentBuilder.createDoc().withId("id_ods_no_length").with(txtFile.toPath()).with(new Project("local-datashare"))
+                .ofContentType("application/vnd.oasis.opendocument.spreadsheet").build();
+        mockIndexer.indexFile("local-datashare", docWithoutContentLength);
+
+        get("/api/local-datashare/documents/src/id_ods_no_length").should()
+                .haveHeader("Content-Length", null);
+    }
+
+    @Test
     public void test_get_source_file_without_metadata() throws Exception {
         File txtFile = new File(temp.getRoot(), "/my/path/to/file.ods");
         MockIndexer.write(txtFile, "content");


### PR DESCRIPTION
In production, it is most likely preventing the download of embedded files because the header would contain -1 (as embedded documents don't have a content length set in the index)