### PR TITLE
fix: cli mode awaits for its own spawned tasks

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -41,13 +41,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.icij.datashare.PropertiesProvider.propertiesToMap;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
 import static org.icij.datashare.user.User.localUser;
@@ -174,43 +174,63 @@ class CliApp {
 
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
+        List<String> taskIds = new ArrayList<>();
         if (pipeline.has(Stage.DEDUPLICATE)) {
-            taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.SCANIDX)) {
-            taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.SCAN)) {
-            taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.INDEX)) {
-            taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.ENQUEUEIDX)) {
-            taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.CATEGORIZE)) {
-            taskManager.startTask(CategorizeTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(CategorizeTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.CREATENLPBATCHESFROMIDX)) {
-            taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.NLP)) {
-            taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties)));
         }
 
         if (pipeline.has(Stage.ARTIFACT)) {
-            taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties));
+            taskIds.add(taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties)));
         }
-        taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS);
+        awaitTasks(taskManager, taskIds);
         taskManager.shutdown();
+    }
+
+    static void awaitTasks(TaskManager taskManager, List<String> taskIds) throws IOException {
+        int pollingInterval = taskManager.getTerminationPollingInterval();
+        while (true) {
+            boolean allDone = taskIds.stream().allMatch(taskId -> {
+                try {
+                    return taskManager.getTask(taskId).getState().isFinal();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            if (allDone) break;
+            try {
+                Thread.sleep(pollingInterval);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     static int handleUserCreate(UserAdminService service, Properties properties) {

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -41,13 +41,15 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Properties;
 import java.util.function.Supplier;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.icij.datashare.PropertiesProvider.propertiesToMap;
 import static org.icij.datashare.cli.DatashareCliOptions.*;
 import static org.icij.datashare.user.User.localUser;
@@ -174,7 +176,7 @@ class CliApp {
 
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
-        List<String> taskIds = new ArrayList<>();
+        Set<String> taskIds = new HashSet<>();
         if (pipeline.has(Stage.DEDUPLICATE)) {
             taskIds.add(taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties)));
         }
@@ -210,27 +212,8 @@ class CliApp {
         if (pipeline.has(Stage.ARTIFACT)) {
             taskIds.add(taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties)));
         }
-        awaitTasks(taskManager, taskIds);
+        taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS, taskIds);
         taskManager.shutdown();
-    }
-
-    static void awaitTasks(TaskManager taskManager, List<String> taskIds) throws IOException {
-        int pollingInterval = taskManager.getTerminationPollingInterval();
-        while (true) {
-            boolean allDone = taskIds.stream().allMatch(taskId -> {
-                try {
-                    return taskManager.getTask(taskId).getState().isFinal();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            if (allDone) break;
-            try {
-                Thread.sleep(pollingInterval);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
     }
 
     static int handleUserCreate(UserAdminService service, Properties properties) {

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
@@ -3,18 +3,20 @@ package org.icij.datashare;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskManagerMemory;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
+import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.user.User;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
-import static java.util.Collections.*;
+import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.cli.DatashareCliOptions.TASK_MANAGER_POLLING_INTERVAL_OPT;
 import static org.mockito.Mockito.mock;
 
@@ -26,7 +28,7 @@ public class CliAppTest {
             new CountDownLatch(1));
 
     @Test(timeout = 2000)
-    public void test_await_tasks_ignores_stale_tasks_in_repo() throws Exception {
+    public void test_await_termination_with_scope_ignores_stale_tasks_in_repo() throws Exception {
         // GIVEN
         Task<Long> staleTask = new Task<>(ScanTask.class.getName(), User.local(), new HashMap<>());
         staleTask.setProgress(0.5);
@@ -34,9 +36,9 @@ public class CliAppTest {
 
         // GIVEN
         String taskId = taskManager.startTask(ScanTask.class.getName(), User.local(), new HashMap<>());
-        taskManager.getTask(taskId).setResult(new org.icij.datashare.asynctasks.TaskResult<>(0L));
+        taskManager.getTask(taskId).setResult(new TaskResult<>(0L));
 
         // WHEN/THEN
-        CliApp.awaitTasks(taskManager, singletonList(taskId));
+        assertThat(taskManager.awaitTermination(1, TimeUnit.SECONDS, Set.of(taskId))).isTrue();
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
@@ -1,0 +1,42 @@
+package org.icij.datashare;
+
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskManagerMemory;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
+import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.ScanTask;
+import org.icij.datashare.user.User;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.Collections.*;
+import static org.icij.datashare.cli.DatashareCliOptions.TASK_MANAGER_POLLING_INTERVAL_OPT;
+import static org.mockito.Mockito.mock;
+
+public class CliAppTest {
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
+    private final TaskManagerMemory taskManager = new TaskManagerMemory(
+            mock(DatashareTaskFactory.class), taskRepository,
+            new PropertiesProvider(Map.of(TASK_MANAGER_POLLING_INTERVAL_OPT, "100")),
+            new CountDownLatch(1));
+
+    @Test(timeout = 2000)
+    public void test_await_tasks_ignores_stale_tasks_in_repo() throws Exception {
+        // GIVEN
+        Task<Long> staleTask = new Task<>(ScanTask.class.getName(), User.local(), new HashMap<>());
+        staleTask.setProgress(0.5);
+        taskRepository.insert(staleTask, null);
+
+        // GIVEN
+        String taskId = taskManager.startTask(ScanTask.class.getName(), User.local(), new HashMap<>());
+        taskManager.getTask(taskId).setResult(new org.icij.datashare.asynctasks.TaskResult<>(0L));
+
+        // WHEN/THEN
+        CliApp.awaitTasks(taskManager, singletonList(taskId));
+    }
+}

--- a/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
+++ b/datashare-tasks/src/main/java/org/icij/datashare/asynctasks/TaskManager.java
@@ -56,6 +56,10 @@ public interface TaskManager extends Closeable {
         return waitTasksToBeDone(timeout, timeUnit) == 0L;
     }
 
+    default boolean awaitTermination(int timeout, TimeUnit timeUnit, Set<String> scopeTaskIds) throws InterruptedException, IOException {
+        return waitTasksToBeDone(timeout, timeUnit, scopeTaskIds) == 0L;
+    }
+
     default Map<String, Boolean> stopTasks(User user) throws IOException {
         return stopTasks(TaskFilters.empty().withUser(user));
     }
@@ -115,20 +119,31 @@ public interface TaskManager extends Closeable {
      * @throws IOException if the task list cannot be retrieved because of a network failure.
      */
     default long waitTasksToBeDone(int timeout, TimeUnit timeUnit) throws IOException {
+        return waitTasksToBeDone(timeout, timeUnit, null);
+    }
+
+    default long waitTasksToBeDone(int timeout, TimeUnit timeUnit, Set<String> scopeTaskIds) throws IOException {
         long startTime = System.currentTimeMillis();
         long maxDuration = timeUnit.toMillis(timeout);
         TaskFilters filterNotCompleted = TaskFilters.empty().withStates(NON_FINAL_STATES);
-        long nUnfinished = getTaskIds(filterNotCompleted).count();
+        long nUnfinished = countUnfinished(filterNotCompleted, scopeTaskIds);
         while (System.currentTimeMillis() - startTime < maxDuration && nUnfinished > 0) {
             try {
                 Thread.sleep(Math.min(getTerminationPollingInterval(), maxDuration));
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            Stream<String> taskIds = getTaskIds(filterNotCompleted);
-            nUnfinished = taskIds.count();
+            nUnfinished = countUnfinished(filterNotCompleted, scopeTaskIds);
         }
         return nUnfinished;
+    }
+
+    private long countUnfinished(TaskFilters filterNotCompleted, Set<String> scopeTaskIds) throws IOException {
+        Stream<String> unfinished = getTaskIds(filterNotCompleted);
+        if (scopeTaskIds != null) {
+            unfinished = unfinished.filter(scopeTaskIds::contains);
+        }
+        return unfinished.count();
     }
 
     // for tests


### PR DESCRIPTION
This PR aims to fix cli mode hanging after finishing tasks. Instead of waiting for the 'RUNNING' tasks of the repository to finish, it now waits for it's own created tasks.