### PR TITLE
feat(api): artifact-aware embedded download gate and HEAD /documents/src/:id

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
@@ -5,8 +5,13 @@ import org.icij.datashare.HumanReadableSize;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Duplicate;
+import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
 
 import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT;
 
@@ -14,6 +19,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNL
  * This class is responsible for verifying properties and conditions of documents.
  */
 public class DocumentVerifier {
+    private static final Logger logger = LoggerFactory.getLogger(DocumentVerifier.class);
 
     private static final String DEFAULT_MAX_SIZE = "1G";
 
@@ -42,17 +48,40 @@ public class DocumentVerifier {
      * @return true if the root document size is allowed, false otherwise.
      */
     public boolean isRootDocumentSizeAllowed(Document document) {
+        return isRootDocumentSizeAllowed(document, document.getProject());
+    }
+
+    // The project the caller will actually serve from: the artifact cache must be probed under the
+    // same project the source will be read under, or the gate can approve what the read cannot find.
+    public boolean isRootDocumentSizeAllowed(Document document, Project servingProject) {
         if (document.isRootDocument()) {
             return true;
         }
         // A cached raw artifact is read straight off disk: the root is never opened, so its size is
         // irrelevant. Checked before the root lookup, so a cache hit costs one stat and no ES call.
-        if (sources.hasCachedEmbeddedSource(document.getProject(), document)) {
+        if (sources.hasCachedEmbeddedSource(servingProject, document)) {
             return true;
         }
         long maxSizeBytes = getEmbeddedDocumentDownloadMaxSizeBytes();
         Document rootDocument = getRootDocument(document);
+        // An orphaned embed (root missing from the index, e.g. a mid-parse OOM that never wrote
+        // the root) must not NPE into a 500: refuse the download, it's safe and diagnosable.
+        if (rootDocument == null) {
+            logger.warn("cannot verify root document size for document {}: root document {} not found",
+                    document.getId(), document.getRootDocument());
+            return false;
+        }
         return rootDocument.getContentLength() < maxSizeBytes;
+    }
+
+    // Cheap "could this be served at all" probe for HEAD, which must not extract: either the
+    // embedded bytes are already cached under servingProject (the project the caller will actually
+    // read under, same reasoning as isRootDocumentSizeAllowed's overload), or the file we would
+    // read (the document's own path for a root, the root's path for an embed) has to exist. An
+    // embed whose root file is present can still fail to extract, which only the real read can
+    // discover, so HEAD stays optimistic there.
+    public boolean isSourceAvailable(Document document, Project servingProject) {
+        return sources.hasCachedEmbeddedSource(servingProject, document) || Files.exists(document.getPath());
     }
 
     /**

--- a/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
@@ -35,6 +35,8 @@ public class DocumentVerifier {
 
     /**
      * Checks if the root document size is allowed based on the provided document's properties.
+     * Also returns true when the embedded document's raw artifact is already cached, since serving
+     * it from the cache never opens the root document.
      *
      * @param document The document to verify.
      * @return true if the root document size is allowed, false otherwise.

--- a/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/DocumentVerifier.java
@@ -6,6 +6,7 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Duplicate;
 import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 
 import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT;
 
@@ -18,6 +19,7 @@ public class DocumentVerifier {
 
     private final Indexer indexer;
     private final PropertiesProvider propertiesProvider;
+    private final SourceExtractor sources;
 
     /**
      * Constructs a new DocumentVerifier with the provided indexer and propertiesProvider.
@@ -28,6 +30,7 @@ public class DocumentVerifier {
     public DocumentVerifier(Indexer indexer, PropertiesProvider propertiesProvider) {
         this.indexer = indexer;
         this.propertiesProvider = propertiesProvider;
+        this.sources = new SourceExtractor(propertiesProvider);
     }
 
     /**
@@ -38,6 +41,11 @@ public class DocumentVerifier {
      */
     public boolean isRootDocumentSizeAllowed(Document document) {
         if (document.isRootDocument()) {
+            return true;
+        }
+        // A cached raw artifact is read straight off disk: the root is never opened, so its size is
+        // irrelevant. Checked before the root lookup, so a cache hit costs one stat and no ES call.
+        if (sources.hasCachedEmbeddedSource(document.getProject(), document)) {
             return true;
         }
         long maxSizeBytes = getEmbeddedDocumentDownloadMaxSizeBytes();

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -122,6 +122,9 @@ public class DocumentResource {
     @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project or downloads are restricted")
     @ApiResponse(responseCode = "404", description = "if no document is found")
     @ApiResponse(responseCode = "413", description = "if the root document is too large and no raw artifact is cached for this embedded document")
+    // HEAD requests also match the @Get route above, and fluent-http picks the route with the
+    // fewest query params on a tie: keep this route's param count below the GET route's
+    // (currently 3 vs 4, "filter_metadata" is GET-only) or GET starts silently handling HEAD again.
     @Head("/:project/documents/src/:id?routing=:routing")
     public Payload headSourceFile(final String project, final String id, final String routing, final Context context) {
         return sourceFile(project, id, routing, context, document -> ok());

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.lang.Boolean.parseBoolean;
@@ -106,17 +107,42 @@ public class DocumentResource {
     public Payload getSourceFile(final String project, final String id,
                                  final String routing, final String filterMetadata, final Context context) throws IOException {
         boolean inline = context.request().query().getBoolean("inline");
+        return sourceFile(project, id, routing, context,
+                document -> getPayload(document, project, inline, parseBoolean(filterMetadata)));
+    }
+
+    @Operation(description = "Tells whether the source of a document can be downloaded, without transferring it. Same decision as GET on the same route (permissions, existence, and the embedded-document size limit), so clients don't have to reimplement the rule.",
+                parameters = {
+                    @Parameter(name = "project", description = "project id", in = ParameterIn.PATH),
+                    @Parameter(name = "id", description = "hash of the document", in = ParameterIn.PATH),
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY),
+                }
+    )
+    @ApiResponse(responseCode = "200", description = "the source can be downloaded")
+    @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project or downloads are restricted")
+    @ApiResponse(responseCode = "404", description = "if no document is found")
+    @ApiResponse(responseCode = "413", description = "if the root document is too large and no raw artifact is cached for this embedded document")
+    @Head("/:project/documents/src/:id?routing=:routing")
+    public Payload headSourceFile(final String project, final String id, final String routing, final Context context) {
+        return sourceFile(project, id, routing, context, document -> ok());
+    }
+
+    // Single decision for both verbs of the source route: GET serves the bytes, HEAD serves the
+    // verdict alone. Keeping them on one path is what stops the two from drifting apart, which is
+    // exactly how the frontend ended up reimplementing the size rule in the first place.
+    private Payload sourceFile(final String project, final String id, final String routing,
+                               final Context context, final Function<Document, Payload> whenAllowed) {
         boolean isProjectGranted = ((DatashareUser) context.currentUser()).isGranted(project);
         boolean isDownloadAllowed = isAllowed(repository.getProject(project), context.request().clientAddress());
-        if (isProjectGranted && isDownloadAllowed) {
-            List<String> sourceExcludes = List.of("content", "content_translated");
-            Document document = indexer.get(project, id, routing == null ? id : routing, sourceExcludes);
-            if(documentVerifier.isRootDocumentSizeAllowed(document)) {
-                return getPayload(document, project, inline, parseBoolean(filterMetadata));
-            }
+        if (!isProjectGranted || !isDownloadAllowed) {
+            return PayloadFormatter.error("You are not allowed to download this document", HttpStatus.FORBIDDEN);
+        }
+        List<String> sourceExcludes = List.of("content", "content_translated");
+        Document document = notFoundIfNull(indexer.get(project, id, routing == null ? id : routing, sourceExcludes));
+        if (!documentVerifier.isRootDocumentSizeAllowed(document)) {
             return PayloadFormatter.error("The file or its parent is too large", HttpStatus.REQUEST_ENTITY_TOO_LARGE);
         }
-        return PayloadFormatter.error("You are not allowed to download this document", HttpStatus.FORBIDDEN);
+        return whenAllowed.apply(document);
     }
 
     @Operation(description = "Fetches extracted text by slice (pagination)",

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -103,6 +103,7 @@ public class DocumentResource {
                  description = "returns the source of the document.")
     @ApiResponse(responseCode = "404", description = "if no document is found")
     @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project")
+    @ApiResponse(responseCode = "413", description = "if the root document is too large and no raw artifact is cached for this embedded document")
     @Get("/:project/documents/src/:id?routing=:routing&filter_metadata=:filter_metadata")
     public Payload getSourceFile(final String project, final String id,
                                  final String routing, final String filterMetadata, final Context context) throws IOException {
@@ -127,7 +128,8 @@ public class DocumentResource {
     // (currently 3 vs 4, "filter_metadata" is GET-only) or GET starts silently handling HEAD again.
     @Head("/:project/documents/src/:id?routing=:routing")
     public Payload headSourceFile(final String project, final String id, final String routing, final Context context) {
-        return sourceFile(project, id, routing, context, document -> ok());
+        return sourceFile(project, id, routing, context,
+                document -> documentVerifier.isSourceAvailable(document, project(project)) ? ok() : Payload.notFound());
     }
 
     // Single decision for both verbs of the source route: GET serves the bytes, HEAD serves the
@@ -142,7 +144,7 @@ public class DocumentResource {
         }
         List<String> sourceExcludes = List.of("content", "content_translated");
         Document document = notFoundIfNull(indexer.get(project, id, routing == null ? id : routing, sourceExcludes));
-        if (!documentVerifier.isRootDocumentSizeAllowed(document)) {
+        if (!documentVerifier.isRootDocumentSizeAllowed(document, project(project))) {
             return PayloadFormatter.error("The file or its parent is too large", HttpStatus.REQUEST_ENTITY_TOO_LARGE);
         }
         return whenAllowed.apply(document);

--- a/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
@@ -8,12 +8,19 @@ import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 import org.junit.Test;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 
+import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -21,6 +28,7 @@ public class DocumentVerifierTest {
 
     @Mock private Indexer indexer;
     @Mock private PropertiesProvider propertiesProvider;
+    @Rule public TemporaryFolder artifactDir = new TemporaryFolder();
     private DocumentVerifier documentVerifier;
 
     @Before
@@ -75,5 +83,51 @@ public class DocumentVerifierTest {
 
     private void indexFile(String index, Document document) {
         when(indexer.get(index, document.getId())).thenReturn(document);
+    }
+
+    @Test
+    public void test_is_root_document_size_allowed_true_for_embedded_doc_with_cached_raw_artifact() throws Exception {
+        Project project = new Project("local-datashare");
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(2L * 1024 * 1024 * 1024).build();
+        Document doc = DocumentBuilder.createDoc(embeddedId).with(project).withParentId("bar").withRootId("bar").build();
+        Path rawFile = artifactDir.getRoot().toPath().resolve("local-datashare").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
+        Files.createDirectories(rawFile.getParent());
+        Files.write(rawFile, "embedded bytes".getBytes());
+
+        when(indexer.get(project.getId(), "bar")).thenReturn(rootDoc);
+        when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT)).thenReturn(Optional.of("1G"));
+        when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.of(artifactDir.getRoot().toString()));
+
+        assertTrue(documentVerifier.isRootDocumentSizeAllowed(doc));
+        // The cache hit must be checked before the root lookup: a cached embed costs one stat and
+        // zero Elasticsearch calls.
+        verify(indexer, never()).get(project.getId(), "bar");
+    }
+
+    @Test
+    public void test_is_root_document_size_allowed_false_for_embedded_doc_without_cached_raw_artifact() {
+        Project project = new Project("local-datashare");
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(2L * 1024 * 1024 * 1024).build();
+        Document doc = DocumentBuilder.createDoc(embeddedId).with(project).withParentId("bar").withRootId("bar").build();
+
+        when(indexer.get(project.getId(), "bar")).thenReturn(rootDoc);
+        when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT)).thenReturn(Optional.of("1G"));
+        when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.of(artifactDir.getRoot().toString()));
+
+        assertFalse(documentVerifier.isRootDocumentSizeAllowed(doc));
+    }
+
+    @Test
+    public void test_is_root_document_size_allowed_false_for_big_root_when_no_artifact_dir_configured() {
+        Project project = new Project("local-datashare");
+        Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(2L * 1024 * 1024 * 1024).build();
+        Document doc = DocumentBuilder.createDoc("foo").with(project).withParentId("bar").withRootId("bar").build();
+
+        when(indexer.get(project.getId(), "bar")).thenReturn(rootDoc);
+        when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT)).thenReturn(Optional.of("1G"));
+
+        assertFalse(documentVerifier.isRootDocumentSizeAllowed(doc));
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
@@ -121,6 +121,19 @@ public class DocumentVerifierTest {
     }
 
     @Test
+    public void test_is_root_document_size_allowed_false_for_embedded_doc_with_missing_root() {
+        Project project = new Project("local-datashare");
+        Document doc = DocumentBuilder.createDoc("foo").with(project).withParentId("bar").withRootId("bar").build();
+
+        // A mid-parse OOM writes the root last, so children can be indexed with no root: refuse
+        // rather than NPE on the missing root's content length.
+        when(indexer.get(project.getId(), "bar")).thenReturn(null);
+        when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT)).thenReturn(Optional.of("1G"));
+
+        assertFalse(documentVerifier.isRootDocumentSizeAllowed(doc));
+    }
+
+    @Test
     public void test_is_root_document_size_allowed_false_for_big_root_when_no_artifact_dir_configured() {
         Project project = new Project("local-datashare");
         Document rootDoc = DocumentBuilder.createDoc("bar").with(project).withContentLength(2L * 1024 * 1024 * 1024).build();

--- a/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/DocumentVerifierTest.java
@@ -94,6 +94,7 @@ public class DocumentVerifierTest {
         Path rawFile = artifactDir.getRoot().toPath().resolve("local-datashare").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
         Files.createDirectories(rawFile.getParent());
         Files.write(rawFile, "embedded bytes".getBytes());
+        Files.write(rawFile.resolveSibling("raw.json"), "{}".getBytes());
 
         when(indexer.get(project.getId(), "bar")).thenReturn(rootDoc);
         when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT)).thenReturn(Optional.of("1G"));

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -693,6 +693,15 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_head_source_file_missing_on_disk_should_respond_404() {
+        // Same fixture as test_source_file_not_found_should_return_404 (a distinct doc id so the
+        // two don't interfere): the document is indexed but its file is gone from disk, so HEAD
+        // must not answer 200 where GET would answer 404.
+        mockIndexer.indexFile("local-datashare", "missing_file_head", Paths.get("missing/file"), null, null);
+        head("/api/local-datashare/documents/src/missing_file_head").should().respond(404);
+    }
+
+    @Test
     public void test_head_source_file_unknown_id_should_respond_404() {
         head("/api/local-datashare/documents/src/unknown_id").should().respond(404);
         // GET and HEAD must agree: this id used to NPE into a 500 on the GET side.

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -26,6 +26,7 @@ import org.slf4j.event.Level;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -631,6 +632,69 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_recommendations_by_docids_forbidden_for_non_member_project() {
         get("/api/users/recommendationsby?project=foo_index&docIds=d1,d2").should().respond(403);
+    }
+
+    @Test
+    public void test_head_source_file_root_document_should_respond_200() throws Exception {
+        File txtFile = new File(temp.getRoot(), "head.txt");
+        MockIndexer.write(txtFile, "text content");
+        mockIndexer.indexFile("local-datashare", "id_head_txt", txtFile.toPath(), null, null);
+
+        head("/api/local-datashare/documents/src/id_head_txt").should().respond(200);
+    }
+
+    @Test
+    public void test_head_source_file_should_have_no_body() throws Exception {
+        File txtFile = new File(temp.getRoot(), "head_no_body.txt");
+        MockIndexer.write(txtFile, "text content");
+        mockIndexer.indexFile("local-datashare", "id_head_no_body", txtFile.toPath(), null, null);
+
+        Response response = head("/api/local-datashare/documents/src/id_head_no_body").response();
+
+        assertThat(response.code()).isEqualTo(200);
+        assertThat(response.content()).isEmpty();
+        // The same GET does send the bytes, so the empty body above is HEAD's doing, not an empty file.
+        get("/api/local-datashare/documents/src/id_head_no_body").should().respond(200).contain("text content");
+    }
+
+    @Test
+    public void test_head_source_root_too_big_should_respond_413() {
+        String path = getClass().getResource("/docs/embedded_doc.eml").getPath();
+        Project index = new Project("local-datashare");
+        Document documentBar = createDoc("bar").with(index).withContentLength(2L * 1024 * 1024 * 1024).build();
+        Document documentFoo = createDoc("foo").with(index).with(path).withParentId("bar").withRootId("bar").build();
+        mockIndexer.indexFile("local-datashare", documentBar, documentFoo);
+
+        head("/api/local-datashare/documents/src/foo?routing=bar").should().respond(413);
+        // GET and HEAD must agree on the refusal.
+        get("/api/local-datashare/documents/src/foo?routing=bar").should().respond(413);
+    }
+
+    @Test
+    public void test_head_source_root_too_big_with_cached_raw_artifact_should_respond_200() throws Exception {
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        String path = getClass().getResource("/docs/embedded_doc.eml").getPath();
+        Project index = new Project("local-datashare");
+        Document documentBar = createDoc("bar").with(index).withContentLength(2L * 1024 * 1024 * 1024).build();
+        Document embedded = createDoc(embeddedId).with(index).with(path).withParentId("bar").withRootId("bar").build();
+        mockIndexer.indexFile("local-datashare", documentBar, embedded);
+        File artifactDir = temp.newFolder("artifacts");
+        java.nio.file.Path rawFile = artifactDir.toPath().resolve("local-datashare").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
+        Files.createDirectories(rawFile.getParent());
+        Files.write(rawFile, "embedded bytes".getBytes());
+        when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.of(artifactDir.toString()));
+
+        head("/api/local-datashare/documents/src/" + embeddedId + "?routing=bar").should().respond(200);
+    }
+
+    @Test
+    public void test_head_source_file_unknown_id_should_respond_404() {
+        head("/api/local-datashare/documents/src/unknown_id").should().respond(404);
+    }
+
+    @Test
+    public void test_head_source_file_forbidden_index_should_respond_403() {
+        head("/api/foo_index/documents/src/id").should().respond(403);
     }
 
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -686,6 +686,7 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
         java.nio.file.Path rawFile = artifactDir.toPath().resolve("local-datashare").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
         Files.createDirectories(rawFile.getParent());
         Files.write(rawFile, "embedded bytes".getBytes());
+        Files.write(rawFile.resolveSibling("raw.json"), "{}".getBytes());
         when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.of(artifactDir.toString()));
 
         head("/api/local-datashare/documents/src/" + embeddedId + "?routing=bar").should().respond(200);
@@ -694,6 +695,8 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_head_source_file_unknown_id_should_respond_404() {
         head("/api/local-datashare/documents/src/unknown_id").should().respond(404);
+        // GET and HEAD must agree: this id used to NPE into a 500 on the GET side.
+        get("/api/local-datashare/documents/src/unknown_id").should().respond(404);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -671,6 +671,10 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    // "bar" deliberately has no readable path: if HEAD ever fell back to running GET's
+    // extraction (see the route-precedence comment on headSourceFile), that extraction would
+    // throw FileNotFoundException and this test would fail with 404 instead of 200. Don't
+    // "fix" the fixture by giving "bar" a real path, that would remove this regression trip-wire.
     public void test_head_source_root_too_big_with_cached_raw_artifact_should_respond_200() throws Exception {
         String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
         String path = getClass().getResource("/docs/embedded_doc.eml").getPath();

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.text.artifact;
 
 import org.icij.datashare.text.Document;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 
 import java.nio.file.Files;
 import java.util.Map;
@@ -41,7 +42,7 @@ public class RawArtifact implements Artifact {
             // entry, an OCR-off image... Verify the raw payload actually landed before handing back
             // a terminal-able entry, so a silent miss fails loudly (nbFailed, re-runnable) instead of
             // being recorded as produced.
-            if (Files.notExists(context.docArtifactDir().resolve("raw"))) {
+            if (Files.notExists(context.docArtifactDir().resolve(ArtifactPath.RAW_FILE))) {
                 throw new ArtifactException("raw extraction produced no bytes for " + document.getId(), null);
             }
             return entry;

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
@@ -5,6 +5,9 @@ import java.nio.file.Path;
 /** Content-addressed on-disk layout for per-document artifacts under artifactDir. */
 public class ArtifactPath {
     public static final String MANIFEST_FILE = "manifest.json";
+    // extract-lib's EmbeddedArtifactWriter owns these names: the raw payload and its sidecar.
+    public static final String RAW_FILE = "raw";
+    public static final String RAW_SIDECAR_FILE = "raw.json";
 
     private ArtifactPath() {}
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -174,9 +174,17 @@ public class SourceExtractor {
     // are, serving it never opens (nor re-parses) the root document, which is what lets the
     // download gate ignore the root's size. extract-lib writes this payload temp-then-atomic-move,
     // so its mere existence means complete, readable bytes.
+    // The raw.json sidecar is part of the condition, not a nicety: extract-lib serves from cache
+    // only when it can also load the sidecar, and falls back to a live parse of the root when it
+    // cannot. The sidecar is moved into place after the payload, so a worker killed between the two
+    // leaves a raw file that would NOT spare us the root parse.
     public boolean hasCachedEmbeddedSource(final Project project, final Document document) {
         Path artifactPath = getArtifactPath(project);
-        return artifactPath != null && Files.exists(ArtifactPath.dir(artifactPath, document.getId()).resolve("raw"));
+        if (artifactPath == null) {
+            return false;
+        }
+        Path documentArtifactDir = ArtifactPath.dir(artifactPath, document.getId());
+        return Files.exists(documentArtifactDir.resolve("raw")) && Files.exists(documentArtifactDir.resolve("raw.json"));
     }
 
     private Path getArtifactPath(Project project) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -167,6 +168,15 @@ public class SourceExtractor {
     // produced by an OCR parser.
     private static boolean useOcr(Document document) {
         return document.getOcrParser() != null;
+    }
+
+    // Whether the embedded document's bytes are already sitting in the artifact cache. When they
+    // are, serving it never opens (nor re-parses) the root document, which is what lets the
+    // download gate ignore the root's size. extract-lib writes this payload temp-then-atomic-move,
+    // so its mere existence means complete, readable bytes.
+    public boolean hasCachedEmbeddedSource(final Project project, final Document document) {
+        Path artifactPath = getArtifactPath(project);
+        return artifactPath != null && Files.exists(ArtifactPath.dir(artifactPath, document.getId()).resolve("raw"));
     }
 
     private Path getArtifactPath(Project project) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractor.java
@@ -170,21 +170,20 @@ public class SourceExtractor {
         return document.getOcrParser() != null;
     }
 
-    // Whether the embedded document's bytes are already sitting in the artifact cache. When they
-    // are, serving it never opens (nor re-parses) the root document, which is what lets the
-    // download gate ignore the root's size. extract-lib writes this payload temp-then-atomic-move,
-    // so its mere existence means complete, readable bytes.
-    // The raw.json sidecar is part of the condition, not a nicety: extract-lib serves from cache
-    // only when it can also load the sidecar, and falls back to a live parse of the root when it
-    // cannot. The sidecar is moved into place after the payload, so a worker killed between the two
-    // leaves a raw file that would NOT spare us the root parse.
     public boolean hasCachedEmbeddedSource(final Project project, final Document document) {
         Path artifactPath = getArtifactPath(project);
         if (artifactPath == null) {
             return false;
         }
         Path documentArtifactDir = ArtifactPath.dir(artifactPath, document.getId());
-        return Files.exists(documentArtifactDir.resolve("raw")) && Files.exists(documentArtifactDir.resolve("raw.json"));
+        Path rawPayload = documentArtifactDir.resolve(ArtifactPath.RAW_FILE);
+        Path rawSidecar = documentArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE);
+        // Readable, not merely present: the files are written 0600 by whichever process produced
+        // them, and an unreadable artifact sends extract-lib back to a live parse of the root.
+        // Non-empty too: extract-lib records a zero-byte payload for embeds whose bytes it could
+        // not read, and serving those as a cache hit would return an empty 200 where the size
+        // limit used to return 413.
+        return Files.isReadable(rawPayload) && Files.isReadable(rawSidecar) && rawPayload.toFile().length() > 0;
     }
 
     private Path getArtifactPath(Project project) {

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
@@ -413,11 +413,28 @@ public class SourceExtractorTest {
         Path rawFile = artifactDir.toPath().resolve("prj").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
         Files.createDirectories(rawFile.getParent());
         Files.write(rawFile, "embedded bytes".getBytes());
+        Files.write(rawFile.resolveSibling("raw.json"), "{}".getBytes());
         Document embedded = DocumentBuilder.createDoc(embeddedId).with(project("prj")).build();
 
         SourceExtractor extractor = new SourceExtractor(new PropertiesProvider(Map.of(ARTIFACT_DIR_OPT, artifactDir.toString())));
 
         assertThat(extractor.hasCachedEmbeddedSource(project("prj"), embedded)).isTrue();
+    }
+
+    @Test
+    public void test_has_cached_embedded_source_false_when_raw_file_has_no_sidecar() throws Exception {
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        File artifactDir = tmpDir.newFolder("artifacts_no_sidecar");
+        // A worker killed between the payload move and the sidecar move leaves exactly this state,
+        // and extract-lib would fall back to a live parse of the root, so it is not a cache hit.
+        Path rawFile = artifactDir.toPath().resolve("prj").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
+        Files.createDirectories(rawFile.getParent());
+        Files.write(rawFile, "embedded bytes".getBytes());
+        Document embedded = DocumentBuilder.createDoc(embeddedId).with(project("prj")).build();
+
+        SourceExtractor extractor = new SourceExtractor(new PropertiesProvider(Map.of(ARTIFACT_DIR_OPT, artifactDir.toString())));
+
+        assertThat(extractor.hasCachedEmbeddedSource(project("prj"), embedded)).isFalse();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
@@ -33,6 +33,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -402,5 +403,43 @@ public class SourceExtractorTest {
                 ARTIFACT_DIR_OPT, tmpDir.getRoot().toString(),
                 NO_DIGEST_PROJECT_OPT, String.valueOf(noDigestProject))
         );
+    }
+
+    @Test
+    public void test_has_cached_embedded_source_true_when_raw_file_exists() throws Exception {
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        File artifactDir = tmpDir.newFolder("artifacts");
+        // extract-lib's layout: <artifactDir>/<project>/<id[0:2]>/<id[2:4]>/<id>/raw
+        Path rawFile = artifactDir.toPath().resolve("prj").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
+        Files.createDirectories(rawFile.getParent());
+        Files.write(rawFile, "embedded bytes".getBytes());
+        Document embedded = DocumentBuilder.createDoc(embeddedId).with(project("prj")).build();
+
+        SourceExtractor extractor = new SourceExtractor(new PropertiesProvider(Map.of(ARTIFACT_DIR_OPT, artifactDir.toString())));
+
+        assertThat(extractor.hasCachedEmbeddedSource(project("prj"), embedded)).isTrue();
+    }
+
+    @Test
+    public void test_has_cached_embedded_source_false_when_dir_exists_without_raw_file() throws Exception {
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        File artifactDir = tmpDir.newFolder("artifacts_no_raw");
+        // The document dir can exist with only a manifest in it (nothing produced yet).
+        Files.createDirectories(artifactDir.toPath().resolve("prj").resolve("a1").resolve("b2").resolve(embeddedId));
+        Document embedded = DocumentBuilder.createDoc(embeddedId).with(project("prj")).build();
+
+        SourceExtractor extractor = new SourceExtractor(new PropertiesProvider(Map.of(ARTIFACT_DIR_OPT, artifactDir.toString())));
+
+        assertThat(extractor.hasCachedEmbeddedSource(project("prj"), embedded)).isFalse();
+    }
+
+    @Test
+    public void test_has_cached_embedded_source_false_when_no_artifact_dir_configured() {
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        Document embedded = DocumentBuilder.createDoc(embeddedId).with(project("prj")).build();
+
+        SourceExtractor extractor = new SourceExtractor(new PropertiesProvider(Map.of()));
+
+        assertThat(extractor.hasCachedEmbeddedSource(project("prj"), embedded)).isFalse();
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/SourceExtractorTest.java
@@ -422,6 +422,23 @@ public class SourceExtractorTest {
     }
 
     @Test
+    public void test_has_cached_embedded_source_false_when_raw_file_is_empty() throws Exception {
+        String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
+        File artifactDir = tmpDir.newFolder("artifacts_empty_raw");
+        // extract-lib writes a zero-byte raw (plus sidecar) for embeds whose bytes it could not
+        // read out of a container, so that must not count as a cache hit.
+        Path rawFile = artifactDir.toPath().resolve("prj").resolve("a1").resolve("b2").resolve(embeddedId).resolve("raw");
+        Files.createDirectories(rawFile.getParent());
+        Files.createFile(rawFile);
+        Files.write(rawFile.resolveSibling("raw.json"), "{}".getBytes());
+        Document embedded = DocumentBuilder.createDoc(embeddedId).with(project("prj")).build();
+
+        SourceExtractor extractor = new SourceExtractor(new PropertiesProvider(Map.of(ARTIFACT_DIR_OPT, artifactDir.toString())));
+
+        assertThat(extractor.hasCachedEmbeddedSource(project("prj"), embedded)).isFalse();
+    }
+
+    @Test
     public void test_has_cached_embedded_source_false_when_raw_file_has_no_sidecar() throws Exception {
         String embeddedId = "a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2";
         File artifactDir = tmpDir.newFolder("artifacts_no_sidecar");


### PR DESCRIPTION
Backend half of #2287: an embedded document whose `raw` artifact is already cached is now downloadable whatever its root document's size, and the API exposes that decision so the client can stop recomputing the rule.

- feat: allow the embedded download when a readable, non-empty `raw` payload and its sidecar are cached, whatever the root size (one gate, so single and batch download are both fixed)
- feat: add `HEAD /api/:project/documents/src/:id`, answering 403/404/413/200 from the same decision path as `GET`
- fix: an unknown document id returns 404 instead of NPE-ing into a 500
- fix: probe the artifact cache under the project the caller actually serves from
- fix: refuse instead of NPE when an embedded document's root is missing from the index
- docs: document `GET`'s 413 and the HEAD/GET route precedence (HEAD requests also match the `@Get` route)
- test: 16 new tests across the gate, the cache predicate and the HEAD contract

Frontend follow-up, separate: `isRootTooBig` should read this endpoint instead of recomputing the size rule, treating any non-200 as "cannot download".
