### PR TITLE
refactor(pipeline): remove the POISON pill mechanism

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
+++ b/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
@@ -21,10 +21,6 @@ public class PipelineHelper {
         stages.sort(Stage.comparator);
     }
 
-    public boolean has(Stage stage) {
-        return stages.contains(stage);
-    }
-
     public String getQueueNameFor(Stage stage) {
         return stage.isFirstEnum() ? null: getQueueName(propertiesProvider, stage);
     }

--- a/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
+++ b/datashare-api/src/main/java/org/icij/datashare/PipelineHelper.java
@@ -19,6 +19,14 @@ public class PipelineHelper {
         stages = stream(propertiesProvider.get(STAGES_OPT).orElse("SCAN,INDEX,NLP"). // defaults existing stages for web mode
                 split(String.valueOf(STAGES_SEPARATOR))).map(Stage::valueOf).collect(toList());
         stages.sort(Stage.comparator);
+        // Pipeline order runs NLP before CREATENLPBATCHESFROMIDX, and CreateNlpBatchesFromIndex
+        // searches for documents .without(nlpPipeline): by the time it runs, NLP has already marked
+        // every document it would have selected, so it would create no batch at all.
+        if (stages.contains(Stage.NLP) && stages.contains(Stage.CREATENLPBATCHESFROMIDX)) {
+            throw new IllegalArgumentException(String.format(
+                    "%s and %s are alternatives, not a sequence: configure one or the other, not both",
+                    Stage.NLP, Stage.CREATENLPBATCHESFROMIDX));
+        }
     }
 
     public String getQueueNameFor(Stage stage) {

--- a/datashare-api/src/test/java/org/icij/datashare/PipelineHelperTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/PipelineHelperTest.java
@@ -105,6 +105,13 @@ public class PipelineHelperTest {
         assertThat(pipelineHelper.getQueueNameFor(Stage.INDEX)).isEqualTo("extract:queue:index");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void test_rejects_nlp_together_with_createnlpbatchesfromidx() {
+        new PipelineHelper(new PropertiesProvider(new HashMap<>() {{
+            put("stages", "SCAN,INDEX,CREATENLPBATCHESFROMIDX,NLP");
+        }}));
+    }
+
     @Test
     public void test_get_queue_name_when_no_stage_is_provided_like_in_web_mode() {
         assertThat(new PipelineHelper(new PropertiesProvider(new HashMap<>() )).getQueueNameFor(Stage.NLP)).isEqualTo("extract:queue:nlp");

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -196,6 +196,9 @@ class CliApp {
      * Consumers stop as soon as their input queue is empty (there is no end-of-stream sentinel), so
      * this barrier is what makes "empty" mean "the producer is done" for any number of workers.
      * PipelineHelper.stages is already sorted by Stage.comparator, which is pipeline order.
+     * That enum order runs CREATENLPBATCHESFROMIDX after NLP, so configuring both stages together
+     * is not a supported pairing: CreateNlpBatchesFromIndex searches .without(nlpPipeline), and by
+     * the time it runs, NLP has already marked every document it would otherwise have selected.
      * ponytail: launcher-side barrier, so a producer and its consumer stage no longer overlap. If
      * that overlap ever measures, gate the consumer on the upstream task state (pass the producer's
      * task id in the consumer's args) rather than reintroducing a sentinel.
@@ -208,10 +211,6 @@ class CliApp {
                 continue;
             }
             String taskId = taskManager.startTask(taskClass, nullUser(), propertiesToMap(properties));
-            if (taskId == null) {
-                logger.error("stage {} could not be started, stopping the pipeline", stage);
-                return;
-            }
             taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS, Set.of(taskId));
             Task.State state = taskManager.getTask(taskId).getState();
             if (state != Task.State.DONE) {

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -27,7 +27,7 @@ import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
 import org.icij.datashare.tasks.IndexTask;
-import org.icij.datashare.tasks.PipelineTask;
+import org.icij.datashare.tasks.UpstreamGate;
 import org.icij.datashare.tasks.ScanIndexTask;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.text.indexing.Indexer;
@@ -200,7 +200,7 @@ class CliApp {
 
     /**
      * Starts every configured stage, then awaits them all at once. Each stage carries the previous
-     * stage's task id in its args under {@link PipelineTask#UPSTREAM_TASK_ID}, so a consumer knows
+     * stage's task id in its args under {@link UpstreamGate#UPSTREAM_TASK_ID}, so a consumer knows
      * which producer feeds its input queue and keeps polling while that producer runs. Stages
      * therefore overlap, which a bounded in-memory queue needs to make progress on a large corpus:
      * what makes termination correct is that gate, not the launch sequencing.
@@ -220,7 +220,7 @@ class CliApp {
             }
             Map<String, Object> args = propertiesToMap(properties);
             if (upstreamTaskId != null) {
-                args.put(PipelineTask.UPSTREAM_TASK_ID, upstreamTaskId);
+                args.put(UpstreamGate.UPSTREAM_TASK_ID, upstreamTaskId);
             }
             upstreamTaskId = taskManager.startTask(taskClass, nullUser(), args);
             stagesByTaskId.put(upstreamTaskId, stage);

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -176,8 +177,13 @@ class CliApp {
 
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
-        runPipeline(taskManager, pipeline, properties);
+        boolean completed = runPipeline(taskManager, pipeline, properties);
         taskManager.shutdown();
+        if (!completed) {
+            // a partial run must not look like a success: `datashare ... && post-process.sh` would
+            // otherwise post-process a corpus that was never fully indexed
+            System.exit(EXIT_RUNTIME);
+        }
     }
 
     static final Map<Stage, Class<?>> TASK_CLASSES = Map.of(
@@ -195,16 +201,16 @@ class CliApp {
      * Runs the configured stages one at a time, awaiting each stage's task before starting the next.
      * Consumers stop as soon as their input queue is empty (there is no end-of-stream sentinel), so
      * this barrier is what makes "empty" mean "the producer is done" for any number of workers.
-     * PipelineHelper.stages is already sorted by Stage.comparator, which is pipeline order.
-     * That enum order runs CREATENLPBATCHESFROMIDX after NLP, so configuring both stages together
-     * is not a supported pairing: CreateNlpBatchesFromIndex searches .without(nlpPipeline), and by
-     * the time it runs, NLP has already marked every document it would otherwise have selected.
+     * PipelineHelper.stages is already sorted by Stage.comparator, which is pipeline order, and is
+     * de-duplicated here so a repeated --stages entry runs its stage once.
      * ponytail: launcher-side barrier, so a producer and its consumer stage no longer overlap. If
      * that overlap ever measures, gate the consumer on the upstream task state (pass the producer's
      * task id in the consumer's args) rather than reintroducing a sentinel.
+     *
+     * @return true when every configured stage completed, false when the pipeline aborted
      */
-    static void runPipeline(TaskManager taskManager, PipelineHelper pipeline, Properties properties) throws Exception {
-        for (Stage stage : pipeline.stages) {
+    static boolean runPipeline(TaskManager taskManager, PipelineHelper pipeline, Properties properties) throws Exception {
+        for (Stage stage : new LinkedHashSet<>(pipeline.stages)) {
             Class<?> taskClass = TASK_CLASSES.get(stage);
             if (taskClass == null) {
                 logger.warn("no task class for stage {}, skipping it", stage);
@@ -215,9 +221,10 @@ class CliApp {
             Task.State state = taskManager.getTask(taskId).getState();
             if (state != Task.State.DONE) {
                 logger.error("stage {} ended in state {}, stopping the pipeline: a downstream stage would read its partial queue as complete", stage, state);
-                return;
+                return false;
             }
         }
+        return true;
     }
 
     static int handleUserCreate(UserAdminService service, Properties properties) {

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -27,6 +27,7 @@ import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
 import org.icij.datashare.tasks.ExtractNlpTask;
 import org.icij.datashare.tasks.IndexTask;
+import org.icij.datashare.tasks.PipelineTask;
 import org.icij.datashare.tasks.ScanIndexTask;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.text.indexing.Indexer;
@@ -43,10 +44,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Properties;
 import java.util.function.Supplier;
 
@@ -198,33 +199,42 @@ class CliApp {
             Stage.ARTIFACT, ArtifactTask.class);
 
     /**
-     * Runs the configured stages one at a time, awaiting each stage's task before starting the next.
-     * Consumers stop as soon as their input queue is empty (there is no end-of-stream sentinel), so
-     * this barrier is what makes "empty" mean "the producer is done" for any number of workers.
+     * Starts every configured stage, then awaits them all at once. Each stage carries the previous
+     * stage's task id in its args under {@link PipelineTask#UPSTREAM_TASK_ID}, so a consumer knows
+     * which producer feeds its input queue and keeps polling while that producer runs. Stages
+     * therefore overlap, which a bounded in-memory queue needs to make progress on a large corpus:
+     * what makes termination correct is that gate, not the launch sequencing.
      * PipelineHelper.stages is already sorted by Stage.comparator, which is pipeline order, and is
      * de-duplicated here so a repeated --stages entry runs its stage once.
-     * ponytail: launcher-side barrier, so a producer and its consumer stage no longer overlap. If
-     * that overlap ever measures, gate the consumer on the upstream task state (pass the producer's
-     * task id in the consumer's args) rather than reintroducing a sentinel.
      *
-     * @return true when every configured stage completed, false when the pipeline aborted
+     * @return true when every configured stage completed, false when any of them did not
      */
     static boolean runPipeline(TaskManager taskManager, PipelineHelper pipeline, Properties properties) throws Exception {
+        Map<String, Stage> stagesByTaskId = new LinkedHashMap<>();
+        String upstreamTaskId = null;
         for (Stage stage : new LinkedHashSet<>(pipeline.stages)) {
             Class<?> taskClass = TASK_CLASSES.get(stage);
             if (taskClass == null) {
                 logger.warn("no task class for stage {}, skipping it", stage);
                 continue;
             }
-            String taskId = taskManager.startTask(taskClass, nullUser(), propertiesToMap(properties));
-            taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS, Set.of(taskId));
-            Task.State state = taskManager.getTask(taskId).getState();
+            Map<String, Object> args = propertiesToMap(properties);
+            if (upstreamTaskId != null) {
+                args.put(PipelineTask.UPSTREAM_TASK_ID, upstreamTaskId);
+            }
+            upstreamTaskId = taskManager.startTask(taskClass, nullUser(), args);
+            stagesByTaskId.put(upstreamTaskId, stage);
+        }
+        taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS, stagesByTaskId.keySet());
+        boolean completed = true;
+        for (Map.Entry<String, Stage> startedStage : stagesByTaskId.entrySet()) {
+            Task.State state = taskManager.getTask(startedStage.getKey()).getState();
             if (state != Task.State.DONE) {
-                logger.error("stage {} ended in state {}, stopping the pipeline: a downstream stage would read its partial queue as complete", stage, state);
-                return false;
+                logger.error("stage {} ended in state {}: its output is partial", startedStage.getValue(), state);
+                completed = false;
             }
         }
-        return true;
+        return completed;
     }
 
     static int handleUserCreate(UserAdminService service, Properties properties) {

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -21,6 +21,7 @@ import org.icij.datashare.tasks.ArtifactTask;
 import org.icij.datashare.tasks.CreateNlpBatchesFromIndex;
 import org.icij.datashare.tasks.CategorizeTask;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.tasks.DeduplicateTask;
 import org.icij.datashare.tasks.EnqueueFromIndexTask;
@@ -42,7 +43,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -176,44 +176,49 @@ class CliApp {
 
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
-        Set<String> taskIds = new HashSet<>();
-        if (pipeline.has(Stage.DEDUPLICATE)) {
-            taskIds.add(taskManager.startTask(DeduplicateTask.class, nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.SCANIDX)) {
-            taskIds.add(taskManager.startTask(ScanIndexTask.class, nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.SCAN)) {
-            taskIds.add(taskManager.startTask(ScanTask.class, nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.INDEX)) {
-            taskIds.add(taskManager.startTask(IndexTask.class, nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.ENQUEUEIDX)) {
-            taskIds.add(taskManager.startTask(EnqueueFromIndexTask.class, nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.CATEGORIZE)) {
-            taskIds.add(taskManager.startTask(CategorizeTask.class, nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.CREATENLPBATCHESFROMIDX)) {
-            taskIds.add(taskManager.startTask(CreateNlpBatchesFromIndex.class.getName(), nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.NLP)) {
-            taskIds.add(taskManager.startTask(ExtractNlpTask.class, nullUser(), propertiesToMap(properties)));
-        }
-
-        if (pipeline.has(Stage.ARTIFACT)) {
-            taskIds.add(taskManager.startTask(ArtifactTask.class, nullUser(), propertiesToMap(properties)));
-        }
-        taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS, taskIds);
+        runPipeline(taskManager, pipeline, properties);
         taskManager.shutdown();
+    }
+
+    static final Map<Stage, Class<?>> TASK_CLASSES = Map.of(
+            Stage.SCAN, ScanTask.class,
+            Stage.SCANIDX, ScanIndexTask.class,
+            Stage.DEDUPLICATE, DeduplicateTask.class,
+            Stage.INDEX, IndexTask.class,
+            Stage.ENQUEUEIDX, EnqueueFromIndexTask.class,
+            Stage.CATEGORIZE, CategorizeTask.class,
+            Stage.CREATENLPBATCHESFROMIDX, CreateNlpBatchesFromIndex.class,
+            Stage.NLP, ExtractNlpTask.class,
+            Stage.ARTIFACT, ArtifactTask.class);
+
+    /**
+     * Runs the configured stages one at a time, awaiting each stage's task before starting the next.
+     * Consumers stop as soon as their input queue is empty (there is no end-of-stream sentinel), so
+     * this barrier is what makes "empty" mean "the producer is done" for any number of workers.
+     * PipelineHelper.stages is already sorted by Stage.comparator, which is pipeline order.
+     * ponytail: launcher-side barrier, so a producer and its consumer stage no longer overlap. If
+     * that overlap ever measures, gate the consumer on the upstream task state (pass the producer's
+     * task id in the consumer's args) rather than reintroducing a sentinel.
+     */
+    static void runPipeline(TaskManager taskManager, PipelineHelper pipeline, Properties properties) throws Exception {
+        for (Stage stage : pipeline.stages) {
+            Class<?> taskClass = TASK_CLASSES.get(stage);
+            if (taskClass == null) {
+                logger.warn("no task class for stage {}, skipping it", stage);
+                continue;
+            }
+            String taskId = taskManager.startTask(taskClass, nullUser(), propertiesToMap(properties));
+            if (taskId == null) {
+                logger.error("stage {} could not be started, stopping the pipeline", stage);
+                return;
+            }
+            taskManager.awaitTermination(Integer.MAX_VALUE, SECONDS, Set.of(taskId));
+            Task.State state = taskManager.getTask(taskId).getState();
+            if (state != Task.State.DONE) {
+                logger.error("stage {} ended in state {}, stopping the pipeline: a downstream stage would read its partial queue as complete", stage, state);
+                return;
+            }
+        }
     }
 
     static int handleUserCreate(UserAdminService service, Properties properties) {

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -128,7 +128,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         }
         executorService = Executors.newFixedThreadPool(Math.max(getTaskWorkersNb(), 1));
         if (getTaskWorkersNb() > 1) {
-            logger.warn("taskWorkers is set to {}: pipeline stages started together may run concurrently. A consumer stage stops as soon as its input queue is empty, so it can exit before its producer stage finished enqueuing.", getTaskWorkersNb());
+            logger.warn("taskWorkers is set to {}: pipeline stages can then run concurrently, so a consumer stage may exit as soon as its input queue looks empty and strand documents. CLI runs are sequenced by CliApp.runPipeline and are unaffected.", getTaskWorkersNb());
         }
         try {
             this.injector = Guice.createInjector(this);

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -128,7 +128,7 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
         }
         executorService = Executors.newFixedThreadPool(Math.max(getTaskWorkersNb(), 1));
         if (getTaskWorkersNb() > 1) {
-            logger.warn("taskWorkers is set to {}: pipeline stages can then run concurrently, so a consumer stage may exit as soon as its input queue looks empty and strand documents. CLI runs are sequenced by CliApp.runPipeline and are unaffected.", getTaskWorkersNb());
+            logger.info("taskWorkers is set to {}: pipeline stages can run concurrently. Consumer stages launched with an upstream task id keep draining until their producer is done; a stage started against a queue with no upstream stops on its first empty poll.", getTaskWorkersNb());
         }
         try {
             this.injector = Guice.createInjector(this);

--- a/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/CommonMode.java
@@ -127,6 +127,9 @@ public abstract class CommonMode extends AbstractModule implements Closeable {
             }
         }
         executorService = Executors.newFixedThreadPool(Math.max(getTaskWorkersNb(), 1));
+        if (getTaskWorkersNb() > 1) {
+            logger.warn("taskWorkers is set to {}: pipeline stages started together may run concurrently. A consumer stage stops as soon as its input queue is empty, so it can exit before its producer stage finished enqueuing.", getTaskWorkersNb());
+        }
         try {
             this.injector = Guice.createInjector(this);
         } catch (CreationException e) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -7,7 +7,6 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
-import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -29,8 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
-import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_FORCE_OPT;
@@ -58,15 +54,11 @@ public class ArtifactTask extends PipelineTask<String> {
     private final Path artifactDir;
     private final int parallelism;
     private final ExecutorService executor;
-    private final TaskRepository taskRepository;
-    private final Map<String, Object> taskArgs;
 
     @Inject
-    public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
-        super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class);
+    public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
+        super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class, gateFactory.forTask(taskView));
         this.indexer = indexer;
-        this.taskRepository = taskRepository;
-        this.taskArgs = taskView.args;
         project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
         parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
@@ -160,7 +152,7 @@ public class ArtifactTask extends PipelineTask<String> {
                 throw e;
             }
             if (queueEntry == null) {
-                if (drained(taskRepository)) {
+                if (drained()) {
                     break;
                 }
                 try {
@@ -197,15 +189,6 @@ public class ArtifactTask extends PipelineTask<String> {
                 nbFailed.incrementAndGet();
             }
         }
-    }
-
-    /**
-     * Unlike the other pipeline tasks, this one is configured from the injected app properties and
-     * not from the task args, so the launcher-set upstream id is only found in the args map.
-     */
-    @Override
-    protected Optional<String> upstreamTaskId() {
-        return ofNullable((String) taskArgs.get(UPSTREAM_TASK_ID));
     }
 
     protected SourceExtractor createSourceExtractor() {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -165,6 +165,7 @@ public class ArtifactTask extends PipelineTask<String> {
                 continue;
             }
             if (isLegacySentinel(queueEntry)) {
+                logger.warn("skipping legacy POISON sentinel in queue {}", inputQueue.getName());
                 continue;
             }
             try {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -7,6 +7,7 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
+import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,6 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
+import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_FORCE_OPT;
@@ -54,11 +58,15 @@ public class ArtifactTask extends PipelineTask<String> {
     private final Path artifactDir;
     private final int parallelism;
     private final ExecutorService executor;
+    private final TaskRepository taskRepository;
+    private final Map<String, Object> taskArgs;
 
     @Inject
-    public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
+    public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
         super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class);
         this.indexer = indexer;
+        this.taskRepository = taskRepository;
+        this.taskArgs = taskView.args;
         project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
         parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
@@ -152,7 +160,17 @@ public class ArtifactTask extends PipelineTask<String> {
                 throw e;
             }
             if (queueEntry == null) {
-                break;
+                if (drained(taskRepository)) {
+                    break;
+                }
+                try {
+                    Thread.sleep(upstreamPollIntervalMs());
+                } catch (InterruptedException e) {
+                    // a Runnable cannot throw it: re-interrupt so call()'s check reports CANCELLED
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                continue;
             }
             if (isLegacySentinel(queueEntry)) {
                 continue;
@@ -179,6 +197,15 @@ public class ArtifactTask extends PipelineTask<String> {
                 nbFailed.incrementAndGet();
             }
         }
+    }
+
+    /**
+     * Unlike the other pipeline tasks, this one is configured from the injected app properties and
+     * not from the task args, so the launcher-set upstream id is only found in the args map.
+     */
+    @Override
+    protected Optional<String> upstreamTaskId() {
+        return ofNullable((String) taskArgs.get(UPSTREAM_TASK_ID));
     }
 
     protected SourceExtractor createSourceExtractor() {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -43,9 +42,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_FORCE_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACTS_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
-import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_POLLING_INTERVAL_SEC;
 import static org.icij.datashare.cli.DatashareCliOptions.PARALLELISM_OPT;
-import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 
 @TemporalSingleActivityWorkflow(name = "artifact", activityOptions = @ActivityOpts(timeout = "P1D"))
 @TaskGroup(TaskGroupType.Java)
@@ -55,7 +52,6 @@ public class ArtifactTask extends PipelineTask<String> {
     private final Indexer indexer;
     private final Project project;
     private final Path artifactDir;
-    private final int pollingInterval;
     private final int parallelism;
     private final ExecutorService executor;
 
@@ -64,7 +60,6 @@ public class ArtifactTask extends PipelineTask<String> {
         super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class);
         this.indexer = indexer;
         project = Project.project(propertiesProvider.get(DEFAULT_PROJECT_OPT).orElse(DEFAULT_DEFAULT_PROJECT));
-        pollingInterval = Integer.parseInt(propertiesProvider.get(POLLING_INTERVAL_SECONDS_OPT).orElse(DEFAULT_POLLING_INTERVAL_SEC));
         parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
         executor = Executors.newFixedThreadPool(parallelism, namedThreadFactory("artifact-worker"));
@@ -82,15 +77,7 @@ public class ArtifactTask extends PipelineTask<String> {
     @Override
     public Long call() throws Exception {
         super.call();
-        logger.info("creating artifact cache in {} for project {} from queue {} with {} worker(s) and polling interval {}s", artifactDir, project, inputQueue.getName(), parallelism, pollingInterval);
-        // Clean any stale STRING_POISON left in the input queue by a PRIOR aborted run before
-        // starting workers. Doing this at startup (rather than teardown) means the cleanup no
-        // longer depends on this run's workers having joined: a worker stuck in a
-        // non-interruptible parse past the old awaitTermination window can no longer race the
-        // drain and leave a sentinel that zeroes/truncates the next run. This run's own trailing
-        // straggler poison (left by the propagation relay at teardown) is simply left in the
-        // queue; the NEXT run's startup drain cleans it (self-healing).
-        drainStaleResidualPoison();
+        logger.info("creating artifact cache in {} for project {} from queue {} with {} worker(s)", artifactDir, project, inputQueue.getName(), parallelism);
         AtomicLong nbDocs = new AtomicLong(0);
         AtomicLong nbSkipped = new AtomicLong(0);
         AtomicLong nbFailed = new AtomicLong(0);
@@ -119,8 +106,7 @@ public class ArtifactTask extends PipelineTask<String> {
             // single cleanup point for every path: normal completion, worker failure, and
             // cancellation (where the InterruptedException from future.get() propagates out and
             // TaskWorkerLoop records the run as cancelled). No awaitTermination() here: waiting
-            // delayed cancellation, and the residual-poison cleanup now runs at startup so it no
-            // longer needs the workers to have joined.
+            // would only delay cancellation, and workers leave nothing in the queue to clean up.
             executor.shutdownNow();
         }
         if (nbSkipped.get() > 0) {
@@ -145,88 +131,29 @@ public class ArtifactTask extends PipelineTask<String> {
         boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository());
         Path projectRoot = artifactDir.resolve(project.name);
-        try {
-            String queueEntry;
-            // POISON is the primary, timing-independent termination signal offered by
-            // EnqueueFromIndexTask once it is done enqueuing; re-offer it so every other
-            // worker in this pool also sees it and terminates (poison propagation, as
-            // DeduplicateTask does across stages). The null-poll exit is only a fallback and
-            // must tolerate TRANSIENT empties: EnqueueFromIndexTask produces concurrently, so a
-            // worker that drains everything enqueued-so-far can get a null before the producer's
-            // next scroll batch (and before the trailing poison) arrives. Exiting on the first
-            // null would strand every doc enqueued afterwards. So mirror ExtractNlpTask: allow up
-            // to NB_MAX_POLLS CONSECUTIVE null polls before giving up, resetting the budget on any
-            // real entry.
-            int nbMaxPolls = ExtractNlpTask.NB_MAX_POLLS;
-            while (nbMaxPolls > 0) {
-                queueEntry = inputQueue.poll(pollingInterval, TimeUnit.SECONDS);
-                if (STRING_POISON.equals(queueEntry)) {
-                    inputQueue.offer(STRING_POISON);
-                    break;
-                }
-                if (queueEntry == null) {
-                    nbMaxPolls--;
+        String queueEntry;
+        // The launcher awaits ENQUEUEIDX before starting this stage, so an empty queue means the
+        // producer is done: a non-blocking poll returning null is the terminal condition, for one
+        // worker or for N. The interrupt check keeps cancellation prompt, since cancel() calls
+        // executor.shutdownNow() while a worker may be between two polls.
+        while (!Thread.currentThread().isInterrupted() && (queueEntry = inputQueue.poll()) != null) {
+            try {
+                Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), SOURCE_EXCLUDES);
+                if (doc == null) {
+                    nbSkipped.incrementAndGet();
                     continue;
                 }
-                nbMaxPolls = ExtractNlpTask.NB_MAX_POLLS;
-                try {
-                    Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), SOURCE_EXCLUDES);
-                    if (doc == null) {
-                        nbSkipped.incrementAndGet();
-                        continue;
-                    }
-                    // Each polled node is produced into its own content-addressed directory.
-                    Path docArtifactDir = ArtifactPath.dir(projectRoot, doc.getId());
-                    if (producer.run(selected, new ArtifactContext(project, doc, docArtifactDir, extractor), force)) {
-                        nbDocs.incrementAndGet();
-                    } else {
-                        nbFailed.incrementAndGet();
-                    }
-                } catch (Throwable e) {
-                    logger.error("error in ArtifactTask loop", e);
+                // Each polled node is produced into its own content-addressed directory.
+                Path docArtifactDir = ArtifactPath.dir(projectRoot, doc.getId());
+                if (producer.run(selected, new ArtifactContext(project, doc, docArtifactDir, extractor), force)) {
+                    nbDocs.incrementAndGet();
+                } else {
                     nbFailed.incrementAndGet();
                 }
+            } catch (Throwable e) {
+                logger.error("error in ArtifactTask loop", e);
+                nbFailed.incrementAndGet();
             }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    // The input queue name is static (<queueName>:artifact) and is never deleted between runs
-    // (MemoryDocumentQueue.close() is a no-op, RedisDocumentQueue.close() only closes the
-    // client). The poison-propagation relay in runWorker always leaves exactly one re-offered
-    // STRING_POISON behind once the last worker reads it and breaks. Left uncleaned, that
-    // sentinel sits at the head of the next ARTIFACT run (a documented, supported re-run
-    // workflow via --artifactsForce) and terminates every worker before it processes a single
-    // doc ref, silently reporting 0 processed. Drain it here, at STARTUP of the next run.
-    //
-    // Running at startup (before submitting workers) rather than at teardown is what makes this
-    // safe without waiting on the previous run's workers: the stale poison is whatever a prior
-    // run left in the queue, and this run's own poison has not been produced yet
-    // (EnqueueFromIndexTask emits it concurrently, at the END of its enqueue). A prior worker
-    // stuck in a non-interruptible parse therefore cannot race this drain.
-    //
-    // On the kill/cancellation path the queue can hold real doc refs BEHIND the poison too:
-    // workers were interrupted before draining that far, e.g. [realDocX, realDocY, POISON].
-    // Stopping at the first non-poison entry would offer realDocX back and quit, leaving POISON
-    // in the queue behind it, so the next run's workers hit the stale POISON after only a couple
-    // of docs and terminate early, stranding the rest. So instead drain the ENTIRE queue
-    // (bounded by whatever is present right now: poll() is non-blocking and returns null once
-    // empty), discard every STRING_POISON regardless of position, and re-offer only the real doc
-    // refs, in their original FIFO order. If this drain happens to remove an already-arrived
-    // legit poison, the null-retry fallback in runWorker still terminates workers correctly. This
-    // is intentionally NOT inputQueue.delete(): delete() would also wipe those real, unprocessed
-    // entries, reintroducing silent data loss on the failure/cancellation paths.
-    private void drainStaleResidualPoison() {
-        List<String> realEntries = new ArrayList<>();
-        String entry;
-        while ((entry = inputQueue.poll()) != null) {
-            if (!STRING_POISON.equals(entry)) {
-                realEntries.add(entry);
-            }
-        }
-        for (String realEntry : realEntries) {
-            inputQueue.offer(realEntry);
         }
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -132,10 +132,8 @@ public class ArtifactTask extends PipelineTask<String> {
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository());
         Path projectRoot = artifactDir.resolve(project.name);
         String queueEntry;
-        // The launcher awaits ENQUEUEIDX before starting this stage, so an empty queue means the
-        // producer is done: a non-blocking poll returning null is the terminal condition, for one
-        // worker or for N. The interrupt check keeps cancellation prompt, since cancel() calls
-        // executor.shutdownNow() while a worker may be between two polls.
+        // The interrupt check keeps cancellation prompt, since cancel() calls executor.shutdownNow()
+        // while a worker may sit between two non-blocking polls.
         while (!Thread.currentThread().isInterrupted() && (queueEntry = inputQueue.poll()) != null) {
             try {
                 Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), SOURCE_EXCLUDES);
@@ -151,6 +149,10 @@ public class ArtifactTask extends PipelineTask<String> {
                     nbFailed.incrementAndGet();
                 }
             } catch (Throwable e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
                 logger.error("error in ArtifactTask loop", e);
                 nbFailed.incrementAndGet();
             }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -164,7 +164,7 @@ public class ArtifactTask extends PipelineTask<String> {
                     break;
                 }
                 try {
-                    Thread.sleep(upstreamPollIntervalMs());
+                    Thread.sleep(UPSTREAM_POLL_INTERVAL_MS);
                 } catch (InterruptedException e) {
                     // a Runnable cannot throw it: re-interrupt so call()'s check reports CANCELLED
                     Thread.currentThread().interrupt();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -99,6 +99,13 @@ public class ArtifactTask extends PipelineTask<String> {
                     nbFailures++;
                 }
             }
+            // The other drains end on their own interrupt check. Here future.get() only throws when
+            // the task thread is interrupted while still waiting, which does not hold for a future
+            // that had already completed when cancel() landed. Thread.interrupted() tests AND clears,
+            // so the flag does not leak onto the runner thread with the InterruptedException.
+            if (Thread.interrupted()) {
+                throw new InterruptedException("cancelled while draining " + inputQueue.getName());
+            }
             if (nbFailures > 0) {
                 throw new IllegalStateException(String.format("%d of %d artifact worker(s) terminated abnormally", nbFailures, futures.size()), firstCause);
             }
@@ -131,10 +138,25 @@ public class ArtifactTask extends PipelineTask<String> {
         boolean force = Boolean.parseBoolean(propertiesProvider.get(ARTIFACTS_FORCE_OPT).orElse("false"));
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository());
         Path projectRoot = artifactDir.resolve(project.name);
-        String queueEntry;
         // The interrupt check keeps cancellation prompt, since cancel() calls executor.shutdownNow()
         // while a worker may sit between two non-blocking polls.
-        while (!Thread.currentThread().isInterrupted() && (queueEntry = inputQueue.poll()) != null) {
+        while (!Thread.currentThread().isInterrupted()) {
+            String queueEntry;
+            try {
+                queueEntry = inputQueue.poll();
+            } catch (RuntimeException e) {
+                if (causedByInterrupt(e)) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                throw e;
+            }
+            if (queueEntry == null) {
+                break;
+            }
+            if (isLegacySentinel(queueEntry)) {
+                continue;
+            }
             try {
                 Document doc = getDocument(indexer, project.name, DocReference.parse(queueEntry), SOURCE_EXCLUDES);
                 if (doc == null) {
@@ -149,7 +171,7 @@ public class ArtifactTask extends PipelineTask<String> {
                     nbFailed.incrementAndGet();
                 }
             } catch (Throwable e) {
-                if (e instanceof InterruptedException) {
+                if (causedByInterrupt(e)) {
                     Thread.currentThread().interrupt();
                     break;
                 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -55,10 +55,26 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
     public Long call() throws Exception {
         super.call();
         logger.info("enriching {} docs from inputQueue {} and adding them in {}", inputQueue.size(), inputQueue.getName(), outputQueue.getName());
-        String queueEntry;
         long nbMessages = 0;
 
-        while (!Thread.currentThread().isInterrupted() && (queueEntry = inputQueue.poll()) != null) {
+        while (!Thread.currentThread().isInterrupted()) {
+            String queueEntry;
+            try {
+                queueEntry = inputQueue.poll();
+            } catch (RuntimeException e) {
+                if (causedByInterrupt(e)) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                throw e;
+            }
+            if (queueEntry == null) {
+                break;
+            }
+            // before the offer below, so the sentinel is not forwarded downstream
+            if (isLegacySentinel(queueEntry)) {
+                continue;
+            }
             try {
                 Document retrievedFromIndexer = getDocument(indexer, project.getName(), DocReference.parse(queueEntry));
                 if (retrievedFromIndexer != null) {
@@ -71,14 +87,17 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
                     logger.warn("unable to offer {} to queue {}", queueEntry, outputQueue.getName());
                 }
             } catch (Exception e) {
-                if (e instanceof InterruptedException) {
+                if (causedByInterrupt(e)) {
                     Thread.currentThread().interrupt();
                     break;
                 }
                 logger.error("error in CategorizeTask loop", e);
             }
         }
-        if (Thread.currentThread().isInterrupted()) {
+        // Thread.interrupted() tests AND clears: TaskWorkerLoop never clears the flag itself, so
+        // leaving it set would leak the interrupt onto the runner thread and make the next task
+        // start already cancelled.
+        if (Thread.interrupted()) {
             throw new InterruptedException("cancelled while draining " + inputQueue.getName());
         }
         logger.info("exiting CategorizeTask loop after {} messages.", nbMessages);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -40,8 +39,6 @@ import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT
 @TaskGroup(TaskGroupType.Java)
 public class CategorizeTask extends PipelineTask<String> implements Monitorable {
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private static final int NB_MAX_POLLS = 3;
-    private static final int POLLING_INTERVAL_SECONDS = 60;
     private final AtomicInteger processed = new AtomicInteger(0);
     private final Function<Double, Void> progressCallback;
     private final Indexer indexer;
@@ -60,33 +57,22 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
         logger.info("enriching {} docs from inputQueue {} and adding them in {}", inputQueue.size(), inputQueue.getName(), outputQueue.getName());
         String queueEntry;
         long nbMessages = 0;
-        int nbMaxPolls = NB_MAX_POLLS;
-        int pollingIntervalSeconds = POLLING_INTERVAL_SECONDS;
 
-        while (!(STRING_POISON.equals(queueEntry = inputQueue.poll( (pollingIntervalSeconds * 1000L), TimeUnit.MILLISECONDS)))
-                && nbMaxPolls > 0) {
+        while ((queueEntry = inputQueue.poll()) != null) {
             try {
-                if (queueEntry != null) {
-                    Document retrievedFromIndexer = getDocument(indexer, project.getName(), DocReference.parse(queueEntry));
-                    if(retrievedFromIndexer != null) {
-                        enrichWithType(retrievedFromIndexer);
-                    }
-                    nbMessages++;
-                    processed.incrementAndGet();
-                    progressCallback.apply(getProgressRate());
-                    if(!outputQueue.offer(queueEntry)){
-                        logger.warn("unable to offer {} to queue {}", queueEntry, outputQueue.getName());
-                    }
-                } else {
-                    logger.info("will poll document queue again for pollingInterval={} seconds ({}/{})", pollingIntervalSeconds, nbMaxPolls, NB_MAX_POLLS);
-                    nbMaxPolls--;
+                Document retrievedFromIndexer = getDocument(indexer, project.getName(), DocReference.parse(queueEntry));
+                if (retrievedFromIndexer != null) {
+                    enrichWithType(retrievedFromIndexer);
+                }
+                nbMessages++;
+                processed.incrementAndGet();
+                progressCallback.apply(getProgressRate());
+                if (!outputQueue.offer(queueEntry)) {
+                    logger.warn("unable to offer {} to queue {}", queueEntry, outputQueue.getName());
                 }
             } catch (Exception e) {
                 logger.error("error in CategorizeTask loop", e);
             }
-        }
-        if(!outputQueue.offer(STRING_POISON)){
-            logger.warn("unable to offer POISON to queue {}", outputQueue.getName());
         }
         logger.info("exiting CategorizeTask loop after {} messages.", nbMessages);
         return nbMessages;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -77,6 +77,7 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
             }
             // before the offer below, so the sentinel is not forwarded downstream
             if (isLegacySentinel(queueEntry)) {
+                logger.warn("skipping legacy POISON sentinel in queue {}", inputQueue.getName());
                 continue;
             }
             try {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -7,7 +7,6 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
-import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -44,11 +43,9 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
     private final Function<Double, Void> progressCallback;
     private final Indexer indexer;
     private final Project project;
-    private final TaskRepository taskRepository;
     @Inject
-    public CategorizeTask(final Indexer indexer, final DocumentCollectionFactory<String> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
-        super(Stage.CATEGORIZE, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class);
-        this.taskRepository = taskRepository;
+    public CategorizeTask(final Indexer indexer, final DocumentCollectionFactory<String> factory, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
+        super(Stage.CATEGORIZE, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class, gateFactory.forTask(taskView));
         this.progressCallback = progressCallback;
         this.indexer = indexer;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
@@ -72,7 +69,7 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
                 throw e;
             }
             if (queueEntry == null) {
-                if (drained(taskRepository)) {
+                if (drained()) {
                     break;
                 }
                 Thread.sleep(UPSTREAM_POLL_INTERVAL_MS);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -75,7 +75,7 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
                 if (drained(taskRepository)) {
                     break;
                 }
-                Thread.sleep(upstreamPollIntervalMs());
+                Thread.sleep(UPSTREAM_POLL_INTERVAL_MS);
                 continue;
             }
             // before the offer below, so the sentinel is not forwarded downstream

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -58,7 +58,7 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
         String queueEntry;
         long nbMessages = 0;
 
-        while ((queueEntry = inputQueue.poll()) != null) {
+        while (!Thread.currentThread().isInterrupted() && (queueEntry = inputQueue.poll()) != null) {
             try {
                 Document retrievedFromIndexer = getDocument(indexer, project.getName(), DocReference.parse(queueEntry));
                 if (retrievedFromIndexer != null) {
@@ -71,8 +71,15 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
                     logger.warn("unable to offer {} to queue {}", queueEntry, outputQueue.getName());
                 }
             } catch (Exception e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
                 logger.error("error in CategorizeTask loop", e);
             }
+        }
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("cancelled while draining " + inputQueue.getName());
         }
         logger.info("exiting CategorizeTask loop after {} messages.", nbMessages);
         return nbMessages;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/CategorizeTask.java
@@ -7,6 +7,7 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
+import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -43,9 +44,11 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
     private final Function<Double, Void> progressCallback;
     private final Indexer indexer;
     private final Project project;
+    private final TaskRepository taskRepository;
     @Inject
-    public CategorizeTask(final Indexer indexer, final DocumentCollectionFactory<String> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
+    public CategorizeTask(final Indexer indexer, final DocumentCollectionFactory<String> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
         super(Stage.CATEGORIZE, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class);
+        this.taskRepository = taskRepository;
         this.progressCallback = progressCallback;
         this.indexer = indexer;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
@@ -69,7 +72,11 @@ public class CategorizeTask extends PipelineTask<String> implements Monitorable 
                 throw e;
             }
             if (queueEntry == null) {
-                break;
+                if (drained(taskRepository)) {
+                    break;
+                }
+                Thread.sleep(upstreamPollIntervalMs());
+                continue;
             }
             // before the offer below, so the sentinel is not forwarded downstream
             if (isLegacySentinel(queueEntry)) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -8,6 +8,7 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
+import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -27,11 +28,13 @@ import java.util.function.Predicate;
 public class DeduplicateTask extends PipelineTask<Path> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final DocumentCollectionFactory<Path> factory;
+    private final TaskRepository taskRepository;
 
     @Inject
-    public DeduplicateTask(final DocumentCollectionFactory<Path> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
+    public DeduplicateTask(final DocumentCollectionFactory<Path> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
         super(Stage.DEDUPLICATE, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
         this.factory = factory;
+        this.taskRepository = taskRepository;
     }
 
     @Override
@@ -62,7 +65,11 @@ public class DeduplicateTask extends PipelineTask<Path> {
                     throw e;
                 }
                 if (path == null) {
-                    break;
+                    if (drained(taskRepository)) {
+                        break;
+                    }
+                    Thread.sleep(upstreamPollIntervalMs());
+                    continue;
                 }
                 if (filter.test(path)) {
                     outputQueue.add(path);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -50,13 +50,28 @@ public class DeduplicateTask extends PipelineTask<Path> {
     long transferToOutputQueue(Predicate<Path> filter) throws Exception {
         long originalSize = inputQueue.size();
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
-            Path path;
-            while (!Thread.currentThread().isInterrupted() && (path = inputQueue.poll()) != null) {
+            while (!Thread.currentThread().isInterrupted()) {
+                Path path;
+                try {
+                    path = inputQueue.poll();
+                } catch (RuntimeException e) {
+                    if (causedByInterrupt(e)) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                    throw e;
+                }
+                if (path == null) {
+                    break;
+                }
                 if (filter.test(path)) {
                     outputQueue.add(path);
                 }
             }
-            if (Thread.currentThread().isInterrupted()) {
+            // Thread.interrupted() tests AND clears: TaskWorkerLoop never clears the flag itself, so
+            // leaving it set would leak the interrupt onto the runner thread and make the next task
+            // start already cancelled.
+            if (Thread.interrupted()) {
                 throw new InterruptedException("cancelled while draining " + inputQueue.getName());
             }
             return originalSize - outputQueue.size();

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -51,10 +51,13 @@ public class DeduplicateTask extends PipelineTask<Path> {
         long originalSize = inputQueue.size();
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
             Path path;
-            while ((path = inputQueue.poll()) != null) {
+            while (!Thread.currentThread().isInterrupted() && (path = inputQueue.poll()) != null) {
                 if (filter.test(path)) {
                     outputQueue.add(path);
                 }
+            }
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException("cancelled while draining " + inputQueue.getName());
             }
             return originalSize - outputQueue.size();
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -68,7 +68,7 @@ public class DeduplicateTask extends PipelineTask<Path> {
                     if (drained(taskRepository)) {
                         break;
                     }
-                    Thread.sleep(upstreamPollIntervalMs());
+                    Thread.sleep(UPSTREAM_POLL_INTERVAL_MS);
                     continue;
                 }
                 if (filter.test(path)) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -51,12 +51,11 @@ public class DeduplicateTask extends PipelineTask<Path> {
         long originalSize = inputQueue.size();
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
             Path path;
-            while (!(path = inputQueue.take()).equals(PATH_POISON)) {
+            while ((path = inputQueue.poll()) != null) {
                 if (filter.test(path)) {
                     outputQueue.add(path);
                 }
             }
-            outputQueue.add(PATH_POISON);
             return originalSize - outputQueue.size();
         }
     }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -8,7 +8,6 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
-import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -28,13 +27,11 @@ import java.util.function.Predicate;
 public class DeduplicateTask extends PipelineTask<Path> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final DocumentCollectionFactory<Path> factory;
-    private final TaskRepository taskRepository;
 
     @Inject
-    public DeduplicateTask(final DocumentCollectionFactory<Path> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
-        super(Stage.DEDUPLICATE, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
+    public DeduplicateTask(final DocumentCollectionFactory<Path> factory, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
+        super(Stage.DEDUPLICATE, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class, gateFactory.forTask(taskView));
         this.factory = factory;
-        this.taskRepository = taskRepository;
     }
 
     @Override
@@ -65,7 +62,7 @@ public class DeduplicateTask extends PipelineTask<Path> {
                     throw e;
                 }
                 if (path == null) {
-                    if (drained(taskRepository)) {
+                    if (drained()) {
                         break;
                     }
                     Thread.sleep(UPSTREAM_POLL_INTERVAL_MS);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
@@ -90,15 +90,6 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
                 docsToProcess.forEach(doc -> outputQueue.add(DocReference.fromDocument((Document) doc).toQueueEntry()));
                 docsToProcess = searcher.scroll(scrollDuration).toList();
             } while (!docsToProcess.isEmpty());
-            searcher.clearScroll();
-            if (nextStage == Stage.ARTIFACT) {
-                // ArtifactTask workers terminate on this sentinel instead of an empty-poll
-                // timeout, so a slow/large scroll can never race a worker into exiting before
-                // all doc refs are enqueued. Scoped to ARTIFACT only: NLP consumers
-                // (ExtractNlpTask) have their own termination (bounded null-poll retries) and
-                // are left untouched.
-                outputQueue.add(STRING_POISON);
-            }
             logger.info("enqueued into {} {} files", outputQueue.getName(), totalHits);
         }
         return totalHits;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/EnqueueFromIndexTask.java
@@ -90,6 +90,7 @@ public class EnqueueFromIndexTask extends PipelineTask<String> {
                 docsToProcess.forEach(doc -> outputQueue.add(DocReference.fromDocument((Document) doc).toQueueEntry()));
                 docsToProcess = searcher.scroll(scrollDuration).toList();
             } while (!docsToProcess.isEmpty());
+            searcher.clearScroll();
             logger.info("enqueued into {} {} files", outputQueue.getName(), totalHits);
         }
         return totalHits;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -87,7 +87,7 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
                 if (drained(taskRepository)) {
                     break;
                 }
-                Thread.sleep(upstreamPollIntervalMs());
+                Thread.sleep(UPSTREAM_POLL_INTERVAL_MS);
                 continue;
             }
             if (isLegacySentinel(queueEntry)) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -70,15 +70,22 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
         logger.info("extracting Named Entities with pipeline {} for {} from queue {}", nlpPipeline.getType(), project, inputQueue.getName());
         String queueEntry;
         long nbMessages = 0;
-        while ((queueEntry = inputQueue.poll()) != null) {
+        while (!Thread.currentThread().isInterrupted() && (queueEntry = inputQueue.poll()) != null) {
             try {
                 findNamedEntities(project, queueEntry);
                 nbMessages++;
                 processed.incrementAndGet();
                 progressCallback.apply(getProgressRate());
             } catch (Throwable e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
                 logger.error("error in ExtractNlpTask loop on doc {}", queueEntry, e);
             }
+        }
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("cancelled while draining " + inputQueue.getName());
         }
         logger.info("exiting ExtractNlpTask loop after {} messages.", nbMessages);
         return nbMessages;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -11,6 +11,7 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
+import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extension.PipelineRegistry;
@@ -48,15 +49,17 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
     private final int maxContentLengthChars;
     private final Function<Double, Void> progressCallback;
     private final AtomicInteger processed = new AtomicInteger(0);
+    private final TaskRepository taskRepository;
 
     @Inject
-    public ExtractNlpTask(Indexer indexer, PipelineRegistry registry, final DocumentCollectionFactory<String> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
-        this(indexer, registry.get(Pipeline.Type.parse((String)taskView.args.get(NLP_PIPELINE_OPT))), factory, taskView, progressCallback);
+    public ExtractNlpTask(Indexer indexer, PipelineRegistry registry, final DocumentCollectionFactory<String> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
+        this(indexer, registry.get(Pipeline.Type.parse((String)taskView.args.get(NLP_PIPELINE_OPT))), factory, taskRepository, taskView, progressCallback);
     }
 
 
-    ExtractNlpTask(Indexer indexer, Pipeline pipeline, final DocumentCollectionFactory<String> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
+    ExtractNlpTask(Indexer indexer, Pipeline pipeline, final DocumentCollectionFactory<String> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
         super(Stage.NLP, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class);
+        this.taskRepository = taskRepository;
         this.nlpPipeline = pipeline;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
         maxContentLengthChars = (int) HumanReadableSize.parse(ofNullable((String)taskView.args.get(MAX_CONTENT_LENGTH_OPT)).orElse(valueOf(DEFAULT_MAX_CONTENT_LENGTH)));
@@ -81,7 +84,11 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
                 throw e;
             }
             if (queueEntry == null) {
-                break;
+                if (drained(taskRepository)) {
+                    break;
+                }
+                Thread.sleep(upstreamPollIntervalMs());
+                continue;
             }
             if (isLegacySentinel(queueEntry)) {
                 continue;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -68,23 +68,41 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
     public Long call() throws Exception {
         super.call();
         logger.info("extracting Named Entities with pipeline {} for {} from queue {}", nlpPipeline.getType(), project, inputQueue.getName());
-        String queueEntry;
         long nbMessages = 0;
-        while (!Thread.currentThread().isInterrupted() && (queueEntry = inputQueue.poll()) != null) {
+        while (!Thread.currentThread().isInterrupted()) {
+            String queueEntry;
+            try {
+                queueEntry = inputQueue.poll();
+            } catch (RuntimeException e) {
+                if (causedByInterrupt(e)) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                throw e;
+            }
+            if (queueEntry == null) {
+                break;
+            }
+            if (isLegacySentinel(queueEntry)) {
+                continue;
+            }
             try {
                 findNamedEntities(project, queueEntry);
                 nbMessages++;
                 processed.incrementAndGet();
                 progressCallback.apply(getProgressRate());
             } catch (Throwable e) {
-                if (e instanceof InterruptedException) {
+                if (causedByInterrupt(e)) {
                     Thread.currentThread().interrupt();
                     break;
                 }
                 logger.error("error in ExtractNlpTask loop on doc {}", queueEntry, e);
             }
         }
-        if (Thread.currentThread().isInterrupted()) {
+        // Thread.interrupted() tests AND clears: TaskWorkerLoop never clears the flag itself, so
+        // leaving it set would leak the interrupt onto the runner thread and make the next task
+        // start already cancelled.
+        if (Thread.interrupted()) {
             throw new InterruptedException("cancelled while draining " + inputQueue.getName());
         }
         logger.info("exiting ExtractNlpTask loop after {} messages.", nbMessages);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -88,6 +88,7 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
                 continue;
             }
             if (isLegacySentinel(queueEntry)) {
+                logger.warn("skipping legacy POISON sentinel in queue {}", inputQueue.getName());
                 continue;
             }
             try {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -11,7 +11,6 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
-import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extension.PipelineRegistry;
@@ -49,17 +48,15 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
     private final int maxContentLengthChars;
     private final Function<Double, Void> progressCallback;
     private final AtomicInteger processed = new AtomicInteger(0);
-    private final TaskRepository taskRepository;
 
     @Inject
-    public ExtractNlpTask(Indexer indexer, PipelineRegistry registry, final DocumentCollectionFactory<String> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
-        this(indexer, registry.get(Pipeline.Type.parse((String)taskView.args.get(NLP_PIPELINE_OPT))), factory, taskRepository, taskView, progressCallback);
+    public ExtractNlpTask(Indexer indexer, PipelineRegistry registry, final DocumentCollectionFactory<String> factory, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
+        this(indexer, registry.get(Pipeline.Type.parse((String)taskView.args.get(NLP_PIPELINE_OPT))), factory, gateFactory.forTask(taskView), taskView, progressCallback);
     }
 
 
-    ExtractNlpTask(Indexer indexer, Pipeline pipeline, final DocumentCollectionFactory<String> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
-        super(Stage.NLP, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class);
-        this.taskRepository = taskRepository;
+    ExtractNlpTask(Indexer indexer, Pipeline pipeline, final DocumentCollectionFactory<String> factory, final UpstreamGate gate, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) {
+        super(Stage.NLP, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class, gate);
         this.nlpPipeline = pipeline;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
         maxContentLengthChars = (int) HumanReadableSize.parse(ofNullable((String)taskView.args.get(MAX_CONTENT_LENGTH_OPT)).orElse(valueOf(DEFAULT_MAX_CONTENT_LENGTH)));
@@ -84,7 +81,7 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
                 throw e;
             }
             if (queueEntry == null) {
-                if (drained(taskRepository)) {
+                if (drained()) {
                     break;
                 }
                 Thread.sleep(UPSTREAM_POLL_INTERVAL_MS);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -27,16 +27,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.valueOf;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
-import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_POLLING_INTERVAL_SEC;
 import static org.icij.datashare.cli.DatashareCliOptions.MAX_CONTENT_LENGTH_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.NLP_PIPELINE_OPT;
-import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 import org.icij.datashare.asynctasks.TaskGroupType;
 import static org.icij.extract.document.Identifier.shorten;
 
@@ -44,13 +41,11 @@ import static org.icij.extract.document.Identifier.shorten;
 @TaskGroup(TaskGroupType.Java)
 public class ExtractNlpTask extends PipelineTask<String> implements Monitorable {
     private static final int DEFAULT_MAX_CONTENT_LENGTH = 1024 * 1024;
-    public static final int NB_MAX_POLLS = 3;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Indexer indexer;
     private final Pipeline nlpPipeline;
     private final Project project;
     private final int maxContentLengthChars;
-    private final float pollingIntervalSeconds;
     private final Function<Double, Void> progressCallback;
     private final AtomicInteger processed = new AtomicInteger(0);
 
@@ -65,7 +60,6 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
         this.nlpPipeline = pipeline;
         project = Project.project(ofNullable((String)taskView.args.get(DEFAULT_PROJECT_OPT)).orElse(DEFAULT_DEFAULT_PROJECT));
         maxContentLengthChars = (int) HumanReadableSize.parse(ofNullable((String)taskView.args.get(MAX_CONTENT_LENGTH_OPT)).orElse(valueOf(DEFAULT_MAX_CONTENT_LENGTH)));
-        pollingIntervalSeconds = Float.parseFloat(ofNullable((String)taskView.args.get(POLLING_INTERVAL_SECONDS_OPT)).orElse(DEFAULT_POLLING_INTERVAL_SEC));
         this.indexer = indexer;
         this.progressCallback = progressCallback;
     }
@@ -76,19 +70,12 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
         logger.info("extracting Named Entities with pipeline {} for {} from queue {}", nlpPipeline.getType(), project, inputQueue.getName());
         String queueEntry;
         long nbMessages = 0;
-        int nbMaxPolls = NB_MAX_POLLS;
-        while (!(STRING_POISON.equals(queueEntry = inputQueue.poll((long) (pollingIntervalSeconds * 1000), TimeUnit.MILLISECONDS)))
-                && nbMaxPolls > 0) {
+        while ((queueEntry = inputQueue.poll()) != null) {
             try {
-                if (queueEntry != null) {
-                    findNamedEntities(project, queueEntry);
-                    nbMessages++;
-                    processed.incrementAndGet();
-                    progressCallback.apply(getProgressRate());
-                } else {
-                    logger.info("will poll document queue again for pollingInterval={} seconds ({}/{})", pollingIntervalSeconds, nbMaxPolls, NB_MAX_POLLS);
-                    nbMaxPolls--;
-                }
+                findNamedEntities(project, queueEntry);
+                nbMessages++;
+                processed.incrementAndGet();
+                progressCallback.apply(getProgressRate());
             } catch (Throwable e) {
                 logger.error("error in ExtractNlpTask loop on doc {}", queueEntry, e);
             }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -11,7 +11,6 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
-import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -65,8 +64,8 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
     private final Integer indexTimeout;
 
     @Inject
-    public IndexTask(final ElasticsearchSpewer spewer, final DocumentCollectionFactory<Path> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) throws IOException {
-        super(Stage.INDEX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
+    public IndexTask(final ElasticsearchSpewer spewer, final DocumentCollectionFactory<Path> factory, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) throws IOException {
+        super(Stage.INDEX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class, gateFactory.forTask(taskView));
         parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(Runtime.getRuntime().availableProcessors());
         indexTimeout = getIndexTimeout();
         warnIfParseTimeoutDisabled();
@@ -101,8 +100,8 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         drainer = new DocumentQueueDrainer<>(inputQueue, progressTrackConsumer).configure(allTaskOptions);
         // The drainer has no notion of an upstream stage: without a latch it stops on its first
         // empty poll, which is only right when the producer has already finished.
-        if (upstreamTaskId().isPresent()) {
-            drainer.setLatch(new UpstreamSealableLatch(() -> drained(taskRepository), UPSTREAM_POLL_INTERVAL_MS));
+        if (gate != UpstreamGate.NONE) {
+            drainer.setLatch(new UpstreamSealableLatch(this::drained, UPSTREAM_POLL_INTERVAL_MS));
         }
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -74,6 +74,13 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
 
         consumer = new DocumentConsumer(spewer, this.extractor, this.parallelism);
         progressTrackConsumer = path -> {
+            // ponytail: transitional. Redis queue keys survive upgrades, so a pre-21.16 run can
+            // leave a "POISON" path in this queue. Skip it instead of trying to extract a file
+            // named POISON. Remove once no live queue predates 21.16.
+            if (PATH_POISON.equals(path)) {
+                logger.warn("skipping legacy POISON entry in queue {}", inputQueue.getName());
+                return;
+            }
             consumer.accept(path);
             processed.incrementAndGet();
             if (progressCallback != null) {
@@ -92,7 +99,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         super.call();
         logger.info("Processing up to {} file(s) in parallel", parallelism);
         try {
-            totalToProcess = drainer.drain(PATH_POISON).get();
+            totalToProcess = drainer.drain().get();
             drainer.shutdown();
             drainer.awaitTermination(10, SECONDS); // drain is finished
             logger.info("drained {} documents. Waiting for consumer to shutdown", totalToProcess);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -150,6 +150,6 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
     @Override
     public double getProgressRate() {
         totalToProcess = max(inputQueue.size(), totalToProcess);
-        return (double)(totalToProcess - inputQueue.size()) / totalToProcess;
+        return totalToProcess == 0 ? 0 : (double)(totalToProcess - inputQueue.size()) / totalToProcess;
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import org.icij.time.HumanDuration;
 
@@ -48,6 +49,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.*;
 @Option(name = "projectName", description = "task project name")
 @TaskGroup(TaskGroupType.Java)
 public class IndexTask extends PipelineTask<Path> implements Monitorable{
+    private static final Path PATH_POISON = Paths.get("POISON");
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Extractor extractor;
     private final DocumentQueueDrainer<Path> drainer;
@@ -76,7 +78,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         progressTrackConsumer = path -> {
             // ponytail: transitional. Redis queue keys survive upgrades, so a pre-21.16 run can
             // leave a "POISON" path in this queue. Skip it instead of trying to extract a file
-            // named POISON. Remove once no live queue predates 21.16.
+            // named POISON. delete in 21.18.
             if (PATH_POISON.equals(path)) {
                 logger.warn("skipping legacy POISON entry in queue {}", inputQueue.getName());
                 return;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -103,7 +103,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         // The drainer has no notion of an upstream stage: without a latch it stops on its first
         // empty poll, which is only right when the producer has already finished.
         if (upstreamTaskId().isPresent()) {
-            drainer.setLatch(new UpstreamSealableLatch(() -> drained(taskRepository), upstreamPollIntervalMs()));
+            drainer.setLatch(new UpstreamSealableLatch(() -> drained(taskRepository), UPSTREAM_POLL_INTERVAL_MS));
         }
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -11,6 +11,7 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskGroup;
 import org.icij.datashare.asynctasks.TaskGroupType;
+import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.temporal.ActivityOpts;
 import org.icij.datashare.asynctasks.temporal.TemporalSingleActivityWorkflow;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -64,7 +65,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
     private final Integer indexTimeout;
 
     @Inject
-    public IndexTask(final ElasticsearchSpewer spewer, final DocumentCollectionFactory<Path> factory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) throws IOException {
+    public IndexTask(final ElasticsearchSpewer spewer, final DocumentCollectionFactory<Path> factory, final TaskRepository taskRepository, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) throws IOException {
         super(Stage.INDEX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class);
         parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(Runtime.getRuntime().availableProcessors());
         indexTimeout = getIndexTimeout();
@@ -99,6 +100,11 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
             consumer.setReporter(new Reporter(factory.createMap(propertiesProvider.getProperties().get(REPORT_NAME_OPT).toString())));
         }
         drainer = new DocumentQueueDrainer<>(inputQueue, progressTrackConsumer).configure(allTaskOptions);
+        // The drainer has no notion of an upstream stage: without a latch it stops on its first
+        // empty poll, which is only right when the producer has already finished.
+        if (upstreamTaskId().isPresent()) {
+            drainer.setLatch(new UpstreamSealableLatch(() -> drained(taskRepository), upstreamPollIntervalMs()));
+        }
     }
 
     @Override

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -58,6 +58,8 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
     private long totalToProcess;
 
     private final AtomicInteger processed = new AtomicInteger(0);
+    // entries the drainer counted as consumed but that were not documents (legacy sentinel)
+    private final AtomicInteger skipped = new AtomicInteger(0);
     private final Integer parallelism;
     private final Integer indexTimeout;
 
@@ -81,6 +83,9 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
             // named POISON. delete in 21.18.
             if (PATH_POISON.equals(path)) {
                 logger.warn("skipping legacy POISON entry in queue {}", inputQueue.getName());
+                // DocumentQueueDrainer counts every entry it hands us, so discount this one
+                // to keep the returned total and the progress rate about real documents only
+                skipped.incrementAndGet();
                 return;
             }
             consumer.accept(path);
@@ -101,7 +106,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         super.call();
         logger.info("Processing up to {} file(s) in parallel", parallelism);
         try {
-            totalToProcess = drainer.drain().get();
+            totalToProcess = drainer.drain().get() - skipped.get();
             drainer.shutdown();
             drainer.awaitTermination(10, SECONDS); // drain is finished
             logger.info("drained {} documents. Waiting for consumer to shutdown", totalToProcess);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -79,9 +79,8 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
 
         consumer = new DocumentConsumer(spewer, this.extractor, this.parallelism);
         progressTrackConsumer = path -> {
-            // ponytail: transitional. Redis queue keys survive upgrades, so a pre-21.16 run can
-            // leave a "POISON" path in this queue. Skip it instead of trying to extract a file
-            // named POISON. delete in 21.18.
+            // Transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a
+            // "POISON" path in this queue. Skip it instead of trying to extract a file named POISON.
             if (PATH_POISON.equals(path)) {
                 logger.warn("skipping legacy POISON entry in queue {}", inputQueue.getName());
                 // DocumentQueueDrainer counts every entry it hands us, so discount this one

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -12,6 +12,7 @@ import org.icij.datashare.user.User;
 import org.icij.datashare.user.UserTask;
 import org.icij.extract.queue.DocumentQueue;
 import org.icij.task.DefaultTask;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
@@ -26,6 +27,7 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
      */
     protected static final long UPSTREAM_POLL_INTERVAL_MS = 1000;
 
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     protected final DocumentQueue<T> inputQueue;
     protected final DocumentQueue<T> outputQueue;
     protected final Stage stage;
@@ -116,19 +118,15 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
     }
 
     // Transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a "POISON"
-    // entry in a String queue. Skip it instead of resolving it as a doc reference.
-    protected boolean isLegacySentinel(String queueEntry) {
-        if (!"POISON".equals(queueEntry)) {
-            return false;
-        }
-        LoggerFactory.getLogger(getClass()).warn("skipping legacy POISON sentinel in queue {}", inputQueue.getName());
-        return true;
+    // entry in a String queue. Callers skip it instead of resolving it as a doc reference.
+    protected static boolean isLegacySentinel(String queueEntry) {
+        return "POISON".equals(queueEntry);
     }
 
     private Document warnIfNull(Document document, String projectName, String docId) {
         // indexer.get() also returns null on fetch failures (it logs them as ERROR), not only on missing ids
         if (document == null) {
-            LoggerFactory.getLogger(getClass()).warn("document <{}> could not be retrieved from index {} (missing document or index fetch error), skipping", docId, projectName);
+            logger.warn("document <{}> could not be retrieved from index {} (missing document or index fetch error), skipping", docId, projectName);
         }
         return document;
     }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -141,9 +141,8 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
         return !upstreamRunning(taskRepository) && inputQueue.isEmpty();
     }
 
-    // ponytail: transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a
-    // "POISON" entry in a String queue. Skip it instead of resolving it as a doc reference.
-    // Delete in 21.18, together with IndexTask's PATH_POISON guard.
+    // Transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a "POISON"
+    // entry in a String queue. Skip it instead of resolving it as a doc reference.
     protected boolean isLegacySentinel(String queueEntry) {
         if (!"POISON".equals(queueEntry)) {
             return false;

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -4,8 +4,6 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.CancellableTask;
-import org.icij.datashare.asynctasks.TaskRepository;
-import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.text.DocReference;
 import org.icij.datashare.text.Document;
@@ -16,18 +14,11 @@ import org.icij.extract.queue.DocumentQueue;
 import org.icij.task.DefaultTask;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 
 public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserTask, CancellableTask {
-    /**
-     * Task-arg key carrying the id of the task whose output feeds this stage's input queue. Set by
-     * the launcher (CliApp.runPipeline, TaskResource), never by an operator: it is not a CLI option.
-     */
-    public static final String UPSTREAM_TASK_ID = "upstreamTaskId";
     /**
      * How long a drain waits before re-polling a queue whose producer is still running. Fixed, not
      * an option: it paces an internal wait, and reading pollingInterval made stage handoff up to a
@@ -40,14 +31,21 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
     protected final Stage stage;
     protected final User user;
     protected final PropertiesProvider propertiesProvider;
+    protected final UpstreamGate gate;
     private final DocumentCollectionFactory<T> factory;
     private volatile Thread taskThread;
 
+    /** For producer stages: nothing feeds their input queue, the gate is {@link UpstreamGate#NONE}. */
     public PipelineTask(Stage stage, User user, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz) {
+        this(stage, user, factory, propertiesProvider, clazz, UpstreamGate.NONE);
+    }
+
+    public PipelineTask(Stage stage, User user, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz, UpstreamGate gate) {
         this.propertiesProvider = propertiesProvider;
         this.stage = stage;
         this.user = user;
         this.factory = factory;
+        this.gate = gate;
         this.inputQueue = getInputQueue(clazz);
         this.outputQueue = getOutputQueue(clazz);
     }
@@ -107,44 +105,14 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
     }
 
     /**
-     * The id of the task feeding this stage's input queue, or empty when this stage runs standalone
-     * against an already filled queue. Read from the task args, which is where the launcher puts it.
+     * True when a drain that just polled an empty queue may stop: the producer feeding it is done
+     * and the queue is still empty. The gate read comes first on purpose, so an entry enqueued
+     * between the caller's poll and that read is caught by the emptiness check instead of being
+     * stranded. With no upstream this is just "the queue is empty", the pre-gate behaviour: stop
+     * on the first empty poll.
      */
-    protected Optional<String> upstreamTaskId() {
-        return propertiesProvider.get(UPSTREAM_TASK_ID);
-    }
-
-    /**
-     * True while the producer feeding this stage may still enqueue. An absent upstream id or an
-     * unknown task means "no upstream to wait for", so the consumer falls back to exiting on an
-     * empty queue, which is the pre-gate behaviour. A repository read failure says nothing about
-     * the producer, so it counts as still running: retrying costs a poll interval, whereas calling
-     * it finished can end the drain on a transient error and strand whatever is enqueued next.
-     * JooqTaskRepository throws jOOQ's unchecked DataAccessException, hence the RuntimeException.
-     */
-    protected boolean upstreamRunning(TaskRepository taskRepository) {
-        return upstreamTaskId().map(upstreamTaskId -> {
-            try {
-                return !taskRepository.getTask(upstreamTaskId).getState().isFinal();
-            } catch (UnknownTask e) {
-                LoggerFactory.getLogger(getClass()).warn("upstream task {} is unknown, treating it as finished", upstreamTaskId, e);
-                return false;
-            } catch (IOException | RuntimeException e) {
-                LoggerFactory.getLogger(getClass()).warn("cannot read upstream task {} state, treating it as still running", upstreamTaskId, e);
-                return true;
-            }
-        }).orElse(false);
-    }
-
-    /**
-     * True when a drain that just polled an empty queue may stop: the producer feeding it is
-     * terminal and the queue is still empty. The state read comes first on purpose, so an entry
-     * enqueued between the caller's poll and that read is caught by the emptiness check instead of
-     * being stranded. With no upstream id this is just "the queue is empty", which is the pre-gate
-     * behaviour: stop on the first empty poll.
-     */
-    protected boolean drained(TaskRepository taskRepository) {
-        return !upstreamRunning(taskRepository) && inputQueue.isEmpty();
+    protected boolean drained() {
+        return !gate.mayGrow() && inputQueue.isEmpty();
     }
 
     // Transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a "POISON"

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
-import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 
 public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserTask, CancellableTask {
     /**
@@ -29,7 +28,12 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
      * the launcher (CliApp.runPipeline, TaskResource), never by an operator: it is not a CLI option.
      */
     public static final String UPSTREAM_TASK_ID = "upstreamTaskId";
-    private static final long DEFAULT_UPSTREAM_POLL_INTERVAL_MS = 1000;
+    /**
+     * How long a drain waits before re-polling a queue whose producer is still running. Fixed, not
+     * an option: it paces an internal wait, and reading pollingInterval made stage handoff up to a
+     * minute slow (that option's CLI default) while muddying what that option means.
+     */
+    protected static final long UPSTREAM_POLL_INTERVAL_MS = 1000;
 
     protected final DocumentQueue<T> inputQueue;
     protected final DocumentQueue<T> outputQueue;
@@ -135,11 +139,6 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
      */
     protected boolean drained(TaskRepository taskRepository) {
         return !upstreamRunning(taskRepository) && inputQueue.isEmpty();
-    }
-
-    /** How long to wait before re-polling a queue whose producer is still running. */
-    protected long upstreamPollIntervalMs() {
-        return propertiesProvider.get(POLLING_INTERVAL_SECONDS_OPT).map(Float::parseFloat).map(s -> (long)(s * 1000)).orElse(DEFAULT_UPSTREAM_POLL_INTERVAL_MS);
     }
 
     // ponytail: transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -4,6 +4,8 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.CancellableTask;
+import org.icij.datashare.asynctasks.TaskRepository;
+import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.text.DocReference;
 import org.icij.datashare.text.Document;
@@ -14,11 +16,21 @@ import org.icij.extract.queue.DocumentQueue;
 import org.icij.task.DefaultTask;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
+import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 
 public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserTask, CancellableTask {
+    /**
+     * Task-arg key carrying the id of the task whose output feeds this stage's input queue. Set by
+     * the launcher (CliApp.runPipeline, TaskResource), never by an operator: it is not a CLI option.
+     */
+    public static final String UPSTREAM_TASK_ID = "upstreamTaskId";
+    private static final long DEFAULT_UPSTREAM_POLL_INTERVAL_MS = 1000;
+
     protected final DocumentQueue<T> inputQueue;
     protected final DocumentQueue<T> outputQueue;
     protected final Stage stage;
@@ -88,6 +100,46 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
             }
         }
         return false;
+    }
+
+    /**
+     * The id of the task feeding this stage's input queue, or empty when this stage runs standalone
+     * against an already filled queue. Read from the task args, which is where the launcher puts it.
+     */
+    protected Optional<String> upstreamTaskId() {
+        return propertiesProvider.get(UPSTREAM_TASK_ID);
+    }
+
+    /**
+     * True while the producer feeding this stage may still enqueue. An absent upstream id, an
+     * unknown task, or a repository failure all mean "no upstream to wait for", so the consumer
+     * falls back to exiting on an empty queue, which is the pre-gate behaviour.
+     */
+    protected boolean upstreamRunning(TaskRepository taskRepository) {
+        return upstreamTaskId().map(upstreamTaskId -> {
+            try {
+                return !taskRepository.getTask(upstreamTaskId).getState().isFinal();
+            } catch (UnknownTask | IOException e) {
+                LoggerFactory.getLogger(getClass()).warn("cannot read upstream task {} state, treating it as finished", upstreamTaskId, e);
+                return false;
+            }
+        }).orElse(false);
+    }
+
+    /**
+     * True when a drain that just polled an empty queue may stop: the producer feeding it is
+     * terminal and the queue is still empty. The state read comes first on purpose, so an entry
+     * enqueued between the caller's poll and that read is caught by the emptiness check instead of
+     * being stranded. With no upstream id this is just "the queue is empty", which is the pre-gate
+     * behaviour: stop on the first empty poll.
+     */
+    protected boolean drained(TaskRepository taskRepository) {
+        return !upstreamRunning(taskRepository) && inputQueue.isEmpty();
+    }
+
+    /** How long to wait before re-polling a queue whose producer is still running. */
+    protected long upstreamPollIntervalMs() {
+        return propertiesProvider.get(POLLING_INTERVAL_SECONDS_OPT).map(Float::parseFloat).map(s -> (long)(s * 1000)).orElse(DEFAULT_UPSTREAM_POLL_INTERVAL_MS);
     }
 
     // ponytail: transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -14,8 +14,6 @@ import org.icij.extract.queue.DocumentQueue;
 import org.icij.task.DefaultTask;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import static java.util.Optional.ofNullable;
@@ -27,7 +25,6 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
     protected final User user;
     protected final PropertiesProvider propertiesProvider;
     private final DocumentCollectionFactory<T> factory;
-    public static Path PATH_POISON = Paths.get("POISON");
     private volatile Thread taskThread;
 
     public PipelineTask(Stage stage, User user, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -28,7 +28,6 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
     protected final PropertiesProvider propertiesProvider;
     private final DocumentCollectionFactory<T> factory;
     public static Path PATH_POISON = Paths.get("POISON");
-    public static String STRING_POISON = "POISON";
     private volatile Thread taskThread;
 
     public PipelineTask(Stage stage, User user, DocumentCollectionFactory<T> factory, final PropertiesProvider propertiesProvider, Class<T> clazz) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -73,6 +73,34 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
         return warnIfNull(indexer.get(projectName, ref.id(), ref.routing(), sourceExcludes), projectName, ref.id());
     }
 
+    /**
+     * True when this throwable is, or wraps, an InterruptedException. Redisson and the
+     * Elasticsearch rest-client both re-interrupt the thread and rethrow a RuntimeException
+     * wrapping the InterruptedException, so a plain instanceof test misses a real cancellation.
+     */
+    protected static boolean causedByInterrupt(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof InterruptedException) {
+                return true;
+            }
+            if (cause == cause.getCause()) {
+                break;
+            }
+        }
+        return false;
+    }
+
+    // ponytail: transitional. Redis queue keys survive upgrades, so a pre-21.16 run can leave a
+    // "POISON" entry in a String queue. Skip it instead of resolving it as a doc reference.
+    // Delete in 21.18, together with IndexTask's PATH_POISON guard.
+    protected boolean isLegacySentinel(String queueEntry) {
+        if (!"POISON".equals(queueEntry)) {
+            return false;
+        }
+        LoggerFactory.getLogger(getClass()).warn("skipping legacy POISON sentinel in queue {}", inputQueue.getName());
+        return true;
+    }
+
     private Document warnIfNull(Document document, String projectName, String docId) {
         // indexer.get() also returns null on fetch failures (it logs them as ERROR), not only on missing ids
         if (document == null) {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/PipelineTask.java
@@ -115,17 +115,23 @@ public abstract class PipelineTask<T> extends DefaultTask<Long> implements UserT
     }
 
     /**
-     * True while the producer feeding this stage may still enqueue. An absent upstream id, an
-     * unknown task, or a repository failure all mean "no upstream to wait for", so the consumer
-     * falls back to exiting on an empty queue, which is the pre-gate behaviour.
+     * True while the producer feeding this stage may still enqueue. An absent upstream id or an
+     * unknown task means "no upstream to wait for", so the consumer falls back to exiting on an
+     * empty queue, which is the pre-gate behaviour. A repository read failure says nothing about
+     * the producer, so it counts as still running: retrying costs a poll interval, whereas calling
+     * it finished can end the drain on a transient error and strand whatever is enqueued next.
+     * JooqTaskRepository throws jOOQ's unchecked DataAccessException, hence the RuntimeException.
      */
     protected boolean upstreamRunning(TaskRepository taskRepository) {
         return upstreamTaskId().map(upstreamTaskId -> {
             try {
                 return !taskRepository.getTask(upstreamTaskId).getState().isFinal();
-            } catch (UnknownTask | IOException e) {
-                LoggerFactory.getLogger(getClass()).warn("cannot read upstream task {} state, treating it as finished", upstreamTaskId, e);
+            } catch (UnknownTask e) {
+                LoggerFactory.getLogger(getClass()).warn("upstream task {} is unknown, treating it as finished", upstreamTaskId, e);
                 return false;
+            } catch (IOException | RuntimeException e) {
+                LoggerFactory.getLogger(getClass()).warn("cannot read upstream task {} state, treating it as still running", upstreamTaskId, e);
+                return true;
             }
         }).orElse(false);
     }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ScanTask.java
@@ -40,8 +40,6 @@ public class ScanTask extends PipelineTask<Path> {
     public Long call() throws Exception {
         super.call();
         ScannerVisitor scannerVisitor = scanner.createScannerVisitor(path);
-        Long scanned = scannerVisitor.call();
-        outputQueue.add(PATH_POISON);
-        return scanned;
+        return scannerVisitor.call();
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/UpstreamGate.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/UpstreamGate.java
@@ -38,8 +38,12 @@ public interface UpstreamGate {
 
         /**
          * The gate for this task view: repository-backed when the launcher set an upstream id in
-         * the args, {@link #NONE} otherwise. An unknown task or a repository failure means "won't
-         * grow", so the consumer falls back to stopping on an empty queue, the pre-gate behaviour.
+         * the args, {@link #NONE} otherwise. An unknown task means "no upstream to wait for", so
+         * the consumer falls back to stopping on an empty queue, the pre-gate behaviour. A
+         * repository read failure says nothing about the producer, so it counts as still running:
+         * retrying costs a poll interval, whereas calling it finished can end the drain on a
+         * transient error and strand whatever is enqueued next. JooqTaskRepository throws jOOQ's
+         * unchecked DataAccessException, hence the RuntimeException.
          */
         public UpstreamGate forTask(Task<?> taskView) {
             String upstreamTaskId = (String) taskView.args.get(UPSTREAM_TASK_ID);
@@ -49,9 +53,12 @@ public interface UpstreamGate {
             return () -> {
                 try {
                     return !taskRepository.getTask(upstreamTaskId).getState().isFinal();
-                } catch (UnknownTask | IOException e) {
-                    LoggerFactory.getLogger(Factory.class).warn("cannot read upstream task {} state, treating it as finished", upstreamTaskId, e);
+                } catch (UnknownTask e) {
+                    LoggerFactory.getLogger(Factory.class).warn("upstream task {} is unknown, treating it as finished", upstreamTaskId, e);
                     return false;
+                } catch (IOException | RuntimeException e) {
+                    LoggerFactory.getLogger(Factory.class).warn("cannot read upstream task {} state, treating it as still running", upstreamTaskId, e);
+                    return true;
                 }
             };
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/UpstreamGate.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/UpstreamGate.java
@@ -1,0 +1,59 @@
+package org.icij.datashare.tasks;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepository;
+import org.icij.datashare.asynctasks.UnknownTask;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Answers the only question a consumer stage may ask about its surroundings: can my input queue
+ * still receive entries? It hides both the task repository and the upstream task id from the
+ * tasks, which stay standalone pieces of code.
+ */
+public interface UpstreamGate {
+    /**
+     * Task-arg key carrying the id of the task whose output feeds this stage's input queue. Set by
+     * the launcher (CliApp.runPipeline, TaskResource), never by an operator: it is not a CLI option.
+     */
+    String UPSTREAM_TASK_ID = "upstreamTaskId";
+
+    /** True while the producer feeding this stage's input queue may still enqueue. */
+    boolean mayGrow();
+
+    /** No producer to wait for: the queue never grows, so a drain stops on its first empty poll. */
+    UpstreamGate NONE = () -> false;
+
+    @Singleton
+    class Factory {
+        private final TaskRepository taskRepository;
+
+        @Inject
+        public Factory(TaskRepository taskRepository) {
+            this.taskRepository = taskRepository;
+        }
+
+        /**
+         * The gate for this task view: repository-backed when the launcher set an upstream id in
+         * the args, {@link #NONE} otherwise. An unknown task or a repository failure means "won't
+         * grow", so the consumer falls back to stopping on an empty queue, the pre-gate behaviour.
+         */
+        public UpstreamGate forTask(Task<?> taskView) {
+            String upstreamTaskId = (String) taskView.args.get(UPSTREAM_TASK_ID);
+            if (upstreamTaskId == null) {
+                return NONE;
+            }
+            return () -> {
+                try {
+                    return !taskRepository.getTask(upstreamTaskId).getState().isFinal();
+                } catch (UnknownTask | IOException e) {
+                    LoggerFactory.getLogger(Factory.class).warn("cannot read upstream task {} state, treating it as finished", upstreamTaskId, e);
+                    return false;
+                }
+            };
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/UpstreamSealableLatch.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/UpstreamSealableLatch.java
@@ -1,0 +1,40 @@
+package org.icij.datashare.tasks;
+
+import org.icij.concurrent.SealableLatch;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * A SealableLatch that is sealed once the input queue is drained, meaning empty with a terminal
+ * producer task. It lets DocumentQueueDrainer keep polling a temporarily empty queue while the
+ * producer is still enqueuing, and stop as soon as the producer is done and the queue is empty.
+ */
+class UpstreamSealableLatch implements SealableLatch {
+    private final BooleanSupplier drained;
+    private final long pollIntervalMs;
+    private volatile boolean sealed = false;
+
+    UpstreamSealableLatch(BooleanSupplier drained, long pollIntervalMs) {
+        this.drained = drained;
+        this.pollIntervalMs = pollIntervalMs;
+    }
+
+    /** Nothing to wake up: the drainer re-polls on its own once {@link #await()} returns. */
+    @Override
+    public void signal() {}
+
+    @Override
+    public void await() throws InterruptedException {
+        Thread.sleep(pollIntervalMs);
+    }
+
+    @Override
+    public void seal() {
+        sealed = true;
+    }
+
+    @Override
+    public boolean isSealed() {
+        return sealed || drained.getAsBoolean();
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -418,7 +418,10 @@ public class TaskResource {
         } else {
             properties.remove(REPORT_NAME_OPT); // avoid use of reportMap to override ES docs
         }
-        ofNullable(taskManager.startTask(IndexTask.class, user, propertiesToMap(properties))).ifPresent(taskIds::add);
+        Map<String, Object> indexArgs = propertiesToMap(properties);
+        // the scan is still walking the data dir: this is what keeps the index task draining
+        indexArgs.put(PipelineTask.UPSTREAM_TASK_ID, scanResponse.taskId);
+        ofNullable(taskManager.startTask(IndexTask.class, user, indexArgs)).ifPresent(taskIds::add);
         return new JsonPayload(new TasksResponse(taskIds));
     }
 
@@ -535,10 +538,15 @@ public class TaskResource {
         properties.put(NLP_PIPELINE_OPT, pipelineName);
         syncModels(parseBoolean(properties.getProperty(SYNC_MODELS_OPTION, "true")));
         List<String> tasks = new LinkedList<>();
+        Map<String, Object> nlpArgs = propertiesToMap(properties);
         if (parseBoolean(properties.getProperty(RESUME_OPT, "true"))) {
-            tasks.add(taskManager.startTask(EnqueueFromIndexTask.class, ((User) context.currentUser()), propertiesToMap(properties)));
+            String enqueueTaskId = taskManager.startTask(EnqueueFromIndexTask.class, ((User) context.currentUser()), propertiesToMap(properties));
+            tasks.add(enqueueTaskId);
+            // without it the NLP task would exit on its first empty poll, while the enqueuing task
+            // is still scrolling the index, and report DONE having processed nothing
+            nlpArgs.put(PipelineTask.UPSTREAM_TASK_ID, enqueueTaskId);
         }
-        tasks.add(taskManager.startTask(ExtractNlpTask.class, (User) context.currentUser(), propertiesToMap(properties)));
+        tasks.add(taskManager.startTask(ExtractNlpTask.class, (User) context.currentUser(), nlpArgs));
         return new JsonPayload(new TasksResponse(tasks));
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -420,7 +420,7 @@ public class TaskResource {
         }
         Map<String, Object> indexArgs = propertiesToMap(properties);
         // the scan is still walking the data dir: this is what keeps the index task draining
-        indexArgs.put(PipelineTask.UPSTREAM_TASK_ID, scanResponse.taskId);
+        indexArgs.put(UpstreamGate.UPSTREAM_TASK_ID, scanResponse.taskId);
         ofNullable(taskManager.startTask(IndexTask.class, user, indexArgs)).ifPresent(taskIds::add);
         return new JsonPayload(new TasksResponse(taskIds));
     }
@@ -544,7 +544,7 @@ public class TaskResource {
             tasks.add(enqueueTaskId);
             // without it the NLP task would exit on its first empty poll, while the enqueuing task
             // is still scrolling the index, and report DONE having processed nothing
-            nlpArgs.put(PipelineTask.UPSTREAM_TASK_ID, enqueueTaskId);
+            nlpArgs.put(UpstreamGate.UPSTREAM_TASK_ID, enqueueTaskId);
         }
         tasks.add(taskManager.startTask(ExtractNlpTask.class, (User) context.currentUser(), nlpArgs));
         return new JsonPayload(new TasksResponse(tasks));
@@ -559,7 +559,7 @@ public class TaskResource {
         Properties clone = (Properties) properties.clone();
         // Set by the launcher below, never by a client: a forged id makes the started consumer poll
         // for as long as the referenced task lives, pinning a worker for as long as the caller wants.
-        clone.remove(PipelineTask.UPSTREAM_TASK_ID);
+        clone.remove(UpstreamGate.UPSTREAM_TASK_ID);
         clone.setProperty(QUEUE_NAME_OPT, "extract:queue"); // Override any given queue name value
         clone.setProperty(REPORT_NAME_OPT, getReportMapNameFor(properties));
         clone.setProperty(DIGEST_PROJECT_NAME_OPT, clone.getProperty(DEFAULT_PROJECT_OPT, "local-datashare"));

--- a/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/TaskResource.java
@@ -557,6 +557,9 @@ public class TaskResource {
 
     public static Properties applyProjectTo(Properties properties) {
         Properties clone = (Properties) properties.clone();
+        // Set by the launcher below, never by a client: a forged id makes the started consumer poll
+        // for as long as the referenced task lives, pinning a worker for as long as the caller wants.
+        clone.remove(PipelineTask.UPSTREAM_TASK_ID);
         clone.setProperty(QUEUE_NAME_OPT, "extract:queue"); // Override any given queue name value
         clone.setProperty(REPORT_NAME_OPT, getReportMapNameFor(properties));
         clone.setProperty(DIGEST_PROJECT_NAME_OPT, clone.getProperty(DEFAULT_PROJECT_OPT, "local-datashare"));

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
@@ -6,22 +6,15 @@ import org.icij.datashare.asynctasks.TaskManagerMemory;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
-import org.icij.datashare.tasks.ArtifactTask;
-import org.icij.datashare.tasks.CategorizeTask;
-import org.icij.datashare.tasks.CreateNlpBatchesFromIndex;
 import org.icij.datashare.tasks.DatashareTaskFactory;
-import org.icij.datashare.tasks.DeduplicateTask;
-import org.icij.datashare.tasks.EnqueueFromIndexTask;
-import org.icij.datashare.tasks.ExtractNlpTask;
 import org.icij.datashare.tasks.IndexTask;
-import org.icij.datashare.tasks.ScanIndexTask;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.user.User;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -72,7 +65,7 @@ public class CliAppTest {
         Properties properties = new Properties();
         properties.setProperty("stages", "INDEX,SCAN");
 
-        CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties);
+        assertThat(CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties)).isTrue();
 
         InOrder inOrder = inOrder(mockedManager);
         inOrder.verify(mockedManager).startTask(eq(ScanTask.class), any(), any());
@@ -91,23 +84,32 @@ public class CliAppTest {
         Properties properties = new Properties();
         properties.setProperty("stages", "SCAN,INDEX");
 
-        CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties);
+        // false is what makes the launcher exit non-zero instead of looking like a success
+        assertThat(CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties)).isFalse();
 
         verify(mockedManager, never()).startTask(eq(IndexTask.class), any(), any());
     }
 
     @Test
+    public void test_run_pipeline_runs_a_repeated_stage_only_once() throws Exception {
+        TaskManager mockedManager = mock(TaskManager.class);
+        when(mockedManager.startTask(eq(ScanTask.class), any(), any())).thenReturn("id-scan");
+        when(mockedManager.startTask(eq(IndexTask.class), any(), any())).thenReturn("id-index");
+        doReturn(doneTask()).when(mockedManager).getTask("id-scan");
+        doReturn(doneTask()).when(mockedManager).getTask("id-index");
+        Properties properties = new Properties();
+        properties.setProperty("stages", "SCAN,SCAN,INDEX");
+
+        assertThat(CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties)).isTrue();
+
+        // twice would walk and enqueue the whole data dir a second time
+        verify(mockedManager).startTask(eq(ScanTask.class), any(), any());
+    }
+
+    @Test
     public void test_task_classes_maps_every_stage_to_its_task_class() {
-        assertThat(CliApp.TASK_CLASSES.get(Stage.SCAN)).isEqualTo(ScanTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.SCANIDX)).isEqualTo(ScanIndexTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.DEDUPLICATE)).isEqualTo(DeduplicateTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.INDEX)).isEqualTo(IndexTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.ENQUEUEIDX)).isEqualTo(EnqueueFromIndexTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.CATEGORIZE)).isEqualTo(CategorizeTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.CREATENLPBATCHESFROMIDX)).isEqualTo(CreateNlpBatchesFromIndex.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.NLP)).isEqualTo(ExtractNlpTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.ARTIFACT)).isEqualTo(ArtifactTask.class);
-        assertThat(CliApp.TASK_CLASSES.get(Stage.BATCHNLP)).isNull();
+        // asserted against the enum, so a stage added without a task class fails here
+        assertThat(EnumSet.copyOf(CliApp.TASK_CLASSES.keySet())).isEqualTo(EnumSet.complementOf(EnumSet.of(Stage.BATCHNLP)));
     }
 
     private static Task<Long> doneTask() {

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
@@ -1,24 +1,37 @@
 package org.icij.datashare;
 
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskManager;
 import org.icij.datashare.asynctasks.TaskManagerMemory;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.TaskResult;
+import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.IndexTask;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.user.User;
 import org.junit.Test;
+import org.mockito.InOrder;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.cli.DatashareCliOptions.TASK_MANAGER_POLLING_INTERVAL_OPT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CliAppTest {
     private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
@@ -40,5 +53,45 @@ public class CliAppTest {
 
         // WHEN/THEN
         assertThat(taskManager.awaitTermination(1, TimeUnit.SECONDS, Set.of(taskId))).isTrue();
+    }
+
+    @Test
+    public void test_run_pipeline_starts_a_stage_only_after_the_previous_one_is_done() throws Exception {
+        TaskManager mockedManager = mock(TaskManager.class);
+        when(mockedManager.startTask(eq(ScanTask.class), any(), any())).thenReturn("id-scan");
+        when(mockedManager.startTask(eq(IndexTask.class), any(), any())).thenReturn("id-index");
+        doReturn(doneTask()).when(mockedManager).getTask("id-scan");
+        doReturn(doneTask()).when(mockedManager).getTask("id-index");
+        Properties properties = new Properties();
+        properties.setProperty("stages", "SCAN,INDEX");
+
+        CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties);
+
+        InOrder inOrder = inOrder(mockedManager);
+        inOrder.verify(mockedManager).startTask(eq(ScanTask.class), any(), any());
+        inOrder.verify(mockedManager).awaitTermination(anyInt(), any(), eq(Set.of("id-scan")));
+        inOrder.verify(mockedManager).startTask(eq(IndexTask.class), any(), any());
+        inOrder.verify(mockedManager).awaitTermination(anyInt(), any(), eq(Set.of("id-index")));
+    }
+
+    @Test
+    public void test_run_pipeline_stops_when_a_stage_does_not_complete() throws Exception {
+        TaskManager mockedManager = mock(TaskManager.class);
+        when(mockedManager.startTask(eq(ScanTask.class), any(), any())).thenReturn("id-scan");
+        Task<Long> failed = new Task<>(ScanTask.class.getName(), User.local(), new HashMap<>());
+        failed.setError(new TaskError(new RuntimeException("boom")));
+        doReturn(failed).when(mockedManager).getTask("id-scan");
+        Properties properties = new Properties();
+        properties.setProperty("stages", "SCAN,INDEX");
+
+        CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties);
+
+        verify(mockedManager, never()).startTask(eq(IndexTask.class), any(), any());
+    }
+
+    private static Task<Long> doneTask() {
+        Task<Long> task = new Task<>(ScanTask.class.getName(), User.local(), new HashMap<>());
+        task.setResult(new TaskResult<>(0L));
+        return task;
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
@@ -8,7 +8,7 @@ import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.tasks.IndexTask;
-import org.icij.datashare.tasks.PipelineTask;
+import org.icij.datashare.tasks.UpstreamGate;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.user.User;
 import org.junit.Test;
@@ -93,11 +93,11 @@ public class CliAppTest {
         // this id is how IndexTask knows to keep polling while the scan is still enqueuing
         ArgumentCaptor<Map<String, Object>> args = ArgumentCaptor.forClass(Map.class);
         verify(mockedManager).startTask(eq(IndexTask.class), any(), args.capture());
-        assertThat(args.getValue().get(PipelineTask.UPSTREAM_TASK_ID)).isEqualTo("id-scan");
+        assertThat(args.getValue().get(UpstreamGate.UPSTREAM_TASK_ID)).isEqualTo("id-scan");
         // the first stage has no producer to wait for
         ArgumentCaptor<Map<String, Object>> scanArgs = ArgumentCaptor.forClass(Map.class);
         verify(mockedManager).startTask(eq(ScanTask.class), any(), scanArgs.capture());
-        assertThat(scanArgs.getValue().containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
+        assertThat(scanArgs.getValue().containsKey(UpstreamGate.UPSTREAM_TASK_ID)).isFalse();
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
@@ -6,8 +6,15 @@ import org.icij.datashare.asynctasks.TaskManagerMemory;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
+import org.icij.datashare.tasks.ArtifactTask;
+import org.icij.datashare.tasks.CategorizeTask;
+import org.icij.datashare.tasks.CreateNlpBatchesFromIndex;
 import org.icij.datashare.tasks.DatashareTaskFactory;
+import org.icij.datashare.tasks.DeduplicateTask;
+import org.icij.datashare.tasks.EnqueueFromIndexTask;
+import org.icij.datashare.tasks.ExtractNlpTask;
 import org.icij.datashare.tasks.IndexTask;
+import org.icij.datashare.tasks.ScanIndexTask;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.user.User;
 import org.junit.Test;
@@ -63,7 +70,7 @@ public class CliAppTest {
         doReturn(doneTask()).when(mockedManager).getTask("id-scan");
         doReturn(doneTask()).when(mockedManager).getTask("id-index");
         Properties properties = new Properties();
-        properties.setProperty("stages", "SCAN,INDEX");
+        properties.setProperty("stages", "INDEX,SCAN");
 
         CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties);
 
@@ -87,6 +94,20 @@ public class CliAppTest {
         CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties);
 
         verify(mockedManager, never()).startTask(eq(IndexTask.class), any(), any());
+    }
+
+    @Test
+    public void test_task_classes_maps_every_stage_to_its_task_class() {
+        assertThat(CliApp.TASK_CLASSES.get(Stage.SCAN)).isEqualTo(ScanTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.SCANIDX)).isEqualTo(ScanIndexTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.DEDUPLICATE)).isEqualTo(DeduplicateTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.INDEX)).isEqualTo(IndexTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.ENQUEUEIDX)).isEqualTo(EnqueueFromIndexTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.CATEGORIZE)).isEqualTo(CategorizeTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.CREATENLPBATCHESFROMIDX)).isEqualTo(CreateNlpBatchesFromIndex.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.NLP)).isEqualTo(ExtractNlpTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.ARTIFACT)).isEqualTo(ArtifactTask.class);
+        assertThat(CliApp.TASK_CLASSES.get(Stage.BATCHNLP)).isNull();
     }
 
     private static Task<Long> doneTask() {

--- a/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/CliAppTest.java
@@ -8,9 +8,11 @@ import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.asynctasks.bus.amqp.TaskError;
 import org.icij.datashare.tasks.DatashareTaskFactory;
 import org.icij.datashare.tasks.IndexTask;
+import org.icij.datashare.tasks.PipelineTask;
 import org.icij.datashare.tasks.ScanTask;
 import org.icij.datashare.user.User;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.util.EnumSet;
@@ -29,7 +31,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -56,7 +58,7 @@ public class CliAppTest {
     }
 
     @Test
-    public void test_run_pipeline_starts_a_stage_only_after_the_previous_one_is_done() throws Exception {
+    public void test_run_pipeline_starts_every_stage_then_awaits_them_all_at_once() throws Exception {
         TaskManager mockedManager = mock(TaskManager.class);
         when(mockedManager.startTask(eq(ScanTask.class), any(), any())).thenReturn("id-scan");
         when(mockedManager.startTask(eq(IndexTask.class), any(), any())).thenReturn("id-index");
@@ -67,27 +69,51 @@ public class CliAppTest {
 
         assertThat(CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties)).isTrue();
 
+        // stages overlap now: awaiting each one before starting the next would let a bounded queue
+        // deadlock a large corpus, the upstream-task gate is what makes termination correct
         InOrder inOrder = inOrder(mockedManager);
         inOrder.verify(mockedManager).startTask(eq(ScanTask.class), any(), any());
-        inOrder.verify(mockedManager).awaitTermination(anyInt(), any(), eq(Set.of("id-scan")));
         inOrder.verify(mockedManager).startTask(eq(IndexTask.class), any(), any());
-        inOrder.verify(mockedManager).awaitTermination(anyInt(), any(), eq(Set.of("id-index")));
+        inOrder.verify(mockedManager).awaitTermination(anyInt(), any(), eq(Set.of("id-scan", "id-index")));
+        verify(mockedManager, times(1)).awaitTermination(anyInt(), any(), any());
     }
 
     @Test
-    public void test_run_pipeline_stops_when_a_stage_does_not_complete() throws Exception {
+    public void test_run_pipeline_passes_the_previous_stage_task_id_to_the_next_stage() throws Exception {
         TaskManager mockedManager = mock(TaskManager.class);
         when(mockedManager.startTask(eq(ScanTask.class), any(), any())).thenReturn("id-scan");
+        when(mockedManager.startTask(eq(IndexTask.class), any(), any())).thenReturn("id-index");
+        doReturn(doneTask()).when(mockedManager).getTask("id-scan");
+        doReturn(doneTask()).when(mockedManager).getTask("id-index");
+        Properties properties = new Properties();
+        properties.setProperty("stages", "SCAN,INDEX");
+
+        CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties);
+
+        // this id is how IndexTask knows to keep polling while the scan is still enqueuing
+        ArgumentCaptor<Map<String, Object>> args = ArgumentCaptor.forClass(Map.class);
+        verify(mockedManager).startTask(eq(IndexTask.class), any(), args.capture());
+        assertThat(args.getValue().get(PipelineTask.UPSTREAM_TASK_ID)).isEqualTo("id-scan");
+        // the first stage has no producer to wait for
+        ArgumentCaptor<Map<String, Object>> scanArgs = ArgumentCaptor.forClass(Map.class);
+        verify(mockedManager).startTask(eq(ScanTask.class), any(), scanArgs.capture());
+        assertThat(scanArgs.getValue().containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
+    }
+
+    @Test
+    public void test_run_pipeline_reports_a_stage_that_does_not_complete() throws Exception {
+        TaskManager mockedManager = mock(TaskManager.class);
+        when(mockedManager.startTask(eq(ScanTask.class), any(), any())).thenReturn("id-scan");
+        when(mockedManager.startTask(eq(IndexTask.class), any(), any())).thenReturn("id-index");
         Task<Long> failed = new Task<>(ScanTask.class.getName(), User.local(), new HashMap<>());
         failed.setError(new TaskError(new RuntimeException("boom")));
         doReturn(failed).when(mockedManager).getTask("id-scan");
+        doReturn(doneTask()).when(mockedManager).getTask("id-index");
         Properties properties = new Properties();
         properties.setProperty("stages", "SCAN,INDEX");
 
         // false is what makes the launcher exit non-zero instead of looking like a success
         assertThat(CliApp.runPipeline(mockedManager, new PipelineHelper(new PropertiesProvider(properties)), properties)).isFalse();
-
-        verify(mockedManager, never()).startTask(eq(IndexTask.class), any(), any());
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
@@ -6,6 +6,7 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.test.LogbackCapturingRule;
@@ -47,6 +48,7 @@ public class ArtifactChaosIntTest {
     @Rule public TemporaryFolder corpusDir = new TemporaryFolder();
     @Rule public TemporaryFolder artifactDir = new TemporaryFolder();
     @Rule public LogbackCapturingRule logback = new LogbackCapturingRule();
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
 
     @Test(timeout = 300_000)
     public void killed_run_then_rerun_converges_to_full_coverage() throws Exception {
@@ -67,7 +69,7 @@ public class ArtifactChaosIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
@@ -78,7 +80,7 @@ public class ArtifactChaosIntTest {
         int realBeforeBlock = 5;
         AtomicInteger callCount = new AtomicInteger(0);
         CountDownLatch blocked = new CountDownLatch(1);
-        ArtifactTask killedTask = new ArtifactTask(stringQueueFactory, indexer, props,
+        ArtifactTask killedTask = new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
@@ -135,7 +137,7 @@ public class ArtifactChaosIntTest {
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
 
         AtomicInteger reproductions = new AtomicInteger(0);
-        ArtifactTask resumeTask = new ArtifactTask(stringQueueFactory, indexer, props,
+        ArtifactTask resumeTask = new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
@@ -185,11 +187,11 @@ public class ArtifactChaosIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props,
+        new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
 
         ArtifactCoverageChecker.Report report = new ArtifactCoverageChecker(indexer, new SourceExtractor(props))
@@ -241,11 +243,11 @@ public class ArtifactChaosIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props,
+        new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
 
         ArtifactCoverageChecker.Report report = new ArtifactCoverageChecker(indexer, new SourceExtractor(props))

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
@@ -69,7 +69,7 @@ public class ArtifactChaosIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
@@ -80,7 +80,7 @@ public class ArtifactChaosIntTest {
         int realBeforeBlock = 5;
         AtomicInteger callCount = new AtomicInteger(0);
         CountDownLatch blocked = new CountDownLatch(1);
-        ArtifactTask killedTask = new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
+        ArtifactTask killedTask = new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
@@ -137,7 +137,7 @@ public class ArtifactChaosIntTest {
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
 
         AtomicInteger reproductions = new AtomicInteger(0);
-        ArtifactTask resumeTask = new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
+        ArtifactTask resumeTask = new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
@@ -187,11 +187,11 @@ public class ArtifactChaosIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
+        new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
 
         ArtifactCoverageChecker.Report report = new ArtifactCoverageChecker(indexer, new SourceExtractor(props))
@@ -243,11 +243,11 @@ public class ArtifactChaosIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
+        new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
 
         ArtifactCoverageChecker.Report report = new ArtifactCoverageChecker(indexer, new SourceExtractor(props))

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
@@ -55,7 +55,6 @@ public class ArtifactChaosIntTest {
                 "stages", "ARTIFACT,ENQUEUEIDX",
                 "queueName", "test:queue",
                 "artifactDir", artifactDir.getRoot().toString(),
-                "pollingInterval", "1",
                 "parallelism", "1"));
         PropertiesProvider props = new PropertiesProvider(map);
 
@@ -174,7 +173,6 @@ public class ArtifactChaosIntTest {
                 "stages", "ARTIFACT,ENQUEUEIDX",
                 "queueName", "test:queue",
                 "artifactDir", artifactDir.getRoot().toString(),
-                "pollingInterval", "1",
                 "parallelism", "4"));
         PropertiesProvider props = new PropertiesProvider(map);
 
@@ -226,7 +224,6 @@ public class ArtifactChaosIntTest {
                 "stages", "ARTIFACT,ENQUEUEIDX",
                 "queueName", "test:queue",
                 "artifactDir", artifactDir.getRoot().toString(),
-                "pollingInterval", "1",
                 "parallelism", "1"));
         PropertiesProvider props = new PropertiesProvider(map);
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
@@ -57,12 +57,12 @@ public class ArtifactCoverageIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         // 3. ENQUEUEIDX -> ARTIFACT (queue test:queue:artifact), then the task itself
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
+        new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
 
         // 4. coverage

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
@@ -5,6 +5,7 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.Language;
@@ -33,6 +34,7 @@ public class ArtifactCoverageIntTest {
     @Rule public ElasticsearchRule es = new ElasticsearchRule();
     @Rule public TemporaryFolder corpusDir = new TemporaryFolder();
     @Rule public TemporaryFolder artifactDir = new TemporaryFolder();
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
 
     @Test(timeout = 300_000)
     public void every_indexed_document_has_a_terminal_manifest_and_servable_source() throws Exception {
@@ -55,12 +57,12 @@ public class ArtifactCoverageIntTest {
         ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
         ElasticsearchSpewer spewer = new ElasticsearchSpewer(indexer, stringQueueFactory,
                 text -> Language.ENGLISH, new FieldNames(), props);
-        new IndexTask(spewer, indexQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        new IndexTask(spewer, indexQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         // 3. ENQUEUEIDX -> ARTIFACT (queue test:queue:artifact), then the task itself
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props,
+        new ArtifactTask(stringQueueFactory, indexer, props, taskRepository,
                 new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
 
         // 4. coverage

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
@@ -41,7 +41,6 @@ public class ArtifactCoverageIntTest {
                 "stages", "ARTIFACT,ENQUEUEIDX",
                 "queueName", "test:queue",
                 "artifactDir", artifactDir.getRoot().toString(),
-                "pollingInterval", "1",
                 "parallelism", "2"));
         PropertiesProvider props = new PropertiesProvider(map);
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -12,7 +12,6 @@ import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 import org.icij.datashare.user.User;
 import org.icij.extract.document.TikaDocument;
 import org.icij.extract.queue.DocumentQueue;
-import org.icij.extract.queue.MemoryDocumentQueue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -377,93 +376,10 @@ public class ArtifactTaskTest {
     }
 
     @Test(timeout = 10000)
-    public void test_terminates_on_poison_instead_of_polling_timeout() throws Exception {
-        indexEmbeddedDoc();
-        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
-        queue.add(EMBEDDED_DOC_SHA256);
-
-        // pollingInterval is set far beyond the test timeout: if termination still depended on an
-        // empty poll timing out, this call would block until JUnit kills the test. Only the
-        // poison pill can make it return within the 10s budget.
-        //
-        // The poison is now emitted AFTER the run starts (while the first doc is being processed),
-        // not pre-loaded: the startup drain (drainStaleResidualPoison) would strip a pre-loaded
-        // poison as stale before any worker runs. This mirrors production, where EnqueueFromIndexTask
-        // emits the trailing poison concurrently, after the task has started and drained.
-        PropertiesProvider props = new PropertiesProvider(Map.of(
-                "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj",
-                "pollingInterval", "3600"));
-        Long numberOfDocuments = new ArtifactTask(factory, mockEs, props,
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null) {
-            @Override
-            protected SourceExtractor createSourceExtractor() {
-                return new SourceExtractor(props) {
-                    @Override
-                    public TikaDocument extractEmbeddedSources(Project project, Document document) {
-                        queue.add(PipelineTask.STRING_POISON);
-                        return null;
-                    }
-                };
-            }
-        }.call();
-
-        assertThat(numberOfDocuments).isEqualTo(1);
-    }
-
-    @Test(timeout = 10000)
-    public void test_poison_is_not_processed_as_a_document() throws Exception {
-        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
-        queue.add(PipelineTask.STRING_POISON);
-
-        Long numberOfDocuments = runArtifactTask();
-
-        assertThat(numberOfDocuments).isEqualTo(0);
-        assertThat(logback.logs(Level.WARN)).excludes("document <POISON> could not be retrieved from index prj (missing document or index fetch error), skipping");
-        assertThat(logback.logs(Level.ERROR)).excludes("1 document(s) could not be retrieved from index prj and got no artifact cache, re-run the ARTIFACT stage for them");
-    }
-
-    @Test(timeout = 10000)
-    public void test_poison_propagates_to_every_worker() throws Exception {
-        indexEmbeddedDoc();
-        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
-        queue.add(EMBEDDED_DOC_SHA256);
-        // a single poison entry for two workers: whichever worker reads it must re-offer it so
-        // the other worker (blocked on a 3600s poll, well past the test timeout) also sees it and
-        // terminates, instead of being the only one released. The poison is emitted after the run
-        // has started (during doc processing) so the startup drain does not strip it as stale.
-        PropertiesProvider props = new PropertiesProvider(Map.of(
-                "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj",
-                "pollingInterval", "3600",
-                "parallelism", "2"));
-        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
-
-        Long numberOfDocuments = new ArtifactTask(factory, mockEs, props, task, null) {
-            @Override
-            protected SourceExtractor createSourceExtractor() {
-                return new SourceExtractor(props) {
-                    @Override
-                    public TikaDocument extractEmbeddedSources(Project project, Document document) {
-                        queue.add(PipelineTask.STRING_POISON);
-                        return null;
-                    }
-                };
-            }
-        }.call();
-
-        assertThat(numberOfDocuments).isEqualTo(1);
-    }
-
-    @Test(timeout = 10000)
     public void test_two_sequential_runs_on_same_queue_both_process_docs() throws Exception {
         // the ARTIFACT input queue name is static (extract:queue:artifact) and is never deleted
-        // between runs: re-running the stage on the same project (a documented, supported
-        // workflow, see --artifactsForce) reuses it. A poison sentinel left in the queue by run 1
-        // and never drained would sit at the head of run 2's queue, ahead of its real doc refs
-        // (FIFO), and terminate every run-2 worker before it processes a single document. Run 2's
-        // startup drain (drainStaleResidualPoison) now cleans that straggler before its workers
-        // start, so both runs process their doc.
+        // between runs, so a re-run reuses it. Nothing is left behind by run 1 to terminate run 2's
+        // workers early.
         indexEmbeddedDoc();
         String secondId = "1111111111111111111111111111111111111111111111111111111111111111";
         mockIndexer.indexFile("prj", secondId,
@@ -472,80 +388,30 @@ public class ArtifactTaskTest {
 
         DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
         queue.add(EMBEDDED_DOC_SHA256);
-        queue.add(PipelineTask.STRING_POISON);
 
         Long firstRun = runArtifactTask();
         assertThat(firstRun).isEqualTo(1);
 
         queue.add(secondId);
-        queue.add(PipelineTask.STRING_POISON);
 
         Long secondRun = runArtifactTask();
         assertThat(secondRun).isEqualTo(1);
     }
 
     @Test(timeout = 10000)
-    public void test_doc_stranded_behind_stale_poison_is_recovered_by_next_run() throws Exception {
-        // regression: on the kill/cancellation path the queue can end up with a real doc ref
-        // BEHIND the trailing poison (workers interrupted before draining that far), e.g.
-        // [doc, POISON, strandedDoc]. The residual-poison drain must not stop at the first
-        // non-poison entry it polls: doing so would re-offer "doc" but leave POISON in place
-        // ahead of strandedDoc, stranding it. Instead it drains the whole queue and re-offers
-        // every real doc ref in FIFO order, discarding all poison.
-        //
-        // The drain now runs at STARTUP of each run. So the pre-loaded [doc, POISON, strandedDoc]
-        // is cleaned by run 1's own startup drain into [doc, strandedDoc]: run 1 processes both
-        // (firstRun == 2). Run 2 then processes its own doc (secondRun == 1). No doc is ever lost
-        // to a stale sentinel.
+    public void test_legacy_poison_entry_is_skipped_and_the_doc_behind_it_is_processed() throws Exception {
+        // a sentinel written by a pre-21.16 run needs no dedicated code here: it resolves to a doc
+        // reference with id POISON, the indexer returns null for it, and PipelineTask.warnIfNull
+        // already logs and skips. The doc behind it must still be processed.
         indexEmbeddedDoc();
-        String strandedId = "1111111111111111111111111111111111111111111111111111111111111111";
-        String secondRunId = "2".repeat(strandedId.length());
-        mockIndexer.indexFile("prj", strandedId,
-                Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).toURI()),
-                "message/rfc822");
-        mockIndexer.indexFile("prj", secondRunId,
-                Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).toURI()),
-                "message/rfc822");
-
         DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add("POISON");
         queue.add(EMBEDDED_DOC_SHA256);
-        queue.add(PipelineTask.STRING_POISON);
-        queue.add(strandedId);
-
-        Long firstRun = runArtifactTask();
-        assertThat(firstRun).isEqualTo(2);
-
-        queue.add(secondRunId);
-        queue.add(PipelineTask.STRING_POISON);
-
-        Long secondRun = runArtifactTask();
-        assertThat(secondRun).isEqualTo(1);
-    }
-
-    @Test(timeout = 10000)
-    public void test_transient_null_poll_does_not_drop_a_later_doc() throws Exception {
-        // finding 4: EnqueueFromIndexTask produces concurrently, so a worker that drains
-        // everything enqueued-so-far can get a null poll before the next doc arrives. Exiting on
-        // that first null (the old `while (poll() != null)`) would silently drop every doc
-        // enqueued afterwards. Simulate a queue whose first timed poll returns null (transient
-        // empty) and then yields the doc: the worker must retry the null and still process the doc.
-        indexEmbeddedDoc();
-        MemoryDocumentQueue<String> transientNullQueue = new MemoryDocumentQueue<>("extract:queue:artifact", 1024) {
-            private final AtomicInteger timedPolls = new AtomicInteger(0);
-            @Override
-            public String poll(long timeout, TimeUnit unit) throws InterruptedException {
-                if (timedPolls.getAndIncrement() == 0) {
-                    return null; // transient empty on the very first poll, producer not caught up yet
-                }
-                return super.poll(timeout, unit);
-            }
-        };
-        factory.queues.put("extract:queue:artifact", transientNullQueue);
-        transientNullQueue.add(EMBEDDED_DOC_SHA256);
 
         Long numberOfDocuments = runArtifactTask();
 
         assertThat(numberOfDocuments).isEqualTo(1);
+        assertThat(logback.logs(Level.WARN)).contains("document <POISON> could not be retrieved from index prj (missing document or index fetch error), skipping");
     }
 
     private void indexEmbeddedDoc() throws URISyntaxException {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -53,7 +53,7 @@ public class ArtifactTaskTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_missing_artifact_dir() {
-        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
+        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
     }
 
     @Test(timeout = 10000)
@@ -115,7 +115,7 @@ public class ArtifactTaskTest {
                 "parallelism", "2"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -158,7 +158,7 @@ public class ArtifactTaskTest {
                 "parallelism", "2"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 throw new IllegalStateException("no extractor");
@@ -188,7 +188,7 @@ public class ArtifactTaskTest {
         // exactly one of the two workers fails to build its extractor and dies; the other survives.
         // the task must still fail, independently of the parallelism.
         AtomicInteger extractorCalls = new AtomicInteger(0);
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 if (extractorCalls.getAndIncrement() == 0) {
@@ -235,7 +235,7 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "2"));
-        ArtifactTask task = new ArtifactTask(factory, mockEs, props, taskRepository,
+        ArtifactTask task = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository),
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
@@ -273,7 +273,7 @@ public class ArtifactTaskTest {
                 "parallelism", "1"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -330,7 +330,7 @@ public class ArtifactTaskTest {
 
         // a single worker, so cancelling while the first document is in flight must stop the worker
         // before it ever polls the second entry off the queue
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -382,7 +382,7 @@ public class ArtifactTaskTest {
         Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj")),
-                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 
         assertThat(numberOfDocuments).isEqualTo(1);
@@ -452,8 +452,8 @@ public class ArtifactTaskTest {
         ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj")),
-                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(),
-                Map.of(PipelineTask.UPSTREAM_TASK_ID, upstream.id)), null);
+                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(),
+                Map.of(UpstreamGate.UPSTREAM_TASK_ID, upstream.id)), null);
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
@@ -482,7 +482,7 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj"
                 )),
-                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
     }
 
@@ -491,7 +491,7 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", String.valueOf(parallelism))),
-                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
     }
 
@@ -507,7 +507,7 @@ public class ArtifactTaskTest {
         Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj")),
-                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 
         assertThat(numberOfDocuments).isEqualTo(1);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -405,9 +405,8 @@ public class ArtifactTaskTest {
 
     @Test(timeout = 10000)
     public void test_legacy_poison_entry_is_skipped_and_the_doc_behind_it_is_processed() throws Exception {
-        // a sentinel written by a pre-21.16 run needs no dedicated code here: it resolves to a doc
-        // reference with id POISON, the indexer returns null for it, and PipelineTask.warnIfNull
-        // already logs and skips. The doc behind it must still be processed.
+        // a sentinel written by a pre-21.16 run is skipped before it is resolved as a doc reference,
+        // so it is not counted as an unretrievable document. The doc behind it must still be processed.
         indexEmbeddedDoc();
         DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
         queue.add("POISON");
@@ -416,7 +415,9 @@ public class ArtifactTaskTest {
         Long numberOfDocuments = runArtifactTask();
 
         assertThat(numberOfDocuments).isEqualTo(1);
-        assertThat(logback.logs(Level.WARN)).contains("document <POISON> could not be retrieved from index prj (missing document or index fetch error), skipping");
+        assertThat(logback.logs(Level.WARN)).contains("skipping legacy POISON sentinel in queue extract:queue:artifact");
+        // the sentinel must not be reported as a document the operator should re-run the stage for
+        assertThat(logback.logs(Level.ERROR)).excludes("1 document(s) could not be retrieved from index prj and got no artifact cache, re-run the ARTIFACT stage for them");
     }
 
     private void indexEmbeddedDoc() throws URISyntaxException {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -104,7 +103,6 @@ public class ArtifactTaskTest {
         PropertiesProvider props = new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "pollingInterval", "1",
                 "parallelism", "2"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
@@ -148,7 +146,6 @@ public class ArtifactTaskTest {
         PropertiesProvider props = new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "pollingInterval", "1",
                 "parallelism", "2"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
@@ -176,7 +173,6 @@ public class ArtifactTaskTest {
         PropertiesProvider props = new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "pollingInterval", "1",
                 "parallelism", "2"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
@@ -229,7 +225,6 @@ public class ArtifactTaskTest {
         PropertiesProvider props = new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "pollingInterval", "1",
                 "parallelism", "2"));
         ArtifactTask task = new ArtifactTask(factory, mockEs, props,
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null) {
@@ -266,7 +261,6 @@ public class ArtifactTaskTest {
         PropertiesProvider props = new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "pollingInterval", "1",
                 "parallelism", "1"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
@@ -309,23 +303,34 @@ public class ArtifactTaskTest {
     @Test(timeout = 10000)
     public void test_cancel_stops_an_in_flight_run() throws Exception {
         indexEmbeddedDoc();
+        String secondId = "1111111111111111111111111111111111111111111111111111111111111111";
+        mockIndexer.indexFile("prj", secondId,
+                Path.of(Objects.requireNonNull(getClass().getResource("/docs/embedded_doc.eml")).toURI()),
+                "message/rfc822");
         DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
         queue.add(EMBEDDED_DOC_SHA256);
+        queue.add(secondId);
 
         CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch secondStarted = new CountDownLatch(1);
         PropertiesProvider props = new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "pollingInterval", "1",
                 "parallelism", "1"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
+        // a single worker, so cancelling while the first document is in flight must stop the worker
+        // before it ever polls the second entry off the queue
         ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
                     @Override
                     public TikaDocument extractEmbeddedSources(Project project, Document document) {
+                        if (document.getId().equals(secondId)) {
+                            secondStarted.countDown();
+                            return null;
+                        }
                         started.countDown();
                         try {
                             Thread.sleep(10_000);
@@ -355,6 +360,7 @@ public class ArtifactTaskTest {
 
         assertThat(callerThread.isAlive()).isFalse();
         assertThat(thrown.get()).isInstanceOf(InterruptedException.class);
+        assertThat(secondStarted.await(500, TimeUnit.MILLISECONDS)).isFalse();
     }
 
     @Test(timeout = 10000)
@@ -366,8 +372,7 @@ public class ArtifactTaskTest {
         // no "parallelism" key -> ArtifactTask resolves .orElse(1)
         Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj",
-                "pollingInterval", "1")),
+                "defaultProject", "prj")),
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 
@@ -426,8 +431,7 @@ public class ArtifactTaskTest {
     private Long runArtifactTask() throws Exception {
         return new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj",
-                "pollingInterval", "1"
+                "defaultProject", "prj"
                 )),
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
@@ -437,7 +441,6 @@ public class ArtifactTaskTest {
         return new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "pollingInterval", "1",
                 "parallelism", String.valueOf(parallelism))),
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
@@ -454,8 +457,7 @@ public class ArtifactTaskTest {
 
         Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj",
-                "pollingInterval", "1")),
+                "defaultProject", "prj")),
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
-import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -453,8 +452,8 @@ public class ArtifactTaskTest {
         ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj")),
-                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), Map.of(
-                PipelineTask.UPSTREAM_TASK_ID, upstream.id, POLLING_INTERVAL_SECONDS_OPT, "0.05")), null);
+                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(),
+                Map.of(PipelineTask.UPSTREAM_TASK_ID, upstream.id)), null);
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -4,6 +4,7 @@ package org.icij.datashare.tasks;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
+import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.LogbackCapturingRule;
 import org.icij.datashare.text.Document;
@@ -13,6 +14,7 @@ import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 import org.icij.datashare.user.User;
 import org.icij.extract.document.TikaDocument;
 import org.icij.extract.queue.DocumentQueue;
+import org.icij.extract.queue.MemoryDocumentQueue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,12 +28,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
+import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -420,6 +428,45 @@ public class ArtifactTaskTest {
         assertThat(logback.logs(Level.WARN)).contains("skipping legacy POISON sentinel in queue extract:queue:artifact");
         // the sentinel must not be reported as a document the operator should re-run the stage for
         assertThat(logback.logs(Level.ERROR)).excludes("1 document(s) could not be retrieved from index prj and got no artifact cache, re-run the ARTIFACT stage for them");
+    }
+
+    @Test(timeout = 30000)
+    public void test_waits_for_the_upstream_task_before_leaving_an_empty_queue() throws Exception {
+        indexEmbeddedDoc();
+        Task<Long> upstream = new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), Map.of());
+        upstream.setState(Task.State.RUNNING);
+        taskRepository.insert(upstream, null);
+        CountDownLatch firstEmptyPoll = new CountDownLatch(1);
+        DocumentQueue<String> queue = new MemoryDocumentQueue<>("extract:queue:artifact", DEFAULT_QUEUE_CAPACITY) {
+            @Override
+            public String poll() {
+                String polled = super.poll();
+                if (polled == null) {
+                    firstEmptyPoll.countDown();
+                }
+                return polled;
+            }
+        };
+        factory.queues.put("extract:queue:artifact", queue);
+        // this task reads its options from the injected properties, so the upstream id set by the
+        // launcher only exists in the task args: the queue must still be drained
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj")),
+                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), Map.of(
+                PipelineTask.UPSTREAM_TASK_ID, upstream.id, POLLING_INTERVAL_SECONDS_OPT, "0.05")), null);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Long> produced = executor.submit((Callable<Long>) artifactTask::call);
+            assertThat(firstEmptyPoll.await(20, TimeUnit.SECONDS)).isTrue();
+            queue.add(EMBEDDED_DOC_SHA256);
+            upstream.setResult(new TaskResult<>(0L));
+
+            assertThat(produced.get(20, TimeUnit.SECONDS)).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     private void indexEmbeddedDoc() throws URISyntaxException {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.tasks;
 
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.LogbackCapturingRule;
 import org.icij.datashare.text.Document;
@@ -41,10 +42,11 @@ public class ArtifactTaskTest {
     @Mock Indexer mockEs;
     MockIndexer mockIndexer;
     private final MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
 
     @Test(expected = IllegalArgumentException.class)
     public void test_missing_artifact_dir() {
-        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
+        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
     }
 
     @Test(timeout = 10000)
@@ -106,7 +108,7 @@ public class ArtifactTaskTest {
                 "parallelism", "2"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -149,7 +151,7 @@ public class ArtifactTaskTest {
                 "parallelism", "2"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 throw new IllegalStateException("no extractor");
@@ -179,7 +181,7 @@ public class ArtifactTaskTest {
         // exactly one of the two workers fails to build its extractor and dies; the other survives.
         // the task must still fail, independently of the parallelism.
         AtomicInteger extractorCalls = new AtomicInteger(0);
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 if (extractorCalls.getAndIncrement() == 0) {
@@ -226,7 +228,7 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "2"));
-        ArtifactTask task = new ArtifactTask(factory, mockEs, props,
+        ArtifactTask task = new ArtifactTask(factory, mockEs, props, taskRepository,
                 new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
@@ -264,7 +266,7 @@ public class ArtifactTaskTest {
                 "parallelism", "1"));
         Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -321,7 +323,7 @@ public class ArtifactTaskTest {
 
         // a single worker, so cancelling while the first document is in flight must stop the worker
         // before it ever polls the second entry off the queue
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, taskRepository, task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -373,7 +375,7 @@ public class ArtifactTaskTest {
         Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj")),
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 
         assertThat(numberOfDocuments).isEqualTo(1);
@@ -434,7 +436,7 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj"
                 )),
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
     }
 
@@ -443,7 +445,7 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", String.valueOf(parallelism))),
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
     }
 
@@ -459,7 +461,7 @@ public class ArtifactTaskTest {
         Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj")),
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+                taskRepository, new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
                 .call();
 
         assertThat(numberOfDocuments).isEqualTo(1);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.tasks;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.ContentTypeCategory;
@@ -31,6 +32,7 @@ public class CategorizeTaskIntTest {
     private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider()).withRefresh(Refresh.True);
 
     private MemoryDocumentCollectionFactory<String> documentCollectionFactory;
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     private static final String DEFAULT_INPUT_QUEUE_NAME = "extract:queue:categorize";
 
     @Before
@@ -51,7 +53,7 @@ public class CategorizeTaskIntTest {
         Document unknownTypeDoc = aDocWithContentType("other-that-is-not_Kn%wn");
 
         indexAndEnqueue(videoDoc, pdfDoc, unknownTypeDoc);
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
         //WHEN
@@ -72,7 +74,7 @@ public class CategorizeTaskIntTest {
     public void test_categorization_with_different_queue_name() throws Exception {
         //GIVEN
         indexAndEnqueueTwoDocuments("foo:categorize");
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(QUEUE_NAME_OPT, "foo", DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
         //WHEN
@@ -92,7 +94,7 @@ public class CategorizeTaskIntTest {
             progressValues.add(progress);
             return null;
         };
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), callback);
 
         //WHEN
@@ -109,7 +111,7 @@ public class CategorizeTaskIntTest {
         // GIVEN
         // A document that will not be in the index
         enqueue(aDoc());
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
         // WHEN
@@ -138,7 +140,7 @@ public class CategorizeTaskIntTest {
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), args), null).call();
 
-        new CategorizeTask(indexer, documentCollectionFactory,
+        new CategorizeTask(indexer, documentCollectionFactory, taskRepository,
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask2", User.local(), args), NO_OP_PROGRESS).call();
 
         // THEN
@@ -165,7 +167,7 @@ public class CategorizeTaskIntTest {
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), args), null).call();
 
-        new CategorizeTask(indexer, documentCollectionFactory,
+        new CategorizeTask(indexer, documentCollectionFactory, taskRepository,
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask2", User.local(), args), NO_OP_PROGRESS).call();
         Document updatedDoc = indexer.get(es.getIndexName(), toUpdateDoc.getId());
         // THEN
@@ -194,7 +196,7 @@ public class CategorizeTaskIntTest {
         assertThat(documentCollectionFactory.queues.get("extract:queue:categorize"))
                 .contains(embedded.getId() + "|" + root.getId());
 
-        new CategorizeTask(indexer, documentCollectionFactory,
+        new CategorizeTask(indexer, documentCollectionFactory, taskRepository,
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask3", User.local(), args), NO_OP_PROGRESS).call();
 
         // THEN the embedded doc got categorized (fetched and updated with routing)...

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
@@ -53,7 +53,7 @@ public class CategorizeTaskIntTest {
         Document unknownTypeDoc = aDocWithContentType("other-that-is-not_Kn%wn");
 
         indexAndEnqueue(videoDoc, pdfDoc, unknownTypeDoc);
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
         //WHEN
@@ -74,7 +74,7 @@ public class CategorizeTaskIntTest {
     public void test_categorization_with_different_queue_name() throws Exception {
         //GIVEN
         indexAndEnqueueTwoDocuments("foo:categorize");
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(QUEUE_NAME_OPT, "foo", DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
         //WHEN
@@ -94,7 +94,7 @@ public class CategorizeTaskIntTest {
             progressValues.add(progress);
             return null;
         };
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), callback);
 
         //WHEN
@@ -111,7 +111,7 @@ public class CategorizeTaskIntTest {
         // GIVEN
         // A document that will not be in the index
         enqueue(aDoc());
-        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, taskRepository, new Task<>(CategorizeTask.class.getName(),
+        CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
         // WHEN
@@ -140,7 +140,7 @@ public class CategorizeTaskIntTest {
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), args), null).call();
 
-        new CategorizeTask(indexer, documentCollectionFactory, taskRepository,
+        new CategorizeTask(indexer, documentCollectionFactory, new UpstreamGate.Factory(taskRepository),
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask2", User.local(), args), NO_OP_PROGRESS).call();
 
         // THEN
@@ -167,7 +167,7 @@ public class CategorizeTaskIntTest {
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), args), null).call();
 
-        new CategorizeTask(indexer, documentCollectionFactory, taskRepository,
+        new CategorizeTask(indexer, documentCollectionFactory, new UpstreamGate.Factory(taskRepository),
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask2", User.local(), args), NO_OP_PROGRESS).call();
         Document updatedDoc = indexer.get(es.getIndexName(), toUpdateDoc.getId());
         // THEN
@@ -196,7 +196,7 @@ public class CategorizeTaskIntTest {
         assertThat(documentCollectionFactory.queues.get("extract:queue:categorize"))
                 .contains(embedded.getId() + "|" + root.getId());
 
-        new CategorizeTask(indexer, documentCollectionFactory, taskRepository,
+        new CategorizeTask(indexer, documentCollectionFactory, new UpstreamGate.Factory(taskRepository),
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask3", User.local(), args), NO_OP_PROGRESS).call();
 
         // THEN the embedded doc got categorized (fetched and updated with routing)...

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/CategorizeTaskIntTest.java
@@ -23,7 +23,6 @@ import java.util.function.Function;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.PropertiesProvider.QUEUE_NAME_OPT;
-import static org.icij.datashare.tasks.PipelineTask.STRING_POISON;
 
 public class CategorizeTaskIntTest {
 
@@ -51,7 +50,7 @@ public class CategorizeTaskIntTest {
         Document pdfDoc = aDocWithContentType("application/pdf");
         Document unknownTypeDoc = aDocWithContentType("other-that-is-not_Kn%wn");
 
-        indexAndEnqueueWithPoison(videoDoc, pdfDoc, unknownTypeDoc);
+        indexAndEnqueue(videoDoc, pdfDoc, unknownTypeDoc);
         CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
@@ -61,7 +60,7 @@ public class CategorizeTaskIntTest {
         //THEN
         assertThat(res).isEqualTo(3);
         DocumentQueue<String> outPutQueue = documentCollectionFactory.createQueue("extract:queue:nlp", String.class);
-        assertThat(outPutQueue.size()).isEqualTo(4); // with POISON
+        assertThat(outPutQueue.size()).isEqualTo(3);
 
         assertThat(((Document) indexer.get(es.getIndexName(), videoDoc.getId())).getContentTypeCategory()).isEqualTo(ContentTypeCategory.VIDEO);
         assertThat(((Document) indexer.get(es.getIndexName(), pdfDoc.getId())).getContentTypeCategory()).isEqualTo(ContentTypeCategory.DOCUMENT);
@@ -81,7 +80,7 @@ public class CategorizeTaskIntTest {
 
         //THEN
         DocumentQueue<String> outputQueue = documentCollectionFactory.createQueue("foo:nlp", String.class);
-        assertThat(outputQueue.size()).isEqualTo(3); // with POISON
+        assertThat(outputQueue.size()).isEqualTo(2);
     }
 
     @Test
@@ -101,14 +100,15 @@ public class CategorizeTaskIntTest {
 
         //THEN
         assertThat(progressValues.size()).isGreaterThan(1);
-        assertThat(progressValues.get(0)).isLessThan(0.5); //There are 3 values
+        assertThat(progressValues.get(0)).isLessThan(progressValues.get(progressValues.size() - 1));
+        assertThat(progressValues).contains(1.0);
     }
 
     @Test
     public void test_receiving_null_from_indexer() throws Exception {
         // GIVEN
         // A document that will not be in the index
-        enqueueWithPoison(aDoc());
+        enqueue(aDoc());
         CategorizeTask categorizeTask = new CategorizeTask(indexer, documentCollectionFactory, new Task<>(CategorizeTask.class.getName(),
                 "categorizeTask1", User.local(), Map.of(DEFAULT_PROJECT_OPT, es.getIndexName())), NO_OP_PROGRESS);
 
@@ -118,7 +118,7 @@ public class CategorizeTaskIntTest {
         // THEN
         assertThat(res).isEqualTo(1);
         DocumentQueue<String> outPutQueue = documentCollectionFactory.createQueue("extract:queue:nlp", String.class);
-        assertThat(outPutQueue.size()).isEqualTo(2); // with POISON
+        assertThat(outPutQueue.size()).isEqualTo(1);
     }
 
     @Test
@@ -137,8 +137,6 @@ public class CategorizeTaskIntTest {
         // WHEN
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), args), null).call();
-
-        documentCollectionFactory.createQueue("extract:queue:categorize", String.class).add(STRING_POISON);
 
         new CategorizeTask(indexer, documentCollectionFactory,
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask2", User.local(), args), NO_OP_PROGRESS).call();
@@ -166,8 +164,6 @@ public class CategorizeTaskIntTest {
         // WHEN
         new EnqueueFromIndexTask(documentCollectionFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), args), null).call();
-
-        documentCollectionFactory.createQueue("extract:queue:categorize", String.class).add(STRING_POISON);
 
         new CategorizeTask(indexer, documentCollectionFactory,
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask2", User.local(), args), NO_OP_PROGRESS).call();
@@ -198,8 +194,6 @@ public class CategorizeTaskIntTest {
         assertThat(documentCollectionFactory.queues.get("extract:queue:categorize"))
                 .contains(embedded.getId() + "|" + root.getId());
 
-        documentCollectionFactory.createQueue("extract:queue:categorize", String.class).add(STRING_POISON);
-
         new CategorizeTask(indexer, documentCollectionFactory,
                 new Task<>(CategorizeTask.class.getName(), "categorizeTask3", User.local(), args), NO_OP_PROGRESS).call();
 
@@ -219,14 +213,13 @@ public class CategorizeTaskIntTest {
         return DocumentBuilder.createDoc(UUID.randomUUID().toString()).build();
     }
 
-    private void indexAndEnqueueWithPoison(String queueName, Document... documents) {
+    private void indexAndEnqueue(String queueName, Document... documents) {
         Arrays.stream(documents).forEach(this::index);
-        enqueueWithPoison(queueName, documents);
-        enqueuePoison(queueName);
+        enqueue(queueName, documents);
     }
 
-    private void indexAndEnqueueWithPoison(Document... documents) {
-        indexAndEnqueueWithPoison(DEFAULT_INPUT_QUEUE_NAME, documents);
+    private void indexAndEnqueue(Document... documents) {
+        indexAndEnqueue(DEFAULT_INPUT_QUEUE_NAME, documents);
     }
 
     private void indexAndEnqueueTwoDocuments() {
@@ -234,27 +227,18 @@ public class CategorizeTaskIntTest {
     }
 
     private void indexAndEnqueueTwoDocuments(String queueName) {
-        indexAndEnqueueWithPoison(queueName,
+        indexAndEnqueue(queueName,
                 aDocWithContentType("application/pdf"),
                 aDocWithContentType("notOkContentType"));
     }
 
-    private void enqueueWithPoison(String queueName, Document... documents){
+    private void enqueue(String queueName, Document... documents){
         DocumentQueue<String> queue = documentCollectionFactory.createQueue(queueName, String.class);
-
-        Arrays.stream(documents).forEach(d -> {
-            queue.add(d.getId());
-        });
-        queue.add(STRING_POISON);
+        Arrays.stream(documents).forEach(d -> queue.add(d.getId()));
     }
 
-    private void enqueueWithPoison(Document... documents){
-        enqueueWithPoison(DEFAULT_INPUT_QUEUE_NAME, documents);
-    }
-
-    private void enqueuePoison(String queueName) {
-        DocumentQueue<String> queue = documentCollectionFactory.createQueue(queueName, String.class);
-        queue.add(STRING_POISON);
+    private void enqueue(Document... documents){
+        enqueue(DEFAULT_INPUT_QUEUE_NAME, documents);
     }
 
     private void index(Document doc) throws RuntimeException {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 
 import static java.nio.file.Paths.get;
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.tasks.PipelineTask.PATH_POISON;
 
 public class DeduplicateTaskTest {
     DocumentCollectionFactory<Path> docCollectionFactory = new MemoryDocumentCollectionFactory<>();
@@ -21,7 +20,6 @@ public class DeduplicateTaskTest {
 
     @Test(timeout = 2000)
     public void test_filter_empty() throws Exception {
-        docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).add(PATH_POISON);
         assertThat(new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
     }
 
@@ -29,41 +27,36 @@ public class DeduplicateTaskTest {
     public void test_filter_queue_removes_duplicates() throws Exception {
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
-        docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).add(PATH_POISON);
 
         assertThat(new DeduplicateTask(docCollectionFactory,  new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
 
-        assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(2); // with POISON
+        assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(1);
     }
 
     @Test(timeout = 2000)
     public void test_pipeline_task_transfer_to_output_queue() throws Exception {
         task.inputQueue.put(get("/path/to/doc1"));
         task.inputQueue.put(get("/path/to/doc2"));
-        task.inputQueue.put(PATH_POISON);
 
         task.transferToOutputQueue();
 
         assertThat(task.inputQueue.isEmpty()).isTrue();
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
-        assertThat(outputQueue.size()).isEqualTo(3);
+        assertThat(outputQueue.size()).isEqualTo(2);
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc2");
-        assertThat(outputQueue.poll().toString()).isEqualTo(PATH_POISON.toString());
     }
 
     @Test(timeout = 2000)
     public void test_pipeline_task_conditional_transfer_to_output_queue() throws Exception {
         task.inputQueue.put(get("/path/to/doc1"));
         task.inputQueue.put(get("/path/to/doc2"));
-        task.inputQueue.put(PATH_POISON);
 
         task.transferToOutputQueue(p -> p.toString().contains("1"));
 
         assertThat(task.inputQueue.isEmpty()).isTrue();
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
-        assertThat(outputQueue.size()).isEqualTo(2);
+        assertThat(outputQueue.size()).isEqualTo(1);
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");
-        assertThat(outputQueue.poll().toString()).isEqualTo(PATH_POISON.toString());
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.tasks;
 
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.user.User;
@@ -14,13 +15,14 @@ import static java.nio.file.Paths.get;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class DeduplicateTaskTest {
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     DocumentCollectionFactory<Path> docCollectionFactory = new MemoryDocumentCollectionFactory<>();
     Map<String, Object> defaultOpts = Map.of("queueName", "test:queue", "stages", "DEDUPLICATE");
-    DeduplicateTask task = new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null);
+    DeduplicateTask task = new DeduplicateTask(docCollectionFactory, taskRepository, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null);
 
     @Test(timeout = 2000)
     public void test_filter_empty() throws Exception {
-        assertThat(new DeduplicateTask(docCollectionFactory, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
+        assertThat(new DeduplicateTask(docCollectionFactory, taskRepository, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
     }
 
     @Test(timeout = 2000)
@@ -28,7 +30,7 @@ public class DeduplicateTaskTest {
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
 
-        assertThat(new DeduplicateTask(docCollectionFactory,  new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
+        assertThat(new DeduplicateTask(docCollectionFactory, taskRepository, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
 
         assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(1);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -18,11 +18,11 @@ public class DeduplicateTaskTest {
     private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     DocumentCollectionFactory<Path> docCollectionFactory = new MemoryDocumentCollectionFactory<>();
     Map<String, Object> defaultOpts = Map.of("queueName", "test:queue", "stages", "DEDUPLICATE");
-    DeduplicateTask task = new DeduplicateTask(docCollectionFactory, taskRepository, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null);
+    DeduplicateTask task = new DeduplicateTask(docCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null);
 
     @Test(timeout = 2000)
     public void test_filter_empty() throws Exception {
-        assertThat(new DeduplicateTask(docCollectionFactory, taskRepository, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
+        assertThat(new DeduplicateTask(docCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(0);
     }
 
     @Test(timeout = 2000)
@@ -30,7 +30,7 @@ public class DeduplicateTaskTest {
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
         docCollectionFactory.createQueue("test:queue:deduplicate", Path.class).put(get("/path/to/doc"));
 
-        assertThat(new DeduplicateTask(docCollectionFactory, taskRepository, new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
+        assertThat(new DeduplicateTask(docCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null).call()).isEqualTo(1);
 
         assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(1);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/EnqueueFromIndexTaskTest.java
@@ -99,10 +99,7 @@ public class EnqueueFromIndexTaskTest {
         EnqueueFromIndexTask enqueueFromIndex = new EnqueueFromIndexTask(factory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), new User("test"), properties), null);
         enqueueFromIndex.call();
-        // 5 doc refs + the POISON sentinel that lets ArtifactTask workers terminate without
-        // waiting on a poll timeout.
-        assertThat(factory.queues.get("test:queue:artifact")).hasSize(6);
-        assertThat(factory.queues.get("test:queue:artifact")).contains(PipelineTask.STRING_POISON);
+        assertThat(factory.queues.get("test:queue:artifact")).hasSize(5);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
@@ -10,7 +10,6 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.*;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.Indexer;
@@ -45,7 +44,6 @@ public class ExtractNlpTaskIntTest {
     @Mock private Indexer indexer;
     @Mock private AbstractPipeline pipeline;
     private final DocumentCollectionFactory<String> factory;
-    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     private ExtractNlpTask nlpTask;
 
     public ExtractNlpTaskIntTest(Injector injector) {
@@ -91,7 +89,7 @@ public class ExtractNlpTaskIntTest {
         queue.add("docId2");
         queue.add("docId3");
 
-        new ExtractNlpTask(indexer, pipeline, factory, taskRepository, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>() {{
+        new ExtractNlpTask(indexer, pipeline, factory, UpstreamGate.NONE, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>() {{
             put("maxContentLength", "32");
         }}), callback).call();
 
@@ -126,7 +124,7 @@ public class ExtractNlpTaskIntTest {
     @Before
     public void setUp() {
         initMocks(this);
-        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, taskRepository, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
+        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, UpstreamGate.NONE, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
             put("maxContentLength", "32");
         }}), null);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
@@ -60,7 +60,6 @@ public class ExtractNlpTaskIntTest {
         String queueName = new PipelineHelper(new PropertiesProvider()).getQueueNameFor(Stage.NLP);
         DocumentQueue<String> queue = factory.createQueue(queueName, String.class);
         queue.add("docId");
-        queue.add(PipelineTask.STRING_POISON);
 
         nlpTask.call();
 
@@ -89,9 +88,6 @@ public class ExtractNlpTaskIntTest {
         queue.add("docId1");
         queue.add("docId2");
         queue.add("docId3");
-        queue.add(PipelineTask.STRING_POISON);
-
-
 
         new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>() {{
             put("maxContentLength", "32");
@@ -100,7 +96,7 @@ public class ExtractNlpTaskIntTest {
         verify(pipeline, times(3)).initialize(ENGLISH);
         assertThat(progressValues.size()).isGreaterThan(1);
         assertThat(progressValues.get(0)).isLessThan(progressValues.get(progressValues.size() - 1));
-        assertThat(progressValues).contains(0.5);
+        assertThat(progressValues).contains(1.0);
     }
 
     @Parameterized.Parameters

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskIntTest.java
@@ -10,6 +10,7 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.*;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.Indexer;
@@ -44,6 +45,7 @@ public class ExtractNlpTaskIntTest {
     @Mock private Indexer indexer;
     @Mock private AbstractPipeline pipeline;
     private final DocumentCollectionFactory<String> factory;
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     private ExtractNlpTask nlpTask;
 
     public ExtractNlpTaskIntTest(Injector injector) {
@@ -89,7 +91,7 @@ public class ExtractNlpTaskIntTest {
         queue.add("docId2");
         queue.add("docId3");
 
-        new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>() {{
+        new ExtractNlpTask(indexer, pipeline, factory, taskRepository, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>() {{
             put("maxContentLength", "32");
         }}), callback).call();
 
@@ -124,7 +126,7 @@ public class ExtractNlpTaskIntTest {
     @Before
     public void setUp() {
         initMocks(this);
-        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
+        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, taskRepository, new Task<>(ExtractNlpTask.class.getName(), User.local(), new HashMap<>(){{
             put("maxContentLength", "32");
         }}), null);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
@@ -7,6 +7,7 @@ import org.icij.datashare.text.Language;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.nlp.AbstractPipeline;
 import org.icij.datashare.user.User;
+import org.icij.extract.queue.DocumentQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -55,6 +56,21 @@ public class ExtractNlpTaskTest {
                 new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of()), null);
 
         assertThat(nlpTask.call()).isEqualTo(0L);
+    }
+
+    @Test(expected = InterruptedException.class)
+    public void test_call_reports_cancellation_instead_of_completing_when_interrupted() throws Exception {
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:nlp", String.class);
+        queue.add("id1");
+        queue.add("id2");
+        Thread.currentThread().interrupt();
+
+        try {
+            nlpTask.call();
+        } finally {
+            verify(pipeline, never()).initialize(any(Language.class));
+            Thread.interrupted(); // clear the flag so it does not leak into later tests
+        }
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
@@ -1,7 +1,6 @@
 package org.icij.datashare.tasks;
 
 import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Language;
@@ -31,13 +30,12 @@ public class ExtractNlpTaskTest {
     @Mock private Indexer indexer;
     @Mock private AbstractPipeline pipeline;
     private final MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
-    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     private ExtractNlpTask nlpTask;
 
     @Before
     public void setUp() {
         initMocks(this);
-        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, taskRepository, new Task<>(ExtractNlpTask.class.getName(), User.local(),
+        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, UpstreamGate.NONE, new Task<>(ExtractNlpTask.class.getName(), User.local(),
                 Map.of("maxContentLength", "32")), null);
     }
 
@@ -54,7 +52,7 @@ public class ExtractNlpTaskTest {
         // The launcher awaits the producer stage before NLP starts, so an empty queue means done.
         // Deliberately no polling-interval option: the old bounded null-poll budget would have
         // waited out several default polling intervals here and blown this timeout.
-        ExtractNlpTask nlpTask = new ExtractNlpTask(indexer, pipeline, factory, taskRepository,
+        ExtractNlpTask nlpTask = new ExtractNlpTask(indexer, pipeline, factory, UpstreamGate.NONE,
                 new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of()), null);
 
         assertThat(nlpTask.call()).isEqualTo(0L);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
@@ -15,8 +15,6 @@ import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
-import static org.icij.datashare.tasks.ExtractNlpTask.NB_MAX_POLLS;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
 import static org.icij.datashare.text.Language.ENGLISH;
 import static org.icij.datashare.text.Project.project;
@@ -48,14 +46,15 @@ public class ExtractNlpTaskTest {
         verify(pipeline, never()).process(any());
     }
 
-    @Test(timeout = 3000)
-    public void test_exit_after_nb_max_attempts()  throws Exception  {
-        ExtractNlpTask nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(),
-                Map.of(POLLING_INTERVAL_SECONDS_OPT, "0.1")), null);
-        long start = System.currentTimeMillis();
-        nlpTask.call();
-        long end = System.currentTimeMillis();
-        assertThat(end - start).isGreaterThan(NB_MAX_POLLS * 100);
+    @Test(timeout = 2000)
+    public void test_returns_immediately_when_queue_is_empty() throws Exception {
+        // The launcher awaits the producer stage before NLP starts, so an empty queue means done.
+        // Deliberately no polling-interval option: the old bounded null-poll budget would have
+        // waited out several default polling intervals here and blown this timeout.
+        ExtractNlpTask nlpTask = new ExtractNlpTask(indexer, pipeline, factory,
+                new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of()), null);
+
+        assertThat(nlpTask.call()).isEqualTo(0L);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.tasks;
 
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Language;
@@ -30,12 +31,13 @@ public class ExtractNlpTaskTest {
     @Mock private Indexer indexer;
     @Mock private AbstractPipeline pipeline;
     private final MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     private ExtractNlpTask nlpTask;
 
     @Before
     public void setUp() {
         initMocks(this);
-        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, new Task<>(ExtractNlpTask.class.getName(), User.local(),
+        nlpTask = new ExtractNlpTask(indexer, pipeline, factory, taskRepository, new Task<>(ExtractNlpTask.class.getName(), User.local(),
                 Map.of("maxContentLength", "32")), null);
     }
 
@@ -52,7 +54,7 @@ public class ExtractNlpTaskTest {
         // The launcher awaits the producer stage before NLP starts, so an empty queue means done.
         // Deliberately no polling-interval option: the old bounded null-poll budget would have
         // waited out several default polling intervals here and blown this timeout.
-        ExtractNlpTask nlpTask = new ExtractNlpTask(indexer, pipeline, factory,
+        ExtractNlpTask nlpTask = new ExtractNlpTask(indexer, pipeline, factory, taskRepository,
                 new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of()), null);
 
         assertThat(nlpTask.call()).isEqualTo(0L);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ExtractNlpTaskTest.java
@@ -69,6 +69,9 @@ public class ExtractNlpTaskTest {
             nlpTask.call();
         } finally {
             verify(pipeline, never()).initialize(any(Language.class));
+            // both references must still be in the queue: consuming one and dropping it would lose
+            // a document per cancelled run, which asserting on the throw alone cannot detect
+            assertThat(queue).hasSize(2);
             Thread.interrupted(); // clear the flag so it does not leak into later tests
         }
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -8,6 +8,7 @@ import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.ElasticsearchRule;
+import org.icij.datashare.test.LogbackCapturingRule;
 import org.icij.datashare.text.Language;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSpewer;
@@ -20,6 +21,7 @@ import org.icij.task.Options;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.event.Level;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -33,6 +35,7 @@ import static org.mockito.Mockito.verify;
 
 public class IndexTaskIntTest {
     @Rule public ElasticsearchRule es = new ElasticsearchRule();
+    @Rule public LogbackCapturingRule logback = new LogbackCapturingRule();
 
     static final List<Extractor> CREATED_EXTRACTORS = new ArrayList<>();
 
@@ -71,6 +74,21 @@ public class IndexTaskIntTest {
         assertThat(outputQueue).hasSize(2);
         assertThat(outputQueue.poll()).isEqualTo("bc6852541ef5200206a7a9740f3d2d62178a1f53b1aa5417ab426c6ec1f7cbc7");
         assertThat(outputQueue.poll()).isEqualTo(STRING_POISON);
+    }
+
+    @Test
+    public void index_task_skips_a_legacy_poison_entry_at_the_head_of_the_queue() throws Exception {
+        DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
+        // a sentinel written by a pre-21.16 run sits FIRST: the drain must skip it and keep going,
+        // where the old drain(PATH_POISON) would have stopped here and indexed nothing
+        queue.add(PipelineTask.PATH_POISON);
+        queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
+
+        new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+
+        DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);
+        assertThat(outputQueue).contains("bc6852541ef5200206a7a9740f3d2d62178a1f53b1aa5417ab426c6ec1f7cbc7");
+        assertThat(logback.logs(Level.WARN)).contains("skipping legacy POISON entry in queue test:queue:index");
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -79,7 +79,7 @@ public class IndexTaskIntTest {
         DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         // a sentinel written by a pre-21.16 run sits FIRST: the drain must skip it and keep going,
         // where the old drain(PATH_POISON) would have stopped here and indexed nothing
-        queue.add(PipelineTask.PATH_POISON);
+        queue.add(Paths.get("POISON"));
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
         new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -82,8 +82,10 @@ public class IndexTaskIntTest {
         queue.add(Paths.get("POISON"));
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        Long nbDocs = new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
+        // the sentinel is not a document: the returned count must be 1, not 2
+        assertThat(nbDocs).isEqualTo(1);
         DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);
         assertThat(outputQueue).contains("bc6852541ef5200206a7a9740f3d2d62178a1f53b1aa5417ab426c6ec1f7cbc7");
         assertThat(logback.logs(Level.WARN)).contains("skipping legacy POISON entry in queue test:queue:index");

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
-import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 import static org.mockito.Mockito.verify;
 
 public class IndexTaskIntTest {
@@ -146,7 +145,6 @@ public class IndexTaskIntTest {
         inputQueueFactory.queues.put(queueName, queue);
         Map<String, Object> args = new HashMap<>(map);
         args.put(PipelineTask.UPSTREAM_TASK_ID, upstream.id);
-        args.put(POLLING_INTERVAL_SECONDS_OPT, "0.05");
         IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, taskRepository,
                 new Task<>(IndexTask.class.getName(), User.local(), args), null);
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -7,6 +7,7 @@ import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
+import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.ElasticsearchRule;
@@ -18,6 +19,7 @@ import org.icij.datashare.user.User;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.Extractor;
 import org.icij.extract.queue.DocumentQueue;
+import org.icij.extract.queue.MemoryDocumentQueue;
 import org.icij.spewer.FieldNames;
 import org.icij.task.Options;
 import org.junit.Rule;
@@ -29,9 +31,17 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
+import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 import static org.mockito.Mockito.verify;
 
 public class IndexTaskIntTest {
@@ -112,6 +122,46 @@ public class IndexTaskIntTest {
         assertThat(progressValues.size()).isGreaterThan(1);
         assertThat(progressValues.get(0)).isLessThan(progressValues.get(progressValues.size() - 1));
         assertThat(progressValues).contains(0.5);
+    }
+
+    @Test(timeout = 30000)
+    public void index_task_drains_a_queue_filled_while_the_upstream_task_is_running() throws Exception {
+        Task<Long> upstream = new Task<>(ScanTask.class.getName(), User.local(), Map.of());
+        upstream.setState(Task.State.RUNNING);
+        taskRepository.insert(upstream, null);
+        // counted down by the queue itself, so the test knows the drainer has already polled an
+        // empty queue, which is the exact moment the latch has to keep it polling
+        CountDownLatch firstEmptyPoll = new CountDownLatch(1);
+        String queueName = new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX);
+        DocumentQueue<Path> queue = new MemoryDocumentQueue<>(queueName, DEFAULT_QUEUE_CAPACITY) {
+            @Override
+            public Path poll() {
+                Path polled = super.poll();
+                if (polled == null) {
+                    firstEmptyPoll.countDown();
+                }
+                return polled;
+            }
+        };
+        inputQueueFactory.queues.put(queueName, queue);
+        Map<String, Object> args = new HashMap<>(map);
+        args.put(PipelineTask.UPSTREAM_TASK_ID, upstream.id);
+        args.put(POLLING_INTERVAL_SECONDS_OPT, "0.05");
+        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, taskRepository,
+                new Task<>(IndexTask.class.getName(), User.local(), args), null);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Long> indexed = executor.submit((Callable<Long>) indexTask::call);
+            // without the latch the drainer has already stopped by the time this await comes back
+            assertThat(firstEmptyPoll.await(20, TimeUnit.SECONDS)).isTrue();
+            queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
+            upstream.setResult(new TaskResult<>(0L));
+
+            assertThat(indexed.get(20, TimeUnit.SECONDS)).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -5,7 +5,6 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
-import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.extract.DocumentCollectionFactory;
@@ -51,8 +50,8 @@ public class IndexTaskIntTest {
 
     static class ClosingProbeIndexTask extends IndexTask {
         ClosingProbeIndexTask(ElasticsearchSpewer spewer, DocumentCollectionFactory<Path> factory,
-                              TaskRepository taskRepository, Task<Long> task, Function<Double, Void> cb) throws IOException {
-            super(spewer, factory, taskRepository, task, cb);
+                              UpstreamGate.Factory gateFactory, Task<Long> task, Function<Double, Void> cb) throws IOException {
+            super(spewer, factory, gateFactory, task, cb);
         }
         @Override
         protected Extractor createExtractor(DocumentFactory documentFactory, Options<String> options) {
@@ -78,7 +77,7 @@ public class IndexTaskIntTest {
         DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        Long nbDocs = new IndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        Long nbDocs = new IndexTask(spewer, inputQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         assertThat(nbDocs).isEqualTo(1);
         DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);
@@ -94,7 +93,7 @@ public class IndexTaskIntTest {
         queue.add(Paths.get("POISON"));
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        Long nbDocs = new IndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        Long nbDocs = new IndexTask(spewer, inputQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         // the sentinel is not a document: the returned count must be 1, not 2
         assertThat(nbDocs).isEqualTo(1);
@@ -116,7 +115,7 @@ public class IndexTaskIntTest {
         inputQueue.add(Paths.get(ClassLoader.getSystemResource("docs/embedded_doc.eml").getPath()));
         inputQueue.add(Paths.get(ClassLoader.getSystemResource("docs/foo/bar.txt").getPath()));
 
-        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), callback);
+        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), callback);
         indexTask.call();
         assertThat(progressValues.size()).isGreaterThan(1);
         assertThat(progressValues.get(0)).isLessThan(progressValues.get(progressValues.size() - 1));
@@ -144,8 +143,8 @@ public class IndexTaskIntTest {
         };
         inputQueueFactory.queues.put(queueName, queue);
         Map<String, Object> args = new HashMap<>(map);
-        args.put(PipelineTask.UPSTREAM_TASK_ID, upstream.id);
-        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, taskRepository,
+        args.put(UpstreamGate.UPSTREAM_TASK_ID, upstream.id);
+        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, new UpstreamGate.Factory(taskRepository),
                 new Task<>(IndexTask.class.getName(), User.local(), args), null);
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -168,7 +167,7 @@ public class IndexTaskIntTest {
         DocumentQueue<Path> inputQueue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         inputQueue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        IndexTask indexTask = new ClosingProbeIndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null);
+        IndexTask indexTask = new ClosingProbeIndexTask(spewer, inputQueueFactory, new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), User.local(), map), null);
         indexTask.call();
 
         assertThat(CREATED_EXTRACTORS.size()).isEqualTo(1);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -30,7 +30,6 @@ import java.util.*;
 import java.util.function.Function;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.tasks.PipelineTask.STRING_POISON;
 import static org.mockito.Mockito.verify;
 
 public class IndexTaskIntTest {
@@ -63,7 +62,7 @@ public class IndexTaskIntTest {
             outputQueueFactory, text -> Language.ENGLISH, new FieldNames(), propertiesProvider);
 
     @Test
-    public void index_task_should_enqueue_poison_pill() throws Exception {
+    public void index_task_should_enqueue_indexed_doc_ids() throws Exception {
         DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
@@ -71,9 +70,8 @@ public class IndexTaskIntTest {
 
         assertThat(nbDocs).isEqualTo(1);
         DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);
-        assertThat(outputQueue).hasSize(2);
+        assertThat(outputQueue).hasSize(1);
         assertThat(outputQueue.poll()).isEqualTo("bc6852541ef5200206a7a9740f3d2d62178a1f53b1aa5417ab426c6ec1f7cbc7");
-        assertThat(outputQueue.poll()).isEqualTo(STRING_POISON);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskIntTest.java
@@ -5,6 +5,8 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepository;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.test.ElasticsearchRule;
@@ -40,8 +42,8 @@ public class IndexTaskIntTest {
 
     static class ClosingProbeIndexTask extends IndexTask {
         ClosingProbeIndexTask(ElasticsearchSpewer spewer, DocumentCollectionFactory<Path> factory,
-                              Task<Long> task, Function<Double, Void> cb) throws IOException {
-            super(spewer, factory, task, cb);
+                              TaskRepository taskRepository, Task<Long> task, Function<Double, Void> cb) throws IOException {
+            super(spewer, factory, taskRepository, task, cb);
         }
         @Override
         protected Extractor createExtractor(DocumentFactory documentFactory, Options<String> options) {
@@ -52,6 +54,7 @@ public class IndexTaskIntTest {
     }
 
     private final MemoryDocumentCollectionFactory<Path> inputQueueFactory = new MemoryDocumentCollectionFactory<>();
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
     private final MemoryDocumentCollectionFactory<String> outputQueueFactory = new MemoryDocumentCollectionFactory<>();
     private Map<String, Object> map = new HashMap<>() {{
         put("defaultProject", es.getIndexName());
@@ -66,7 +69,7 @@ public class IndexTaskIntTest {
         DocumentQueue<Path> queue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        Long nbDocs = new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        Long nbDocs = new IndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         assertThat(nbDocs).isEqualTo(1);
         DocumentQueue<String> outputQueue = outputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getOutputQueueNameFor(Stage.INDEX), String.class);
@@ -82,7 +85,7 @@ public class IndexTaskIntTest {
         queue.add(Paths.get("POISON"));
         queue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        Long nbDocs = new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
+        Long nbDocs = new IndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null).call();
 
         // the sentinel is not a document: the returned count must be 1, not 2
         assertThat(nbDocs).isEqualTo(1);
@@ -104,7 +107,7 @@ public class IndexTaskIntTest {
         inputQueue.add(Paths.get(ClassLoader.getSystemResource("docs/embedded_doc.eml").getPath()));
         inputQueue.add(Paths.get(ClassLoader.getSystemResource("docs/foo/bar.txt").getPath()));
 
-        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), callback);
+        IndexTask indexTask = new IndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), callback);
         indexTask.call();
         assertThat(progressValues.size()).isGreaterThan(1);
         assertThat(progressValues.get(0)).isLessThan(progressValues.get(progressValues.size() - 1));
@@ -117,7 +120,7 @@ public class IndexTaskIntTest {
         DocumentQueue<Path> inputQueue = inputQueueFactory.createQueue(new PipelineHelper(propertiesProvider).getQueueNameFor(Stage.INDEX), Path.class);
         inputQueue.add(Paths.get(ClassLoader.getSystemResource("docs/doc.txt").getPath()));
 
-        IndexTask indexTask = new ClosingProbeIndexTask(spewer, inputQueueFactory, new Task<>(IndexTask.class.getName(), User.local(), map), null);
+        IndexTask indexTask = new ClosingProbeIndexTask(spewer, inputQueueFactory, taskRepository, new Task<>(IndexTask.class.getName(), User.local(), map), null);
         indexTask.call();
 
         assertThat(CREATED_EXTRACTORS.size()).isEqualTo(1);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -2,6 +2,7 @@ package org.icij.datashare.tasks;
 
 import org.apache.tika.parser.pdf.PDFParserConfig;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.test.LogbackAppenderWrapper;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSpewer;
@@ -27,12 +28,13 @@ import static org.mockito.Mockito.verify;
 
 public class IndexTaskTest {
     private final LogbackAppenderWrapper logWrapper = new LogbackAppenderWrapper();
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
 
     @Test
     public void test_options_include_ocr() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -43,7 +45,7 @@ public class IndexTaskTest {
     public void test_options_include_ocr_language() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -54,7 +56,7 @@ public class IndexTaskTest {
     public void test_options_include_progress_heartbeat_interval() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -65,7 +67,7 @@ public class IndexTaskTest {
     public void test_options_include_language() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("language", "FRENCH");
             put("queueName", "test:queue");
         }}), null);
@@ -79,7 +81,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), Map.of("charset", "UTF-16")), null);
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), Map.of("charset", "UTF-16")), null);
 
         ArgumentCaptor<Options> captor = ArgumentCaptor.forClass(Options.class);
         verify(spewer).configure(captor.capture());
@@ -92,7 +94,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new Task<>(IndexTask.class.getName(), nullUser(), Map.of("defaultProject", "foo", "projectName", "bar")), null);
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), Map.of("defaultProject", "foo", "projectName", "bar")), null);
 
         ArgumentCaptor<Options> captor = ArgumentCaptor.forClass(Options.class);
         verify(spewer).configure(captor.capture());
@@ -105,7 +107,7 @@ public class IndexTaskTest {
     public void test_ocr_strategy_reaches_extractor() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
                 new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
                     put("queueName", "test:queue");
                 }}), null);
@@ -123,7 +125,7 @@ public class IndexTaskTest {
     public void test_max_embed_depth_reaches_extractor() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
                 new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
                     put("queueName", "test:queue");
                 }}), null);
@@ -141,7 +143,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
                 new Task<>(IndexTask.class.getName(), nullUser(),
                         Map.of(PARSE_TIMEOUT_OPT, "48h", "queueName", "test:queue")), null);
 
@@ -156,7 +158,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
                 new Task<>(IndexTask.class.getName(), nullUser(),
                         Map.of(PARSE_TIMEOUT_OPT, "0", "queueName", "test:queue")), null);
 
@@ -169,7 +171,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class),
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
                 new Task<>(IndexTask.class.getName(), nullUser(),
                         Map.of(PARSE_TIMEOUT_OPT, "48h", "queueName", "test:queue")), null);
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/IndexTaskTest.java
@@ -34,7 +34,7 @@ public class IndexTaskTest {
     public void test_options_include_ocr() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -45,7 +45,7 @@ public class IndexTaskTest {
     public void test_options_include_ocr_language() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -56,7 +56,7 @@ public class IndexTaskTest {
     public void test_options_include_progress_heartbeat_interval() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("queueName", "test:queue");
         }}), null);
         Options<String> options = indexTask.options();
@@ -67,7 +67,7 @@ public class IndexTaskTest {
     public void test_options_include_language() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
             put("language", "FRENCH");
             put("queueName", "test:queue");
         }}), null);
@@ -81,7 +81,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), Map.of("charset", "UTF-16")), null);
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), nullUser(), Map.of("charset", "UTF-16")), null);
 
         ArgumentCaptor<Options> captor = ArgumentCaptor.forClass(Options.class);
         verify(spewer).configure(captor.capture());
@@ -94,7 +94,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository, new Task<>(IndexTask.class.getName(), nullUser(), Map.of("defaultProject", "foo", "projectName", "bar")), null);
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository), new Task<>(IndexTask.class.getName(), nullUser(), Map.of("defaultProject", "foo", "projectName", "bar")), null);
 
         ArgumentCaptor<Options> captor = ArgumentCaptor.forClass(Options.class);
         verify(spewer).configure(captor.capture());
@@ -107,7 +107,7 @@ public class IndexTaskTest {
     public void test_ocr_strategy_reaches_extractor() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository),
                 new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
                     put("queueName", "test:queue");
                 }}), null);
@@ -125,7 +125,7 @@ public class IndexTaskTest {
     public void test_max_embed_depth_reaches_extractor() throws Exception {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
-        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
+        IndexTask indexTask = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository),
                 new Task<>(IndexTask.class.getName(), nullUser(), new HashMap<>(){{
                     put("queueName", "test:queue");
                 }}), null);
@@ -143,7 +143,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository),
                 new Task<>(IndexTask.class.getName(), nullUser(),
                         Map.of(PARSE_TIMEOUT_OPT, "48h", "queueName", "test:queue")), null);
 
@@ -158,7 +158,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository),
                 new Task<>(IndexTask.class.getName(), nullUser(),
                         Map.of(PARSE_TIMEOUT_OPT, "0", "queueName", "test:queue")), null);
 
@@ -171,7 +171,7 @@ public class IndexTaskTest {
         ElasticsearchSpewer spewer = mock(ElasticsearchSpewer.class);
         Mockito.when(spewer.configure(Mockito.any())).thenReturn(spewer);
 
-        new IndexTask(spewer, mock(DocumentCollectionFactory.class), taskRepository,
+        new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(taskRepository),
                 new Task<>(IndexTask.class.getName(), nullUser(),
                         Map.of(PARSE_TIMEOUT_OPT, "48h", "queueName", "test:queue")), null);
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ScanTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ScanTaskTest.java
@@ -21,7 +21,7 @@ public class ScanTaskTest extends TestCase {
         assertThat(new ScanTask(documentCollectionFactory, new Task<>("org.icij.datashare.tasks.ScanTask", User.local(),
                 Map.of(DATA_DIR_OPT, Paths.get(ClassLoader.getSystemResource("docs").getPath()).toString())), null).call()).isEqualTo(3);
         DocumentQueue<Path> queue = documentCollectionFactory.createQueue("extract:queue:index", Path.class);
-        assertThat(queue.size()).isEqualTo(4); // with POISON
+        assertThat(queue.size()).isEqualTo(3);
     }
 
     public void test_scan_with_queue_name() throws Exception {
@@ -29,6 +29,6 @@ public class ScanTaskTest extends TestCase {
                 Map.of(DATA_DIR_OPT, Paths.get(ClassLoader.getSystemResource("docs").getPath()).toString(),
                         QUEUE_NAME_OPT, "foo")), null).call()).isEqualTo(3);
         DocumentQueue<Path> queue = documentCollectionFactory.createQueue("foo:index", Path.class);
-        assertThat(queue.size()).isEqualTo(4); // with POISON
+        assertThat(queue.size()).isEqualTo(3);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
@@ -47,7 +47,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
     @Test
     public void test_index_task() throws Exception {
         Task<Long> task = new Task<>(IndexTask.class.getName(), User.local(), new HashMap<>());
-        IndexTask taskRunner = new IndexTask(spewer, mock(DocumentCollectionFactory.class), task, updateCallback);
+        IndexTask taskRunner = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new TaskRepositoryMemory(), task, updateCallback);
         when(taskFactory.createIndexTask(any(), any())).thenReturn(taskRunner);
 
         testTaskWithTaskRunner(task);
@@ -56,7 +56,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
     @Test
     public void test_extract_nlp_task() throws Exception {
         Task<Long> task = new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of("nlpPipeline", "EMAIL"));
-        ExtractNlpTask taskRunner = new ExtractNlpTask(mock(Indexer.class), new PipelineRegistry(new PropertiesProvider()), mock(DocumentCollectionFactory.class), task, updateCallback);
+        ExtractNlpTask taskRunner = new ExtractNlpTask(mock(Indexer.class), new PipelineRegistry(new PropertiesProvider()), mock(DocumentCollectionFactory.class), new TaskRepositoryMemory(), task, updateCallback);
         when(taskFactory.createExtractNlpTask(any(), any())).thenReturn(taskRunner);
 
         testTaskWithTaskRunner(task);
@@ -83,7 +83,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
     @Test
     public void test_deduplicate_task() throws Exception {
         Task<Long> task = new Task<>(DeduplicateTask.class.getName(), User.local(), new HashMap<>());
-        DeduplicateTask taskRunner = new DeduplicateTask(mock(DocumentCollectionFactory.class), task, updateCallback);
+        DeduplicateTask taskRunner = new DeduplicateTask(mock(DocumentCollectionFactory.class), new TaskRepositoryMemory(), task, updateCallback);
         when(taskFactory.createDeduplicateTask(any(), any())).thenReturn(taskRunner);
 
         testTaskWithTaskRunner(task);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/TaskWorkerLoopForPipelineTasksTest.java
@@ -47,7 +47,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
     @Test
     public void test_index_task() throws Exception {
         Task<Long> task = new Task<>(IndexTask.class.getName(), User.local(), new HashMap<>());
-        IndexTask taskRunner = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new TaskRepositoryMemory(), task, updateCallback);
+        IndexTask taskRunner = new IndexTask(spewer, mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(new TaskRepositoryMemory()), task, updateCallback);
         when(taskFactory.createIndexTask(any(), any())).thenReturn(taskRunner);
 
         testTaskWithTaskRunner(task);
@@ -56,7 +56,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
     @Test
     public void test_extract_nlp_task() throws Exception {
         Task<Long> task = new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of("nlpPipeline", "EMAIL"));
-        ExtractNlpTask taskRunner = new ExtractNlpTask(mock(Indexer.class), new PipelineRegistry(new PropertiesProvider()), mock(DocumentCollectionFactory.class), new TaskRepositoryMemory(), task, updateCallback);
+        ExtractNlpTask taskRunner = new ExtractNlpTask(mock(Indexer.class), new PipelineRegistry(new PropertiesProvider()), mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(new TaskRepositoryMemory()), task, updateCallback);
         when(taskFactory.createExtractNlpTask(any(), any())).thenReturn(taskRunner);
 
         testTaskWithTaskRunner(task);
@@ -83,7 +83,7 @@ public class TaskWorkerLoopForPipelineTasksTest {
     @Test
     public void test_deduplicate_task() throws Exception {
         Task<Long> task = new Task<>(DeduplicateTask.class.getName(), User.local(), new HashMap<>());
-        DeduplicateTask taskRunner = new DeduplicateTask(mock(DocumentCollectionFactory.class), new TaskRepositoryMemory(), task, updateCallback);
+        DeduplicateTask taskRunner = new DeduplicateTask(mock(DocumentCollectionFactory.class), new UpstreamGate.Factory(new TaskRepositoryMemory()), task, updateCallback);
         when(taskFactory.createDeduplicateTask(any(), any())).thenReturn(taskRunner);
 
         testTaskWithTaskRunner(task);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateFactoryTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateFactoryTest.java
@@ -3,9 +3,12 @@ package org.icij.datashare.tasks;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.TaskResult;
+import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.user.User;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -45,6 +48,36 @@ public class UpstreamGateFactoryTest {
     @Test
     public void test_unknown_upstream_does_not_grow() {
         assertThat(gateOn("unknown-task-id").mayGrow()).isFalse();
+    }
+
+    @Test
+    public void test_checked_repository_failure_may_grow() {
+        UpstreamGate.Factory throwingFactory = new UpstreamGate.Factory(new TaskRepositoryMemory() {
+            @Override
+            public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
+                throw new IOException("transient repository failure");
+            }
+        });
+
+        UpstreamGate gate = throwingFactory.forTask(new Task<>(ExtractNlpTask.class.getName(), User.local(),
+                Map.of(UPSTREAM_TASK_ID, "some-task-id")));
+
+        assertThat(gate.mayGrow()).isTrue();
+    }
+
+    @Test
+    public void test_unchecked_repository_failure_may_grow() {
+        UpstreamGate.Factory throwingFactory = new UpstreamGate.Factory(new TaskRepositoryMemory() {
+            @Override
+            public <V extends Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
+                throw new IllegalStateException("unchecked repository failure");
+            }
+        });
+
+        UpstreamGate gate = throwingFactory.forTask(new Task<>(ExtractNlpTask.class.getName(), User.local(),
+                Map.of(UPSTREAM_TASK_ID, "some-task-id")));
+
+        assertThat(gate.mayGrow()).isTrue();
     }
 
     private UpstreamGate gateOn(String upstreamTaskId) {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateFactoryTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateFactoryTest.java
@@ -1,0 +1,54 @@
+package org.icij.datashare.tasks;
+
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
+import org.icij.datashare.asynctasks.TaskResult;
+import org.icij.datashare.user.User;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.tasks.UpstreamGate.UPSTREAM_TASK_ID;
+
+public class UpstreamGateFactoryTest {
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
+    private final UpstreamGate.Factory factory = new UpstreamGate.Factory(taskRepository);
+
+    @Test
+    public void test_no_upstream_id_returns_the_none_gate() {
+        Task<Long> taskView = new Task<>(ExtractNlpTask.class.getName(), User.local(), Map.of());
+
+        assertThat(factory.forTask(taskView)).isSameAs(UpstreamGate.NONE);
+        assertThat(UpstreamGate.NONE.mayGrow()).isFalse();
+    }
+
+    @Test
+    public void test_running_upstream_may_grow() throws Exception {
+        Task<Long> upstream = new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), Map.of());
+        upstream.setState(Task.State.RUNNING);
+        taskRepository.insert(upstream, null);
+
+        assertThat(gateOn(upstream.id).mayGrow()).isTrue();
+    }
+
+    @Test
+    public void test_terminal_upstream_does_not_grow() throws Exception {
+        Task<Long> upstream = new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), Map.of());
+        upstream.setState(Task.State.RUNNING);
+        taskRepository.insert(upstream, null);
+        upstream.setResult(new TaskResult<>(0L));
+
+        assertThat(gateOn(upstream.id).mayGrow()).isFalse();
+    }
+
+    @Test
+    public void test_unknown_upstream_does_not_grow() {
+        assertThat(gateOn("unknown-task-id").mayGrow()).isFalse();
+    }
+
+    private UpstreamGate gateOn(String upstreamTaskId) {
+        return factory.forTask(new Task<>(ExtractNlpTask.class.getName(), User.local(),
+                Map.of(UPSTREAM_TASK_ID, upstreamTaskId)));
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
@@ -20,12 +20,14 @@ import org.mockito.Mock;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.Fail.fail;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
 import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 import static org.icij.datashare.tasks.PipelineTask.UPSTREAM_TASK_ID;
@@ -72,6 +74,25 @@ public class UpstreamGateTest {
         assertThat(consumed.get(20, SECONDS)).isEqualTo(2L);
         verify(indexer).get("local-datashare", "docId1", "docId1");
         verify(indexer).get("local-datashare", "docId2", "docId2");
+    }
+
+    @Test(timeout = 30000)
+    public void test_cancelling_a_consumer_waiting_for_its_upstream_reports_an_interruption() throws Exception {
+        Task<Long> upstream = runningUpstreamTask();
+        nlpQueueSignallingEmptyPolls();
+        ExtractNlpTask nlpTask = nlpTaskGatedOn(upstream);
+
+        Future<Long> consumed = consumerExecutor.submit((Callable<Long>) nlpTask::call);
+        assertThat(firstEmptyPoll.await(20, SECONDS)).isTrue();
+        nlpTask.cancel(false);
+
+        try {
+            consumed.get(20, SECONDS);
+            fail("cancelling a waiting consumer must not look like a completed run");
+        } catch (ExecutionException e) {
+            // TaskWorkerLoop turns this into CANCELLED: a waiting drain must not report DONE
+            assertThat(e.getCause()).isInstanceOf(InterruptedException.class);
+        }
     }
 
     @Test(timeout = 10000)

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
@@ -4,8 +4,10 @@ import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepository;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.TaskResult;
+import org.icij.datashare.asynctasks.UnknownTask;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.nlp.AbstractPipeline;
@@ -17,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -102,6 +105,37 @@ public class UpstreamGateTest {
         assertThat(nlpTaskGatedOn(upstream).call()).isEqualTo(0L);
     }
 
+    @Test(timeout = 30000)
+    public void test_an_unchecked_repository_failure_keeps_the_consumer_draining() throws Exception {
+        // JooqTaskRepository throws jOOQ's unchecked DataAccessException on a transient DB error:
+        // that must not fail the consumer, nor end its drain and strand what the producer enqueues
+        Task<Long> upstream = runningUpstreamTask();
+        DocumentQueue<String> queue = nlpQueueSignallingEmptyPolls();
+        ExtractNlpTask nlpTask = nlpTaskGatedOn(upstream, failingOnceTaskRepository());
+
+        Future<Long> consumed = consumerExecutor.submit((Callable<Long>) nlpTask::call);
+        assertThat(firstEmptyPoll.await(20, SECONDS)).isTrue();
+        queue.add("docId1");
+        upstream.setResult(new TaskResult<>(0L));
+
+        assertThat(consumed.get(20, SECONDS)).isEqualTo(1L);
+    }
+
+    private TaskRepositoryMemory failingOnceTaskRepository() {
+        return new TaskRepositoryMemory() {
+            private boolean failed = false;
+
+            @Override
+            public <V extends java.io.Serializable> Task<V> getTask(String taskId) throws IOException, UnknownTask {
+                if (!failed) {
+                    failed = true;
+                    throw new IllegalStateException("transient repository failure");
+                }
+                return taskRepository.getTask(taskId);
+            }
+        };
+    }
+
     private Task<Long> runningUpstreamTask() throws Exception {
         Task<Long> upstream = new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), Map.of());
         upstream.setState(Task.State.RUNNING);
@@ -110,8 +144,12 @@ public class UpstreamGateTest {
     }
 
     private ExtractNlpTask nlpTaskGatedOn(Task<Long> upstream) {
+        return nlpTaskGatedOn(upstream, taskRepository);
+    }
+
+    private ExtractNlpTask nlpTaskGatedOn(Task<Long> upstream, TaskRepository repository) {
         Map<String, Object> args = Map.of(UPSTREAM_TASK_ID, upstream.id);
-        return new ExtractNlpTask(indexer, pipeline, factory, taskRepository,
+        return new ExtractNlpTask(indexer, pipeline, factory, repository,
                 new Task<>(ExtractNlpTask.class.getName(), User.local(), args), progress -> null);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
@@ -32,7 +32,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.Fail.fail;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
-import static org.icij.datashare.tasks.PipelineTask.UPSTREAM_TASK_ID;
+import static org.icij.datashare.tasks.UpstreamGate.UPSTREAM_TASK_ID;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -149,7 +149,8 @@ public class UpstreamGateTest {
 
     private ExtractNlpTask nlpTaskGatedOn(Task<Long> upstream, TaskRepository repository) {
         Map<String, Object> args = Map.of(UPSTREAM_TASK_ID, upstream.id);
-        return new ExtractNlpTask(indexer, pipeline, factory, repository,
+        return new ExtractNlpTask(indexer, pipeline, factory,
+                new UpstreamGate.Factory(repository).forTask(new Task<>(ExtractNlpTask.class.getName(), User.local(), args)),
                 new Task<>(ExtractNlpTask.class.getName(), User.local(), args), progress -> null);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
@@ -29,7 +29,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.Fail.fail;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
-import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
 import static org.icij.datashare.tasks.PipelineTask.UPSTREAM_TASK_ID;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -111,8 +110,7 @@ public class UpstreamGateTest {
     }
 
     private ExtractNlpTask nlpTaskGatedOn(Task<Long> upstream) {
-        // 0.05s keeps the wait loop short: the assertions wait on a latch or on the task's return
-        Map<String, Object> args = Map.of(UPSTREAM_TASK_ID, upstream.id, POLLING_INTERVAL_SECONDS_OPT, "0.05");
+        Map<String, Object> args = Map.of(UPSTREAM_TASK_ID, upstream.id);
         return new ExtractNlpTask(indexer, pipeline, factory, taskRepository,
                 new Task<>(ExtractNlpTask.class.getName(), User.local(), args), progress -> null);
     }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/UpstreamGateTest.java
@@ -1,0 +1,115 @@
+package org.icij.datashare.tasks;
+
+import org.icij.datashare.PipelineHelper;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.Stage;
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.asynctasks.TaskRepositoryMemory;
+import org.icij.datashare.asynctasks.TaskResult;
+import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.nlp.AbstractPipeline;
+import org.icij.datashare.user.User;
+import org.icij.extract.queue.DocumentQueue;
+import org.icij.extract.queue.MemoryDocumentQueue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
+import static org.icij.datashare.cli.DatashareCliOptions.POLLING_INTERVAL_SECONDS_OPT;
+import static org.icij.datashare.tasks.PipelineTask.UPSTREAM_TASK_ID;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Covers the upstream-task gate: a consumer stage runs concurrently with its producer stage and
+ * exits only when its input queue is empty AND the producer task is terminal.
+ */
+public class UpstreamGateTest {
+    @Mock private Indexer indexer;
+    @Mock private AbstractPipeline pipeline;
+    private final MemoryDocumentCollectionFactory<String> factory = new MemoryDocumentCollectionFactory<>();
+    private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
+    private final ExecutorService consumerExecutor = Executors.newSingleThreadExecutor();
+    // counted down by the queue itself, so the test never has to sleep to know the consumer
+    // has already polled an empty queue: that is the exact moment the gate has to hold it
+    private final CountDownLatch firstEmptyPoll = new CountDownLatch(1);
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @After
+    public void tearDown() {
+        consumerExecutor.shutdownNow();
+    }
+
+    @Test(timeout = 30000)
+    public void test_consumer_drains_entries_enqueued_after_it_started_and_returns_when_upstream_is_done() throws Exception {
+        Task<Long> upstream = runningUpstreamTask();
+        DocumentQueue<String> queue = nlpQueueSignallingEmptyPolls();
+        ExtractNlpTask nlpTask = nlpTaskGatedOn(upstream);
+
+        Future<Long> consumed = consumerExecutor.submit((Callable<Long>) nlpTask::call);
+        // without the gate the consumer has already returned 0 by the time this await comes back
+        assertThat(firstEmptyPoll.await(20, SECONDS)).isTrue();
+        queue.add("docId1");
+        queue.add("docId2");
+        upstream.setResult(new TaskResult<>(0L));
+
+        assertThat(consumed.get(20, SECONDS)).isEqualTo(2L);
+        verify(indexer).get("local-datashare", "docId1", "docId1");
+        verify(indexer).get("local-datashare", "docId2", "docId2");
+    }
+
+    @Test(timeout = 10000)
+    public void test_consumer_returns_immediately_when_upstream_is_already_terminal() throws Exception {
+        Task<Long> upstream = runningUpstreamTask();
+        upstream.setResult(new TaskResult<>(0L));
+
+        assertThat(nlpTaskGatedOn(upstream).call()).isEqualTo(0L);
+    }
+
+    private Task<Long> runningUpstreamTask() throws Exception {
+        Task<Long> upstream = new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), Map.of());
+        upstream.setState(Task.State.RUNNING);
+        taskRepository.insert(upstream, null);
+        return upstream;
+    }
+
+    private ExtractNlpTask nlpTaskGatedOn(Task<Long> upstream) {
+        // 0.05s keeps the wait loop short: the assertions wait on a latch or on the task's return
+        Map<String, Object> args = Map.of(UPSTREAM_TASK_ID, upstream.id, POLLING_INTERVAL_SECONDS_OPT, "0.05");
+        return new ExtractNlpTask(indexer, pipeline, factory, taskRepository,
+                new Task<>(ExtractNlpTask.class.getName(), User.local(), args), progress -> null);
+    }
+
+    private DocumentQueue<String> nlpQueueSignallingEmptyPolls() {
+        String queueName = new PipelineHelper(new PropertiesProvider()).getQueueNameFor(Stage.NLP);
+        DocumentQueue<String> queue = new MemoryDocumentQueue<>(queueName, DEFAULT_QUEUE_CAPACITY) {
+            @Override
+            public String poll() {
+                String polled = super.poll();
+                if (polled == null) {
+                    firstEmptyPoll.countDown();
+                }
+                return polled;
+            }
+        };
+        // pre-seed the factory: the task resolves its input queue by name in its constructor
+        factory.queues.put(queueName, queue);
+        return queue;
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -58,6 +58,8 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class TaskResourceTest extends AbstractProdWebServerTest {
+    // matches the name field only: a ScanTask id also appears inside the IndexTask args
+    private static final String SCAN_TASK_NAME_FIELD = "\"name\":\"org.icij.datashare.tasks.ScanTask\"";
     @Rule
     public DatashareTimeRule time = new DatashareTimeRule("2021-07-07T12:23:34Z");
     @Mock
@@ -161,7 +163,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
 
         get("/api/task?args.dataDir=docs").should().contain("ScanTask").not().contain("IndexTask");
         get("/api/task").should().haveType("application/json").contain("IndexTask").contain("ScanTask");
-        get("/api/task?name=Index").should().contain("IndexTask").not().contain("ScanTask");
+        get("/api/task?name=Index").should().contain("IndexTask").not().contain(SCAN_TASK_NAME_FIELD);
     }
 
     @Test
@@ -288,7 +290,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
                 "{\"options\":{\"reportName\": \"foo\"}}").should().haveType("application/json");
 
         get("/api/task/all").should().haveType("application/json").contain("IndexTask").contain("ScanTask");
-        get("/api/task/all?name=Index").should().contain("IndexTask").not().contain("ScanTask");
+        get("/api/task/all?name=Index").should().contain("IndexTask").not().contain(SCAN_TASK_NAME_FIELD);
         get("/api/task/all?args.dataDir=docs").should().contain("ScanTask").not().contain("IndexTask");
     }
 
@@ -470,6 +472,8 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         defaultProperties.put("key", "val");
         defaultProperties.put("user", User.local());
         defaultProperties.remove(REPORT_NAME_OPT);
+        // the index stage is gated on the scan task it follows
+        defaultProperties.put(PipelineTask.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().id);
 
         assertThat(taskManager.getTasks().toList()).hasSize(2);
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ScanTask")).isNotNull();
@@ -491,6 +495,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         defaultProperties.put("path", path);
         defaultProperties.put("user", User.local());
         defaultProperties.remove(REPORT_NAME_OPT);
+        defaultProperties.put(PipelineTask.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().id);
 
         assertThat(taskManager.getTasks().toList()).hasSize(2);
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ScanTask")).isNotNull();
@@ -600,7 +605,10 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
 
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.EnqueueFromIndexTask")).isNotNull();
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask")).isNotNull();
-        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args).includes(entry("nlpPipeline", "EMAIL"));
+        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args).includes(entry("nlpPipeline", "EMAIL"),
+                // gated on the enqueuing task, otherwise a "find names" click can report DONE
+                // having processed nothing while doc refs are still being enqueued
+                entry(PipelineTask.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.EnqueueFromIndexTask").get().id));
     }
 
     @Test
@@ -632,11 +640,13 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_findNames_with_resume_false_should_not_launch_resume_task() {
+    public void test_findNames_with_resume_false_should_not_launch_resume_task() throws IOException {
         RestAssert response = post("/api/task/findNames/EMAIL", "{\"options\":{\"resume\":\"false\", \"waitForNlpApp\": false}}");
         response.should().haveType("application/json");
 
         verify(taskFactory, never()).createEnqueueFromIndexTask(eq(null), any());
+        // no producer to wait for: a standalone NLP run keeps exiting on its first empty poll
+        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args.containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -650,6 +650,24 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_findNames_ignores_a_client_supplied_upstream_task_id() throws IOException {
+        // honouring it would let a caller gate the NLP task on any task they keep alive, pinning a
+        // worker for as long as they want: the launcher is the only thing allowed to set this key
+        RestAssert response = post("/api/task/findNames/EMAIL", "{\"options\":{\"resume\":\"false\", \"waitForNlpApp\": false, \"upstreamTaskId\":\"forged\"}}");
+        response.should().haveType("application/json");
+
+        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args.containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
+    }
+
+    @Test
+    public void test_index_queue_ignores_a_client_supplied_upstream_task_id() throws IOException {
+        RestAssert response = post("/api/task/batchUpdate/index", "{\"options\":{\"upstreamTaskId\":\"forged\"}}");
+        response.should().haveType("application/json");
+
+        assertThat(findTask(taskManager, "org.icij.datashare.tasks.IndexTask").get().args.containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
+    }
+
+    @Test
     public void test_findNames_with_sync_models_false() {
         AbstractModels.syncModels(true);
         RestAssert response = post("/api/task/findNames/EMAIL", "{\"options\":{\"syncModels\":\"false\", \"waitForNlpApp\": false}}");

--- a/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/TaskResourceTest.java
@@ -473,7 +473,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         defaultProperties.put("user", User.local());
         defaultProperties.remove(REPORT_NAME_OPT);
         // the index stage is gated on the scan task it follows
-        defaultProperties.put(PipelineTask.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().id);
+        defaultProperties.put(UpstreamGate.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().id);
 
         assertThat(taskManager.getTasks().toList()).hasSize(2);
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ScanTask")).isNotNull();
@@ -495,7 +495,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         defaultProperties.put("path", path);
         defaultProperties.put("user", User.local());
         defaultProperties.remove(REPORT_NAME_OPT);
-        defaultProperties.put(PipelineTask.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().id);
+        defaultProperties.put(UpstreamGate.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.ScanTask").get().id);
 
         assertThat(taskManager.getTasks().toList()).hasSize(2);
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ScanTask")).isNotNull();
@@ -608,7 +608,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args).includes(entry("nlpPipeline", "EMAIL"),
                 // gated on the enqueuing task, otherwise a "find names" click can report DONE
                 // having processed nothing while doc refs are still being enqueued
-                entry(PipelineTask.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.EnqueueFromIndexTask").get().id));
+                entry(UpstreamGate.UPSTREAM_TASK_ID, findTask(taskManager, "org.icij.datashare.tasks.EnqueueFromIndexTask").get().id));
     }
 
     @Test
@@ -646,7 +646,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
 
         verify(taskFactory, never()).createEnqueueFromIndexTask(eq(null), any());
         // no producer to wait for: a standalone NLP run keeps exiting on its first empty poll
-        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args.containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
+        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args.containsKey(UpstreamGate.UPSTREAM_TASK_ID)).isFalse();
     }
 
     @Test
@@ -656,7 +656,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         RestAssert response = post("/api/task/findNames/EMAIL", "{\"options\":{\"resume\":\"false\", \"waitForNlpApp\": false, \"upstreamTaskId\":\"forged\"}}");
         response.should().haveType("application/json");
 
-        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args.containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
+        assertThat(findTask(taskManager, "org.icij.datashare.tasks.ExtractNlpTask").get().args.containsKey(UpstreamGate.UPSTREAM_TASK_ID)).isFalse();
     }
 
     @Test
@@ -664,7 +664,7 @@ public class TaskResourceTest extends AbstractProdWebServerTest {
         RestAssert response = post("/api/task/batchUpdate/index", "{\"options\":{\"upstreamTaskId\":\"forged\"}}");
         response.should().haveType("application/json");
 
-        assertThat(findTask(taskManager, "org.icij.datashare.tasks.IndexTask").get().args.containsKey(PipelineTask.UPSTREAM_TASK_ID)).isFalse();
+        assertThat(findTask(taskManager, "org.icij.datashare.tasks.IndexTask").get().args.containsKey(UpstreamGate.UPSTREAM_TASK_ID)).isFalse();
     }
 
     @Test

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -1077,7 +1077,7 @@ public final class DatashareCliOptions {
     }
 
     public static void pollingInterval(OptionParser parser) {
-        parser.acceptsAll(singletonList(POLLING_INTERVAL_SECONDS_OPT), "Queue polling interval.")
+        parser.acceptsAll(singletonList(POLLING_INTERVAL_SECONDS_OPT), "task worker termination interval (seconds)")
                 .withRequiredArg()
                 .ofType(String.class).defaultsTo(DEFAULT_POLLING_INTERVAL_SEC);
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -1077,7 +1077,7 @@ public final class DatashareCliOptions {
     }
 
     public static void pollingInterval(OptionParser parser) {
-        parser.acceptsAll(singletonList(POLLING_INTERVAL_SECONDS_OPT), "task worker termination interval (seconds)")
+        parser.acceptsAll(singletonList(POLLING_INTERVAL_SECONDS_OPT), "in-memory task manager only (ignored with a Redis or AMQP task manager): base interval in seconds for waiting on task worker termination, the window is twice this value")
                 .withRequiredArg()
                 .ofType(String.class).defaultsTo(DEFAULT_POLLING_INTERVAL_SEC);
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
@@ -22,7 +22,7 @@ public class WorkerOptions {
     @Option(names = {"--taskRoutingKey"}, description = "Task routing key")
     String taskRoutingKey;
 
-    @Option(names = {"--pollingInterval"}, description = "task worker termination interval (seconds)", defaultValue = "60")
+    @Option(names = {"--pollingInterval"}, description = "in-memory task manager only (ignored with a Redis or AMQP task manager): base interval in seconds for waiting on task worker termination, the window is twice this value", defaultValue = "60")
     String pollingInterval;
 
     @Option(names = {"--taskRepositoryType"}, description = "Task repository type", defaultValue = "DATABASE")

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/WorkerOptions.java
@@ -22,7 +22,7 @@ public class WorkerOptions {
     @Option(names = {"--taskRoutingKey"}, description = "Task routing key")
     String taskRoutingKey;
 
-    @Option(names = {"--pollingInterval"}, description = "Queue polling interval", defaultValue = "60")
+    @Option(names = {"--pollingInterval"}, description = "task worker termination interval (seconds)", defaultValue = "60")
     String pollingInterval;
 
     @Option(names = {"--taskRepositoryType"}, description = "Task repository type", defaultValue = "DATABASE")

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewer.java
@@ -415,11 +415,6 @@ public class ElasticsearchSpewer extends Spewer implements Serializable {
         return this;
     }
 
-    @Override
-    public void close() throws Exception {
-        outputQueue.put("POISON");
-    }
-
     private void setIndex(String indexName) {
         this.indexName = indexName;
     }


### PR DESCRIPTION
Removes the in-band POISON sentinel from the pipeline queues. Consumers now drain until their input queue is empty and their producer's task is terminal, read from `TaskRepository`, which works for any number of consumers, in-process or across processes, and leaves nothing in the queue between runs. `STRING_POISON` is gone; a transitional skip guard for queues written by pre-upgrade runs stays until 21.18.

- refactor(pipeline): drain every stage queue until empty instead of terminating on a sentinel
- refactor(artifact): delete the poison relay, the residual-poison startup drain and the null-poll retry budget
- feat(tasks): gate queue drains on the upstream producer task state, so an empty queue only means "done" when the producer is finished
- feat(pipeline): chain stage task ids in `CliApp.runPipeline` and the `/batchUpdate/index` and `/findNames` endpoints
- feat(index): gate `IndexTask` through `DocumentQueueDrainer`'s existing `SealableLatch`, no extract-lib change
- fix(tasks): make cancellation stop a drain instead of silently draining to the end and reporting DONE
- fix(tasks): survive interrupts that Redisson and the Elasticsearch rest-client rethrow wrapped in a RuntimeException
- fix(tasks): clear the interrupt flag when signalling cancellation, so it does not leak onto the next task on an AMQP worker
- fix(artifact): restore the `searcher.clearScroll()` dropped with the sentinel block
- fix(index): stop counting a skipped legacy sentinel as an indexed document
- fix(cli): exit non-zero when a stage fails, run each configured stage once, reject `NLP` + `CREATENLPBATCHESFROMIDX`
- refactor: delete `PipelineHelper.has()`, the unreachable null-task-id branch and dead `pollingInterval` test properties
- docs(cli): describe what `pollingInterval` actually does
- test: cover concurrent producer/consumer stages, cancellation, the legacy sentinel and the stage barrier

Notes for review: the sentinel used to inflate progress denominators, so two progress assertions now pin `contains(1.0)`; `CREATENLPBATCHESFROMIDX` now runs after `NLP` in enum order, which `PipelineHelper` rejects as a pairing rather than documenting.
