### PR TITLE
fix(nlp): stop the EMAIL pipeline regex from overflowing the stack

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
+++ b/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
@@ -48,13 +48,18 @@ public class EmailPipeline extends AbstractPipeline {
     private static final String RAW_HEADER_FIELD_PREFIX = "Message-Raw-Header-";
     private static final String MESSAGE_FIELD_PREFIX = "Message-";
     private static final String MESSAGE_HEADER_FIELD = "emailHeaderField";
-    final Pattern pattern = Pattern.compile("(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b" +
-            "\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@" +
-            "(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|" +
+    // every repetition below is bounded and the local part is anchored: java.util.regex recurses
+    // once per group iteration, so unbounded repetitions overflowed the stack on a long dotted run,
+    // and an unanchored local part rescanned every run (github.com/ICIJ/datashare/issues/2290).
+    // 63 labels and 255 characters are the RFC 5321 limits, so nothing deliverable is lost. '@' is
+    // out of the lookbehind on purpose: user@bad@host.com must still yield bad@host.com.
+    final Pattern pattern = Pattern.compile("(?:(?<![a-z0-9!#$%&'*+/=?^_`{|}~.-])[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+){0,63}|\"(?:[\\x01-\\x08\\x0b" +
+            "\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f]){0,255}\")@" +
+            "(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.){1,63}[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|" +
             "\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}" +
             "(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:" +
             "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|" +
-            "\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])");
+            "\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f]){1,255})\\])");
 
     private final Set<String> parsedEmailHeaders = unmodifiableSet(new HashSet<>(asList(
             tika("Dc-Title"),

--- a/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
+++ b/datashare-app/src/main/java/org/icij/datashare/nlp/EmailPipeline.java
@@ -48,12 +48,14 @@ public class EmailPipeline extends AbstractPipeline {
     private static final String RAW_HEADER_FIELD_PREFIX = "Message-Raw-Header-";
     private static final String MESSAGE_FIELD_PREFIX = "Message-";
     private static final String MESSAGE_HEADER_FIELD = "emailHeaderField";
-    // every repetition below is bounded and the local part is anchored: java.util.regex recurses
-    // once per group iteration, so unbounded repetitions overflowed the stack on a long dotted run,
-    // and an unanchored local part rescanned every run (github.com/ICIJ/datashare/issues/2290).
-    // 63 labels and 255 characters are the RFC 5321 limits, so nothing deliverable is lost. '@' is
-    // out of the lookbehind on purpose: user@bad@host.com must still yield bad@host.com.
-    final Pattern pattern = Pattern.compile("(?:(?<![a-z0-9!#$%&'*+/=?^_`{|}~.-])[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+){0,63}|\"(?:[\\x01-\\x08\\x0b" +
+    // bounded repetitions, and a local part that cannot start mid token: java.util.regex recurses
+    // once per group iteration, so the unbounded versions of these repetitions overflowed the stack
+    // on a long dotted run, and an unanchored local part rescanned every run quadratically
+    // (github.com/ICIJ/datashare/issues/2290). The bounds sit above what RFC 5321 allows anyway
+    // (64 octet local part, 255 octet domain); past 63 labels a domain is truncated, not dropped.
+    // '.' and '@' stay out of the lookbehind class: P.romera@icij.org must still yield
+    // romera@icij.org (the class is lower case only) and user@bad@host.com must yield bad@host.com.
+    final Pattern pattern = Pattern.compile("(?:(?<![a-z0-9!#$%&'*+/=?^_`{|}~-])[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+){0,63}|\"(?:[\\x01-\\x08\\x0b" +
             "\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f]){0,255}\")@" +
             "(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.){1,63}[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|" +
             "\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}" +

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ExtractNlpTask.java
@@ -90,7 +90,7 @@ public class ExtractNlpTask extends PipelineTask<String> implements Monitorable 
                     nbMaxPolls--;
                 }
             } catch (Throwable e) {
-                logger.error("error in ExtractNlpTask loop", e);
+                logger.error("error in ExtractNlpTask loop on doc {}", queueEntry, e);
             }
         }
         logger.info("exiting ExtractNlpTask loop after {} messages.", nbMessages);

--- a/datashare-app/src/test/java/org/icij/datashare/nlp/EmailPipelineTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/nlp/EmailPipelineTest.java
@@ -105,6 +105,28 @@ public class EmailPipelineTest {
         List<NamedEntity> annotations = pipeline.process(createDocument(content, "docId", Language.ENGLISH));
 
         assertThat(annotations).hasSize(1);
+        // past the label bound the domain is truncated, which is what a 100 000 label host deserves
+        assertThat(annotations.get(0).getMention()).isEqualTo("user@" + "a.".repeat(63) + "a");
+    }
+
+    @Test
+    public void test_finds_email_whose_local_part_starts_after_a_dot() {
+        // the local part class is lower case only, so the match can only start after the dot
+        List<NamedEntity> annotations = pipeline.process(createDocument("write to P.romera@icij.org", "docId", Language.ENGLISH));
+
+        assertThat(annotations).hasSize(1);
+        assertThat(annotations.get(0).getMention()).isEqualTo("romera@icij.org");
+        assertThat(annotations.get(0).getOffsets()).containsExactly(11L);
+    }
+
+    @Test(timeout = 10_000)
+    public void test_finds_email_trailing_a_long_dotted_run() {
+        String content = "w.".repeat(70) + "user@example.com";
+
+        List<NamedEntity> annotations = pipeline.process(createDocument(content, "docId", Language.ENGLISH));
+
+        assertThat(annotations).hasSize(1);
+        assertThat(annotations.get(0).getMention()).endsWith("user@example.com");
     }
 
     @Test(timeout = 10_000)

--- a/datashare-app/src/test/java/org/icij/datashare/nlp/EmailPipelineTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/nlp/EmailPipelineTest.java
@@ -89,6 +89,43 @@ public class EmailPipelineTest {
         assertThat(annotations.get(0).getOffsets()).containsExactly(14L, 48L, 168L, 332L, 1283L, 1482L, 1544L, 1582L);
     }
 
+    @Test(timeout = 10_000)
+    public void test_long_dotted_local_part_does_not_overflow_the_stack() {
+        String content = "hello " + "a.".repeat(100_000) + "b end";
+
+        List<NamedEntity> annotations = pipeline.process(createDocument(content, "docId", Language.ENGLISH));
+
+        assertThat(annotations).isEmpty();
+    }
+
+    @Test(timeout = 10_000)
+    public void test_long_dotted_domain_does_not_overflow_the_stack() {
+        String content = "user@" + "a.".repeat(100_000) + "b end";
+
+        List<NamedEntity> annotations = pipeline.process(createDocument(content, "docId", Language.ENGLISH));
+
+        assertThat(annotations).hasSize(1);
+    }
+
+    @Test(timeout = 10_000)
+    public void test_unterminated_quoted_local_part_does_not_overflow_the_stack() {
+        String content = "hello \"" + "a".repeat(200_000) + " end";
+
+        List<NamedEntity> annotations = pipeline.process(createDocument(content, "docId", Language.ENGLISH));
+
+        assertThat(annotations).isEmpty();
+    }
+
+    @Test(timeout = 10_000)
+    public void test_finds_email_after_a_very_long_character_run() {
+        String content = "a".repeat(1_000_000) + " email@domain.com";
+
+        List<NamedEntity> annotations = pipeline.process(createDocument(content, "docId", Language.ENGLISH));
+
+        assertThat(annotations).hasSize(1);
+        assertThat(annotations.get(0).getMention()).isEqualTo("email@domain.com");
+    }
+
     @Test
     public void test_adds_document_headers_parsing_for_email() {
         Document doc = createDoc("docid")


### PR DESCRIPTION
Fixes the `StackOverflowError` raised during EMAIL extraction (#2290). `java.util.regex` matches a group repetition by recursion, so the unbounded repetitions in the address pattern made stack depth a function of the content: a few thousand dot separated tokens exhausted the stack milliseconds into extraction, and the document was indexed with no EMAIL entity. The same pattern was also quadratic on a long unbroken run of local part characters (246s measured for 200k characters, so over an hour for a 1MB chunk), which anchoring the local part removes.

- fix: bound every group repetition in the address pattern (63 dot separated labels per side, 255 characters in a quoted local part or bracketed literal), which caps recursion depth
- fix: refuse a match attempt starting mid token, so `find()` stops rescanning every run; `.` and `@` stay out of that lookbehind class so `P.romera@icij.org` still yields `romera@icij.org` and `user@bad@host.com` still yields `bad@host.com`
- fix: name the document in the `ExtractNlpTask` loop error log, which previously reported failures with no document reference
- test: 6 regression tests covering the three overflowing constructs, the quadratic scan under a timeout, a local part starting after a dot, and an address trailing a long dotted run

Match semantics are unchanged on the `email.eml` acceptance fixture (same mentions, same offsets). Past 63 labels a domain is truncated and a quoted local part over 255 characters no longer matches; neither is a deliverable address under RFC 5321.