### PR TITLE
fix(tasks): deduplicate each queue entry instead of once at startup

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -16,6 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -37,10 +39,18 @@ public class DeduplicateTask extends PipelineTask<Path> {
     @Override
     public Long call() throws Exception {
         super.call();
-        int duplicates = inputQueue.removeDuplicates();
-        transferToOutputQueue();
-        logger.info("removed {} duplicate paths in inputQueue {}", duplicates, inputQueue.getName());
-        return (long)duplicates;
+        Set<Path> seen = new HashSet<>();
+        long[] dropped = {0};
+        // dedup per entry, not in one upfront pass: SCAN keeps enqueueing while this drain runs
+        transferToOutputQueue(path -> {
+            if (seen.add(path)) {
+                return true;
+            }
+            dropped[0]++;
+            return false;
+        });
+        logger.info("removed {} duplicate paths in inputQueue {}", dropped[0], inputQueue.getName());
+        return dropped[0];
     }
 
     long transferToOutputQueue() throws Exception {

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -40,20 +40,15 @@ public class DeduplicateTask extends PipelineTask<Path> {
     public Long call() throws Exception {
         super.call();
         Set<Path> seen = new HashSet<>();
-        long[] dropped = {0};
         // dedup per entry, not in one upfront pass: SCAN keeps enqueueing while this drain runs
-        transferToOutputQueue(path -> {
-            if (seen.add(path)) {
-                return true;
-            }
-            dropped[0]++;
-            return false;
-        });
-        logger.info("removed {} duplicate paths in inputQueue {}", dropped[0], inputQueue.getName());
-        return dropped[0];
+        long duplicates = transferToOutputQueue(seen::add);
+        logger.info("removed {} duplicate paths in inputQueue {}", duplicates, inputQueue.getName());
+        return duplicates;
     }
 
-    void transferToOutputQueue(Predicate<Path> filter) throws Exception {
+    /** Drains the input queue into the output queue, returning how many entries the filter rejected. */
+    long transferToOutputQueue(Predicate<Path> filter) throws Exception {
+        long rejected = 0;
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
             while (!Thread.currentThread().isInterrupted()) {
                 Path path;
@@ -75,6 +70,8 @@ public class DeduplicateTask extends PipelineTask<Path> {
                 }
                 if (filter.test(path)) {
                     outputQueue.add(path);
+                } else {
+                    rejected++;
                 }
             }
             // Thread.interrupted() tests AND clears: TaskWorkerLoop never clears the flag itself, so
@@ -83,6 +80,7 @@ public class DeduplicateTask extends PipelineTask<Path> {
             if (Thread.interrupted()) {
                 throw new InterruptedException("cancelled while draining " + inputQueue.getName());
             }
+            return rejected;
         }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/DeduplicateTask.java
@@ -53,12 +53,7 @@ public class DeduplicateTask extends PipelineTask<Path> {
         return dropped[0];
     }
 
-    long transferToOutputQueue() throws Exception {
-        return transferToOutputQueue(p -> true);
-    }
-
-    long transferToOutputQueue(Predicate<Path> filter) throws Exception {
-        long originalSize = inputQueue.size();
+    void transferToOutputQueue(Predicate<Path> filter) throws Exception {
         try (DocumentQueue<Path> outputQueue = factory.createQueue(getOutputQueueName(), Path.class)) {
             while (!Thread.currentThread().isInterrupted()) {
                 Path path;
@@ -88,7 +83,6 @@ public class DeduplicateTask extends PipelineTask<Path> {
             if (Thread.interrupted()) {
                 throw new InterruptedException("cancelled while draining " + inputQueue.getName());
             }
-            return originalSize - outputQueue.size();
         }
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -48,7 +48,7 @@ public class DeduplicateTaskTest {
         task.inputQueue.put(get("/path/to/doc1"));
         task.inputQueue.put(get("/path/to/doc2"));
 
-        task.transferToOutputQueue();
+        task.transferToOutputQueue(p -> true);
 
         assertThat(task.inputQueue.isEmpty()).isTrue();
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/DeduplicateTaskTest.java
@@ -2,21 +2,29 @@ package org.icij.datashare.tasks;
 
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
-import org.icij.datashare.extract.DocumentCollectionFactory;
+import org.icij.datashare.asynctasks.TaskResult;
 import org.icij.datashare.extract.MemoryDocumentCollectionFactory;
 import org.icij.datashare.user.User;
 import org.icij.extract.queue.DocumentQueue;
+import org.icij.extract.queue.MemoryDocumentQueue;
 import org.junit.Test;
 
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static java.nio.file.Paths.get;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.PropertiesProvider.DEFAULT_QUEUE_CAPACITY;
 
 public class DeduplicateTaskTest {
     private final TaskRepositoryMemory taskRepository = new TaskRepositoryMemory();
-    DocumentCollectionFactory<Path> docCollectionFactory = new MemoryDocumentCollectionFactory<>();
+    MemoryDocumentCollectionFactory<Path> docCollectionFactory = new MemoryDocumentCollectionFactory<>();
     Map<String, Object> defaultOpts = Map.of("queueName", "test:queue", "stages", "DEDUPLICATE");
     DeduplicateTask task = new DeduplicateTask(docCollectionFactory, new UpstreamGate.Factory(taskRepository), new Task<>(DeduplicateTask.class.getName(), User.local(), defaultOpts), null);
 
@@ -60,5 +68,45 @@ public class DeduplicateTaskTest {
         DocumentQueue<Path> outputQueue = docCollectionFactory.createQueue(task.getOutputQueueName(), Path.class);
         assertThat(outputQueue.size()).isEqualTo(1);
         assertThat(outputQueue.poll().toString()).isEqualTo("/path/to/doc1");
+    }
+
+    @Test(timeout = 30000)
+    public void test_a_duplicate_enqueued_after_the_drain_started_is_dropped() throws Exception {
+        Task<Long> scan = new Task<>(ScanTask.class.getName(), User.local(), Map.of());
+        scan.setState(Task.State.RUNNING);
+        taskRepository.insert(scan, null);
+        // counted down by the queue itself, so the test never sleeps to know the drain has already
+        // polled an empty queue: that is the moment the old upfront removeDuplicates() is behind us
+        CountDownLatch firstEmptyPoll = new CountDownLatch(1);
+        DocumentQueue<Path> queue = new MemoryDocumentQueue<>("test:queue:deduplicate", DEFAULT_QUEUE_CAPACITY) {
+            @Override
+            public Path poll() {
+                Path polled = super.poll();
+                if (polled == null) {
+                    firstEmptyPoll.countDown();
+                }
+                return polled;
+            }
+        };
+        // pre-seed the factory: the task resolves its input queue by name in its constructor
+        docCollectionFactory.queues.put("test:queue:deduplicate", queue);
+        queue.put(get("/path/to/doc"));
+        Map<String, Object> args = Map.of("queueName", "test:queue", "stages", "DEDUPLICATE",
+                UpstreamGate.UPSTREAM_TASK_ID, scan.id);
+        DeduplicateTask task = new DeduplicateTask(docCollectionFactory, new UpstreamGate.Factory(taskRepository),
+                new Task<>(DeduplicateTask.class.getName(), User.local(), args), null);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Long> dropped = executor.submit((Callable<Long>) task::call);
+            assertThat(firstEmptyPoll.await(20, SECONDS)).isTrue();
+            queue.put(get("/path/to/doc")); // the duplicate SCAN enqueues mid-drain
+            scan.setResult(new TaskResult<>(0L));
+
+            assertThat(dropped.get(20, SECONDS)).isEqualTo(1L);
+            assertThat(docCollectionFactory.createQueue("test:queue:index", Path.class).size()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
Fixes #2296. `DeduplicateTask` ran `removeDuplicates()` once before draining, so any path SCAN enqueued afterwards reached the index queue undeduplicated. Dedup now happens per entry, in the filter the drain already accepts.

- fix(tasks): dedup per entry via a seen-set instead of one upfront `removeDuplicates()` pass
- refactor(tasks): return the count the filter rejected from `transferToOutputQueue`, replacing a size delta that was meaningless once the producer ran concurrently
- refactor(tasks): drop the no-argument `transferToOutputQueue()` overload
- test(tasks): cover a duplicate enqueued while the upstream producer is still running