### PR TITLE
feat(artifacts): dedicated ArtifactResource

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/LocalMode.java
@@ -36,6 +36,7 @@ public class LocalMode extends CommonMode {
                 add(UserResource.class).
                 add(NamedEntityResource.class).
                 add(DocumentResource.class).
+                add(ArtifactResource.class).
                 add(DocumentUserRecommendationResource.class).
                 add(BatchSearchResource.class).
                 add(PluginResource.class).

--- a/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
+++ b/datashare-app/src/main/java/org/icij/datashare/mode/ServerMode.java
@@ -129,6 +129,7 @@ public class ServerMode extends CommonMode {
                 add(UserResource.class).
                 add(NamedEntityResource.class).
                 add(DocumentResource.class).
+                add(ArtifactResource.class).
                 add(DocumentUserRecommendationResource.class).
                 add(BatchSearchResource.class).
                 add(PathBannerResource.class).

--- a/datashare-app/src/main/java/org/icij/datashare/utils/DocumentSourceAccess.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/DocumentSourceAccess.java
@@ -1,0 +1,92 @@
+package org.icij.datashare.utils;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.codestory.http.Context;
+import net.codestory.http.constants.HttpStatus;
+import net.codestory.http.payload.Payload;
+import net.codestory.http.types.ContentTypes;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.Repository;
+import org.icij.datashare.session.DatashareUser;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.FileExtension;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
+import org.icij.extract.extractor.EmbeddedDocumentExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.Optional.ofNullable;
+import static net.codestory.http.constants.Headers.CONTENT_LENGTH;
+import static net.codestory.http.errors.NotFoundException.notFoundIfNull;
+import static org.icij.datashare.text.Project.isAllowed;
+import static org.icij.datashare.text.Project.project;
+
+/** The single decision for serving a document's source bytes: who may download, whether the
+ *  document exists, whether its root is within the size limit, and how the payload is built.
+ *  Shared by DocumentResource (/documents/src) and ArtifactResource (/artifacts/raw) so the
+ *  download restriction cannot drift into a bypass on one of the two routes. */
+@Singleton
+public class DocumentSourceAccess {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Repository repository;
+    private final Indexer indexer;
+    private final PropertiesProvider propertiesProvider;
+    private final DocumentVerifier documentVerifier;
+
+    @Inject
+    public DocumentSourceAccess(Repository repository, Indexer indexer, PropertiesProvider propertiesProvider) {
+        this.repository = repository;
+        this.indexer = indexer;
+        this.propertiesProvider = propertiesProvider;
+        this.documentVerifier = new DocumentVerifier(indexer, propertiesProvider);
+    }
+
+    public Payload gated(final String project, final String id, final String routing,
+                         final Context context, final Function<Document, Payload> whenAllowed) {
+        boolean isProjectGranted = ((DatashareUser) context.currentUser()).isGranted(project);
+        boolean isDownloadAllowed = isAllowed(repository.getProject(project), context.request().clientAddress());
+        if (!isProjectGranted || !isDownloadAllowed) {
+            return PayloadFormatter.error("You are not allowed to download this document", HttpStatus.FORBIDDEN);
+        }
+        List<String> sourceExcludes = List.of("content", "content_translated");
+        Document document = notFoundIfNull(indexer.get(project, id, routing == null ? id : routing, sourceExcludes));
+        if (!documentVerifier.isRootDocumentSizeAllowed(document, project(project))) {
+            return PayloadFormatter.error("The file or its parent is too large", HttpStatus.REQUEST_ENTITY_TOO_LARGE);
+        }
+        return whenAllowed.apply(document);
+    }
+
+    public boolean isSourceAvailable(Document document, Project servingProject) {
+        return documentVerifier.isSourceAvailable(document, servingProject);
+    }
+
+    public Payload source(Document doc, String index, boolean inline, boolean filterMetadata) {
+        try {
+            InputStream from = new SourceExtractor(propertiesProvider, filterMetadata).getSource(project(index), doc);
+            String contentType = ofNullable(doc.getContentType()).orElse(ContentTypes.get(doc.getPath().toFile().getName()));
+            // OCR-routed embedded images are stored with a synthetic "image/ocr-<fmt>" content type
+            // (the "ocr-" prefix routes them through the OCR parser). Serve the real media type so the
+            // Content-Type header and the download filename extension are correct (otherwise ".bin").
+            if (contentType != null && contentType.startsWith("image/ocr-")) {
+                contentType = "image/" + contentType.substring("image/ocr-".length());
+            }
+            Payload payload = new Payload(contentType, from);
+            if (!filterMetadata && doc.getContentLength() > 0) {
+                payload.withHeader(CONTENT_LENGTH, String.valueOf(doc.getContentLength()));
+            }
+            String fileName = doc.isRootDocument() ? doc.getName() : doc.getId().substring(0, 10) + "." + FileExtension.get(contentType);
+            return inline ? payload : payload.withHeader("Content-Disposition", "attachment;filename=\"" + fileName + "\"");
+        } catch (FileNotFoundException | EmbeddedDocumentExtractor.ContentNotFoundException fnf) {
+            logger.error("unable to read document source file", fnf);
+            return Payload.notFound();
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/utils/DocumentSourceAccess.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/DocumentSourceAccess.java
@@ -32,7 +32,10 @@ import static org.icij.datashare.text.Project.project;
 /** The single decision for serving a document's source bytes: who may download, whether the
  *  document exists, whether its root is within the size limit, and how the payload is built.
  *  Shared by DocumentResource (/documents/src) and ArtifactResource (/artifacts/raw) so the
- *  download restriction cannot drift into a bypass on one of the two routes. */
+ *  download restriction cannot drift into a bypass on one of the two routes. Keeping both verbs
+ *  of the source route (GET for bytes, HEAD for the verdict alone) on this one path is what stops
+ *  them from drifting apart, which is exactly how the frontend ended up reimplementing the size
+ *  rule in the first place. */
 @Singleton
 public class DocumentSourceAccess {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/datashare-app/src/main/java/org/icij/datashare/utils/DocumentSourceAccess.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/DocumentSourceAccess.java
@@ -31,11 +31,8 @@ import static org.icij.datashare.text.Project.project;
 
 /** The single decision for serving a document's source bytes: who may download, whether the
  *  document exists, whether its root is within the size limit, and how the payload is built.
- *  Shared by DocumentResource (/documents/src) and ArtifactResource (/artifacts/raw) so the
- *  download restriction cannot drift into a bypass on one of the two routes. Keeping both verbs
- *  of the source route (GET for bytes, HEAD for the verdict alone) on this one path is what stops
- *  them from drifting apart, which is exactly how the frontend ended up reimplementing the size
- *  rule in the first place. */
+ *  Shared by /documents/src (both verbs) and /artifacts/raw, so the rule cannot drift into a
+ *  bypass on one of them. */
 @Singleton
 public class DocumentSourceAccess {
     private final Logger logger = LoggerFactory.getLogger(getClass());

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -184,7 +184,7 @@ public class ArtifactResource {
                     DatashareCliOptions.ARTIFACT_DIR_OPT, id, project);
             return null;
         }
-        return ArtifactPath.dir(Path.of(artifactDir.get()).resolve(project), document.getId());
+        return ArtifactPath.dir(ArtifactPath.projectRoot(Path.of(artifactDir.get()), project), document.getId());
     }
 
     private static Map<String, String> structureContentTypes() {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -122,6 +122,9 @@ public class ArtifactResource {
     @Get("/:project/artifacts/structure/:id/:page?routing=:routing&format=:format")
     public Payload structurePage(final String project, final String id, final String page, final String routing,
                                  final String format, final Context context) throws IOException {
+        // Membership gates before format validation, same as every other route here: a non-member
+        // must see 403 regardless of what else is wrong with the request.
+        requireGranted(context, project);
         String extension = ofNullable(format).filter(value -> !value.isBlank()).orElse("md");
         String contentType = STRUCTURE_CONTENT_TYPES.get(extension);
         if (contentType == null) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import net.codestory.http.Context;
 import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Prefix;
+import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.cli.DatashareCliOptions;
@@ -38,6 +39,14 @@ import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 @Singleton
 @Prefix("/api")
 public class ArtifactResource {
+    // Extensions are fixed by type (convention §71). The map is the ?format= whitelist and content-type
+    // lookup; the list is the order of record for disk probing and for the error message, because
+    // Map.of has no defined iteration order.
+    private static final Map<String, String> STRUCTURE_CONTENT_TYPES = Map.of(
+            "md", "text/markdown;charset=UTF-8",
+            "xhtml", "application/xhtml+xml;charset=UTF-8");
+    private static final List<String> STRUCTURE_FORMATS = List.of("md", "xhtml");
+
     private final Indexer indexer;
     private final PropertiesProvider propertiesProvider;
     private final DocumentSourceAccess sources;
@@ -80,6 +89,53 @@ public class ArtifactResource {
     public Payload pageContent(final String project, final String id, final String page,
                                final String routing, final Context context) throws IOException {
         return payload(project, id, page, routing, context, ArtifactType.PAGE, "txt", "text/plain;charset=UTF-8");
+    }
+
+    @Operation(description = "Fetches the number of structure pages for a document and the formats available on disk.",
+            parameters = {
+                    @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
+                    @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "JSON {\"pages\": N, \"formats\": [\"md\", \"xhtml\"]}")
+    @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project")
+    @ApiResponse(responseCode = "404", description = "if the document, artifactDir, or a complete structure artifact is not found")
+    @Get("/:project/artifacts/structure/:id?routing=:routing")
+    public Payload structureManifest(final String project, final String id, final String routing, final Context context) throws IOException {
+        return manifest(project, id, routing, context, ArtifactType.STRUCTURE, STRUCTURE_FORMATS);
+    }
+
+    @Operation(description = "Fetches one structure page of a document, as Markdown (default) or XHTML.",
+            parameters = {
+                    @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
+                    @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
+                    @Parameter(name = "page", description = "1-based page number", in = ParameterIn.PATH),
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY),
+                    @Parameter(name = "format", description = "md (default) or xhtml", in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "the page as text/markdown or application/xhtml+xml")
+    @ApiResponse(responseCode = "400", description = "if format is not one of md, xhtml")
+    @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project")
+    @ApiResponse(responseCode = "404", description = "if the document, the artifact, the page, or that format is not found")
+    @Get("/:project/artifacts/structure/:id/:page?routing=:routing&format=:format")
+    public Payload structurePage(final String project, final String id, final String page, final String routing,
+                                 final String format, final Context context) throws IOException {
+        String extension = ofNullable(format).filter(value -> !value.isBlank()).orElse("md");
+        String contentType = STRUCTURE_CONTENT_TYPES.get(extension);
+        if (contentType == null) {
+            // A bad format is a request error: 404 on this route means "no such page".
+            return PayloadFormatter.error("unsupported format '" + extension + "'; supported formats: "
+                    + String.join(", ", STRUCTURE_FORMATS), HttpStatus.BAD_REQUEST);
+        }
+        Payload payload = payload(project, id, page, routing, context, ArtifactType.STRUCTURE, extension, contentType);
+        // The on-disk XHTML is written pre-sanitized by the structure producer; these headers are
+        // the serving side's defense in depth for a payload written by another producer.
+        return "xhtml".equals(extension)
+                ? payload.withHeader("Content-Security-Policy", "default-src 'none'; sandbox")
+                        .withHeader("X-Content-Type-Options", "nosniff")
+                : payload;
     }
 
     // Resolves the content-addressed dir of a granted, existing document. Returns null when the

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.Boolean.parseBoolean;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 
@@ -139,6 +140,26 @@ public class ArtifactResource {
                 ? payload.withHeader("Content-Security-Policy", "default-src 'none'; sandbox")
                         .withHeader("X-Content-Type-Options", "nosniff")
                 : payload;
+    }
+
+    @Operation(description = "Fetches a document's raw (embedded or source) bytes. Same access rules as /documents/src: project membership, the project's download restriction, and the root-document size limit.",
+            parameters = {
+                    @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
+                    @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY),
+                    @Parameter(name = "inline", description = "if true, serve without the attachment disposition", in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "the raw bytes, with the document's content type")
+    @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project or downloads are restricted")
+    @ApiResponse(responseCode = "404", description = "if no document is found or its bytes cannot be read")
+    @ApiResponse(responseCode = "413", description = "if the root document is too large and no raw artifact is cached for this embedded document")
+    @Get("/:project/artifacts/raw/:id?routing=:routing&inline=:inline")
+    public Payload raw(final String project, final String id, final String routing,
+                       final String inline, final Context context) {
+        boolean serveInline = parseBoolean(inline);
+        return sources.gated(project, id, routing, context,
+                document -> sources.source(document, project, serveInline, false));
     }
 
     // Resolves the content-addressed dir of a granted, existing document. Returns null when the

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -1,0 +1,143 @@
+package org.icij.datashare.web;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import net.codestory.http.Context;
+import net.codestory.http.annotations.Get;
+import net.codestory.http.annotations.Prefix;
+import net.codestory.http.payload.Payload;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.cli.DatashareCliOptions;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.artifact.ArtifactReader;
+import org.icij.datashare.text.artifact.ArtifactType;
+import org.icij.datashare.text.artifact.FilesystemManifestRepository;
+import org.icij.datashare.text.artifact.ManifestEntry;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.icij.datashare.utils.DocumentSourceAccess;
+import org.icij.datashare.utils.PayloadFormatter;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Optional.ofNullable;
+import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
+
+/** Serves per-document artifacts from artifactDir, driven by each document's manifest.json.
+ *  Derived types (page, structure) are strict-store: only a COMPLETE entry is served, anything
+ *  else is a 404. `raw` goes through the same gate as /documents/src, because a root document's
+ *  raw entry is EMPTY by design and strict gating would 404 every root document. */
+@Singleton
+@Prefix("/api")
+public class ArtifactResource {
+    private final Indexer indexer;
+    private final PropertiesProvider propertiesProvider;
+    private final DocumentSourceAccess sources;
+    private final ArtifactReader reader = new ArtifactReader(new FilesystemManifestRepository());
+
+    @Inject
+    public ArtifactResource(Indexer indexer, PropertiesProvider propertiesProvider, DocumentSourceAccess sources) {
+        this.indexer = indexer;
+        this.propertiesProvider = propertiesProvider;
+        this.sources = sources;
+    }
+
+    @Operation(description = "Fetches the number of persisted plain-text pages for a document.",
+            parameters = {
+                    @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
+                    @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "JSON {\"pages\": N}")
+    @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project")
+    @ApiResponse(responseCode = "404", description = "if the document, artifactDir, or a complete page artifact is not found")
+    @Get("/:project/artifacts/page/:id?routing=:routing")
+    public Payload pageManifest(final String project, final String id, final String routing, final Context context) throws IOException {
+        return manifest(project, id, routing, context, ArtifactType.PAGE, List.of());
+    }
+
+    @Operation(description = "Fetches one persisted plain-text page of a document.",
+            parameters = {
+                    @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
+                    @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
+                    @Parameter(name = "page", description = "1-based page number", in = ParameterIn.PATH),
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "the page as text/plain")
+    @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project")
+    @ApiResponse(responseCode = "404", description = "if the document, the artifact, or the page is not found")
+    @Get("/:project/artifacts/page/:id/:page?routing=:routing")
+    public Payload pageContent(final String project, final String id, final String page,
+                               final String routing, final Context context) throws IOException {
+        return payload(project, id, page, routing, context, ArtifactType.PAGE, "txt", "text/plain;charset=UTF-8");
+    }
+
+    // Resolves the content-addressed dir of a granted, existing document. Returns null when the
+    // document is unknown or artifactDir is unset (both 404); throws ForbiddenException (403) when
+    // the project is not granted. The document is always resolved through the indexer first, so a
+    // URL cannot probe arbitrary digests or another project's data.
+    private Path docArtifactDir(final String project, final String id, final String routing, final Context context) {
+        requireGranted(context, project);
+        Document document = indexer.get(project, id, ofNullable(routing).orElse(id), List.of("content", "content_translated"));
+        if (document == null) {
+            return null;
+        }
+        return propertiesProvider.get(DatashareCliOptions.ARTIFACT_DIR_OPT)
+                .map(dir -> ArtifactPath.dir(Path.of(dir).resolve(project), document.getId()))
+                .orElse(null);
+    }
+
+    private Payload manifest(final String project, final String id, final String routing, final Context context,
+                             final ArtifactType type, final List<String> formats) throws IOException {
+        Path docArtifactDir = docArtifactDir(project, id, routing, context);
+        if (docArtifactDir == null) {
+            return Payload.notFound();
+        }
+        ManifestEntry entry = reader.servableEntry(docArtifactDir, type);
+        if (entry == null || entry.total() == null) {
+            return Payload.notFound();
+        }
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("pages", entry.total());
+        if (!formats.isEmpty()) {
+            body.put("formats", reader.formats(docArtifactDir, type, entry, formats));
+        }
+        return PayloadFormatter.json(body).withCode(200);
+    }
+
+    private Payload payload(final String project, final String id, final String page, final String routing,
+                            final Context context, final ArtifactType type, final String extension,
+                            final String contentType) throws IOException {
+        Path docArtifactDir = docArtifactDir(project, id, routing, context);
+        if (docArtifactDir == null) {
+            return Payload.notFound();
+        }
+        ManifestEntry entry = reader.servableEntry(docArtifactDir, type);
+        if (entry == null) {
+            return Payload.notFound();
+        }
+        int pageNumber = parsePageNumber(page);
+        byte[] bytes = pageNumber < 1 ? null : reader.page(docArtifactDir, type, entry, pageNumber, extension);
+        return bytes == null ? Payload.notFound() : new Payload(contentType, bytes).withCode(200);
+    }
+
+    // -1 for anything that is not a positive integer, so non-numeric and out-of-range share the
+    // same 404 answer.
+    private static int parsePageNumber(String page) {
+        try {
+            return Integer.parseInt(page);
+        } catch (NumberFormatException notANumber) {
+            return -1;
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -49,6 +49,8 @@ public class ArtifactResource {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactResource.class);
     // Extensions are fixed by type (convention §71). One ordered map, so adding a format is one
     // edit: its key set is the ?format= whitelist, the disk-probe order and the error-message order.
+    private static final String MARKDOWN = "md";
+    private static final String XHTML = "xhtml";
     private static final Map<String, String> STRUCTURE_CONTENT_TYPES = structureContentTypes();
 
     private final Indexer indexer;
@@ -132,7 +134,7 @@ public class ArtifactResource {
         // Membership gates before format validation, same as every other route here: a non-member
         // must see 403 regardless of what else is wrong with the request.
         requireGranted(context, project);
-        String extension = ofNullable(format).filter(value -> !value.isBlank()).orElse("md");
+        String extension = ofNullable(format).filter(value -> !value.isBlank()).orElse(MARKDOWN);
         String contentType = STRUCTURE_CONTENT_TYPES.get(extension);
         if (contentType == null) {
             // A bad format is a request error: 404 on this route means "no such page".
@@ -142,7 +144,7 @@ public class ArtifactResource {
         Payload payload = payload(project, id, page, routing, ArtifactType.STRUCTURE, extension, contentType);
         // The on-disk XHTML is written pre-sanitized by the structure producer; this is the serving
         // side's defense in depth for a payload written by another producer.
-        return "xhtml".equals(extension)
+        return XHTML.equals(extension)
                 ? payload.withHeader("Content-Security-Policy", "default-src 'none'; sandbox")
                 : payload;
     }
@@ -189,8 +191,8 @@ public class ArtifactResource {
 
     private static Map<String, String> structureContentTypes() {
         Map<String, String> contentTypes = new LinkedHashMap<>();
-        contentTypes.put("md", "text/markdown;charset=UTF-8");
-        contentTypes.put("xhtml", "application/xhtml+xml;charset=UTF-8");
+        contentTypes.put(MARKDOWN, "text/markdown;charset=UTF-8");
+        contentTypes.put(XHTML, "application/xhtml+xml;charset=UTF-8");
         return unmodifiableMap(contentTypes);
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -23,13 +23,19 @@ import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.utils.DocumentSourceAccess;
 import org.icij.datashare.utils.PayloadFormatter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.Boolean.parseBoolean;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 
@@ -40,13 +46,10 @@ import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 @Singleton
 @Prefix("/api")
 public class ArtifactResource {
-    // Extensions are fixed by type (convention §71). The map is the ?format= whitelist and content-type
-    // lookup; the list is the order of record for disk probing and for the error message, because
-    // Map.of has no defined iteration order.
-    private static final Map<String, String> STRUCTURE_CONTENT_TYPES = Map.of(
-            "md", "text/markdown;charset=UTF-8",
-            "xhtml", "application/xhtml+xml;charset=UTF-8");
-    private static final List<String> STRUCTURE_FORMATS = List.of("md", "xhtml");
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactResource.class);
+    // Extensions are fixed by type (convention §71). One ordered map, so adding a format is one
+    // edit: its key set is the ?format= whitelist, the disk-probe order and the error-message order.
+    private static final Map<String, String> STRUCTURE_CONTENT_TYPES = structureContentTypes();
 
     private final Indexer indexer;
     private final PropertiesProvider propertiesProvider;
@@ -72,7 +75,8 @@ public class ArtifactResource {
     @ApiResponse(responseCode = "404", description = "if the document, artifactDir, or a complete page artifact is not found")
     @Get("/:project/artifacts/page/:id?routing=:routing")
     public Payload pageManifest(final String project, final String id, final String routing, final Context context) throws IOException {
-        return manifest(project, id, routing, context, ArtifactType.PAGE, List.of());
+        requireGranted(context, project);
+        return manifest(project, id, routing, ArtifactType.PAGE, List.of());
     }
 
     @Operation(description = "Fetches one persisted plain-text page of a document.",
@@ -89,7 +93,8 @@ public class ArtifactResource {
     @Get("/:project/artifacts/page/:id/:page?routing=:routing")
     public Payload pageContent(final String project, final String id, final String page,
                                final String routing, final Context context) throws IOException {
-        return payload(project, id, page, routing, context, ArtifactType.PAGE, "txt", "text/plain;charset=UTF-8");
+        requireGranted(context, project);
+        return payload(project, id, page, routing, ArtifactType.PAGE, "txt", "text/plain;charset=UTF-8");
     }
 
     @Operation(description = "Fetches the number of structure pages for a document and the formats available on disk.",
@@ -104,7 +109,8 @@ public class ArtifactResource {
     @ApiResponse(responseCode = "404", description = "if the document, artifactDir, or a complete structure artifact is not found")
     @Get("/:project/artifacts/structure/:id?routing=:routing")
     public Payload structureManifest(final String project, final String id, final String routing, final Context context) throws IOException {
-        return manifest(project, id, routing, context, ArtifactType.STRUCTURE, STRUCTURE_FORMATS);
+        requireGranted(context, project);
+        return manifest(project, id, routing, ArtifactType.STRUCTURE, STRUCTURE_CONTENT_TYPES.keySet());
     }
 
     @Operation(description = "Fetches one structure page of a document, as Markdown (default) or XHTML.",
@@ -131,14 +137,13 @@ public class ArtifactResource {
         if (contentType == null) {
             // A bad format is a request error: 404 on this route means "no such page".
             return PayloadFormatter.error("unsupported format '" + extension + "'; supported formats: "
-                    + String.join(", ", STRUCTURE_FORMATS), HttpStatus.BAD_REQUEST);
+                    + String.join(", ", STRUCTURE_CONTENT_TYPES.keySet()), HttpStatus.BAD_REQUEST);
         }
-        Payload payload = payload(project, id, page, routing, context, ArtifactType.STRUCTURE, extension, contentType);
-        // The on-disk XHTML is written pre-sanitized by the structure producer; these headers are
-        // the serving side's defense in depth for a payload written by another producer.
+        Payload payload = payload(project, id, page, routing, ArtifactType.STRUCTURE, extension, contentType);
+        // The on-disk XHTML is written pre-sanitized by the structure producer; this is the serving
+        // side's defense in depth for a payload written by another producer.
         return "xhtml".equals(extension)
                 ? payload.withHeader("Content-Security-Policy", "default-src 'none'; sandbox")
-                        .withHeader("X-Content-Type-Options", "nosniff")
                 : payload;
     }
 
@@ -162,43 +167,56 @@ public class ArtifactResource {
                 document -> sources.source(document, project, serveInline, false));
     }
 
-    // Resolves the content-addressed dir of a granted, existing document. Returns null when the
-    // document is unknown or artifactDir is unset (both 404); throws ForbiddenException (403) when
-    // the project is not granted. The document is always resolved through the indexer first, so a
-    // URL cannot probe arbitrary digests or another project's data.
-    private Path docArtifactDir(final String project, final String id, final String routing, final Context context) {
-        requireGranted(context, project);
+    // Resolves the content-addressed dir of an existing document, for a route that has already
+    // checked project membership. Returns null when the document is unknown or artifactDir is unset
+    // (both 404). The document is always resolved through the indexer first, so a URL cannot probe
+    // arbitrary digests or another project's data.
+    private Path docArtifactDir(final String project, final String id, final String routing) {
         Document document = indexer.get(project, id, ofNullable(routing).orElse(id), List.of("content", "content_translated"));
         if (document == null) {
             return null;
         }
-        return propertiesProvider.get(DatashareCliOptions.ARTIFACT_DIR_OPT)
-                .map(dir -> ArtifactPath.dir(Path.of(dir).resolve(project), document.getId()))
-                .orElse(null);
+        Optional<String> artifactDir = propertiesProvider.get(DatashareCliOptions.ARTIFACT_DIR_OPT);
+        if (artifactDir.isEmpty()) {
+            // Without artifactDir every artifact route answers 404 for every document, which reads
+            // exactly like "this document has no artifacts": say so once per request instead.
+            LOGGER.warn("{} is unset, so no artifact can be served for document {} of project {}",
+                    DatashareCliOptions.ARTIFACT_DIR_OPT, id, project);
+            return null;
+        }
+        return ArtifactPath.dir(Path.of(artifactDir.get()).resolve(project), document.getId());
     }
 
-    private Payload manifest(final String project, final String id, final String routing, final Context context,
-                             final ArtifactType type, final List<String> formats) throws IOException {
-        Path docArtifactDir = docArtifactDir(project, id, routing, context);
+    private static Map<String, String> structureContentTypes() {
+        Map<String, String> contentTypes = new LinkedHashMap<>();
+        contentTypes.put("md", "text/markdown;charset=UTF-8");
+        contentTypes.put("xhtml", "application/xhtml+xml;charset=UTF-8");
+        return unmodifiableMap(contentTypes);
+    }
+
+    private Payload manifest(final String project, final String id, final String routing,
+                             final ArtifactType type, final Collection<String> formats) throws IOException {
+        Path docArtifactDir = docArtifactDir(project, id, routing);
         if (docArtifactDir == null) {
             return Payload.notFound();
         }
         ManifestEntry entry = reader.servableEntry(docArtifactDir, type);
-        if (entry == null || entry.total() == null) {
+        Integer pages = entry == null ? null : reader.servableTotal(docArtifactDir, type, entry);
+        if (pages == null) {
             return Payload.notFound();
         }
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("pages", entry.total());
+        body.put("pages", pages);
         if (!formats.isEmpty()) {
             body.put("formats", reader.formats(docArtifactDir, type, entry, formats));
         }
-        return PayloadFormatter.json(body).withCode(200);
+        return PayloadFormatter.json(body);
     }
 
     private Payload payload(final String project, final String id, final String page, final String routing,
-                            final Context context, final ArtifactType type, final String extension,
+                            final ArtifactType type, final String extension,
                             final String contentType) throws IOException {
-        Path docArtifactDir = docArtifactDir(project, id, routing, context);
+        Path docArtifactDir = docArtifactDir(project, id, routing);
         if (docArtifactDir == null) {
             return Payload.notFound();
         }
@@ -206,18 +224,21 @@ public class ArtifactResource {
         if (entry == null) {
             return Payload.notFound();
         }
-        int pageNumber = parsePageNumber(page);
-        byte[] bytes = pageNumber < 1 ? null : reader.page(docArtifactDir, type, entry, pageNumber, extension);
-        return bytes == null ? Payload.notFound() : new Payload(contentType, bytes).withCode(200);
+        byte[] bytes = reader.page(docArtifactDir, type, entry, parsePageNumber(page), extension);
+        if (bytes == null) {
+            return Payload.notFound();
+        }
+        // Every artifact payload is text derived from an ingested document, served from this origin:
+        // a browser that sniffs its way to another type could execute a malicious document.
+        return new Payload(contentType, bytes).withHeader("X-Content-Type-Options", "nosniff");
     }
 
-    // -1 for anything that is not a positive integer, so non-numeric and out-of-range share the
-    // same 404 answer.
     private static int parsePageNumber(String page) {
         try {
             return Integer.parseInt(page);
         } catch (NumberFormatException notANumber) {
-            return -1;
+            // 0 is out of range for the reader, so a non-numeric page shares the out-of-range 404.
+            return 0;
         }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -62,9 +62,6 @@ public class DocumentResource {
         this.repository = repository;
         this.indexer = indexer;
         this.propertiesProvider = propertiesProvider;
-        // Injected, not constructed: DocumentSourceAccess is a @Singleton so that /documents/src and
-        // /artifacts/raw share one gate, and building a second instance here would let anything it
-        // gains later (a permission cache, a counter) diverge between the two routes.
         this.sources = sources;
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -15,13 +15,10 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import net.codestory.http.Context;
 import net.codestory.http.annotations.*;
-import net.codestory.http.constants.HttpStatus;
 import net.codestory.http.errors.ForbiddenException;
 
-import static net.codestory.http.constants.Headers.CONTENT_LENGTH;
 import static org.icij.datashare.web.errors.ForbiddenException.requireGranted;
 import net.codestory.http.payload.Payload;
-import net.codestory.http.types.ContentTypes;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Repository;
 import org.icij.datashare.Repository.AggregateList;
@@ -32,24 +29,18 @@ import org.icij.datashare.text.artifact.PageArtifact;
 import org.icij.datashare.text.indexing.ExtractedText;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.SearchedText;
-import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 import org.icij.datashare.user.User;
-import org.icij.datashare.utils.DocumentVerifier;
-import org.icij.datashare.utils.PayloadFormatter;
+import org.icij.datashare.utils.DocumentSourceAccess;
 import org.icij.extract.document.DocumentFactory;
-import org.icij.extract.extractor.EmbeddedDocumentExtractor;
 import org.icij.extract.extractor.Extractor;
 import org.icij.extract.extractor.PageIndices;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.lang.Boolean.parseBoolean;
@@ -57,7 +48,6 @@ import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
 import static net.codestory.http.errors.NotFoundException.notFoundIfNull;
 import static net.codestory.http.payload.Payload.ok;
-import static org.icij.datashare.text.Project.isAllowed;
 import static org.icij.datashare.text.Project.project;
 
 @Singleton
@@ -67,14 +57,14 @@ public class DocumentResource {
     private final Repository repository;
     private final Indexer indexer;
     private final PropertiesProvider propertiesProvider;
-    private final DocumentVerifier documentVerifier;
+    private final DocumentSourceAccess sources;
 
     @Inject
     public DocumentResource(Repository repository, Indexer indexer, PropertiesProvider propertiesProvider) {
         this.repository = repository;
         this.indexer = indexer;
         this.propertiesProvider = propertiesProvider;
-        this.documentVerifier = new DocumentVerifier(indexer, propertiesProvider);
+        this.sources = new DocumentSourceAccess(repository, indexer, propertiesProvider);
     }
 
     @Operation(description = "Fetches original datashare document json.",
@@ -109,8 +99,8 @@ public class DocumentResource {
     public Payload getSourceFile(final String project, final String id,
                                  final String routing, final String filterMetadata, final Context context) throws IOException {
         boolean inline = context.request().query().getBoolean("inline");
-        return sourceFile(project, id, routing, context,
-                document -> getPayload(document, project, inline, parseBoolean(filterMetadata)));
+        return sources.gated(project, id, routing, context,
+                document -> sources.source(document, project, inline, parseBoolean(filterMetadata)));
     }
 
     @Operation(description = "Tells whether the source of a document can be downloaded, without transferring it. Same decision as GET on the same route (permissions, existence, and the embedded-document size limit), so clients don't have to reimplement the rule.",
@@ -129,26 +119,8 @@ public class DocumentResource {
     // (currently 3 vs 4, "filter_metadata" is GET-only) or GET starts silently handling HEAD again.
     @Head("/:project/documents/src/:id?routing=:routing")
     public Payload headSourceFile(final String project, final String id, final String routing, final Context context) {
-        return sourceFile(project, id, routing, context,
-                document -> documentVerifier.isSourceAvailable(document, project(project)) ? ok() : Payload.notFound());
-    }
-
-    // Single decision for both verbs of the source route: GET serves the bytes, HEAD serves the
-    // verdict alone. Keeping them on one path is what stops the two from drifting apart, which is
-    // exactly how the frontend ended up reimplementing the size rule in the first place.
-    private Payload sourceFile(final String project, final String id, final String routing,
-                               final Context context, final Function<Document, Payload> whenAllowed) {
-        boolean isProjectGranted = ((DatashareUser) context.currentUser()).isGranted(project);
-        boolean isDownloadAllowed = isAllowed(repository.getProject(project), context.request().clientAddress());
-        if (!isProjectGranted || !isDownloadAllowed) {
-            return PayloadFormatter.error("You are not allowed to download this document", HttpStatus.FORBIDDEN);
-        }
-        List<String> sourceExcludes = List.of("content", "content_translated");
-        Document document = notFoundIfNull(indexer.get(project, id, routing == null ? id : routing, sourceExcludes));
-        if (!documentVerifier.isRootDocumentSizeAllowed(document, project(project))) {
-            return PayloadFormatter.error("The file or its parent is too large", HttpStatus.REQUEST_ENTITY_TOO_LARGE);
-        }
-        return whenAllowed.apply(document);
+        return sources.gated(project, id, routing, context,
+                document -> sources.isSourceAvailable(document, project(project)) ? ok() : Payload.notFound());
     }
 
     @Operation(description = "Fetches extracted text by slice (pagination)",
@@ -540,28 +512,6 @@ public class DocumentResource {
         }
         // targetLanguage not found
         throw new IllegalArgumentException("Target language not found");
-    }
-
-    private Payload getPayload(Document doc, String index, boolean inline, boolean filterMetadata) {
-        try {
-            InputStream from = new SourceExtractor(propertiesProvider, filterMetadata).getSource(project(index), doc);
-            String contentType = ofNullable(doc.getContentType()).orElse(ContentTypes.get(doc.getPath().toFile().getName()));
-            // OCR-routed embedded images are stored with a synthetic "image/ocr-<fmt>" content type
-            // (the "ocr-" prefix routes them through the OCR parser). Serve the real media type so the
-            // Content-Type header and the download filename extension are correct (otherwise ".bin").
-            if (contentType != null && contentType.startsWith("image/ocr-")) {
-                contentType = "image/" + contentType.substring("image/ocr-".length());
-            }
-            Payload payload =  new Payload(contentType, from);
-            if(!filterMetadata && doc.getContentLength() > 0) {
-                payload.withHeader(CONTENT_LENGTH, String.valueOf(doc.getContentLength()));
-            }
-            String fileName = doc.isRootDocument() ? doc.getName(): doc.getId().substring(0, 10) + "." + FileExtension.get(contentType);
-            return inline ? payload: payload.withHeader("Content-Disposition", "attachment;filename=\"" + fileName + "\"");
-        } catch (FileNotFoundException | EmbeddedDocumentExtractor.ContentNotFoundException fnf) {
-            logger.error("unable to read document source file", fnf);
-            return Payload.notFound();
-        }
     }
 
     private static class BatchTagQuery {

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -35,8 +35,6 @@ import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.Extractor;
 import org.icij.extract.extractor.PageIndices;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -53,7 +51,6 @@ import static org.icij.datashare.text.Project.project;
 @Singleton
 @Prefix("/api")
 public class DocumentResource {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final Repository repository;
     private final Indexer indexer;
     private final PropertiesProvider propertiesProvider;

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -186,14 +186,16 @@ public class DocumentResource {
         }
     }
 
-    @Operation(description = "Fetches document extracted text paginated in a json list of texts. It will use the source document and not the indexed extracted content.",
+    @Operation(deprecated = true,
+            description = "Deprecated: use GET /:project/artifacts/page/:id/:page, which serves the persisted page artifact instead of reparsing the source on every request. This route still reparses live and is kept until clients migrate.",
             parameters = {
                     @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
                     @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
                     @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY)
             }
     )
-    @ApiResponse(responseCode = "200", description = "JSON containing text pages array",  useReturnTypeSchema = true)
+    @ApiResponse(responseCode = "200", description = "JSON containing text pages array", useReturnTypeSchema = true)
+    @Deprecated
     @Get("/:project/documents/content/pages/:id?routing=:routing")
     public List<String> getContentByPage(final String project, final String id, final String routing, final Context context) throws IOException {
         requireGranted(context, project);

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -57,11 +57,15 @@ public class DocumentResource {
     private final DocumentSourceAccess sources;
 
     @Inject
-    public DocumentResource(Repository repository, Indexer indexer, PropertiesProvider propertiesProvider) {
+    public DocumentResource(Repository repository, Indexer indexer, PropertiesProvider propertiesProvider,
+                            DocumentSourceAccess sources) {
         this.repository = repository;
         this.indexer = indexer;
         this.propertiesProvider = propertiesProvider;
-        this.sources = new DocumentSourceAccess(repository, indexer, propertiesProvider);
+        // Injected, not constructed: DocumentSourceAccess is a @Singleton so that /documents/src and
+        // /artifacts/raw share one gate, and building a second instance here would let anything it
+        // gains later (a permission cache, a counter) diverge between the two routes.
+        this.sources = sources;
     }
 
     @Operation(description = "Fetches original datashare document json.",

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -1,0 +1,152 @@
+package org.icij.datashare.web;
+
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.db.JooqRepository;
+import org.icij.datashare.session.LocalUserFilter;
+import org.icij.datashare.tasks.MockIndexer;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.utils.DocumentSourceAccess;
+import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ArtifactResourceTest extends AbstractProdWebServerTest {
+    // 64-char digests: ArtifactPath.dir shards on the first two hex pairs.
+    private static final String DIGEST = "6abb96950946b62bb993307c8945c0c096982783bab7fa24901522426840ca3e";
+    @Rule public TemporaryFolder temp = new TemporaryFolder();
+    @Mock JooqRepository jooqRepository;
+    @Mock Indexer indexer;
+    @Mock PropertiesProvider propertiesProvider;
+    MockIndexer mockIndexer;
+    File artifactDir;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        mockIndexer = new MockIndexer(indexer);
+        artifactDir = temp.newFolder("artifacts");
+        when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.of(artifactDir.toString()));
+        when(propertiesProvider.getProperties()).thenReturn(new Properties());
+        when(propertiesProvider.createMerged(any())).thenCallRealMethod();
+        configure(routes -> routes
+                .add(new ArtifactResource(indexer, propertiesProvider,
+                        new DocumentSourceAccess(jooqRepository, indexer, propertiesProvider)))
+                .filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository)));
+    }
+
+    // Indexes the document and returns its content-addressed artifact dir.
+    private Path indexedDocDir(String digest) throws Exception {
+        File file = new File(temp.getRoot(), digest + ".txt");
+        MockIndexer.write(file, "content");
+        mockIndexer.indexFile("local-datashare", digest, file.toPath(), "text/plain", null);
+        Path dir = artifactDir.toPath().resolve("local-datashare")
+                .resolve(digest.substring(0, 2)).resolve(digest.substring(2, 4)).resolve(digest);
+        Files.createDirectories(dir);
+        return dir;
+    }
+
+    private void writeManifest(Path docDir, String json) throws Exception {
+        Files.writeString(docDir.resolve("manifest.json"), json);
+    }
+
+    private void writePages(Path docDir, String extension, String... pages) throws Exception {
+        Path pagesDir = docDir.resolve("pages");
+        Files.createDirectories(pagesDir);
+        for (int page = 1; page <= pages.length; page++) {
+            Files.writeString(pagesDir.resolve(String.format("page-%04d.%s", page, extension)), pages[page - 1]);
+        }
+    }
+
+    private static String filesystemManifest(String type, int total) {
+        return "{\"" + type + "\": {\"status\": \"complete\", \"taskInput\": {\"type\": \"" + type + "\", \"version\": 1},"
+                + " \"pagination\": {\"type\": \"filesystem\", \"total\": " + total + "}}}";
+    }
+
+    @Test
+    public void test_page_manifest_forbidden_for_non_member_project() {
+        get("/api/foo_index/artifacts/page/" + DIGEST).should().respond(403);
+    }
+
+    @Test
+    public void test_page_manifest_not_found_for_unknown_document() {
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_page_manifest_not_found_when_artifact_dir_unset() throws Exception {
+        indexedDocDir(DIGEST);
+        when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.empty());
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_page_manifest_not_found_without_manifest() throws Exception {
+        indexedDocDir(DIGEST);
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_page_manifest_not_found_when_type_absent_from_manifest() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeManifest(docDir, filesystemManifest("structure", 2));
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_page_manifest_not_found_when_entry_is_empty() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeManifest(docDir, "{\"page\": {\"status\": \"empty\", \"taskInput\": {}}}");
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_page_manifest_returns_the_page_count() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, "txt", "page one", "page two");
+        writeManifest(docDir, filesystemManifest("page", 2));
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should()
+                .respond(200).haveType("application/json").contain("\"pages\":2");
+    }
+
+    @Test
+    public void test_page_serves_one_page_as_plain_text() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, "txt", "page one", "page two");
+        writeManifest(docDir, filesystemManifest("page", 2));
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/2").should()
+                .respond(200).haveType("text/plain;charset=UTF-8").contain("page two");
+    }
+
+    @Test
+    public void test_page_out_of_range_and_non_numeric_are_not_found() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, "txt", "page one");
+        writeManifest(docDir, filesystemManifest("page", 1));
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/0").should().respond(404);
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/2").should().respond(404);
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/abc").should().respond(404);
+    }
+
+    @Test
+    public void test_page_missing_on_disk_is_not_found_but_the_count_still_reports_it() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, "txt", "page one", "page two");
+        writeManifest(docDir, filesystemManifest("page", 3));
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().contain("\"pages\":3");
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/3").should().respond(404);
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -128,28 +128,6 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_page_manifest_not_found_when_entry_is_empty() throws Exception {
-        Path docDir = indexedDocDir(DIGEST);
-        writeManifest(docDir, "{\"page\": {\"status\": \"empty\", \"taskInput\": {},"
-                + " \"pages\": {\"total\": 2, \"pagination\": {\"type\": \"filesystem\"}}}}");
-        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
-    }
-
-    @Test
-    public void test_page_manifest_not_found_when_manifest_json_is_malformed() throws Exception {
-        Path docDir = indexedDocDir(DIGEST);
-        writeManifest(docDir, "{not valid json");
-        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
-    }
-
-    @Test
-    public void test_page_manifest_not_found_when_status_is_unknown() throws Exception {
-        Path docDir = indexedDocDir(DIGEST);
-        writeManifest(docDir, "{\"page\": {\"status\": \"bogus\", \"taskInput\": {}}}");
-        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
-    }
-
-    @Test
     public void test_page_manifest_not_found_when_pages_have_no_total() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
         writePages(docDir, ArtifactType.PAGE, "txt", "page one");
@@ -201,12 +179,11 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_page_out_of_range_and_non_numeric_are_not_found() throws Exception {
+    public void test_non_numeric_page_is_not_found() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
         writePages(docDir, ArtifactType.PAGE, "txt", "page one");
         writeManifest(docDir, filesystemManifest("page", 1));
-        get("/api/local-datashare/artifacts/page/" + DIGEST + "/0").should().respond(404);
-        get("/api/local-datashare/artifacts/page/" + DIGEST + "/2").should().respond(404);
+        // Out-of-range numbers are the reader's rule; only the parse belongs to the route.
         get("/api/local-datashare/artifacts/page/" + DIGEST + "/abc").should().respond(404);
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.web;
 
+import net.codestory.rest.Response;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
@@ -19,9 +20,11 @@ import org.mockito.Mock;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.Properties;
 
+import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT;
 import static org.mockito.ArgumentMatchers.any;
@@ -264,8 +267,9 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         File file = new File(temp.getRoot(), "raw-inline.txt");
         MockIndexer.write(file, "source bytes");
         mockIndexer.indexFile("local-datashare", DIGEST, file.toPath(), "text/plain", null);
-        get("/api/local-datashare/artifacts/raw/" + DIGEST + "?inline=true").should()
-                .respond(200).should().not().haveHeader("Content-Disposition", "attachment;filename=\"raw-inline.txt\"");
+        Response response = get("/api/local-datashare/artifacts/raw/" + DIGEST + "?inline=true").response();
+        assertThat(response.code()).isEqualTo(200);
+        assertThat(response.header("Content-Disposition")).isNull();
     }
 
     @Test
@@ -274,8 +278,24 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_raw_not_found_for_unknown_document() {
+    public void test_raw_not_found_for_unknown_document() throws Exception {
         get("/api/local-datashare/artifacts/raw/" + DIGEST).should().respond(404);
+        // Same route, same id, now indexed: a 200 here proves the 404 above came from the
+        // document being unknown, not from the route itself being absent.
+        File file = new File(temp.getRoot(), "known.txt");
+        MockIndexer.write(file, "known bytes");
+        mockIndexer.indexFile("local-datashare", DIGEST, file.toPath(), "text/plain", null);
+        get("/api/local-datashare/artifacts/raw/" + DIGEST).should().respond(200);
+    }
+
+    @Test
+    public void test_raw_serves_an_embedded_documents_bytes() throws Exception {
+        // Same digest and fixture as DocumentResourceTest's embedded source-file tests: DIGEST is
+        // the sha256 of the PDF embedded in embedded_doc.eml.
+        String path = getClass().getResource("/docs/embedded_doc.eml").getPath();
+        mockIndexer.indexFile("local-datashare", DIGEST, Paths.get(path), "application/pdf", "bar");
+        get("/api/local-datashare/artifacts/raw/" + DIGEST + "?routing=bar").should()
+                .respond(200).haveType("application/pdf").contain("PDF-1.3");
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -4,6 +4,9 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.tasks.MockIndexer;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.DocumentBuilder;
+import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.utils.DocumentSourceAccess;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
@@ -20,6 +23,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.icij.datashare.cli.DatashareCliOptions.ARTIFACT_DIR_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -40,6 +44,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         mockIndexer = new MockIndexer(indexer);
         artifactDir = temp.newFolder("artifacts");
         when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.of(artifactDir.toString()));
+        when(propertiesProvider.get(EMBEDDED_DOCUMENT_DOWNLOAD_MAX_SIZE_OPT)).thenReturn(Optional.of("1G"));
         when(propertiesProvider.getProperties()).thenReturn(new Properties());
         when(propertiesProvider.createMerged(any())).thenCallRealMethod();
         configure(routes -> routes
@@ -242,5 +247,45 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         // Membership must gate before format validation: a non-member must not learn that "pdf"
         // is not one of the supported formats before they even learn they are not a member.
         get("/api/foo_index/artifacts/structure/" + DIGEST + "/1?format=pdf").should().respond(403);
+    }
+
+    @Test
+    public void test_raw_serves_the_source_bytes_as_an_attachment() throws Exception {
+        File file = new File(temp.getRoot(), "raw-source.txt");
+        MockIndexer.write(file, "source bytes");
+        mockIndexer.indexFile("local-datashare", DIGEST, file.toPath(), "text/plain", null);
+        get("/api/local-datashare/artifacts/raw/" + DIGEST).should()
+                .respond(200).contain("source bytes")
+                .haveHeader("Content-Disposition", "attachment;filename=\"raw-source.txt\"");
+    }
+
+    @Test
+    public void test_raw_serves_inline_when_asked() throws Exception {
+        File file = new File(temp.getRoot(), "raw-inline.txt");
+        MockIndexer.write(file, "source bytes");
+        mockIndexer.indexFile("local-datashare", DIGEST, file.toPath(), "text/plain", null);
+        get("/api/local-datashare/artifacts/raw/" + DIGEST + "?inline=true").should()
+                .respond(200).should().not().haveHeader("Content-Disposition", "attachment;filename=\"raw-inline.txt\"");
+    }
+
+    @Test
+    public void test_raw_forbidden_for_non_member_project() {
+        get("/api/foo_index/artifacts/raw/" + DIGEST).should().respond(403);
+    }
+
+    @Test
+    public void test_raw_not_found_for_unknown_document() {
+        get("/api/local-datashare/artifacts/raw/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_raw_too_large_root_document_is_rejected() {
+        // Same rule as /documents/src: the gate is shared, so this must answer 413 here too.
+        Project index = new Project("local-datashare");
+        Document root = DocumentBuilder.createDoc("bar").with(index).withContentLength(2L * 1024 * 1024 * 1024).build();
+        Document embedded = DocumentBuilder.createDoc(DIGEST).with(index).with(temp.getRoot().toPath().resolve("any.txt"))
+                .withParentId("bar").withRootId("bar").build();
+        mockIndexer.indexFile("local-datashare", root, embedded);
+        get("/api/local-datashare/artifacts/raw/" + DIGEST + "?routing=bar").should().respond(413);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -5,6 +5,7 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.db.JooqRepository;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.tasks.MockIndexer;
+import org.icij.datashare.test.LogbackCapturingRule;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Project;
@@ -18,6 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
+import org.slf4j.event.Level;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -38,6 +40,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     // 64-char digests: ArtifactPath.dir shards on the first two hex pairs.
     private static final String DIGEST = "6abb96950946b62bb993307c8945c0c096982783bab7fa24901522426840ca3e";
     @Rule public TemporaryFolder temp = new TemporaryFolder();
+    @Rule public LogbackCapturingRule logback = new LogbackCapturingRule();
     @Mock JooqRepository jooqRepository;
     @Mock Indexer indexer;
     @Mock PropertiesProvider propertiesProvider;
@@ -106,6 +109,9 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writeManifest(docDir, filesystemManifest("page", 1));
         when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.empty());
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+        // A misconfiguration that 404s every artifact of every document must not be silent: without
+        // this line in the log it is indistinguishable from a document that has no artifacts.
+        assertThat(logback.logs(Level.WARN).toString()).contains("artifactDir is unset").contains(DIGEST);
     }
 
     @Test
@@ -153,6 +159,9 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writeManifest(docDir, "{\"page\": {\"status\": \"complete\", \"taskInput\": {},"
                 + " \"pagination\": {\"type\": \"filesystem\"}}}");
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+        // The most likely real-world shape disagreement with datashare-python: 404 with an empty log
+        // would be indistinguishable from "no page artifact for this document".
+        assertThat(logback.logs(Level.WARN).toString()).contains("no usable page count").contains(docDir.toString());
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -229,6 +229,9 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         Path docDir = indexedDocDir(DIGEST);
         writeStructurePages(docDir, "md", "# one");
         writeManifest(docDir, filesystemManifest("structure", 1));
+        // Same page, same manifest: only the requested format differs, so a 404 on xhtml can only
+        // be caused by the missing format, not by a missing page or entry.
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=md").should().respond(200);
         get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=xhtml").should().respond(404);
     }
 
@@ -236,5 +239,8 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     public void test_structure_forbidden_for_non_member_project() {
         get("/api/foo_index/artifacts/structure/" + DIGEST).should().respond(403);
         get("/api/foo_index/artifacts/structure/" + DIGEST + "/1").should().respond(403);
+        // Membership must gate before format validation: a non-member must not learn that "pdf"
+        // is not one of the supported formats before they even learn they are not a member.
+        get("/api/foo_index/artifacts/structure/" + DIGEST + "/1?format=pdf").should().respond(403);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -8,7 +8,9 @@ import org.icij.datashare.tasks.MockIndexer;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Project;
+import org.icij.datashare.text.artifact.ArtifactType;
 import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.utils.DocumentSourceAccess;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.Before;
@@ -71,11 +73,12 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         Files.writeString(docDir.resolve("manifest.json"), json);
     }
 
-    private void writePages(Path docDir, String extension, String... pages) throws Exception {
-        Path pagesDir = docDir.resolve("pages");
-        Files.createDirectories(pagesDir);
+    // Written through ArtifactPath, never through an inline page-%04d format: a duplicated format
+    // string would let writer and reader drift together and hide a naming bug from these tests.
+    private void writePages(Path docDir, ArtifactType type, String extension, String... pages) throws Exception {
+        Files.createDirectories(ArtifactPath.payloadDir(docDir, type));
         for (int page = 1; page <= pages.length; page++) {
-            Files.writeString(pagesDir.resolve(String.format("page-%04d.%s", page, extension)), pages[page - 1]);
+            Files.writeString(ArtifactPath.payloadPage(docDir, type, page, extension), pages[page - 1]);
         }
     }
 
@@ -97,7 +100,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_page_manifest_not_found_when_artifact_dir_unset() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writePages(docDir, "txt", "page one");
+        writePages(docDir, ArtifactType.PAGE, "txt", "page one");
         writeManifest(docDir, filesystemManifest("page", 1));
         when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.empty());
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
@@ -141,7 +144,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_page_manifest_returns_the_page_count() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writePages(docDir, "txt", "page one", "page two");
+        writePages(docDir, ArtifactType.PAGE, "txt", "page one", "page two");
         writeManifest(docDir, filesystemManifest("page", 2));
         get("/api/local-datashare/artifacts/page/" + DIGEST).should()
                 .respond(200).haveType("application/json").contain("\"pages\":2");
@@ -150,7 +153,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_page_serves_one_page_as_plain_text() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writePages(docDir, "txt", "page one", "page two");
+        writePages(docDir, ArtifactType.PAGE, "txt", "page one", "page two");
         writeManifest(docDir, filesystemManifest("page", 2));
         get("/api/local-datashare/artifacts/page/" + DIGEST + "/2").should()
                 .respond(200).haveType("text/plain;charset=UTF-8").contain("page two");
@@ -159,7 +162,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_page_out_of_range_and_non_numeric_are_not_found() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writePages(docDir, "txt", "page one");
+        writePages(docDir, ArtifactType.PAGE, "txt", "page one");
         writeManifest(docDir, filesystemManifest("page", 1));
         get("/api/local-datashare/artifacts/page/" + DIGEST + "/0").should().respond(404);
         get("/api/local-datashare/artifacts/page/" + DIGEST + "/2").should().respond(404);
@@ -169,25 +172,17 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_page_missing_on_disk_is_not_found_but_the_count_still_reports_it() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writePages(docDir, "txt", "page one", "page two");
+        writePages(docDir, ArtifactType.PAGE, "txt", "page one", "page two");
         writeManifest(docDir, filesystemManifest("page", 3));
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().contain("\"pages\":3");
         get("/api/local-datashare/artifacts/page/" + DIGEST + "/3").should().respond(404);
     }
 
-    private void writeStructurePages(Path docDir, String extension, String... pages) throws Exception {
-        Path structureDir = docDir.resolve("structure");
-        Files.createDirectories(structureDir);
-        for (int page = 1; page <= pages.length; page++) {
-            Files.writeString(structureDir.resolve(String.format("page-%04d.%s", page, extension)), pages[page - 1]);
-        }
-    }
-
     @Test
     public void test_structure_manifest_lists_the_formats_on_disk() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writeStructurePages(docDir, "md", "# one", "# two");
-        writeStructurePages(docDir, "xhtml", "<html><body>one</body></html>", "<html><body>two</body></html>");
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one", "# two");
+        writePages(docDir, ArtifactType.STRUCTURE, "xhtml", "<html><body>one</body></html>", "<html><body>two</body></html>");
         writeManifest(docDir, filesystemManifest("structure", 2));
         get("/api/local-datashare/artifacts/structure/" + DIGEST).should()
                 .respond(200).contain("\"pages\":2").contain("\"md\"").contain("\"xhtml\"");
@@ -196,7 +191,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_structure_manifest_omits_a_format_absent_from_disk() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writeStructurePages(docDir, "md", "# one");
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
         writeManifest(docDir, filesystemManifest("structure", 1));
         get("/api/local-datashare/artifacts/structure/" + DIGEST).should()
                 .respond(200).contain("\"formats\":[\"md\"]");
@@ -205,7 +200,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_structure_page_defaults_to_markdown() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writeStructurePages(docDir, "md", "# one", "# two");
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one", "# two");
         writeManifest(docDir, filesystemManifest("structure", 2));
         get("/api/local-datashare/artifacts/structure/" + DIGEST + "/2").should()
                 .respond(200).haveType("text/markdown;charset=UTF-8").contain("# two");
@@ -214,7 +209,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_structure_page_serves_xhtml_with_hardening_headers() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writeStructurePages(docDir, "xhtml", "<html><body>one</body></html>");
+        writePages(docDir, ArtifactType.STRUCTURE, "xhtml", "<html><body>one</body></html>");
         writeManifest(docDir, filesystemManifest("structure", 1));
         get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=xhtml").should()
                 .respond(200)
@@ -226,7 +221,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_structure_page_rejects_an_unsupported_format() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writeStructurePages(docDir, "md", "# one");
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
         writeManifest(docDir, filesystemManifest("structure", 1));
         get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=pdf").should()
                 .respond(400).contain("md").contain("xhtml");
@@ -235,7 +230,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_structure_page_not_found_for_a_format_absent_on_disk() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writeStructurePages(docDir, "md", "# one");
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
         writeManifest(docDir, filesystemManifest("structure", 1));
         // Same page, same manifest: only the requested format differs, so a 404 on xhtml can only
         // be caused by the missing format, not by a missing page or entry.

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -77,7 +77,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         Files.writeString(docDir.resolve("manifest.json"), json);
     }
 
-    // Written through ArtifactPath, never through an inline page-%04d format: a duplicated format
+    // Written through ArtifactPath, never through an inline page-N format: a duplicated format
     // string would let writer and reader drift together and hide a naming bug from these tests.
     private void writePages(Path docDir, ArtifactType type, String extension, String... pages) throws Exception {
         Files.createDirectories(ArtifactPath.payloadDir(docDir, type));

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -88,7 +88,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
 
     private static String filesystemManifest(String type, int total) {
         return "{\"" + type + "\": {\"status\": \"complete\", \"taskInput\": {\"type\": \"" + type + "\", \"version\": 1},"
-                + " \"pagination\": {\"type\": \"filesystem\", \"total\": " + total + "}}}";
+                + " \"pages\": {\"total\": " + total + ", \"pagination\": {\"type\": \"filesystem\"}}}}";
     }
 
     @Test
@@ -131,7 +131,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     public void test_page_manifest_not_found_when_entry_is_empty() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
         writeManifest(docDir, "{\"page\": {\"status\": \"empty\", \"taskInput\": {},"
-                + " \"pagination\": {\"type\": \"filesystem\", \"total\": 2}}}");
+                + " \"pages\": {\"total\": 2, \"pagination\": {\"type\": \"filesystem\"}}}}");
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
     }
 
@@ -150,14 +150,14 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_page_manifest_not_found_when_pagination_has_no_total() throws Exception {
+    public void test_page_manifest_not_found_when_pages_have_no_total() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
         writePages(docDir, ArtifactType.PAGE, "txt", "page one");
-        // Complete and paginated, but the pagination block carries no total: Pagination.total is a
+        // Complete and paginated, but the pages block carries no total: Pages.total is a
         // primitive, so it deserializes to 0, which is a malformed manifest rather than a document
         // that was processed into zero pages.
         writeManifest(docDir, "{\"page\": {\"status\": \"complete\", \"taskInput\": {},"
-                + " \"pagination\": {\"type\": \"filesystem\"}}}");
+                + " \"pages\": {\"pagination\": {\"type\": \"filesystem\"}}}}");
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
         // The most likely real-world shape disagreement with datashare-python: 404 with an empty log
         // would be indistinguishable from "no page artifact for this document".
@@ -190,8 +190,8 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         Path docDir = indexedDocDir(DIGEST);
         Files.createDirectories(ArtifactPath.payloadDir(docDir, ArtifactType.PAGE));
         Files.writeString(ArtifactPath.payloadContent(docDir, ArtifactType.PAGE, "txt"), "page onepage two");
-        writeManifest(docDir, "{\"page\": {\"status\": \"complete\", \"taskInput\": {}, \"pagination\":"
-                + " {\"type\": \"byteRanges\", \"total\": 2, \"byteRanges\": [[0, 8], [8, 16]]}}}");
+        writeManifest(docDir, "{\"page\": {\"status\": \"complete\", \"taskInput\": {}, \"pages\": {\"total\": 2,"
+                + " \"pagination\": {\"type\": \"byteRanges\", \"ranges\": [[0, 8], [8, 16]]}}}}");
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(200).contain("\"pages\":2");
         // Same body, type and out-of-range answer as the filesystem-scheme page 2 above: the scheme
         // is a storage detail the route must not expose.

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -88,8 +89,9 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_page_manifest_forbidden_for_non_member_project() {
+    public void test_page_forbidden_for_non_member_project() {
         get("/api/foo_index/artifacts/page/" + DIGEST).should().respond(403);
+        get("/api/foo_index/artifacts/page/" + DIGEST + "/1").should().respond(403);
     }
 
     @Test
@@ -142,6 +144,18 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_page_manifest_not_found_when_pagination_has_no_total() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.PAGE, "txt", "page one");
+        // Complete and paginated, but the pagination block carries no total: Pagination.total is a
+        // primitive, so it deserializes to 0, which is a malformed manifest rather than a document
+        // that was processed into zero pages.
+        writeManifest(docDir, "{\"page\": {\"status\": \"complete\", \"taskInput\": {},"
+                + " \"pagination\": {\"type\": \"filesystem\"}}}");
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
     public void test_page_manifest_returns_the_page_count() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
         writePages(docDir, ArtifactType.PAGE, "txt", "page one", "page two");
@@ -156,7 +170,25 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writePages(docDir, ArtifactType.PAGE, "txt", "page one", "page two");
         writeManifest(docDir, filesystemManifest("page", 2));
         get("/api/local-datashare/artifacts/page/" + DIGEST + "/2").should()
+                .respond(200).haveType("text/plain;charset=UTF-8").contain("page two")
+                // text/plain derived from an ingested document: a sniffing browser must not be
+                // allowed to reinterpret it as something executable.
+                .haveHeader("X-Content-Type-Options", "nosniff");
+    }
+
+    @Test
+    public void test_page_serves_a_byte_range_page_like_the_filesystem_scheme() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        Files.createDirectories(ArtifactPath.payloadDir(docDir, ArtifactType.PAGE));
+        Files.writeString(ArtifactPath.payloadContent(docDir, ArtifactType.PAGE, "txt"), "page onepage two");
+        writeManifest(docDir, "{\"page\": {\"status\": \"complete\", \"taskInput\": {}, \"pagination\":"
+                + " {\"type\": \"byteRanges\", \"total\": 2, \"byteRanges\": [[0, 8], [8, 16]]}}}");
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(200).contain("\"pages\":2");
+        // Same body, type and out-of-range answer as the filesystem-scheme page 2 above: the scheme
+        // is a storage detail the route must not expose.
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/2").should()
                 .respond(200).haveType("text/plain;charset=UTF-8").contain("page two");
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/3").should().respond(404);
     }
 
     @Test
@@ -203,7 +235,8 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writePages(docDir, ArtifactType.STRUCTURE, "md", "# one", "# two");
         writeManifest(docDir, filesystemManifest("structure", 2));
         get("/api/local-datashare/artifacts/structure/" + DIGEST + "/2").should()
-                .respond(200).haveType("text/markdown;charset=UTF-8").contain("# two");
+                .respond(200).haveType("text/markdown;charset=UTF-8").contain("# two")
+                .haveHeader("X-Content-Type-Options", "nosniff");
     }
 
     @Test
@@ -270,6 +303,32 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_raw_forbidden_for_non_member_project() {
         get("/api/foo_index/artifacts/raw/" + DIGEST).should().respond(403);
+    }
+
+    @Test
+    public void test_raw_forbidden_when_the_client_address_is_download_restricted() throws Exception {
+        File file = new File(temp.getRoot(), "restricted.txt");
+        MockIndexer.write(file, "source bytes");
+        mockIndexer.indexFile("local-datashare", DIGEST, file.toPath(), "text/plain", null);
+        get("/api/local-datashare/artifacts/raw/" + DIGEST).should().respond(200);
+        // Granted project, but its download mask excludes the test client: the second rule of the
+        // shared gate, which the membership check short-circuits in the non-member test above.
+        when(jooqRepository.getProject("local-datashare")).thenReturn(new Project("local-datashare", "1.2.3.4"));
+        get("/api/local-datashare/artifacts/raw/" + DIGEST).should().respond(403);
+    }
+
+    @Test
+    public void test_artifacts_are_not_served_through_another_granted_projects_url() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.PAGE, "txt", "page one");
+        writeManifest(docDir, filesystemManifest("page", 1));
+        get("/api/local-datashare/artifacts/page/" + DIGEST + "/1").should().respond(200);
+        // Member of other-project too: the payload sits on disk under its digest, so only the
+        // per-project indexer lookup keeps the same URL from reaching another project's data.
+        when(jooqRepository.getProjects()).thenReturn(List.of(new Project("other-project")));
+        get("/api/other-project/artifacts/page/" + DIGEST).should().respond(404);
+        get("/api/other-project/artifacts/page/" + DIGEST + "/1").should().respond(404);
+        get("/api/other-project/artifacts/raw/" + DIGEST).should().respond(404);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -88,7 +88,9 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_page_manifest_not_found_when_artifact_dir_unset() throws Exception {
-        indexedDocDir(DIGEST);
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, "txt", "page one");
+        writeManifest(docDir, filesystemManifest("page", 1));
         when(propertiesProvider.get(ARTIFACT_DIR_OPT)).thenReturn(Optional.empty());
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
     }
@@ -109,7 +111,22 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_page_manifest_not_found_when_entry_is_empty() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writeManifest(docDir, "{\"page\": {\"status\": \"empty\", \"taskInput\": {}}}");
+        writeManifest(docDir, "{\"page\": {\"status\": \"empty\", \"taskInput\": {},"
+                + " \"pagination\": {\"type\": \"filesystem\", \"total\": 2}}}");
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_page_manifest_not_found_when_manifest_json_is_malformed() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeManifest(docDir, "{not valid json");
+        get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
+    }
+
+    @Test
+    public void test_page_manifest_not_found_when_status_is_unknown() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeManifest(docDir, "{\"page\": {\"status\": \"bogus\", \"taskInput\": {}}}");
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().respond(404);
     }
 
@@ -148,5 +165,76 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writeManifest(docDir, filesystemManifest("page", 3));
         get("/api/local-datashare/artifacts/page/" + DIGEST).should().contain("\"pages\":3");
         get("/api/local-datashare/artifacts/page/" + DIGEST + "/3").should().respond(404);
+    }
+
+    private void writeStructurePages(Path docDir, String extension, String... pages) throws Exception {
+        Path structureDir = docDir.resolve("structure");
+        Files.createDirectories(structureDir);
+        for (int page = 1; page <= pages.length; page++) {
+            Files.writeString(structureDir.resolve(String.format("page-%04d.%s", page, extension)), pages[page - 1]);
+        }
+    }
+
+    @Test
+    public void test_structure_manifest_lists_the_formats_on_disk() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeStructurePages(docDir, "md", "# one", "# two");
+        writeStructurePages(docDir, "xhtml", "<html><body>one</body></html>", "<html><body>two</body></html>");
+        writeManifest(docDir, filesystemManifest("structure", 2));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST).should()
+                .respond(200).contain("\"pages\":2").contain("\"md\"").contain("\"xhtml\"");
+    }
+
+    @Test
+    public void test_structure_manifest_omits_a_format_absent_from_disk() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeStructurePages(docDir, "md", "# one");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST).should()
+                .respond(200).contain("\"formats\":[\"md\"]");
+    }
+
+    @Test
+    public void test_structure_page_defaults_to_markdown() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeStructurePages(docDir, "md", "# one", "# two");
+        writeManifest(docDir, filesystemManifest("structure", 2));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/2").should()
+                .respond(200).haveType("text/markdown;charset=UTF-8").contain("# two");
+    }
+
+    @Test
+    public void test_structure_page_serves_xhtml_with_hardening_headers() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeStructurePages(docDir, "xhtml", "<html><body>one</body></html>");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=xhtml").should()
+                .respond(200)
+                .haveType("application/xhtml+xml;charset=UTF-8")
+                .haveHeader("Content-Security-Policy", "default-src 'none'; sandbox")
+                .haveHeader("X-Content-Type-Options", "nosniff");
+    }
+
+    @Test
+    public void test_structure_page_rejects_an_unsupported_format() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeStructurePages(docDir, "md", "# one");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=pdf").should()
+                .respond(400).contain("md").contain("xhtml");
+    }
+
+    @Test
+    public void test_structure_page_not_found_for_a_format_absent_on_disk() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writeStructurePages(docDir, "md", "# one");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=xhtml").should().respond(404);
+    }
+
+    @Test
+    public void test_structure_forbidden_for_non_member_project() {
+        get("/api/foo_index/artifacts/structure/" + DIGEST).should().respond(403);
+        get("/api/foo_index/artifacts/structure/" + DIGEST + "/1").should().respond(403);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/DocumentResourceTest.java
@@ -14,6 +14,7 @@ import org.icij.datashare.text.DocumentBuilder;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.ExtractedText;
 import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.utils.DocumentSourceAccess;
 import org.icij.datashare.text.indexing.SearchedText;
 import org.icij.datashare.user.User;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
@@ -69,7 +70,8 @@ public class DocumentResourceTest extends AbstractProdWebServerTest {
         when(propertiesProvider.getProperties()).thenReturn(new Properties());
         when(propertiesProvider.createMerged(any())).thenCallRealMethod();
         configure(routes -> {
-            routes.add(new DocumentResource(jooqRepository, indexer, propertiesProvider))
+            routes.add(new DocumentResource(jooqRepository, indexer, propertiesProvider,
+                            new DocumentSourceAccess(jooqRepository, indexer, propertiesProvider)))
                     .filter(new LocalUserFilter(new PropertiesProvider(), jooqRepository));
         });
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -28,7 +28,7 @@ public class ArtifactPayload {
             case STRUCTURE -> !Files.exists(lastPageOrDir(docArtifactDir, entry));
             // One file for every page, swapped in whole, so its existence answers for the payload: the
             // per-page offsets live in the entry, and a run that wrote no pages recorded EMPTY above.
-            case PAGE -> !Files.exists(ArtifactPath.pagesContent(docArtifactDir));
+            case PAGE -> !Files.exists(ArtifactPath.payloadContent(docArtifactDir, type, "txt"));
         };
     }
 
@@ -38,8 +38,8 @@ public class ArtifactPayload {
      *  manifest.json is read from disk and a Python producer writes it too. */
     private static Path lastPageOrDir(Path docArtifactDir, ManifestEntry entry) {
         if (entry.pages() == null || entry.pages().total() < 1) {
-            return ArtifactPath.structureDir(docArtifactDir);
+            return ArtifactPath.payloadDir(docArtifactDir, ArtifactType.STRUCTURE);
         }
-        return ArtifactPath.structurePage(docArtifactDir, entry.pages().total(), "md");
+        return ArtifactPath.payloadPage(docArtifactDir, ArtifactType.STRUCTURE, entry.pages().total(), "md");
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -5,14 +5,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 /** Read side of the artifact store, mirroring {@link ArtifactProducer}. Owns every rule that
  *  involves the manifest or the on-disk layout, so serving code stays HTTP-only: what is
  *  servable, where a page lives, and what a missing payload means. */
 public class ArtifactReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactReader.class);
+    private static final String BYTE_RANGES = "byteRanges";
     private final ManifestRepository manifests;
 
     public ArtifactReader(ManifestRepository manifests) {
@@ -32,6 +35,10 @@ public class ArtifactReader {
         if (total == null || page < 1 || page > total) {
             return null;
         }
+        if (isByteRanges(entry)) {
+            return slice(ArtifactPath.payloadContent(docArtifactDir, type, extension),
+                    entry.pagination().byteRanges().get(page - 1), type, total);
+        }
         Path file = ArtifactPath.payloadPage(docArtifactDir, type, page, extension);
         if (!Files.isRegularFile(file)) {
             // In range per the manifest but absent on disk: the two disagree, which is worth
@@ -40,5 +47,41 @@ public class ArtifactReader {
             return null;
         }
         return Files.readAllBytes(file);
+    }
+
+    /** Which extensions are actually on disk, in the candidate order given. Probes per scheme,
+     *  because the two schemes keep an extension in different files. */
+    public List<String> formats(Path docArtifactDir, ArtifactType type, ManifestEntry entry, List<String> candidates) {
+        boolean byteRanges = isByteRanges(entry);
+        return candidates.stream()
+                .filter(extension -> Files.isRegularFile(byteRanges
+                        ? ArtifactPath.payloadContent(docArtifactDir, type, extension)
+                        : ArtifactPath.payloadPage(docArtifactDir, type, 1, extension)))
+                .toList();
+    }
+
+    private boolean isByteRanges(ManifestEntry entry) {
+        return entry.pagination() != null && BYTE_RANGES.equals(entry.pagination().type());
+    }
+
+    // Half-open [start, end). A range outside the file means manifest and payload disagree, which
+    // is a 404 for that page rather than a truncated body.
+    private byte[] slice(Path content, long[] range, ArtifactType type, int total) throws IOException {
+        if (!Files.isRegularFile(content)) {
+            LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but {} is missing", total, type.token(), content);
+            return null;
+        }
+        long start = range[0];
+        long end = range[1];
+        if (start < 0 || end < start || end > Files.size(content)) {
+            LOGGER.warn("byte range [{}, {}) for '{}' is outside {}", start, end, type.token(), content);
+            return null;
+        }
+        byte[] slice = new byte[(int) (end - start)];
+        try (RandomAccessFile file = new RandomAccessFile(content.toFile(), "r")) {
+            file.seek(start);
+            file.readFully(slice);   // handles the partial-read loop
+        }
+        return slice;
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -1,0 +1,44 @@
+package org.icij.datashare.text.artifact;
+
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Read side of the artifact store, mirroring {@link ArtifactProducer}. Owns every rule that
+ *  involves the manifest or the on-disk layout, so serving code stays HTTP-only: what is
+ *  servable, where a page lives, and what a missing payload means. */
+public class ArtifactReader {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactReader.class);
+    private final ManifestRepository manifests;
+
+    public ArtifactReader(ManifestRepository manifests) {
+        this.manifests = manifests;
+    }
+
+    /** The type's entry when it exists and is servable, else null. Callers map null to 404 and
+     *  never inspect status themselves, so "servable" has one definition. */
+    public ManifestEntry servableEntry(Path docArtifactDir, ArtifactType type) throws IOException {
+        ManifestEntry entry = manifests.get(docArtifactDir, type.token());
+        return entry != null && entry.isComplete() ? entry : null;
+    }
+
+    /** One page's bytes, or null when the page is out of range or its payload is missing. */
+    public byte[] page(Path docArtifactDir, ArtifactType type, ManifestEntry entry, int page, String extension) throws IOException {
+        Integer total = entry.total();
+        if (total == null || page < 1 || page > total) {
+            return null;
+        }
+        Path file = ArtifactPath.payloadPage(docArtifactDir, type, page, extension);
+        if (!Files.isRegularFile(file)) {
+            // In range per the manifest but absent on disk: the two disagree, which is worth
+            // seeing in the logs rather than reshaping the advertised page count silently.
+            LOGGER.warn("manifest advertises {} page(s) for '{}' but {} is missing", total, type.token(), file);
+            return null;
+        }
+        return Files.readAllBytes(file);
+    }
+}

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -50,10 +50,13 @@ public class ArtifactReader {
                     entry.pagination().byteRanges(), page, type, total);
         }
         Path file = ArtifactPath.payloadPage(docArtifactDir, type, page, extension);
-        if (!Files.isRegularFile(file)) {
+        // Readable, not merely present: payloads are written 0600 by whichever process produced
+        // them (same hazard as SourceExtractor#hasCachedEmbeddedSource), and reading one this
+        // process cannot open would throw an IOException the serving side turns into a 500.
+        if (!Files.isReadable(file)) {
             // In range per the manifest but absent on disk: the two disagree, which is worth
             // seeing in the logs rather than reshaping the advertised page count silently.
-            LOGGER.warn("manifest advertises {} page(s) for '{}' but {} is missing", total, type.token(), file);
+            LOGGER.warn("manifest advertises {} page(s) for '{}' but {} is missing or unreadable", total, type.token(), file);
             return null;
         }
         return Files.readAllBytes(file);
@@ -64,7 +67,7 @@ public class ArtifactReader {
     public List<String> formats(Path docArtifactDir, ArtifactType type, ManifestEntry entry, List<String> candidates) {
         boolean byteRanges = isByteRanges(entry);
         return candidates.stream()
-                .filter(extension -> Files.isRegularFile(byteRanges
+                .filter(extension -> Files.isReadable(byteRanges
                         ? ArtifactPath.payloadContent(docArtifactDir, type, extension)
                         : ArtifactPath.payloadPage(docArtifactDir, type, 1, extension)))
                 .toList();
@@ -77,8 +80,8 @@ public class ArtifactReader {
     // Half-open [start, end). A range outside the file means manifest and payload disagree, which
     // is a 404 for that page rather than a truncated body.
     private byte[] slice(Path content, List<long[]> ranges, int page, ArtifactType type, int total) throws IOException {
-        if (!Files.isRegularFile(content)) {
-            LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but {} is missing", total, type.token(), content);
+        if (!Files.isReadable(content)) {
+            LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but {} is missing or unreadable", total, type.token(), content);
             return null;
         }
         if (ranges == null || ranges.size() < page || ranges.get(page - 1).length != 2) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -17,7 +17,6 @@ import java.util.List;
  *  servable, where a page lives, and what a missing payload means. */
 public class ArtifactReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactReader.class);
-    private static final String BYTE_RANGES = "byteRanges";
     private final ManifestRepository manifests;
 
     public ArtifactReader(ManifestRepository manifests) {
@@ -41,19 +40,19 @@ public class ArtifactReader {
     }
 
     /**
-     * The page count a servable entry advertises, or null when its pagination cannot be trusted:
+     * The page count a servable entry advertises, or null when its pages block cannot be trusted:
      * absent, renamed by a producer whose manifest shape differs (unknown properties are ignored on
-     * read), or non-positive because Pagination.total is a primitive that an absent field fills with
-     * 0. Warned rather than silent: such a manifest is otherwise indistinguishable from a document
+     * read), or non-positive because Pages.total is a primitive that an absent field fills with 0.
+     * Warned rather than silent: such a manifest is otherwise indistinguishable from a document
      * that has no artifact of this type at all, and the strict-store contract says it is not found.
      */
     public Integer servableTotal(Path docArtifactDir, ArtifactType type, ManifestEntry entry) {
-        Integer total = entry.total();
-        if (total != null && total > 0) {
-            return total;
+        Pages pages = entry.pages();
+        if (pages != null && pages.total() > 0) {
+            return pages.total();
         }
-        LOGGER.warn("complete '{}' entry in {} advertises no usable page count ({}): its pagination block is "
-                + "absent, renamed, or carries a non-positive total", type.token(), docArtifactDir, total);
+        LOGGER.warn("complete '{}' entry in {} advertises no usable page count: its pages block is "
+                + "absent, renamed, or carries a non-positive total", type.token(), docArtifactDir);
         return null;
     }
 
@@ -63,9 +62,10 @@ public class ArtifactReader {
         if (total == null || page < 1 || page > total) {
             return null;
         }
-        if (isByteRanges(entry)) {
+        ByteRangePagination byteRanges = byteRanges(entry);
+        if (byteRanges != null) {
             return slice(ArtifactPath.payloadContent(docArtifactDir, type, extension),
-                    entry.pagination().byteRanges(), page, type, total);
+                    byteRanges.ranges(), page, type, total);
         }
         Path file = ArtifactPath.payloadPage(docArtifactDir, type, page, extension);
         // Readable, not merely present: payloads are written 0600 by whichever process produced
@@ -83,7 +83,7 @@ public class ArtifactReader {
     /** Which extensions are actually on disk, in the candidate order given. Probes per scheme,
      *  because the two schemes keep an extension in different files. */
     public List<String> formats(Path docArtifactDir, ArtifactType type, ManifestEntry entry, Collection<String> candidates) {
-        boolean byteRanges = isByteRanges(entry);
+        boolean byteRanges = byteRanges(entry) != null;
         return candidates.stream()
                 .filter(extension -> Files.isReadable(byteRanges
                         ? ArtifactPath.payloadContent(docArtifactDir, type, extension)
@@ -91,8 +91,11 @@ public class ArtifactReader {
                 .toList();
     }
 
-    private boolean isByteRanges(ManifestEntry entry) {
-        return entry.pagination() != null && BYTE_RANGES.equals(entry.pagination().type());
+    // The scheme when it is the byte-range one, else null: every other case (filesystem, or a pages
+    // block with no pagination at all) is served as one file per page.
+    private ByteRangePagination byteRanges(ManifestEntry entry) {
+        return entry.pages() != null && entry.pages().pagination() instanceof ByteRangePagination ranges
+                ? ranges : null;
     }
 
     // Half-open [start, end). A range outside the file means manifest and payload disagree, which

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -37,7 +37,7 @@ public class ArtifactReader {
         }
         if (isByteRanges(entry)) {
             return slice(ArtifactPath.payloadContent(docArtifactDir, type, extension),
-                    entry.pagination().byteRanges().get(page - 1), type, total);
+                    entry.pagination().byteRanges(), page, type, total);
         }
         Path file = ArtifactPath.payloadPage(docArtifactDir, type, page, extension);
         if (!Files.isRegularFile(file)) {
@@ -66,14 +66,19 @@ public class ArtifactReader {
 
     // Half-open [start, end). A range outside the file means manifest and payload disagree, which
     // is a 404 for that page rather than a truncated body.
-    private byte[] slice(Path content, long[] range, ArtifactType type, int total) throws IOException {
+    private byte[] slice(Path content, List<long[]> ranges, int page, ArtifactType type, int total) throws IOException {
         if (!Files.isRegularFile(content)) {
             LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but {} is missing", total, type.token(), content);
             return null;
         }
+        if (ranges == null || ranges.size() < page || ranges.get(page - 1).length != 2) {
+            LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but range {} is malformed", total, type.token(), page);
+            return null;
+        }
+        long[] range = ranges.get(page - 1);
         long start = range[0];
         long end = range[1];
-        if (start < 0 || end < start || end > Files.size(content)) {
+        if (start < 0 || end < start || end > Files.size(content) || end - start > Integer.MAX_VALUE) {
             LOGGER.warn("byte range [{}, {}) for '{}' is outside {}", start, end, type.token(), content);
             return null;
         }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 
 /** Read side of the artifact store, mirroring {@link ArtifactProducer}. Owns every rule that
@@ -39,9 +40,26 @@ public class ArtifactReader {
         return entry != null && entry.isComplete() ? entry : null;
     }
 
+    /**
+     * The page count a servable entry advertises, or null when its pagination cannot be trusted:
+     * absent, renamed by a producer whose manifest shape differs (unknown properties are ignored on
+     * read), or non-positive because Pagination.total is a primitive that an absent field fills with
+     * 0. Warned rather than silent: such a manifest is otherwise indistinguishable from a document
+     * that has no artifact of this type at all, and the strict-store contract says it is not found.
+     */
+    public Integer servableTotal(Path docArtifactDir, ArtifactType type, ManifestEntry entry) {
+        Integer total = entry.total();
+        if (total != null && total > 0) {
+            return total;
+        }
+        LOGGER.warn("complete '{}' entry in {} advertises no usable page count ({}): its pagination block is "
+                + "absent, renamed, or carries a non-positive total", type.token(), docArtifactDir, total);
+        return null;
+    }
+
     /** One page's bytes, or null when the page is out of range or its payload is missing. */
     public byte[] page(Path docArtifactDir, ArtifactType type, ManifestEntry entry, int page, String extension) throws IOException {
-        Integer total = entry.total();
+        Integer total = servableTotal(docArtifactDir, type, entry);
         if (total == null || page < 1 || page > total) {
             return null;
         }
@@ -64,7 +82,7 @@ public class ArtifactReader {
 
     /** Which extensions are actually on disk, in the candidate order given. Probes per scheme,
      *  because the two schemes keep an extension in different files. */
-    public List<String> formats(Path docArtifactDir, ArtifactType type, ManifestEntry entry, List<String> candidates) {
+    public List<String> formats(Path docArtifactDir, ArtifactType type, ManifestEntry entry, Collection<String> candidates) {
         boolean byteRanges = isByteRanges(entry);
         return candidates.stream()
                 .filter(extension -> Files.isReadable(byteRanges

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.artifact;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,9 +24,18 @@ public class ArtifactReader {
     }
 
     /** The type's entry when it exists and is servable, else null. Callers map null to 404 and
-     *  never inspect status themselves, so "servable" has one definition. */
+     *  never inspect status themselves, so "servable" has one definition. A corrupt manifest.json
+     *  (bad syntax, or an unrecognised status) is not servable either: manifest.json is written by
+     *  other producers, including datashare-python, so this is the boundary where a malformed one
+     *  reads as "not found" rather than propagating as a 500 to whoever asks for a serving read. */
     public ManifestEntry servableEntry(Path docArtifactDir, ArtifactType type) throws IOException {
-        ManifestEntry entry = manifests.get(docArtifactDir, type.token());
+        ManifestEntry entry;
+        try {
+            entry = manifests.get(docArtifactDir, type.token());
+        } catch (JsonProcessingException malformed) {
+            LOGGER.warn("ignoring unreadable manifest for '{}' in {}", type.token(), docArtifactDir, malformed);
+            return null;
+        }
         return entry != null && entry.isComplete() ? entry : null;
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
@@ -1,11 +1,14 @@
 package org.icij.datashare.text.artifact;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.MapMaker;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -23,6 +26,7 @@ import static java.nio.file.StandardOpenOption.WRITE;
 /** Filesystem-backed manifest persistence. Writes are concurrency-safe (in-JVM ReentrantLock +
  *  cross-process FileLock) and atomic (temp + ATOMIC_MOVE). */
 public class FilesystemManifestRepository implements ManifestRepository {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilesystemManifestRepository.class);
     private static final String LOCK_FILE = ArtifactPath.MANIFEST_FILE + ".lock";
     private static final long LOCK_TIMEOUT_MS = 30_000;
     private static final ObjectMapper MAPPER = JsonObjectMapper.getMapper();
@@ -40,11 +44,18 @@ public class FilesystemManifestRepository implements ManifestRepository {
         if (!Files.exists(manifest)) {
             return null;
         }
-        // Read as a tree, then convert the one type asked for: datashare-python owns other types in the
-        // same file and writes fields ManifestEntry does not model, and a round-trip through the record
-        // destroyed them (a docling payload's byte offsets are the only copy there is).
-        JsonNode entry = read(manifest).get(type);
-        return entry == null ? null : MAPPER.treeToValue(entry, ManifestEntry.class);
+        try {
+            // Read as a tree, then convert the one type asked for: datashare-python owns other types in the
+            // same file and writes fields ManifestEntry does not model, and a round-trip through the record
+            // destroyed them (a docling payload's byte offsets are the only copy there is).
+            JsonNode entry = read(manifest).get(type);
+            return entry == null ? null : MAPPER.treeToValue(entry, ManifestEntry.class);
+        } catch (JsonProcessingException malformed) {
+            // manifest.json is written by other producers, including datashare-python: a corrupt
+            // one (bad syntax or an unrecognised status) is not servable, whoever asks for it.
+            LOGGER.warn("ignoring unreadable manifest at {}", manifest, malformed);
+            return null;
+        }
     }
 
     @Override

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
@@ -1,14 +1,11 @@
 package org.icij.datashare.text.artifact;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.MapMaker;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -26,7 +23,6 @@ import static java.nio.file.StandardOpenOption.WRITE;
 /** Filesystem-backed manifest persistence. Writes are concurrency-safe (in-JVM ReentrantLock +
  *  cross-process FileLock) and atomic (temp + ATOMIC_MOVE). */
 public class FilesystemManifestRepository implements ManifestRepository {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FilesystemManifestRepository.class);
     private static final String LOCK_FILE = ArtifactPath.MANIFEST_FILE + ".lock";
     private static final long LOCK_TIMEOUT_MS = 30_000;
     private static final ObjectMapper MAPPER = JsonObjectMapper.getMapper();
@@ -44,18 +40,11 @@ public class FilesystemManifestRepository implements ManifestRepository {
         if (!Files.exists(manifest)) {
             return null;
         }
-        try {
-            // Read as a tree, then convert the one type asked for: datashare-python owns other types in the
-            // same file and writes fields ManifestEntry does not model, and a round-trip through the record
-            // destroyed them (a docling payload's byte offsets are the only copy there is).
-            JsonNode entry = read(manifest).get(type);
-            return entry == null ? null : MAPPER.treeToValue(entry, ManifestEntry.class);
-        } catch (JsonProcessingException malformed) {
-            // manifest.json is written by other producers, including datashare-python: a corrupt
-            // one (bad syntax or an unrecognised status) is not servable, whoever asks for it.
-            LOGGER.warn("ignoring unreadable manifest at {}", manifest, malformed);
-            return null;
-        }
+        // Read as a tree, then convert the one type asked for: datashare-python owns other types in the
+        // same file and writes fields ManifestEntry does not model, and a round-trip through the record
+        // destroyed them (a docling payload's byte offsets are the only copy there is).
+        JsonNode entry = read(manifest).get(type);
+        return entry == null ? null : MAPPER.treeToValue(entry, ManifestEntry.class);
     }
 
     @Override

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/FilesystemManifestRepository.java
@@ -2,6 +2,7 @@ package org.icij.datashare.text.artifact;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.MapMaker;
 import org.icij.datashare.json.JsonObjectMapper;
@@ -107,7 +108,9 @@ public class FilesystemManifestRepository implements ManifestRepository {
     private ObjectNode read(Path manifest) throws IOException {
         JsonNode root = MAPPER.readTree(Files.readAllBytes(manifest));
         if (!root.isObject()) {
-            throw new IOException(manifest + " is not a JSON object");
+            // A JsonProcessingException like the one bad syntax raises, so a reader telling corrupt
+            // manifests apart from real IO failures catches this shape too instead of 500ing on it.
+            throw MismatchedInputException.from(null, ObjectNode.class, manifest + " is not a JSON object");
         }
         return (ObjectNode) root;
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -235,7 +235,7 @@ public class PageArtifact implements Artifact {
     // [start, end), contiguous, first start 0, last end == length.
     private static List<long[]> writePages(ArtifactContext context, List<String> pages) throws IOException {
         List<long[]> ranges = new ArrayList<>();
-        AtomicDirectorySwap.replace(ArtifactPath.pagesDir(context.docArtifactDir()), staging -> {
+        AtomicDirectorySwap.replace(ArtifactPath.payloadDir(context.docArtifactDir(), TYPE), staging -> {
             long offset = 0;
             try (OutputStream out = Files.newOutputStream(staging.resolve(ArtifactPath.PAGES_CONTENT_FILE))) {
                 for (String page : pages) {
@@ -253,7 +253,7 @@ public class PageArtifact implements Artifact {
     // still served by any reader that lists the directory. The whole pages/ dir, since content.txt is
     // all it holds.
     private static void discardPayload(Path docArtifactDir) {
-        AtomicDirectorySwap.discard(ArtifactPath.pagesDir(docArtifactDir));
+        AtomicDirectorySwap.discard(ArtifactPath.payloadDir(docArtifactDir, TYPE));
     }
 
     private boolean ocrEnabled() {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
@@ -134,7 +134,7 @@ public class StructureArtifact implements Artifact {
     // document's artifact dir on the way: with raw out of the selection nothing else creates it, so an
     // ARTIFACT run over a fresh artifactDir would otherwise fail on every document.
     static void writePages(Path docArtifactDir, List<Page> pages) throws IOException {
-        AtomicDirectorySwap.replace(ArtifactPath.structureDir(docArtifactDir), staging -> {
+        AtomicDirectorySwap.replace(ArtifactPath.payloadDir(docArtifactDir, TYPE), staging -> {
             for (int index = 0; index < pages.size(); index++) {
                 write(staging, index + 1, pages.get(index));
             }
@@ -144,7 +144,7 @@ public class StructureArtifact implements Artifact {
     // Losing the payload is the point: it is regenerable, and one the manifest does not account for is
     // still served by any reader that lists the directory.
     private static void discardPayload(Path docArtifactDir) {
-        AtomicDirectorySwap.discard(ArtifactPath.structureDir(docArtifactDir));
+        AtomicDirectorySwap.discard(ArtifactPath.payloadDir(docArtifactDir, TYPE));
     }
 
     private static void write(Path pagesDir, int pageNumber, Page page) throws IOException {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
+import org.icij.datashare.text.artifact.ArtifactType;
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -31,17 +32,22 @@ public class ArtifactPath {
         return dir(projectRoot, digest).resolve(MANIFEST_FILE);
     }
 
-    /** The structure artifact's own directory: one file per page and per format. */
-    public static Path structureDir(Path docArtifactDir) {
-        return docArtifactDir.resolve(STRUCTURE_DIR);
+    /** Payload subdirectory for a paginated type: one file per page and per format. */
+    public static Path payloadDir(Path docArtifactDir, ArtifactType type) {
+        return docArtifactDir.resolve(payloadDirName(type));
     }
 
-    /** {@code page-%d.<extension>}, 1-based, as the convention's filesystem pagination requires. */
-    public static Path structurePage(Path docArtifactDir, int page, String extension) {
-        return structureDir(docArtifactDir).resolve(pageFilename(page, extension));
+    /** One page file of a filesystem-paginated payload, 1-based. */
+    public static Path payloadPage(Path docArtifactDir, ArtifactType type, int page, String extension) {
+        return payloadDir(docArtifactDir, type).resolve(pageFilename(page, extension));
     }
 
-    /** Just the filename, for a caller writing pages under a directory other than the final structure/
+    /** The single file a byte-ranges-paginated payload slices pages out of. */
+    public static Path payloadContent(Path docArtifactDir, ArtifactType type, String extension) {
+        return payloadDir(docArtifactDir, type).resolve("content." + extension);
+    }
+
+    /** Just the filename, for a caller writing pages under a directory other than the final payload
      *  one (the producer's atomic-swap temp directory). Unpadded, so a reader formats the name from a
      *  page number without knowing a width. {@link Locale#ROOT} so the default locale cannot decide the
      *  digits: with LANG=ar_EG.UTF-8 it would write page-١٢.md. */
@@ -49,14 +55,12 @@ public class ArtifactPath {
         return String.format(Locale.ROOT, "page-%d.%s", page, extension);
     }
 
-    /** The page artifact's own directory. */
-    public static Path pagesDir(Path docArtifactDir) {
-        return docArtifactDir.resolve(PAGES_DIR);
-    }
-
-    /** The single payload file of the byte-ranges scheme, whose per-page offsets live in the
-     *  manifest entry instead of in file names. The extension is fixed by the type: page is text. */
-    public static Path pagesContent(Path docArtifactDir) {
-        return pagesDir(docArtifactDir).resolve(PAGES_CONTENT_FILE);
+    private static String payloadDirName(ArtifactType type) {
+        return switch (type) {
+            case PAGE -> PAGES_DIR;
+            case STRUCTURE -> STRUCTURE_DIR;
+            // raw is a single file next to manifest.json (extract-lib owns that name), not a directory.
+            case RAW -> throw new IllegalArgumentException("artifact type 'raw' has no payload directory");
+        };
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -70,8 +70,8 @@ public class ArtifactPayloadTest {
     @Test
     public void test_structure_payload_missing_the_last_page_it_advertises_is_missing() throws Exception {
         // AtomicDirectorySwap.discard deletes page by page, so the directory can survive holding a subset.
-        Files.createDirectories(ArtifactPath.structureDir(docDir()));
-        Files.writeString(ArtifactPath.structurePage(docDir(), 1, "md"), "# Title");
+        Files.createDirectories(ArtifactPath.payloadDir(docDir(), ArtifactType.STRUCTURE));
+        Files.writeString(ArtifactPath.payloadPage(docDir(), ArtifactType.STRUCTURE, 1, "md"), "# Title");
 
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
                 ManifestEntry.paginated(TASK_INPUT, 2).withTerminalStatus())).isTrue();
@@ -80,7 +80,7 @@ public class ArtifactPayloadTest {
     @Test
     public void test_a_structure_entry_advertising_no_page_count_falls_back_to_its_directory() throws Exception {
         // A Python producer writes manifest.json too, so the count can be absent or nonsensical.
-        Files.createDirectories(ArtifactPath.structureDir(docDir()));
+        Files.createDirectories(ArtifactPath.payloadDir(docDir(), ArtifactType.STRUCTURE));
 
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
                 ManifestEntry.singleFile(TASK_INPUT, "text/markdown", "page-1.md").withTerminalStatus())).isFalse();
@@ -88,9 +88,9 @@ public class ArtifactPayloadTest {
 
     @Test
     public void test_structure_payload_dir_holding_the_pages_it_advertises_is_not_missing() throws Exception {
-        Files.createDirectories(ArtifactPath.structureDir(docDir()));
-        Files.writeString(ArtifactPath.structurePage(docDir(), 1, "md"), "# Title");
-        Files.writeString(ArtifactPath.structurePage(docDir(), 2, "md"), "# Second");
+        Files.createDirectories(ArtifactPath.payloadDir(docDir(), ArtifactType.STRUCTURE));
+        Files.writeString(ArtifactPath.payloadPage(docDir(), ArtifactType.STRUCTURE, 1, "md"), "# Title");
+        Files.writeString(ArtifactPath.payloadPage(docDir(), ArtifactType.STRUCTURE, 2, "md"), "# Second");
 
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
                 ManifestEntry.paginated(TASK_INPUT, 2).withTerminalStatus())).isFalse();

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
@@ -51,8 +51,8 @@ public class ArtifactProducerTest {
                     Files.write(docArtifactDir.resolve(ArtifactPath.RAW_FILE), new byte[]{1});
                     Files.write(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE), "{}".getBytes());
                 } else {
-                    Files.createDirectories(ArtifactPath.structureDir(docArtifactDir));
-                    Files.writeString(ArtifactPath.structurePage(docArtifactDir, 1, "md"), "page");
+                    Files.createDirectories(ArtifactPath.payloadDir(docArtifactDir, ArtifactType.STRUCTURE));
+                    Files.writeString(ArtifactPath.payloadPage(docArtifactDir, ArtifactType.STRUCTURE, 1, "md"), "page");
                 }
             } catch (IOException cannotWrite) {
                 throw new ArtifactException("cannot write the fake payload", cannotWrite);
@@ -97,7 +97,7 @@ public class ArtifactProducerTest {
         // A payload gone from under a complete entry must be repaired by a plain re-run, not skipped (#2300).
         CountingArtifact structure = new CountingArtifact("structure", 1);
         producer.run(List.of(structure), ctx(), false);
-        AtomicDirectorySwap.discard(ArtifactPath.structureDir(dir.getRoot().toPath()));
+        AtomicDirectorySwap.discard(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE));
 
         producer.run(List.of(structure), ctx(), false);
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -138,4 +138,62 @@ public class ArtifactReaderTest {
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("md", "txt"))).containsExactly("txt");
     }
+
+    @Test
+    public void test_page_is_null_when_range_has_negative_start() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{-1, 5});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_range_is_inverted() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{9, 4});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_range_exceeds_max_int_size() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{0, (long) Integer.MAX_VALUE + 1});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_returns_empty_slice_for_zero_length_range() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{4, 4});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        byte[] result = reader.page(node, ArtifactType.PAGE, entry, 1, "txt");
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void test_page_is_null_when_manifest_advertises_more_ranges_than_exist() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{0, 7});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        // Manifest says 3 pages but only 1 range exists; request page 2
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 2, "txt")).isNull();
+    }
+
+    @Test
+    public void test_formats_preserves_candidate_order() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
+        Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "content");
+        Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "md"), "content");
+        manifests.put(node, ArtifactType.PAGE.token(),
+                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(1, List.of(new long[]{0, 7})))
+                        .withStatus(ManifestEntryStatus.COMPLETE));
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("md", "txt"))).containsExactly("md", "txt");
+        assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("txt", "md"))).containsExactly("txt", "md");
+    }
+
+    @Test
+    public void test_formats_returns_empty_list_when_no_candidates_are_present() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{0, 7});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("md", "html"))).isEmpty();
+    }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -89,6 +89,19 @@ public class ArtifactReaderTest {
     }
 
     @Test
+    public void test_nothing_is_servable_when_the_pagination_block_has_no_total() throws Exception {
+        Path node = dir.getRoot().toPath();
+        // Pagination.total is a primitive, so an absent total deserializes to 0, not to null: the
+        // entry is complete but the manifest is malformed, which the strict store reads as absent.
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE),
+                "{\"page\": {\"status\": \"complete\", \"taskInput\": {}, \"pagination\": {\"type\": \"filesystem\"}}}");
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(entry).isNotNull();
+        assertThat(reader.servableTotal(node, ArtifactType.PAGE, entry)).isNull();
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
     public void test_page_reads_the_filesystem_page() throws Exception {
         Path node = withFilesystemPages(2, "page one", "page two");
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -58,6 +58,22 @@ public class ArtifactReaderTest {
     }
 
     @Test
+    public void test_servable_entry_is_null_when_manifest_json_is_malformed() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(node);
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE), "{not valid json");
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE)).isNull();
+    }
+
+    @Test
+    public void test_servable_entry_is_null_when_status_is_unknown() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(node);
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE), "{\"page\": {\"status\": \"bogus\", \"taskInput\": {}}}");
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE)).isNull();
+    }
+
+    @Test
     public void test_servable_entry_is_null_when_status_absent() throws Exception {
         Path node = dir.getRoot().toPath();
         manifests.put(node, ArtifactType.PAGE.token(), ManifestEntry.paginated(Map.of(), Pagination.filesystem(2)));

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -303,11 +303,4 @@ public class ArtifactReaderTest {
         assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("md", "txt"))).containsExactly("md", "txt");
         assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("txt", "md"))).containsExactly("txt", "md");
     }
-
-    @Test
-    public void test_formats_returns_empty_list_when_no_candidates_are_present() throws Exception {
-        Path node = withByteRanges("content", "txt", new long[]{0, 7});
-        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
-        assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("md", "html"))).isEmpty();
-    }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -75,6 +75,14 @@ public class ArtifactReaderTest {
     }
 
     @Test
+    public void test_servable_entry_is_null_when_manifest_json_is_not_an_object() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(node);
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE), "[]");
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE)).isNull();
+    }
+
+    @Test
     public void test_servable_entry_is_null_when_status_is_unknown() throws Exception {
         Path node = dir.getRoot().toPath();
         Files.createDirectories(node);

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -20,6 +20,13 @@ public class ArtifactReaderTest {
     private final ManifestRepository manifests = new FilesystemManifestRepository();
     private final ArtifactReader reader = new ArtifactReader(manifests);
 
+    // Nothing in Java writes the byte-range scheme (see ByteRangePagination), so there is no
+    // production factory for it: the read side is exercised from a hand-built entry.
+    private static ManifestEntry byteRangeEntry(int total, List<long[]> ranges) {
+        Pages pages = new Pages(total, new ByteRangePagination(ByteRangePagination.TYPE, ranges));
+        return new ManifestEntry(null, Map.of(), pages, null, null, null, null);
+    }
+
     private Path withFilesystemPages(int total, String... pages) throws Exception {
         Path node = dir.getRoot().toPath();
         Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
@@ -27,7 +34,7 @@ public class ArtifactReaderTest {
             Files.writeString(ArtifactPath.payloadPage(node, ArtifactType.PAGE, page, "txt"), pages[page - 1]);
         }
         manifests.put(node, ArtifactType.PAGE.token(),
-                ManifestEntry.paginated(Map.of(), Pagination.filesystem(total)).withStatus(ManifestEntryStatus.COMPLETE));
+                ManifestEntry.paginated(Map.of(), total).withStatus(ManifestEntryStatus.COMPLETE));
         return node;
     }
 
@@ -36,7 +43,7 @@ public class ArtifactReaderTest {
         Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
         Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, extension), content);
         manifests.put(node, ArtifactType.PAGE.token(),
-                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(ranges.length, List.of(ranges)))
+                byteRangeEntry(ranges.length, List.of(ranges))
                         .withStatus(ManifestEntryStatus.COMPLETE));
         return node;
     }
@@ -76,25 +83,37 @@ public class ArtifactReaderTest {
     }
 
     @Test
+    public void test_servable_entry_is_null_when_the_pagination_scheme_is_unknown() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(node);
+        // Pagination is sealed over the two schemes datashare knows, so a producer advertising a
+        // third one fails to deserialize: that reads as "not found", not as a 500 for the caller.
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE), "{\"page\": {\"status\": \"complete\", "
+                + "\"taskInput\": {}, \"pages\": {\"total\": 1, \"pagination\": {\"type\": \"sqlite\"}}}}");
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE)).isNull();
+    }
+
+    @Test
     public void test_servable_entry_is_null_when_status_absent() throws Exception {
         Path node = dir.getRoot().toPath();
-        manifests.put(node, ArtifactType.PAGE.token(), ManifestEntry.paginated(Map.of(), Pagination.filesystem(2)));
+        manifests.put(node, ArtifactType.PAGE.token(), ManifestEntry.paginated(Map.of(), 2));
         assertThat(reader.servableEntry(node, ArtifactType.PAGE)).isNull();
     }
 
     @Test
     public void test_servable_entry_carries_the_total() throws Exception {
         Path node = withFilesystemPages(2, "one", "two");
-        assertThat(reader.servableEntry(node, ArtifactType.PAGE).total()).isEqualTo(2);
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE).pages().total()).isEqualTo(2);
     }
 
     @Test
-    public void test_nothing_is_servable_when_the_pagination_block_has_no_total() throws Exception {
+    public void test_nothing_is_servable_when_the_pages_block_has_no_total() throws Exception {
         Path node = dir.getRoot().toPath();
-        // Pagination.total is a primitive, so an absent total deserializes to 0, not to null: the
+        // Pages.total is a primitive, so an absent total deserializes to 0, not to null: the
         // entry is complete but the manifest is malformed, which the strict store reads as absent.
         Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE),
-                "{\"page\": {\"status\": \"complete\", \"taskInput\": {}, \"pagination\": {\"type\": \"filesystem\"}}}");
+                "{\"page\": {\"status\": \"complete\", \"taskInput\": {}, "
+                        + "\"pages\": {\"pagination\": {\"type\": \"filesystem\"}}}}");
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(entry).isNotNull();
         assertThat(reader.servableTotal(node, ArtifactType.PAGE, entry)).isNull();
@@ -122,7 +141,7 @@ public class ArtifactReaderTest {
         // must 404 rather than the count shrinking on every request.
         Path node = withFilesystemPages(3, "one", "two");
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
-        assertThat(entry.total()).isEqualTo(3);
+        assertThat(entry.pages().total()).isEqualTo(3);
         assertThat(reader.page(node, ArtifactType.PAGE, entry, 3, "txt")).isNull();
     }
 
@@ -239,7 +258,7 @@ public class ArtifactReaderTest {
         Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "01234567");
         // total=3 with only 2 ranges: page 3 passes page > total guard but fails ranges.size() < page
         manifests.put(node, ArtifactType.PAGE.token(),
-                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(3, List.of(new long[]{0, 4}, new long[]{4, 8})))
+                byteRangeEntry(3, List.of(new long[]{0, 4}, new long[]{4, 8}))
                         .withStatus(ManifestEntryStatus.COMPLETE));
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(reader.page(node, ArtifactType.PAGE, entry, 3, "txt")).isNull();
@@ -252,7 +271,7 @@ public class ArtifactReaderTest {
         Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "content");
         // Entry with type="byteRanges" but null byteRanges list (legitimately deserialized when field absent)
         manifests.put(node, ArtifactType.PAGE.token(),
-                ManifestEntry.paginated(Map.of(), new Pagination("byteRanges", 1, null))
+                byteRangeEntry(1, null)
                         .withStatus(ManifestEntryStatus.COMPLETE));
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
@@ -265,7 +284,7 @@ public class ArtifactReaderTest {
         Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "content");
         // Range with length 1 instead of 2
         manifests.put(node, ArtifactType.PAGE.token(),
-                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(1, List.of(new long[]{0})))
+                byteRangeEntry(1, List.of(new long[]{0}))
                         .withStatus(ManifestEntryStatus.COMPLETE));
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
@@ -278,7 +297,7 @@ public class ArtifactReaderTest {
         Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "content");
         Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "md"), "content");
         manifests.put(node, ArtifactType.PAGE.token(),
-                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(1, List.of(new long[]{0, 7})))
+                byteRangeEntry(1, List.of(new long[]{0, 7}))
                         .withStatus(ManifestEntryStatus.COMPLETE));
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("md", "txt"))).containsExactly("md", "txt");

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -8,6 +8,7 @@ import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -25,6 +26,16 @@ public class ArtifactReaderTest {
         }
         manifests.put(node, ArtifactType.PAGE.token(),
                 ManifestEntry.paginated(Map.of(), Pagination.filesystem(total)).withStatus(ManifestEntryStatus.COMPLETE));
+        return node;
+    }
+
+    private Path withByteRanges(String content, String extension, long[]... ranges) throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
+        Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, extension), content);
+        manifests.put(node, ArtifactType.PAGE.token(),
+                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(ranges.length, List.of(ranges)))
+                        .withStatus(ManifestEntryStatus.COMPLETE));
         return node;
     }
 
@@ -89,5 +100,42 @@ public class ArtifactReaderTest {
         Path node = withFilesystemPages(1, "one");
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "md")).isNull();
+    }
+
+    @Test
+    public void test_page_reads_a_byte_range_slice() throws Exception {
+        Path node = withByteRanges("page onepage two", "txt", new long[]{0, 8}, new long[]{8, 16});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(new String(reader.page(node, ArtifactType.PAGE, entry, 1, "txt"), StandardCharsets.UTF_8)).isEqualTo("page one");
+        assertThat(new String(reader.page(node, ArtifactType.PAGE, entry, 2, "txt"), StandardCharsets.UTF_8)).isEqualTo("page two");
+    }
+
+    @Test
+    public void test_page_is_null_when_a_range_runs_past_end_of_file() throws Exception {
+        Path node = withByteRanges("short", "txt", new long[]{0, 5}, new long[]{5, 99});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 2, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_the_content_file_is_missing() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{0, 7});
+        Files.delete(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"));
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
+    public void test_formats_probes_page_one_under_filesystem_pagination() throws Exception {
+        Path node = withFilesystemPages(1, "one");
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("txt", "md"))).containsExactly("txt");
+    }
+
+    @Test
+    public void test_formats_probes_the_content_file_under_byte_ranges() throws Exception {
+        Path node = withByteRanges("content", "txt", new long[]{0, 7});
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("md", "txt"))).containsExactly("txt");
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -169,11 +169,42 @@ public class ArtifactReaderTest {
     }
 
     @Test
-    public void test_page_is_null_when_manifest_advertises_more_ranges_than_exist() throws Exception {
-        Path node = withByteRanges("content", "txt", new long[]{0, 7});
+    public void test_page_is_null_when_total_exceeds_range_list_size() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
+        Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "01234567");
+        // total=3 with only 2 ranges: page 3 passes page > total guard but fails ranges.size() < page
+        manifests.put(node, ArtifactType.PAGE.token(),
+                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(3, List.of(new long[]{0, 4}, new long[]{4, 8})))
+                        .withStatus(ManifestEntryStatus.COMPLETE));
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
-        // Manifest says 3 pages but only 1 range exists; request page 2
-        assertThat(reader.page(node, ArtifactType.PAGE, entry, 2, "txt")).isNull();
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 3, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_byte_ranges_list_is_null() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
+        Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "content");
+        // Entry with type="byteRanges" but null byteRanges list (legitimately deserialized when field absent)
+        manifests.put(node, ArtifactType.PAGE.token(),
+                ManifestEntry.paginated(Map.of(), new Pagination("byteRanges", 1, null))
+                        .withStatus(ManifestEntryStatus.COMPLETE));
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_range_is_malformed_wrong_length() throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
+        Files.writeString(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"), "content");
+        // Range with length 1 instead of 2
+        manifests.put(node, ArtifactType.PAGE.token(),
+                ManifestEntry.paginated(Map.of(), Pagination.byteRanges(1, List.of(new long[]{0})))
+                        .withStatus(ManifestEntryStatus.COMPLETE));
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -1,0 +1,93 @@
+package org.icij.datashare.text.artifact;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ArtifactReaderTest {
+    @Rule public TemporaryFolder dir = new TemporaryFolder();
+    private final ManifestRepository manifests = new FilesystemManifestRepository();
+    private final ArtifactReader reader = new ArtifactReader(manifests);
+
+    private Path withFilesystemPages(int total, String... pages) throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.PAGE));
+        for (int page = 1; page <= pages.length; page++) {
+            Files.writeString(ArtifactPath.payloadPage(node, ArtifactType.PAGE, page, "txt"), pages[page - 1]);
+        }
+        manifests.put(node, ArtifactType.PAGE.token(),
+                ManifestEntry.paginated(Map.of(), Pagination.filesystem(total)).withStatus(ManifestEntryStatus.COMPLETE));
+        return node;
+    }
+
+    @Test
+    public void test_servable_entry_is_null_when_no_manifest() throws Exception {
+        assertThat(reader.servableEntry(dir.getRoot().toPath(), ArtifactType.PAGE)).isNull();
+    }
+
+    @Test
+    public void test_servable_entry_is_null_for_another_type() throws Exception {
+        Path node = withFilesystemPages(1, "page one");
+        assertThat(reader.servableEntry(node, ArtifactType.STRUCTURE)).isNull();
+    }
+
+    @Test
+    public void test_servable_entry_is_null_when_empty_status() throws Exception {
+        Path node = dir.getRoot().toPath();
+        manifests.put(node, ArtifactType.PAGE.token(), ManifestEntry.empty(Map.of()));
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE)).isNull();
+    }
+
+    @Test
+    public void test_servable_entry_is_null_when_status_absent() throws Exception {
+        Path node = dir.getRoot().toPath();
+        manifests.put(node, ArtifactType.PAGE.token(), ManifestEntry.paginated(Map.of(), Pagination.filesystem(2)));
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE)).isNull();
+    }
+
+    @Test
+    public void test_servable_entry_carries_the_total() throws Exception {
+        Path node = withFilesystemPages(2, "one", "two");
+        assertThat(reader.servableEntry(node, ArtifactType.PAGE).total()).isEqualTo(2);
+    }
+
+    @Test
+    public void test_page_reads_the_filesystem_page() throws Exception {
+        Path node = withFilesystemPages(2, "page one", "page two");
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(new String(reader.page(node, ArtifactType.PAGE, entry, 2, "txt"), StandardCharsets.UTF_8)).isEqualTo("page two");
+    }
+
+    @Test
+    public void test_page_is_null_out_of_range() throws Exception {
+        Path node = withFilesystemPages(2, "one", "two");
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 0, "txt")).isNull();
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 3, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_the_file_is_missing() throws Exception {
+        // total says 3, only 2 files exist: the manifest is authoritative for the count, so page 3
+        // must 404 rather than the count shrinking on every request.
+        Path node = withFilesystemPages(3, "one", "two");
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(entry.total()).isEqualTo(3);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 3, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_extension_does_not_exist() throws Exception {
+        Path node = withFilesystemPages(1, "one");
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "md")).isNull();
+    }
+}

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -10,8 +10,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 public class ArtifactReaderTest {
     @Rule public TemporaryFolder dir = new TemporaryFolder();
@@ -139,6 +141,39 @@ public class ArtifactReaderTest {
         Files.delete(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"));
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
         assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    // Payloads are written by whichever process produced them, sometimes 0600 under another uid,
+    // so an unreadable payload must read as "not found" instead of throwing an IOException the
+    // serving side would turn into a 500.
+    private void assumeUnreadable(Path file) throws Exception {
+        Files.setPosixFilePermissions(file, Set.of());
+        // Skipped rather than asserted when the test uid reads a mode-000 file anyway (root).
+        assumeTrue(!Files.isReadable(file));
+    }
+
+    @Test
+    public void test_page_is_null_when_the_filesystem_page_is_unreadable() throws Exception {
+        Path node = withFilesystemPages(1, "page one");
+        assumeUnreadable(ArtifactPath.payloadPage(node, ArtifactType.PAGE, 1, "txt"));
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
+    public void test_page_is_null_when_the_byte_ranges_content_is_unreadable() throws Exception {
+        Path node = withByteRanges("page one", "txt", new long[]{0, 8});
+        assumeUnreadable(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt"));
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
+    public void test_formats_omits_an_unreadable_payload() throws Exception {
+        Path node = withFilesystemPages(1, "one");
+        assumeUnreadable(ArtifactPath.payloadPage(node, ArtifactType.PAGE, 1, "txt"));
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.formats(node, ArtifactType.PAGE, entry, List.of("txt"))).isEmpty();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -175,7 +175,7 @@ public class PageArtifactTest {
     }
 
     private Path contentTxt(ArtifactContext context) {
-        return ArtifactPath.pagesContent(context.docArtifactDir());
+        return ArtifactPath.payloadContent(context.docArtifactDir(), ArtifactType.PAGE, "txt");
     }
 
     @Test
@@ -185,7 +185,7 @@ public class PageArtifactTest {
         new PageArtifact(new PropertiesProvider()).produce(context);
 
         assertThat(Files.readString(contentTxt(context))).contains(ACCENTED_PAGE).contains("Page two text");
-        assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
+        assertThat(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE).toFile().list())
                 .isEqualTo(new String[]{"content.txt"});
     }
 
@@ -199,7 +199,7 @@ public class PageArtifactTest {
 
         new PageArtifact(new PropertiesProvider()).produce(context);
 
-        Path control = ArtifactPath.pagesDir(context.docArtifactDir()).resolve("control");
+        Path control = ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE).resolve("control");
         Files.write(control, new byte[0]);
         assertThat(Files.getPosixFilePermissions(contentTxt(context)))
                 .isEqualTo(Files.getPosixFilePermissions(control));
@@ -286,7 +286,7 @@ public class PageArtifactTest {
         } catch (ArtifactException expected) {
             assertThat(expected.getMessage()).contains(doc.getId());
         }
-        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        assertThat(Files.exists(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE))).isFalse();
         verify(sources).getSource(project, doc);
     }
 
@@ -309,7 +309,7 @@ public class PageArtifactTest {
         } catch (UnreadableContentException expected) {
             assertThat(expected.getMessage()).contains(context.document().getId());
         }
-        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        assertThat(Files.exists(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE))).isFalse();
     }
 
     @Test
@@ -358,7 +358,7 @@ public class PageArtifactTest {
         } catch (ArtifactException expected) {
             assertThat(expected.getMessage()).contains(context.document().getId());
         }
-        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        assertThat(Files.exists(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE))).isFalse();
         verify(sources).getSource(project, context.document());
     }
 
@@ -379,7 +379,7 @@ public class PageArtifactTest {
         } catch (ArtifactException expected) {
             assertThat(expected.getMessage()).contains(context.document().getId());
         }
-        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        assertThat(Files.exists(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE))).isFalse();
         verify(sources).getSource(project, context.document());
     }
 
@@ -395,7 +395,7 @@ public class PageArtifactTest {
         assertThat(entry.isTerminal()).isTrue();
         assertThat(entry.pages()).isNull();
         assertThat(entry.taskInput().get("pipeline")).isEqualTo("tika");
-        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        assertThat(Files.exists(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE))).isFalse();
     }
 
     @Test
@@ -411,7 +411,7 @@ public class PageArtifactTest {
         ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
 
         assertThat(entry.status()).isEqualTo(ManifestEntryStatus.EMPTY);
-        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        assertThat(Files.exists(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE))).isFalse();
     }
 
     @Test
@@ -429,7 +429,7 @@ public class PageArtifactTest {
             new PageArtifact(new PropertiesProvider()).produce(context);
             fail("expected an UnreadableContentException");
         } catch (UnreadableContentException expected) {
-            assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+            assertThat(Files.exists(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE))).isFalse();
         }
     }
 
@@ -585,7 +585,7 @@ public class PageArtifactTest {
         }
 
         assertThat(Files.readAllBytes(contentTxt(good))).isEqualTo(previous);
-        assertThat(ArtifactPath.pagesDir(good.docArtifactDir()).toFile().list())
+        assertThat(ArtifactPath.payloadDir(good.docArtifactDir(), ArtifactType.PAGE).toFile().list())
                 .isEqualTo(new String[]{"content.txt"}); // no .tmp left behind
     }
 
@@ -600,7 +600,7 @@ public class PageArtifactTest {
         new PageArtifact(new PropertiesProvider()).produce(context);
 
         assertThat(Files.readString(contentTxt(context))).contains("Page two text");
-        assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
+        assertThat(ArtifactPath.payloadDir(context.docArtifactDir(), ArtifactType.PAGE).toFile().list())
                 .isEqualTo(new String[]{"content.txt"});
     }
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -72,7 +72,7 @@ public class StructureArtifactTest {
     }
 
     private Path page(int number, String extension) {
-        return ArtifactPath.structurePage(dir.getRoot().toPath(), number, extension);
+        return ArtifactPath.payloadPage(dir.getRoot().toPath(), ArtifactType.STRUCTURE, number, extension);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class StructureArtifactTest {
     }
 
     private List<String> storedPageNames() throws Exception {
-        try (Stream<Path> entries = Files.list(ArtifactPath.structureDir(dir.getRoot().toPath()))) {
+        try (Stream<Path> entries = Files.list(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE))) {
             return entries.map(entry -> entry.getFileName().toString()).sorted().toList();
         }
     }
@@ -174,7 +174,7 @@ public class StructureArtifactTest {
         } catch (ArtifactException expected) {
             // the directory must not be created before the source is known to be readable
         }
-        assertThat(Files.exists(ArtifactPath.structureDir(dir.getRoot().toPath()))).isFalse();
+        assertThat(Files.exists(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE))).isFalse();
     }
 
     @Test
@@ -192,7 +192,7 @@ public class StructureArtifactTest {
             new StructureArtifact().produce(new ArtifactContext(project, broken, dir.getRoot().toPath(), sources));
             org.junit.Assert.fail("expected an UnreadableContentException");
         } catch (UnreadableContentException expected) {
-            assertThat(Files.exists(ArtifactPath.structureDir(dir.getRoot().toPath()))).isFalse();
+            assertThat(Files.exists(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE))).isFalse();
         }
     }
 
@@ -260,7 +260,7 @@ public class StructureArtifactTest {
         ManifestEntry entry = new StructureArtifact().produce(contextFor(HTML, docArtifactDir));
 
         assertThat(entry.pages().total()).isEqualTo(1);
-        assertThat(Files.readString(ArtifactPath.structurePage(docArtifactDir, 1, "md"))).contains("# Title");
+        assertThat(Files.readString(ArtifactPath.payloadPage(docArtifactDir, ArtifactType.STRUCTURE, 1, "md"))).contains("# Title");
     }
 
     // The two cases below go through the real producer loop, which owns the manifest write and
@@ -301,7 +301,7 @@ public class StructureArtifactTest {
         // What a failed AtomicDirectorySwap.restore leaves behind: the only copy of the pages in a holding
         // pen while the target is gone, until now recoverable only by hand (#2300).
         Path pen = dir.getRoot().toPath().resolve(".structure-" + UUID.randomUUID() + ".replaced");
-        Files.move(ArtifactPath.structureDir(dir.getRoot().toPath()), pen);
+        Files.move(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE), pen);
 
         producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPathTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPathTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.text.indexing.elasticsearch;
 
 import org.junit.Test;
+import org.icij.datashare.text.artifact.ArtifactType;
 import java.nio.file.Path;
 import java.util.Locale;
 import static org.fest.assertions.Assertions.assertThat;
@@ -23,21 +24,18 @@ public class ArtifactPathTest {
     }
 
     @Test
-    public void test_structure_dir_is_under_the_node_dir() {
-        Path docDir = ArtifactPath.dir(Path.of("/artifact/prj"), DIGEST);
-        assertThat(ArtifactPath.structureDir(docDir).toString())
-                .isEqualTo("/artifact/prj/6a/bb/" + DIGEST + "/structure");
+    public void test_payload_dir_is_named_per_type() {
+        Path node = Path.of("/artifact/prj/6a/bb/" + DIGEST);
+        assertThat(ArtifactPath.payloadDir(node, ArtifactType.PAGE).toString()).isEqualTo(node + "/pages");
+        assertThat(ArtifactPath.payloadDir(node, ArtifactType.STRUCTURE).toString()).isEqualTo(node + "/structure");
     }
 
     @Test
-    public void test_structure_page_is_one_based_and_unpadded() {
-        Path docDir = ArtifactPath.dir(Path.of("/artifact/prj"), DIGEST);
-        assertThat(ArtifactPath.structurePage(docDir, 1, "md").getFileName().toString())
-                .isEqualTo("page-1.md");
-        assertThat(ArtifactPath.structurePage(docDir, 12, "xhtml").getFileName().toString())
-                .isEqualTo("page-12.xhtml");
-        assertThat(ArtifactPath.structurePage(docDir, 12345, "md").getFileName().toString())
-                .isEqualTo("page-12345.md");
+    public void test_payload_page_is_one_based_and_unpadded() {
+        Path node = Path.of("/artifact/prj/6a/bb/" + DIGEST);
+        assertThat(ArtifactPath.payloadPage(node, ArtifactType.PAGE, 1, "txt").toString()).isEqualTo(node + "/pages/page-1.txt");
+        assertThat(ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, 12, "xhtml").toString()).isEqualTo(node + "/structure/page-12.xhtml");
+        assertThat(ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, 12345, "md").toString()).isEqualTo(node + "/structure/page-12345.md");
     }
 
     @Test
@@ -53,16 +51,13 @@ public class ArtifactPathTest {
     }
 
     @Test
-    public void test_pages_dir_is_under_the_node_dir() {
-        Path docDir = ArtifactPath.dir(Path.of("/artifact/prj"), DIGEST);
-        assertThat(ArtifactPath.pagesDir(docDir).toString())
-                .isEqualTo("/artifact/prj/6a/bb/" + DIGEST + "/pages");
+    public void test_payload_content_is_the_byte_ranges_file() {
+        Path node = Path.of("/artifact/prj/6a/bb/" + DIGEST);
+        assertThat(ArtifactPath.payloadContent(node, ArtifactType.PAGE, "txt").toString()).isEqualTo(node + "/pages/content.txt");
     }
 
-    @Test
-    public void test_pages_content_is_the_single_file_of_the_byte_ranges_scheme() {
-        Path docDir = ArtifactPath.dir(Path.of("/artifact/prj"), DIGEST);
-        assertThat(ArtifactPath.pagesContent(docDir).toString())
-                .isEqualTo("/artifact/prj/6a/bb/" + DIGEST + "/pages/content.txt");
+    @Test(expected = IllegalArgumentException.class)
+    public void test_raw_has_no_payload_dir() {
+        ArtifactPath.payloadDir(Path.of("/artifact/prj/6a/bb/" + DIGEST), ArtifactType.RAW);
     }
 }


### PR DESCRIPTION
Serves per-document artifacts from disk at `/:project/artifacts/<type>/:id`, driven by each document's `manifest.json` under `artifactDir`. Closes #2228.

- feat: add `ArtifactReader`, serving both filesystem and byte-range pagination, with guards for malformed manifests
- feat: add `ArtifactResource` with `raw`, `page` and `structure` routes (`?format=md|xhtml`)
- refactor: extract the source download gate into `DocumentSourceAccess`, shared with `/documents/src`
- refactor: collapse the `structure/` and `pages/` path helpers onto one type-keyed `payloadDir`/`payloadPage`/`payloadContent`
- fix: read pagination through the sealed schemes `ManifestEntry` models, on the unpadded `page-N` names
- docs: deprecate `/documents/content/pages` in favour of the page artifact route

Suggested follow-ups (not in this diff): stream page payloads instead of buffering a `byte[]` bounded only by `Integer.MAX_VALUE`; cache the immutable `COMPLETE` manifest so paging an N-page document is not N Elasticsearch GETs plus N manifest parses; unify the remaining copies of the artifact-dir resolution; add a route-enumerating test so a future route added without a membership gate cannot ship green; decide whether a `pages` block with no `pagination` should read as the convention's single `content.<ext>` rather than falling through to `page-N`; reject a page whose manifest ranges no longer describe the live `content.txt`, the post-swap staleness `PageArtifact` defers to this issue.
