### PR TITLE
feat(artifacts): persist the page artifact on disk

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/text/artifact/ArtifactType.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/artifact/ArtifactType.java
@@ -12,8 +12,9 @@ import java.util.stream.Collectors;
 public enum ArtifactType {
     RAW("raw"),
     STRUCTURE("structure"),
-    // The convention's type table spells this `pages`; the serving routes, the manifest key and this
-    // token are `page`. The doc is what gets fixed (see the spec's follow-ups), not this spelling.
+    // Singular, like the serving routes and the manifest key; the payload directory it writes is the
+    // plural `pages/` (see ArtifactPath.PAGES_DIR), which is the mapping the convention's type table
+    // records.
     PAGE("page");
 
     private final String token;

--- a/datashare-api/src/main/java/org/icij/datashare/text/artifact/ArtifactType.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/artifact/ArtifactType.java
@@ -11,7 +11,10 @@ import java.util.stream.Collectors;
  *  Adding a type is a datashare change, by design (unknown = unsupported). */
 public enum ArtifactType {
     RAW("raw"),
-    STRUCTURE("structure");
+    STRUCTURE("structure"),
+    // The convention's type table spells this `pages`; the serving routes, the manifest key and this
+    // token are `page`. The doc is what gets fixed (see the spec's follow-ups), not this spelling.
+    PAGE("page");
 
     private final String token;
 

--- a/datashare-api/src/main/java/org/icij/datashare/text/artifact/ByteRangePagination.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/artifact/ByteRangePagination.java
@@ -2,8 +2,12 @@ package org.icij.datashare.text.artifact;
 
 import java.util.List;
 
-/** Half-open [start, end) byte offsets into a single content file, one per page. Only
- *  datashare-python writes this scheme, so nothing here builds one: it exists to be read back. */
+/** Half-open [start, end) byte offsets into a single content file, one per page. Written here by the
+ *  page artifact, and by datashare-python's own producers. */
 public record ByteRangePagination(String type, List<long[]> ranges) implements Pagination {
     public static final String TYPE = "byteRanges";
+
+    public ByteRangePagination(List<long[]> ranges) {
+        this(TYPE, ranges);
+    }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.text.artifact;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
 import java.util.Map;
 
 /** One artifact type's entry in a document's manifest.json. Single-file types use
@@ -19,9 +20,16 @@ public record ManifestEntry(
         return new ManifestEntry(null, taskInput, null, contentType, filename, null, null);
     }
 
-    /** A payload split into one file per page, the only scheme Java writes (see {@link Pagination}). */
+    /** A payload split into one file per page (see {@link FilesystemPagination}). */
     public static ManifestEntry paginated(Map<String, Object> taskInput, int total) {
         return new ManifestEntry(null, taskInput, new Pages(total, new FilesystemPagination()), null, null, null, null);
+    }
+
+    /** A single content file split by half-open byte ranges, one per page. `total` is derived from the
+     *  offsets themselves, so a producer cannot record a count that disagrees with the ranges it wrote. */
+    public static ManifestEntry paginated(Map<String, Object> taskInput, List<long[]> ranges) {
+        return new ManifestEntry(null, taskInput, new Pages(ranges.size(), new ByteRangePagination(ranges)),
+                null, null, null, null);
     }
 
     /** A node that was processed but has no payload to serve from its own dir (e.g. a root

--- a/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.artifact;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import java.util.Map;
@@ -54,10 +55,14 @@ public record ManifestEntry(
         return isTerminal() && taskInput.equals(this.taskInput);
     }
 
+    /** Convenience predicate for callers, not part of the stored shape: the convention's entry
+     *  carries `status`, and Jackson would otherwise write this getter as a `complete` field. */
+    @JsonIgnore
     public boolean isComplete() {
         return status != null && status.isServable();
     }
 
+    @JsonIgnore
     public boolean isTerminal() {
         return status != null && status.isTerminal();
     }

--- a/datashare-api/src/test/java/org/icij/datashare/text/artifact/ArtifactTypeTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/artifact/ArtifactTypeTest.java
@@ -40,4 +40,12 @@ public class ArtifactTypeTest {
     public void test_tokens_lists_all_known_types() {
         assertThat(ArtifactType.tokens()).contains("raw").contains("structure");
     }
+
+    @Test
+    public void test_page_token_is_singular_matching_the_serving_route() {
+        assertThat(ArtifactType.PAGE.token()).isEqualTo("page");
+        assertThat(ArtifactType.fromToken("page")).isEqualTo(ArtifactType.PAGE);
+        assertThat(ArtifactType.fromToken(" PAGE ")).isEqualTo(ArtifactType.PAGE);
+        assertThat(ArtifactType.tokens()).contains("page");
+    }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/text/artifact/ManifestEntryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/artifact/ManifestEntryTest.java
@@ -91,4 +91,18 @@ public class ManifestEntryTest {
     public void test_an_entry_with_no_pages_object_has_no_page_attributes() throws Exception {
         assertThat(mapper.readValue("{\"status\":\"complete\"}", ManifestEntry.class).pages()).isNull();
     }
+
+    @Test
+    public void test_convenience_predicates_are_not_serialized() throws Exception {
+        ManifestEntry entry = ManifestEntry.paginated(Map.of("pipeline", "tika"), 2)
+                .withStatus(ManifestEntryStatus.COMPLETE);
+
+        String json = mapper.writeValueAsString(entry);
+
+        // The colon matters: the serialized entry legitimately contains the VALUE "complete" as its
+        // status, so excluding the bare quoted word could never pass. What must be absent is a
+        // FIELD named complete or terminal.
+        assertThat(json).excludes("\"complete\":").excludes("\"terminal\":");
+        assertThat(json).contains("\"status\":\"complete\"");
+    }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/text/artifact/PaginationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/artifact/PaginationTest.java
@@ -27,8 +27,9 @@ public class PaginationTest {
 
     @Test
     public void test_byte_ranges_pagination_written_by_another_producer_is_readable() throws Exception {
-        // datashare-python writes this scheme too, from its own producers: an entry it wrote must read
-        // back here with the same page count and offsets.
+        // `ranges` is the `byteRanges` pagination shape from the storage convention (docs repo
+        // document-artifacts-convention.md), which datashare-python writes from its own producers: an
+        // entry it wrote must read back here with the same page count and offsets.
         ManifestEntry read = mapper.readValue("{\"status\":\"complete\",\"pages\":{\"total\":2,"
                 + "\"pagination\":{\"type\":\"byteRanges\",\"ranges\":[[0,10],[10,20]]}}}", ManifestEntry.class);
 

--- a/datashare-api/src/test/java/org/icij/datashare/text/artifact/PaginationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/artifact/PaginationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -26,7 +27,8 @@ public class PaginationTest {
 
     @Test
     public void test_byte_ranges_pagination_written_by_another_producer_is_readable() throws Exception {
-        // The only reason ByteRangePagination exists: nothing in Java writes that scheme.
+        // datashare-python writes this scheme too, from its own producers: an entry it wrote must read
+        // back here with the same page count and offsets.
         ManifestEntry read = mapper.readValue("{\"status\":\"complete\",\"pages\":{\"total\":2,"
                 + "\"pagination\":{\"type\":\"byteRanges\",\"ranges\":[[0,10],[10,20]]}}}", ManifestEntry.class);
 
@@ -40,5 +42,22 @@ public class PaginationTest {
         Pagination read = mapper.readValue(mapper.writeValueAsString(new FilesystemPagination()), Pagination.class);
         assertThat(read).isInstanceOf(FilesystemPagination.class);
         assertThat(read.type()).isEqualTo("filesystem");
+    }
+
+    @Test
+    public void test_a_byte_ranges_entry_serializes_as_the_convention_shape() throws Exception {
+        String json = mapper.writeValueAsString(ManifestEntry.paginated(Map.of("pipeline", "tika"),
+                List.of(new long[]{0, 125}, new long[]{125, 400})));
+
+        assertThat(json).contains(
+                "\"pages\":{\"total\":2,\"pagination\":{\"type\":\"byteRanges\",\"ranges\":[[0,125],[125,400]]}}");
+    }
+
+    @Test
+    public void test_byte_ranges_total_is_derived_from_the_range_count() {
+        Map<String, Object> taskInput = Map.of("pipeline", "tika");
+        assertThat(ManifestEntry.paginated(taskInput,
+                List.of(new long[]{0, 1}, new long[]{1, 2}, new long[]{2, 3})).pages().total()).isEqualTo(3);
+        assertThat(ManifestEntry.paginated(taskInput, List.of()).pages().total()).isEqualTo(0);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -132,8 +132,8 @@ public class ArtifactTask extends PipelineTask<String> {
     private void runWorker(AtomicLong nbDocs, AtomicLong nbSkipped, AtomicLong nbFailed) {
         SourceExtractor extractor = createSourceExtractor();
         // Decide once per worker which artifact types to produce: an absent --artifacts flag means the
-        // whole catalog, raw and structure (see ArtifactRegistry#withDefaults).
-        ArtifactRegistry registry = ArtifactRegistry.withDefaults();
+        // whole catalog, raw, structure and page (see ArtifactRegistry#withDefaults).
+        ArtifactRegistry registry = ArtifactRegistry.withDefaults(propertiesProvider);
         List<Artifact> selected = registry.select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
         boolean force = ArtifactStages.force(propertiesProvider);
         // The producer owns what counts as a cancellation (see ArtifactProducer#isCancellation), so this

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -120,7 +120,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         // that requeues forever. When set, extract-lib writes embed bytes to the same project root the
         // ManifestRecorder writes manifests to.
         ArtifactStages.artifactProjectRoot(propertiesProvider).ifPresent(projectRoot -> {
-            List<Artifact> selected = ArtifactRegistry.withDefaults().select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
+            List<Artifact> selected = ArtifactRegistry.withDefaults(propertiesProvider).select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
             extractor.setEmbedOutputPath(projectRoot);
             spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, ArtifactStages.force(propertiesProvider)));
         });

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -6,6 +6,7 @@ import com.google.inject.assistedinject.Assisted;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.icij.datashare.PipelineHelper;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.Stage;
 import org.icij.datashare.asynctasks.Task;
@@ -17,6 +18,7 @@ import org.icij.datashare.extract.DocumentCollectionFactory;
 import org.icij.datashare.monitoring.Monitorable;
 import org.icij.datashare.text.artifact.Artifact;
 import org.icij.datashare.text.artifact.ArtifactRegistry;
+import org.icij.datashare.text.artifact.ArtifactType;
 import org.icij.datashare.text.artifact.FilesystemManifestRepository;
 import org.icij.datashare.text.artifact.ManifestRecorder;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchSpewer;
@@ -121,6 +123,16 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
         // ManifestRecorder writes manifests to.
         ArtifactStages.artifactProjectRoot(propertiesProvider).ifPresent(projectRoot -> {
             List<Artifact> selected = ArtifactRegistry.withDefaults(propertiesProvider).select(propertiesProvider.get(ARTIFACTS_OPT).orElse(null));
+            // Only raw falls out of the streaming parse (see ManifestRecorder): a selection naming any
+            // other type reads as a promise this stage does not keep, so say so rather than drop it in
+            // silence. Silent when ARTIFACT is coming, since the run does produce them then: a warning
+            // that fires on a correct run is one nobody reads. Once per run, not per document.
+            List<String> notAtIndexTime = selected.stream().map(Artifact::type)
+                    .filter(type -> type != ArtifactType.RAW).map(ArtifactType::token).toList();
+            if (!notAtIndexTime.isEmpty() && !new PipelineHelper(propertiesProvider).stages.contains(Stage.ARTIFACT)) {
+                logger.warn("--artifacts selects {}, which the INDEX stage does not produce, and ARTIFACT is not in "
+                        + "--stages: only the 'raw' entry will be recorded.", notAtIndexTime);
+            }
             extractor.setEmbedOutputPath(projectRoot);
             spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, ArtifactStages.force(propertiesProvider)));
         });

--- a/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
+++ b/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.text.artifact;
 
+import org.icij.datashare.PropertiesProvider;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -20,14 +22,18 @@ public class ArtifactRegistry {
 
     /** The app's catalog of Java-produced artifact types, shared by the INDEX and ARTIFACT stages so a
      *  newly registered producer cannot be honored by one and missed by the other. Order matters: raw
-     *  first, so structure on an embedded document reads bytes raw's production has already cached.
+     *  first, so structure and page on an embedded document read bytes raw's production has already
+     *  cached. Takes the properties because page builds an extractor from the run's options (OCR in
+     *  particular); raw and structure need none.
      *  <p>
      *  Every catalog type runs when no selector is given, structure included. A deployment that also
      *  runs datashare-python's structure producer shares the manifest key and the structure/ directory
      *  with it, and the two task inputs can never match, so each run destroys the other's payload:
-     *  such a deployment has to pin ownership with an explicit {@code --artifacts raw}. */
-    public static ArtifactRegistry withDefaults() {
-        return new ArtifactRegistry(List.of(new RawArtifact(), new StructureArtifact()));
+     *  such a deployment has to pin ownership with an explicit {@code --artifacts raw}. page has no
+     *  such rival producer: the pages/ payload is Java's alone. */
+    public static ArtifactRegistry withDefaults(PropertiesProvider propertiesProvider) {
+        return new ArtifactRegistry(
+                List.of(new RawArtifact(), new StructureArtifact(), new PageArtifact(propertiesProvider)));
     }
 
     public List<Artifact> select(String flagValue) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/DocumentResource.java
@@ -28,6 +28,7 @@ import org.icij.datashare.Repository.AggregateList;
 import org.icij.datashare.cli.DatashareCliOptions;
 import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.text.*;
+import org.icij.datashare.text.artifact.PageArtifact;
 import org.icij.datashare.text.indexing.ExtractedText;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.SearchedText;
@@ -204,7 +205,10 @@ public class DocumentResource {
                 extractor.disableOcr();
             }
             if (doc.isRootDocument()) {
-                return extractor.extractPageIndices(doc.getPath(), metadata -> true, doc.getId());
+                // The document's own text, not "every part": the indices describe this document's
+                // indexed content, which holds its own text and its inline parts, not an attachment's
+                // (that one is its own document, with pages of its own).
+                return extractor.extractPageIndices(doc.getPath(), PageArtifact.ownTextOf(doc.getPath()), doc.getId());
             } else {
                 return extractor.extractPageIndices(doc.getPath(),
                         metadata -> doc.getTitle().equals(metadata.get("resourceName")) ||
@@ -230,7 +234,9 @@ public class DocumentResource {
                 extractor.disableOcr();
             }
             if (doc.isRootDocument()) {
-                return extractor.extractPages(doc.getPath());
+                // Same selection as the cached page artifact, and for the same reason (see above): the
+                // pages served here and the pages stored there must be the same pages.
+                return extractor.extractPages(doc.getPath(), PageArtifact.ownTextOf(doc.getPath()));
             } else {
                 return extractor.extractPages(doc.getPath(),
                         metadata -> doc.getTitle().equals(metadata.get("resourceName")) ||

--- a/datashare-app/src/test/java/org/icij/datashare/text/artifact/ArtifactRegistryTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/text/artifact/ArtifactRegistryTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.artifact;
 
+import org.icij.datashare.PropertiesProvider;
 import org.junit.Test;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -69,16 +70,19 @@ public class ArtifactRegistryTest {
     }
 
     @Test
-    public void test_structure_runs_by_default() {
-        // raw first, so structure on an embedded document reads bytes raw's production cached.
-        assertThat(types(ArtifactRegistry.withDefaults().select(null))).isEqualTo(List.of("raw", "structure"));
-        assertThat(types(ArtifactRegistry.withDefaults().select("true"))).isEqualTo(List.of("raw", "structure"));
-        assertThat(types(ArtifactRegistry.withDefaults().select("raw,structure")))
+    public void test_the_whole_catalog_runs_by_default() {
+        // raw first, so structure and page on an embedded document read bytes raw's production cached.
+        assertThat(types(ArtifactRegistry.withDefaults(new PropertiesProvider()).select(null)))
+                .isEqualTo(List.of("raw", "structure", "page"));
+        assertThat(types(ArtifactRegistry.withDefaults(new PropertiesProvider()).select("true")))
+                .isEqualTo(List.of("raw", "structure", "page"));
+        assertThat(types(ArtifactRegistry.withDefaults(new PropertiesProvider()).select("raw,structure")))
                 .isEqualTo(List.of("raw", "structure"));
     }
 
     @Test
     public void test_default_catalog_can_be_narrowed_to_one_type() {
-        assertThat(types(ArtifactRegistry.withDefaults().select("structure"))).isEqualTo(List.of("structure"));
+        assertThat(types(ArtifactRegistry.withDefaults(new PropertiesProvider()).select("page")))
+                .isEqualTo(List.of("page"));
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCliOptions.java
@@ -499,7 +499,8 @@ public final class DatashareCliOptions {
     static void artifacts(OptionParser parser) {
         parser.acceptsAll(
                 List.of(ARTIFACTS_OPT),
-                "Artifact types to produce (comma-separated, e.g. " + ArtifactType.tokens() + "). Bare flag = all types." )
+                "Artifact types to produce (comma-separated, e.g. " + ArtifactType.tokens() + "). Bare flag = all types. "
+                        + "The INDEX stage produces 'raw' only; every other type is produced by the ARTIFACT stage." )
                 .withOptionalArg();
     }
 

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/PipelineOptions.java
@@ -24,7 +24,8 @@ public class PipelineOptions {
     // Mirrors the JOpt withOptionalArg semantics. Left null when absent so toProperties omits the
     // key and INDEX produces no artifacts.
     @Option(names = {"--artifacts"}, arity = "0..1", fallbackValue = "true",
-            description = "Artifact types to produce, comma-separated (bare flag = all types); unknown types are rejected.")
+            description = "Artifact types to produce, comma-separated (bare flag = all types); unknown types are rejected. "
+                    + "The INDEX stage produces 'raw' only; every other type is produced by the ARTIFACT stage.")
     String artifacts;
 
     // Explicit true/false like --ocr, no bare flag: the JOpt surface uses withRequiredArg, and a bare

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/Artifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/Artifact.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.text.artifact;
 
+import org.icij.datashare.text.Document;
+
 import java.util.Map;
 
 /** A derived representation of a document, produced alongside it and stored under its artifact dir.
@@ -14,6 +16,14 @@ public interface Artifact {
      *  processed with the same config in two different batches must compare equal. Keep it compact
      *  (mirrors datashare-python TaskArgs.as_manifest_task_input). */
     Map<String, Object> taskInput();
+
+    /** The fingerprint to compare and to record for one document: {@link #taskInput()} unless the
+     *  payload also depends on something the document carries (the OCR that was applied to it, say).
+     *  Still config, not data: an override MUST return the same value for a given document and run
+     *  config, so the same doc in two different batches compares equal. */
+    default Map<String, Object> taskInput(Document document) {
+        return taskInput();
+    }
 
     /** Produce payload files under context.docArtifactDir() and return the entry to record (without
      *  status). Return ManifestEntry.empty(taskInput()) when this node has no payload of this type

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -26,6 +26,9 @@ public class ArtifactPayload {
             case RAW -> !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
                     || !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
             case STRUCTURE -> !Files.exists(lastPageOrDir(docArtifactDir, entry));
+            // One file for every page, swapped in whole, so its existence answers for the payload: the
+            // per-page offsets live in the entry, and a run that wrote no pages recorded EMPTY above.
+            case PAGE -> !Files.exists(ArtifactPath.pagesContent(docArtifactDir));
         };
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -97,7 +97,8 @@ public class ArtifactProducer {
         // No stack trace: these are benign, and a corpus holds enough of them to bury the real failures.
         LOGGER.warn("{}: recording an empty '{}' entry so it is not parsed again", failure.getMessage(), type.token());
         try {
-            repository.put(context.docArtifactDir(), type.token(), ManifestEntry.empty(artifact.taskInput()));
+            repository.put(context.docArtifactDir(), type.token(),
+                    ManifestEntry.empty(artifact.taskInput(context.document())));
             return true;
         } catch (IOException recordFailure) {
             LOGGER.error("failed to record artifact '{}' for document {}", type.token(), context.document().getId(), recordFailure);
@@ -136,7 +137,9 @@ public class ArtifactProducer {
 
     private boolean isCurrent(ArtifactType type, Artifact artifact, ArtifactContext context) throws IOException {
         ManifestEntry existing = repository.get(context.docArtifactDir(), type.token());
-        if (existing == null || !existing.isCurrentFor(artifact.taskInput())) {
+        // The document's own fingerprint, the one produce() records: comparing the run-level one here
+        // would skip a document whose payload was made under a different per-document input.
+        if (existing == null || !existing.isCurrentFor(artifact.taskInput(context.document()))) {
             return false;
         }
         // A terminal entry is not proof the payload survived a JVM death mid-swap or a failed restore.

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -73,10 +73,14 @@ public class PageArtifact implements Artifact {
             return document.getPath();
         }
         Path raw = context.docArtifactDir().resolve(ArtifactPath.RAW_FILE);
-        if (Files.notExists(raw)) {
+        // Zero-byte, not just absent: extract-lib records an empty raw payload for embeds whose
+        // bytes it could not read (the same rule SourceExtractor.hasCachedEmbeddedSource applies), and
+        // pagination would otherwise accept it as a source, find no page divs, and record a terminal
+        // EMPTY that skip-if-current never retries.
+        if (Files.notExists(raw) || Files.size(raw) == 0) {
             context.sources().getSource(context.project(), document).close();
         }
-        if (Files.notExists(raw)) {
+        if (Files.notExists(raw) || Files.size(raw) == 0) {
             throw new IOException("no raw payload to paginate for embedded document " + document.getId());
         }
         return raw;
@@ -99,15 +103,21 @@ public class PageArtifact implements Artifact {
         }
     }
 
-    // Writes the whole payload to a temp file in the same directory (so the move is same-filesystem
-    // and therefore atomic), then swaps it in. A run that fails partway leaves the previous
-    // content.txt, which is what the still-complete manifest entry advertises, instead of a
-    // truncated one. Offsets are the byte counts actually written, so the recorded ranges cannot
-    // disagree with the file: half-open [start, end), contiguous, first start 0, last end == length.
+    // Writes the whole payload to a unique temp file in the same directory (so the move is
+    // same-filesystem and therefore atomic), then swaps it in. A failure before the move leaves the
+    // previous content.txt in place, still matching its complete manifest entry. A failure after the
+    // move (the caller's repository.put, e.g. a manifest lock timeout) can instead leave the new
+    // content.txt live while the manifest still describes the previous one; guarding against that is
+    // a consumer-side concern (#2228), not this method's. Offsets are the byte counts actually
+    // written, so the recorded ranges cannot disagree with the file: half-open [start, end),
+    // contiguous, first start 0, last end == length.
     private static List<long[]> writePages(ArtifactContext context, List<String> pages) throws IOException {
         Path content = ArtifactPath.pagesContent(context.docArtifactDir());
-        Path temp = content.resolveSibling(content.getFileName() + ".tmp");
         Files.createDirectories(content.getParent());
+        // A unique name per attempt: two producers racing on the same document (shared artifactDir
+        // across hosts, or the same doc queued twice) must never open the same temp path, or the
+        // loser's write truncates the winner's file to a hole of NUL bytes mid-write.
+        Path temp = Files.createTempFile(content.getParent(), "content", ".txt.tmp");
         List<long[]> ranges = new ArrayList<>();
         long offset = 0;
         try {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -70,7 +70,10 @@ public class PageArtifact implements Artifact {
     // extracting the embed from its root.
     private Path sourcePath(ArtifactContext context) throws IOException {
         Document document = context.document();
-        if (document.getExtractionLevel() <= 0) {
+        // isRootDocument(), not the extraction level alone: it is where the rootId and the level are
+        // required to agree, so a document whose labels disagree takes the embedded path below, as it
+        // does in SourceExtractor and RawArtifact, instead of being paginated from its container's file.
+        if (document.isRootDocument()) {
             return document.getPath();
         }
         Path raw = context.docArtifactDir().resolve(ArtifactPath.RAW_FILE);

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -7,6 +7,7 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Hasher;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.icij.datashare.utils.AtomicDirectorySwap;
 import org.icij.datashare.utils.BuildVersions;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.Extractor;
@@ -66,6 +67,9 @@ public class PageArtifact implements Artifact {
             // live endpoint returns for such a document too. EMPTY is terminal, so the document is
             // recorded once and not reprocessed on every run.
             if (pages.isEmpty()) {
+                // An earlier run's content.txt would otherwise stay on disk, described by no manifest
+                // entry and still served by any reader that lists the directory.
+                discardPayload(context.docArtifactDir());
                 return ManifestEntry.empty(taskInput());
             }
             return ManifestEntry.paginated(taskInput(), writePages(context, pages));
@@ -73,6 +77,10 @@ public class PageArtifact implements Artifact {
             // Unchecked, and not an ArtifactException, so the catch-all below would otherwise demote the
             // fatal bucket to one more per-document failure and drain the queue instead of ending the run.
             throw fatal;
+        } catch (UnreadableContentException unreadable) {
+            // The producer records this one as processed with no payload too, so the payload goes now.
+            discardPayload(context.docArtifactDir());
+            throw unreadable;
         } catch (ArtifactException alreadyClassified) {
             // Raised by extractPages(), so wrapping it again would only double its message.
             throw alreadyClassified;
@@ -195,6 +203,13 @@ public class PageArtifact implements Artifact {
             Files.deleteIfExists(temp);
         }
         return ranges;
+    }
+
+    // Losing the payload is the point: it is regenerable, and one the manifest does not account for is
+    // still served by any reader that lists the directory. The whole pages/ dir, since content.txt is all
+    // it holds beyond a temp file a crashed run left behind.
+    private static void discardPayload(Path docArtifactDir) {
+        AtomicDirectorySwap.discard(ArtifactPath.pagesDir(docArtifactDir));
     }
 
     private boolean ocrEnabled() {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -3,13 +3,17 @@ package org.icij.datashare.text.artifact;
 import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaConfigException;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.extractor.DocumentSelector;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Hasher;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.icij.datashare.text.structure.StructureMarkdownExtractor;
 import org.icij.datashare.utils.AtomicDirectorySwap;
 import org.icij.datashare.utils.BuildVersions;
 import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.extractor.EmbedSpawner;
 import org.icij.extract.extractor.Extractor;
 import org.icij.task.Options;
 import org.xml.sax.SAXException;
@@ -143,10 +147,45 @@ public class PageArtifact implements Artifact {
             if (document.getOcrParser() == null) {
                 extractor.disableOcr();
             }
-            return extractor.extractPages(source);
+            return extractor.extractPages(source, ownTextOf(source));
         } catch (IOException failure) {
             throw classify(document, failure);
         }
+    }
+
+    /**
+     * Selects the text that belongs to the document being paginated, which is what its pages must hold:
+     * they are its indexed content, paginated, so a page saying something the content field does not is
+     * a page the reader cannot search for. Three things belong to it, and nothing else does:
+     * <ul>
+     *   <li>the file being parsed itself. The selector gates the root parse too, not just the parts:
+     *       ParsingReaderWithContentHandler#ParsingTask hands the page-splitting handler to the parse
+     *       only when the selector accepts it, and a plain handler otherwise, so refusing the root
+     *       yields a document with no pages at all. Recognised by name, as DocumentResource recognises
+     *       an embed, which also lets in a part named exactly like the file holding it;</li>
+     *   <li>an INLINE part, which is what a scanned page's image is. {@link EmbedSpawner#parseEmbedded}
+     *       concatenates those into the document being parsed and the content field holds their OCR
+     *       text, so the pages must hold it too;</li>
+     *   <li>a nameless text or html part, which is how a mail's own body can reach the extractor: it is
+     *       not a part anyone detaches, so it has no name of its own. {@link StructureMarkdownExtractor#isOwnBody}
+     *       rather than "nameless" alone, so a nameless PST message (message/rfc822, a document of its
+     *       own) is still refused. Accepted consequence, as there: a nameless text attachment is
+     *       inlined, duplicating text that also has an artifact of its own.</li>
+     * </ul>
+     * Everything else is a document of its own: spawned by extract-lib, indexed as its own ES document,
+     * and given its own page artifact. Refusing it also means never parsing it, since Tika asks before
+     * it recurses, so a mail archive's tree is no longer parsed, OCR'd and buffered (64 MB, then spilled
+     * to java.io.tmpdir) to produce text that is then thrown away.
+     */
+    public static DocumentSelector ownTextOf(Path source) {
+        String name = source.getFileName().toString();
+        return metadata -> {
+            String resourceName = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY);
+            return name.equals(resourceName)
+                    || TikaCoreProperties.EmbeddedResourceType.INLINE.toString()
+                            .equals(metadata.get(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE))
+                    || StructureMarkdownExtractor.isOwnBody(metadata);
+        };
     }
 
     /**

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -56,8 +56,23 @@ public class PageArtifact implements Artifact {
         }
     }
 
+    // A root's bytes are the original file; an embed's are its own cached raw payload, so an embed
+    // costs one parse of itself instead of one parse of the whole root (289 root parses for a
+    // 289-embed OST). getSource() writes that payload when it is missing, as a side effect of
+    // extracting the embed from its root.
     private Path sourcePath(ArtifactContext context) throws IOException {
-        return context.document().getPath();
+        Document document = context.document();
+        if (document.getExtractionLevel() <= 0) {
+            return document.getPath();
+        }
+        Path raw = context.docArtifactDir().resolve(ArtifactPath.RAW_FILE);
+        if (Files.notExists(raw)) {
+            context.sources().getSource(context.project(), document).close();
+        }
+        if (Files.notExists(raw)) {
+            throw new IOException("no raw payload to paginate for embedded document " + document.getId());
+        }
+        return raw;
     }
 
     // One Extractor per document, as the live endpoint does per request: disableOcr() is one-way, so

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -50,6 +50,12 @@ public class PageArtifact implements Artifact {
         Document document = context.document();
         try {
             List<String> pages = extractPages(document, sourcePath(context));
+            // Nothing to serve and nothing to write: no page divs means no pages, which is what the
+            // live endpoint returns for such a document too. EMPTY is terminal, so the document is
+            // recorded once and not reprocessed on every run.
+            if (pages.isEmpty()) {
+                return ManifestEntry.empty(taskInput());
+            }
             return ManifestEntry.paginated(taskInput(), writePages(context, pages));
         } catch (Exception failure) {
             throw new ArtifactException("page extraction failed for " + document.getId(), failure);

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -98,19 +99,30 @@ public class PageArtifact implements Artifact {
         }
     }
 
-    // Offsets are the byte counts actually written, so the recorded ranges cannot disagree with the
-    // file: half-open [start, end), contiguous, first start 0, last end == file length.
+    // Writes the whole payload to a temp file in the same directory (so the move is same-filesystem
+    // and therefore atomic), then swaps it in. A run that fails partway leaves the previous
+    // content.txt, which is what the still-complete manifest entry advertises, instead of a
+    // truncated one. Offsets are the byte counts actually written, so the recorded ranges cannot
+    // disagree with the file: half-open [start, end), contiguous, first start 0, last end == length.
     private static List<long[]> writePages(ArtifactContext context, List<String> pages) throws IOException {
-        Files.createDirectories(ArtifactPath.pagesDir(context.docArtifactDir()));
+        Path content = ArtifactPath.pagesContent(context.docArtifactDir());
+        Path temp = content.resolveSibling(content.getFileName() + ".tmp");
+        Files.createDirectories(content.getParent());
         List<long[]> ranges = new ArrayList<>();
         long offset = 0;
-        try (OutputStream out = Files.newOutputStream(ArtifactPath.pagesContent(context.docArtifactDir()))) {
-            for (String page : pages) {
-                byte[] bytes = page.getBytes(StandardCharsets.UTF_8);
-                out.write(bytes);
-                ranges.add(new long[]{offset, offset + bytes.length});
-                offset += bytes.length;
+        try {
+            try (OutputStream out = Files.newOutputStream(temp)) {
+                for (String page : pages) {
+                    byte[] bytes = page.getBytes(StandardCharsets.UTF_8);
+                    out.write(bytes);
+                    ranges.add(new long[]{offset, offset + bytes.length});
+                    offset += bytes.length;
+                }
             }
+            Files.move(temp, content, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } finally {
+            // A half-written temp file must never survive this call, whether the write or the move failed.
+            Files.deleteIfExists(temp);
         }
         return ranges;
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -51,10 +51,23 @@ public class PageArtifact implements Artifact {
     public Map<String, Object> taskInput() {
         // A fingerprint of the code that made the bytes, as StructureArtifact records: Tika renders the
         // text, extract-lib owns the parser set and the page splitting, and the datashare version covers
-        // what this class decides. The run's OCR setting, not the per-document one: taskInput() gets no
-        // document, and its contract keeps per-document state out so the same doc compares equal across
-        // batches.
-        return Map.of("pipeline", "tika", "version", TIKA_VERSION, "ocr", ocrEnabled(),
+        // what this class decides. The run's OCR setting is the best this document-less overload can do;
+        // what actually paginated a document is the overload below.
+        return taskInput(ocrEnabled());
+    }
+
+    @Override
+    public Map<String, Object> taskInput(Document document) {
+        // The OCR that made these pages, not the one the run asked for: extractPages() turns OCR off for
+        // a document indexed without it, so the run's flag alone stamps OCR-free pages as OCR'd. Re-index
+        // that file with OCR on and nothing the fingerprint sees changes (same bytes, same digest, same
+        // artifact dir), so skip-if-current serves the OCR-free pages forever. Still config, not data:
+        // the same document under the same run config compares equal in any batch.
+        return taskInput(ocrEnabled() && document.getOcrParser() != null);
+    }
+
+    private static Map<String, Object> taskInput(boolean ocr) {
+        return Map.of("pipeline", "tika", "version", TIKA_VERSION, "ocr", ocr,
                 "extract", BuildVersions.EXTRACT, "datashare", BuildVersions.DATASHARE);
     }
 
@@ -70,9 +83,9 @@ public class PageArtifact implements Artifact {
                 // An earlier run's content.txt would otherwise stay on disk, described by no manifest
                 // entry and still served by any reader that lists the directory.
                 discardPayload(context.docArtifactDir());
-                return ManifestEntry.empty(taskInput());
+                return ManifestEntry.empty(taskInput(document));
             }
-            return ManifestEntry.paginated(taskInput(), writePages(context, pages));
+            return ManifestEntry.paginated(taskInput(document), writePages(context, pages));
         } catch (ArtifactConfigurationException fatal) {
             // Unchecked, and not an ArtifactException, so the catch-all below would otherwise demote the
             // fatal bucket to one more per-document failure and drain the queue instead of ending the run.

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -2,7 +2,20 @@ package org.icij.datashare.text.artifact;
 
 import org.apache.tika.Tika;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Hasher;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.icij.extract.document.DocumentFactory;
+import org.icij.extract.extractor.Extractor;
+import org.icij.task.Options;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
@@ -34,7 +47,51 @@ public class PageArtifact implements Artifact {
 
     @Override
     public ManifestEntry produce(ArtifactContext context) throws ArtifactException {
-        throw new UnsupportedOperationException("not implemented yet");
+        Document document = context.document();
+        try {
+            List<String> pages = extractPages(document, sourcePath(context));
+            return ManifestEntry.paginated(taskInput(), writePages(context, pages));
+        } catch (Exception failure) {
+            throw new ArtifactException("page extraction failed for " + document.getId(), failure);
+        }
+    }
+
+    private Path sourcePath(ArtifactContext context) throws IOException {
+        return context.document().getPath();
+    }
+
+    // One Extractor per document, as the live endpoint does per request: disableOcr() is one-way, so
+    // a document indexed without OCR cannot share an Extractor with one indexed with it. embedOutput
+    // is deliberately left unset: this producer writes its own payload and nothing else.
+    private List<String> extractPages(Document document, Path source) throws IOException {
+        Hasher hasher = Hasher.valueOf(document.getId().length());
+        DocumentFactory documentFactory = new DocumentFactory()
+                .configure(Options.from(Map.of("digestAlgorithm", hasher.toStringWithoutDash())));
+        try (Extractor extractor = new Extractor(documentFactory, Options.from(propertiesProvider.getProperties()))) {
+            // Same rule as DocumentResource.getPages: a document indexed without OCR must be
+            // paginated without OCR, or its pages would not match its indexed content.
+            if (document.getOcrParser() == null) {
+                extractor.disableOcr();
+            }
+            return extractor.extractPages(source);
+        }
+    }
+
+    // Offsets are the byte counts actually written, so the recorded ranges cannot disagree with the
+    // file: half-open [start, end), contiguous, first start 0, last end == file length.
+    private static List<long[]> writePages(ArtifactContext context, List<String> pages) throws IOException {
+        Files.createDirectories(ArtifactPath.pagesDir(context.docArtifactDir()));
+        List<long[]> ranges = new ArrayList<>();
+        long offset = 0;
+        try (OutputStream out = Files.newOutputStream(ArtifactPath.pagesContent(context.docArtifactDir()))) {
+            for (String page : pages) {
+                byte[] bytes = page.getBytes(StandardCharsets.UTF_8);
+                out.write(bytes);
+                ranges.add(new long[]{offset, offset + bytes.length});
+                offset += bytes.length;
+            }
+        }
+        return ranges;
     }
 
     private boolean ocrEnabled() {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.text.artifact;
 
 import org.apache.tika.Tika;
+import org.apache.tika.exception.TikaConfigException;
+import org.apache.tika.exception.TikaException;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Hasher;
@@ -8,6 +10,7 @@ import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.Extractor;
 import org.icij.task.Options;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -59,6 +62,9 @@ public class PageArtifact implements Artifact {
                 return ManifestEntry.empty(taskInput());
             }
             return ManifestEntry.paginated(taskInput(), writePages(context, pages));
+        } catch (ArtifactException alreadyClassified) {
+            // Raised by extractPages(), so wrapping it again would only double its message.
+            throw alreadyClassified;
         } catch (Exception failure) {
             throw new ArtifactException("page extraction failed for " + document.getId(), failure);
         }
@@ -93,7 +99,7 @@ public class PageArtifact implements Artifact {
     // One Extractor per document, as the live endpoint does per request: disableOcr() is one-way, so
     // a document indexed without OCR cannot share an Extractor with one indexed with it. embedOutput
     // is deliberately left unset: this producer writes its own payload and nothing else.
-    private List<String> extractPages(Document document, Path source) throws IOException {
+    private List<String> extractPages(Document document, Path source) throws IOException, ArtifactException {
         Hasher hasher = Hasher.valueOf(document.getId().length());
         DocumentFactory documentFactory = new DocumentFactory()
                 .configure(Options.from(Map.of("digestAlgorithm", hasher.toStringWithoutDash())));
@@ -104,7 +110,41 @@ public class PageArtifact implements Artifact {
                 extractor.disableOcr();
             }
             return extractor.extractPages(source);
+        } catch (IOException failure) {
+            throw classify(document, failure);
         }
+    }
+
+    /**
+     * Sorts a parse failure into the three buckets {@link StructureArtifact} sorts its own into, since
+     * what a failure means decides whether the document is ever looked at again: a broken Tika
+     * configuration ends the run, Tika's memory limit and its zip-bomb false positive are worth another
+     * one, and content no parser can read is recorded as empty rather than re-parsed forever.
+     * <p>
+     * Read off the cause chain rather than by catch type: extract-lib parses on its own thread and hands
+     * whatever it caught back as the cause of an IOException (ParsingReaderWithContentHandler#read), so
+     * every bucket arrives here as the same exception. An IOException with no parse failure under it (a
+     * stalled mount, a truncated read) stays retryable, as it does there.
+     */
+    private static ArtifactException classify(Document document, IOException failure) {
+        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+            if (cause instanceof TikaConfigException) {
+                throw new ArtifactConfigurationException(cause);
+            }
+            if (cause instanceof TikaException || cause instanceof SAXException) {
+                return StructureArtifact.isRetryable(cause) ? retryable(document, failure)
+                        : new UnreadableContentException(document.getId(), cause);
+            }
+            // A custom exception can return itself from getCause(), which would spin this walk forever.
+            if (cause == cause.getCause()) {
+                break;
+            }
+        }
+        return retryable(document, failure);
+    }
+
+    private static ArtifactException retryable(Document document, IOException failure) {
+        return new ArtifactException("page extraction failed for " + document.getId(), failure);
     }
 
     // Writes the whole payload to a unique temp file in the same directory (so the move is

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -159,11 +159,21 @@ public class PageArtifact implements Artifact {
      * whatever it caught back as the cause of an IOException (ParsingReaderWithContentHandler#read), so
      * every bucket arrives here as the same exception. An IOException with no parse failure under it (a
      * stalled mount, a truncated read) stays retryable, as it does there.
+     * <p>
+     * The fatal bucket is the one exception to reading down the chain: only what the parse thread itself
+     * threw counts. Pagination spawns embeds into the same parse, so a TikaConfigException found deeper
+     * is one embed's parser going wrong, and ending the whole run on it would drain the queue on a single
+     * bad document.
      */
-    private static ArtifactException classify(Document document, IOException failure) {
+    static ArtifactException classify(Document document, IOException failure) {
+        if (failure.getCause() instanceof TikaConfigException) {
+            throw new ArtifactConfigurationException(failure.getCause());
+        }
         for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+            // Deeper down: this side going wrong for one document, and a run with the configuration
+            // fixed can still read it, so retryable rather than terminal.
             if (cause instanceof TikaConfigException) {
-                throw new ArtifactConfigurationException(cause);
+                return retryable(document, failure);
             }
             if (cause instanceof TikaException || cause instanceof SAXException) {
                 return StructureArtifact.isRetryable(cause) ? retryable(document, failure)

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -7,6 +7,7 @@ import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Hasher;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.icij.datashare.utils.BuildVersions;
 import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.Extractor;
 import org.icij.task.Options;
@@ -31,6 +32,8 @@ public class PageArtifact implements Artifact {
     private static final ArtifactType TYPE = ArtifactType.PAGE;
     // Tika.getString() returns "Apache Tika <version>"; extract-lib strips the same prefix.
     private static final String TIKA_PREFIX = "Apache Tika";
+    // Read once: Tika.getString() re-reads a jar resource, and taskInput() is called per document.
+    private static final String TIKA_VERSION = Tika.getString().replace(TIKA_PREFIX, "").strip();
 
     private final PropertiesProvider propertiesProvider;
 
@@ -45,9 +48,13 @@ public class PageArtifact implements Artifact {
 
     @Override
     public Map<String, Object> taskInput() {
-        // The run's OCR setting, not the per-document one: taskInput() gets no document, and its
-        // contract keeps per-document state out so the same doc compares equal across batches.
-        return Map.of("pipeline", "tika", "version", tikaVersion(), "ocr", ocrEnabled());
+        // A fingerprint of the code that made the bytes, as StructureArtifact records: Tika renders the
+        // text, extract-lib owns the parser set and the page splitting, and the datashare version covers
+        // what this class decides. The run's OCR setting, not the per-document one: taskInput() gets no
+        // document, and its contract keeps per-document state out so the same doc compares equal across
+        // batches.
+        return Map.of("pipeline", "tika", "version", TIKA_VERSION, "ocr", ocrEnabled(),
+                "extract", BuildVersions.EXTRACT, "datashare", BuildVersions.DATASHARE);
     }
 
     @Override
@@ -186,9 +193,5 @@ public class PageArtifact implements Artifact {
 
     private boolean ocrEnabled() {
         return propertiesProvider.get(OCR_OPT).map(Boolean::parseBoolean).orElse(true);
-    }
-
-    private static String tikaVersion() {
-        return Tika.getString().replace(TIKA_PREFIX, "").strip();
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -23,11 +23,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
 
@@ -226,28 +224,20 @@ public class PageArtifact implements Artifact {
         return new ArtifactException("page extraction failed for " + document.getId(), failure);
     }
 
-    // Writes the whole payload to a unique temp file in the same directory (so the move is
-    // same-filesystem and therefore atomic), then swaps it in. A failure before the move leaves the
-    // previous content.txt in place, still matching its complete manifest entry. A failure after the
-    // move (the caller's repository.put, e.g. a manifest lock timeout) can instead leave the new
-    // content.txt live while the manifest still describes the previous one; guarding against that is
-    // a consumer-side concern (#2228), not this method's. Offsets are the byte counts actually
-    // written, so the recorded ranges cannot disagree with the file: half-open [start, end),
-    // contiguous, first start 0, last end == length.
+    // Through AtomicDirectorySwap, as the structure artifact writes its own pages: a failure before the
+    // swap leaves the previous content.txt in place, still matching its complete manifest entry, and the
+    // staging dir it writes into is unique per attempt, so two producers racing on the same document
+    // (shared artifactDir across hosts, or the same doc queued twice) cannot write to one another's
+    // bytes. A failure after the swap (the caller's repository.put, e.g. a manifest lock timeout) can
+    // instead leave the new content.txt live while the manifest still describes the previous one;
+    // guarding against that is a consumer-side concern (#2228), not this method's. Offsets are the byte
+    // counts actually written, so the recorded ranges cannot disagree with the file: half-open
+    // [start, end), contiguous, first start 0, last end == length.
     private static List<long[]> writePages(ArtifactContext context, List<String> pages) throws IOException {
-        Path content = ArtifactPath.pagesContent(context.docArtifactDir());
-        Files.createDirectories(content.getParent());
-        // A unique name per attempt: two producers racing on the same document (shared artifactDir
-        // across hosts, or the same doc queued twice) must never open the same temp path, or the
-        // loser's write truncates the winner's file to a hole of NUL bytes mid-write. Built by hand
-        // rather than with Files.createTempFile, which creates the file mode rw------- and would
-        // carry that restrictive mode onto content.txt through the ATOMIC_MOVE below, instead of the
-        // umask default every other artifact file gets.
-        Path temp = content.resolveSibling(content.getFileName() + "." + UUID.randomUUID() + ".tmp");
         List<long[]> ranges = new ArrayList<>();
-        long offset = 0;
-        try {
-            try (OutputStream out = Files.newOutputStream(temp)) {
+        AtomicDirectorySwap.replace(ArtifactPath.pagesDir(context.docArtifactDir()), staging -> {
+            long offset = 0;
+            try (OutputStream out = Files.newOutputStream(staging.resolve(ArtifactPath.PAGES_CONTENT_FILE))) {
                 for (String page : pages) {
                     byte[] bytes = page.getBytes(StandardCharsets.UTF_8);
                     out.write(bytes);
@@ -255,17 +245,13 @@ public class PageArtifact implements Artifact {
                     offset += bytes.length;
                 }
             }
-            Files.move(temp, content, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-        } finally {
-            // A half-written temp file must never survive this call, whether the write or the move failed.
-            Files.deleteIfExists(temp);
-        }
+        });
         return ranges;
     }
 
     // Losing the payload is the point: it is regenerable, and one the manifest does not account for is
-    // still served by any reader that lists the directory. The whole pages/ dir, since content.txt is all
-    // it holds beyond a temp file a crashed run left behind.
+    // still served by any reader that lists the directory. The whole pages/ dir, since content.txt is
+    // all it holds.
     private static void discardPayload(Path docArtifactDir) {
         AtomicDirectorySwap.discard(ArtifactPath.pagesDir(docArtifactDir));
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -218,10 +218,6 @@ public class PageArtifact implements Artifact {
                 return StructureArtifact.isRetryable(cause) ? retryable(document, failure)
                         : new UnreadableContentException(document.getId(), cause);
             }
-            // A custom exception can return itself from getCause(), which would spin this walk forever.
-            if (cause == cause.getCause()) {
-                break;
-            }
         }
         return retryable(document, failure);
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -18,6 +18,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
 
@@ -116,8 +117,11 @@ public class PageArtifact implements Artifact {
         Files.createDirectories(content.getParent());
         // A unique name per attempt: two producers racing on the same document (shared artifactDir
         // across hosts, or the same doc queued twice) must never open the same temp path, or the
-        // loser's write truncates the winner's file to a hole of NUL bytes mid-write.
-        Path temp = Files.createTempFile(content.getParent(), "content", ".txt.tmp");
+        // loser's write truncates the winner's file to a hole of NUL bytes mid-write. Built by hand
+        // rather than with Files.createTempFile, which creates the file mode rw------- and would
+        // carry that restrictive mode onto content.txt through the ATOMIC_MOVE below, instead of the
+        // umask default every other artifact file gets.
+        Path temp = content.resolveSibling(content.getFileName() + "." + UUID.randomUUID() + ".tmp");
         List<long[]> ranges = new ArrayList<>();
         long offset = 0;
         try {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -1,0 +1,47 @@
+package org.icij.datashare.text.artifact;
+
+import org.apache.tika.Tika;
+import org.icij.datashare.PropertiesProvider;
+
+import java.util.Map;
+
+import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
+
+/** The page artifact: a document's paginated PLAIN extracted text, written as a single
+ *  pages/content.txt whose per-page half-open byte ranges live in the manifest entry. */
+public class PageArtifact implements Artifact {
+    private static final ArtifactType TYPE = ArtifactType.PAGE;
+    // Tika.getString() returns "Apache Tika <version>"; extract-lib strips the same prefix.
+    private static final String TIKA_PREFIX = "Apache Tika";
+
+    private final PropertiesProvider propertiesProvider;
+
+    public PageArtifact(PropertiesProvider propertiesProvider) {
+        this.propertiesProvider = propertiesProvider;
+    }
+
+    @Override
+    public ArtifactType type() {
+        return TYPE;
+    }
+
+    @Override
+    public Map<String, Object> taskInput() {
+        // The run's OCR setting, not the per-document one: taskInput() gets no document, and its
+        // contract keeps per-document state out so the same doc compares equal across batches.
+        return Map.of("pipeline", "tika", "version", tikaVersion(), "ocr", ocrEnabled());
+    }
+
+    @Override
+    public ManifestEntry produce(ArtifactContext context) throws ArtifactException {
+        throw new UnsupportedOperationException("not implemented yet");
+    }
+
+    private boolean ocrEnabled() {
+        return propertiesProvider.get(OCR_OPT).map(Boolean::parseBoolean).orElse(true);
+    }
+
+    private static String tikaVersion() {
+        return Tika.getString().replace(TIKA_PREFIX, "").strip();
+    }
+}

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -69,6 +69,10 @@ public class PageArtifact implements Artifact {
                 return ManifestEntry.empty(taskInput());
             }
             return ManifestEntry.paginated(taskInput(), writePages(context, pages));
+        } catch (ArtifactConfigurationException fatal) {
+            // Unchecked, and not an ArtifactException, so the catch-all below would otherwise demote the
+            // fatal bucket to one more per-document failure and drain the queue instead of ending the run.
+            throw fatal;
         } catch (ArtifactException alreadyClassified) {
             // Raised by extractPages(), so wrapping it again would only double its message.
             throw alreadyClassified;
@@ -106,7 +110,9 @@ public class PageArtifact implements Artifact {
     // One Extractor per document, as the live endpoint does per request: disableOcr() is one-way, so
     // a document indexed without OCR cannot share an Extractor with one indexed with it. embedOutput
     // is deliberately left unset: this producer writes its own payload and nothing else.
-    private List<String> extractPages(Document document, Path source) throws IOException, ArtifactException {
+    // Package-private, not private: nothing this side can make a real Tika configuration break, so the
+    // fatal bucket is only reachable from a test that stands in for this method.
+    List<String> extractPages(Document document, Path source) throws IOException, ArtifactException {
         Hasher hasher = Hasher.valueOf(document.getId().length());
         DocumentFactory documentFactory = new DocumentFactory()
                 .configure(Options.from(Map.of("digestAlgorithm", hasher.toStringWithoutDash())));

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
@@ -60,6 +60,10 @@ public class StructureArtifact implements Artifact {
             List<Page> pages = parse(source, context.document());
             writePages(context.docArtifactDir(), pages);
             return ManifestEntry.paginated(taskInput(), pages.size());
+        } catch (ArtifactConfigurationException fatal) {
+            // Unchecked, and not an ArtifactException, so the catch-all below would otherwise demote the
+            // fatal bucket to one more per-document failure and drain the queue instead of ending the run.
+            throw fatal;
         } catch (UnreadableContentException unreadable) {
             // The producer records this one as processed with no payload too, so the payload goes now.
             discardPayload(context.docArtifactDir());
@@ -88,8 +92,11 @@ public class StructureArtifact implements Artifact {
      * </ul>
      * A cancelled parse also arrives as a TikaException, so this is not the last word: the producer asks
      * whether the run was cancelled before it records anything.
+     * <p>
+     * Package-private, not private: nothing this side can make a real Tika configuration break, so the
+     * fatal bucket is only reachable from a test that stands in for this method.
      */
-    private List<Page> parse(InputStream source, Document document) throws IOException, ArtifactException {
+    List<Page> parse(InputStream source, Document document) throws IOException, ArtifactException {
         try {
             return extractor.extract(source, document.getContentType(), resourceName(document));
         } catch (TikaConfigException fatal) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
@@ -11,6 +11,7 @@ public class ArtifactPath {
     public static final String RAW_SIDECAR_FILE = "raw.json";
     public static final String STRUCTURE_DIR = "structure";
     public static final String PAGES_DIR = "pages";
+    public static final String PAGES_CONTENT_FILE = "content.txt";
 
     private ArtifactPath() {}
 
@@ -56,6 +57,6 @@ public class ArtifactPath {
     /** The single payload file of the byte-ranges scheme, whose per-page offsets live in the
      *  manifest entry instead of in file names. The extension is fixed by the type: page is text. */
     public static Path pagesContent(Path docArtifactDir) {
-        return pagesDir(docArtifactDir).resolve("content.txt");
+        return pagesDir(docArtifactDir).resolve(PAGES_CONTENT_FILE);
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPath.java
@@ -10,6 +10,7 @@ public class ArtifactPath {
     public static final String RAW_FILE = "raw";
     public static final String RAW_SIDECAR_FILE = "raw.json";
     public static final String STRUCTURE_DIR = "structure";
+    public static final String PAGES_DIR = "pages";
 
     private ArtifactPath() {}
 
@@ -45,5 +46,16 @@ public class ArtifactPath {
      *  digits: with LANG=ar_EG.UTF-8 it would write page-١٢.md. */
     public static String pageFilename(int page, String extension) {
         return String.format(Locale.ROOT, "page-%d.%s", page, extension);
+    }
+
+    /** The page artifact's own directory. */
+    public static Path pagesDir(Path docArtifactDir) {
+        return docArtifactDir.resolve(PAGES_DIR);
+    }
+
+    /** The single payload file of the byte-ranges scheme, whose per-page offsets live in the
+     *  manifest entry instead of in file names. The extension is fixed by the type: page is text. */
+    public static Path pagesContent(Path docArtifactDir) {
+        return pagesDir(docArtifactDir).resolve("content.txt");
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -233,7 +233,7 @@ public class StructureMarkdownExtractor {
     // narrow this down, since MailContentHandler defaults it to ATTACHMENT for a part with no
     // Content-Disposition header. Accepted consequence: a nameless attachment text part is inlined,
     // duplicating text that has its own artifact, while every named part is still refused.
-    static boolean isOwnBody(Metadata metadata) {
+    public static boolean isOwnBody(Metadata metadata) {
         return metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY) == null
                 && INLINE_BODY_TYPES.contains(baseContentType(metadata));
     }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -1,13 +1,36 @@
 package org.icij.datashare.text.artifact;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
+import org.icij.extract.extractor.Extractor;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.mockito.Mockito.mock;
 
 public class PageArtifactTest {
+    @Rule public TemporaryFolder dir = new TemporaryFolder();
+
+    private final Project project = Project.project("prj");
+
     @Test
     public void test_type_is_page() {
         assertThat(new PageArtifact(new PropertiesProvider()).type()).isEqualTo(ArtifactType.PAGE);
@@ -31,5 +54,88 @@ public class PageArtifactTest {
         assertThat(new PageArtifact(properties).taskInput().get("ocr")).isEqualTo(false);
         assertThat(new PageArtifact(properties).taskInput())
                 .isNotEqualTo(new PageArtifact(new PropertiesProvider()).taskInput());
+    }
+
+    // A two-page PDF with real text: no tesseract needed, and each page has a distinct body so the
+    // byte ranges can be checked against the page they claim to delimit.
+    private Path twoPagePdf() throws IOException {
+        Path pdf = dir.getRoot().toPath().resolve("report.pdf");
+        try (PDDocument document = new PDDocument()) {
+            for (String text : List.of("Page one text", "Page two text")) {
+                PDPage page = new PDPage();
+                document.addPage(page);
+                try (PDPageContentStream content = new PDPageContentStream(document, page)) {
+                    content.beginText();
+                    content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                    content.newLineAtOffset(50, 700);
+                    content.showText(text);
+                    content.endText();
+                }
+            }
+            document.save(pdf.toFile());
+        }
+        return pdf;
+    }
+
+    private ArtifactContext rootContext(Path source) {
+        Document doc = createDoc("6abb96950946b62bb993307c8945c0c096982783bab7fa24901522426840ca3e")
+                .with(source).ofContentType("application/pdf").build();
+        Path docArtifactDir = dir.getRoot().toPath().resolve("docdir");
+        return new ArtifactContext(project, doc, docArtifactDir, mock(SourceExtractor.class));
+    }
+
+    private Path contentTxt(ArtifactContext context) {
+        return ArtifactPath.pagesContent(context.docArtifactDir());
+    }
+
+    @Test
+    public void test_produce_writes_one_content_file_and_nothing_else() throws Exception {
+        ArtifactContext context = rootContext(twoPagePdf());
+
+        new PageArtifact(new PropertiesProvider()).produce(context);
+
+        assertThat(Files.readString(contentTxt(context))).contains("Page one text").contains("Page two text");
+        assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
+                .isEqualTo(new String[]{"content.txt"});
+    }
+
+    @Test
+    public void test_produce_returns_contiguous_byte_ranges_covering_the_content_file() throws Exception {
+        ArtifactContext context = rootContext(twoPagePdf());
+
+        ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
+
+        assertThat(entry.pages().total()).isEqualTo(2);
+        assertThat(entry.pages().pagination().type()).isEqualTo("byteRanges");
+        List<long[]> ranges = ((ByteRangePagination) entry.pages().pagination()).ranges();
+        assertThat(ranges.get(0)[0]).isEqualTo(0);
+        assertThat(ranges.get(0)[1]).isEqualTo(ranges.get(1)[0]);
+        assertThat(ranges.get(1)[1]).isEqualTo(Files.size(contentTxt(context)));
+        assertThat(entry.isComplete()).isFalse(); // the producer loop stamps status, not produce()
+        assertThat(entry.contentType()).isNull();
+    }
+
+    private static String slice(byte[] content, long[] range) {
+        return new String(content, (int) range[0], (int) (range[1] - range[0]), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void test_pages_match_the_live_extractor_page_by_page() throws Exception {
+        Path pdf = twoPagePdf();
+        ArtifactContext context = rootContext(pdf);
+        List<String> live;
+        try (Extractor extractor = new Extractor()) {
+            extractor.disableOcr();
+            live = extractor.extractPages(pdf);
+        }
+
+        ManifestEntry entry = new PageArtifact(new PropertiesProvider(Map.of("ocr", "false"))).produce(context);
+
+        byte[] content = Files.readAllBytes(contentTxt(context));
+        List<long[]> ranges = ((ByteRangePagination) entry.pages().pagination()).ranges();
+        assertThat(ranges).hasSize(live.size());
+        for (int index = 0; index < live.size(); index++) {
+            assertThat(slice(content, ranges.get(index))).isEqualTo(live.get(index));
+        }
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -219,4 +219,26 @@ public class PageArtifactTest {
         assertThat(entry.taskInput().get("pipeline")).isEqualTo("tika");
         assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
     }
+
+    @Test
+    public void test_a_failed_regeneration_leaves_the_previous_payload_untouched() throws Exception {
+        ArtifactContext good = rootContext(twoPagePdf());
+        new PageArtifact(new PropertiesProvider()).produce(good);
+        byte[] previous = Files.readAllBytes(contentTxt(good));
+
+        Path unreadable = dir.getRoot().toPath().resolve("gone.pdf");
+        ArtifactContext broken = new ArtifactContext(project,
+                createDoc(good.document().getId()).with(unreadable).ofContentType("application/pdf").build(),
+                good.docArtifactDir(), mock(SourceExtractor.class));
+        try {
+            new PageArtifact(new PropertiesProvider()).produce(broken);
+            fail("expected an ArtifactException");
+        } catch (ArtifactException expected) {
+            assertThat(expected.getMessage()).contains(good.document().getId());
+        }
+
+        assertThat(Files.readAllBytes(contentTxt(good))).isEqualTo(previous);
+        assertThat(ArtifactPath.pagesDir(good.docArtifactDir()).toFile().list())
+                .isEqualTo(new String[]{"content.txt"}); // no .tmp left behind
+    }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -429,6 +429,37 @@ public class PageArtifactTest {
     }
 
     @Test
+    public void test_a_configuration_failure_reported_by_the_parse_thread_ends_the_run() throws Exception {
+        // ParsingReaderWithContentHandler#read hands back what the parse thread threw as the direct
+        // cause, so that is where a configuration this run cannot recover from shows up.
+        Document document = rootContext(twoPagePdf()).document();
+        IOException fromTheParser = new IOException("", new TikaConfigException("no parser for it"));
+
+        try {
+            PageArtifact.classify(document, fromTheParser);
+            fail("expected an ArtifactConfigurationException");
+        } catch (ArtifactConfigurationException expected) {
+            assertThat(expected.getCause()).isInstanceOf(TikaConfigException.class);
+        }
+    }
+
+    @Test
+    public void test_a_configuration_failure_from_deeper_in_the_chain_fails_one_document() throws Exception {
+        // Pagination spawns embeds into the same parse, so a TikaConfigException found further down the
+        // chain is one embed's parser going wrong, not this run's configuration. Ending the run on it
+        // would drain the queue on a single bad document. Retryable, not terminal: a config problem is
+        // this side going wrong, and the next run can have it fixed.
+        Document document = rootContext(twoPagePdf()).document();
+        IOException fromAnEmbed = new IOException("", new IOException("embedded parse failed",
+                new TikaConfigException("no parser for it")));
+
+        ArtifactException classified = PageArtifact.classify(document, fromAnEmbed);
+
+        assertThat(classified instanceof UnreadableContentException).isFalse();
+        assertThat(classified.getMessage()).contains(document.getId());
+    }
+
+    @Test
     public void test_a_failed_regeneration_leaves_the_previous_payload_untouched() throws Exception {
         ArtifactContext good = rootContext(twoPagePdf());
         new PageArtifact(new PropertiesProvider()).produce(good);

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -37,6 +37,11 @@ public class PageArtifactTest {
 
     private final Project project = Project.project("prj");
 
+    // Multi-byte UTF-8, rendered fine by Helvetica: 19 chars, 23 bytes (é and û each cost one extra
+    // byte). Referenced by its known char count below, not by decoding the written bytes back,
+    // since a decode of a wrongly-sliced multi-byte range is corrupted rather than merely shorter.
+    private static final String ACCENTED_PAGE = "Pagé un: coût élevé";
+
     @Test
     public void test_type_is_page() {
         assertThat(new PageArtifact(new PropertiesProvider()).type()).isEqualTo(ArtifactType.PAGE);
@@ -63,11 +68,13 @@ public class PageArtifactTest {
     }
 
     // A two-page PDF with real text: no tesseract needed, and each page has a distinct body so the
-    // byte ranges can be checked against the page they claim to delimit.
+    // byte ranges can be checked against the page they claim to delimit. The first page is
+    // multi-byte UTF-8 (Helvetica renders accents fine), so a range recorded in chars instead of
+    // bytes would be caught rather than passing by ASCII coincidence.
     private Path twoPagePdf() throws IOException {
         Path pdf = dir.getRoot().toPath().resolve("report.pdf");
         try (PDDocument document = new PDDocument()) {
-            for (String text : List.of("Page one text", "Page two text")) {
+            for (String text : List.of(ACCENTED_PAGE, "Page two text")) {
                 PDPage page = new PDPage();
                 document.addPage(page);
                 try (PDPageContentStream content = new PDPageContentStream(document, page)) {
@@ -103,14 +110,15 @@ public class PageArtifactTest {
 
         new PageArtifact(new PropertiesProvider()).produce(context);
 
-        assertThat(Files.readString(contentTxt(context))).contains("Page one text").contains("Page two text");
+        assertThat(Files.readString(contentTxt(context))).contains(ACCENTED_PAGE).contains("Page two text");
         assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
                 .isEqualTo(new String[]{"content.txt"});
     }
 
     @Test
     public void test_produce_returns_contiguous_byte_ranges_covering_the_content_file() throws Exception {
-        ArtifactContext context = rootContext(twoPagePdf());
+        Path pdf = twoPagePdf();
+        ArtifactContext context = rootContext(pdf);
 
         ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
 
@@ -122,6 +130,17 @@ public class PageArtifactTest {
         assertThat(ranges.get(1)[1]).isEqualTo(Files.size(contentTxt(context)));
         assertThat(entry.isComplete()).isFalse(); // the producer loop stamps status, not produce()
         assertThat(entry.contentType()).isNull();
+        // Mutation-killing: the first page is multi-byte UTF-8, so a range recorded in chars
+        // (page.length()) instead of bytes (bytes.length) would make this equal, not exceed, the
+        // extracted page's own char count. Proven by mutation: reverting bytes.length to
+        // page.length() in writePages makes this fail with "22 should be greater than 22".
+        String firstPage;
+        try (Extractor extractor = new Extractor()) {
+            extractor.disableOcr();
+            firstPage = extractor.extractPages(pdf).get(0);
+        }
+        long firstRangeByteLength = ranges.get(0)[1] - ranges.get(0)[0];
+        assertThat(firstRangeByteLength).isGreaterThan((long) firstPage.length());
     }
 
     private static String slice(byte[] content, long[] range) {
@@ -167,7 +186,7 @@ public class PageArtifactTest {
         ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
 
         assertThat(entry.pages().total()).isEqualTo(2);
-        assertThat(Files.readString(contentTxt(context))).contains("Page one text");
+        assertThat(Files.readString(contentTxt(context))).contains(ACCENTED_PAGE);
         verifyNoInteractions(sources); // the payload was already there: no re-extraction
     }
 
@@ -205,6 +224,26 @@ public class PageArtifactTest {
         }
         assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
         verify(sources).getSource(project, context.document());
+    }
+
+    @Test
+    public void test_produce_fails_when_an_embedded_document_has_a_zero_byte_raw_payload() throws Exception {
+        SourceExtractor sources = mock(SourceExtractor.class);
+        ArtifactContext context = embeddedContext(sources);
+        Files.createDirectories(context.docArtifactDir());
+        Files.createFile(context.docArtifactDir().resolve(ArtifactPath.RAW_FILE));
+        // getSource() is called since the cached payload is empty, but does not repair it: the raw
+        // file stays zero bytes.
+        when(sources.getSource(project, context.document()))
+                .thenReturn(new java.io.ByteArrayInputStream(new byte[0]));
+
+        try {
+            new PageArtifact(new PropertiesProvider()).produce(context);
+            fail("expected an ArtifactException");
+        } catch (ArtifactException expected) {
+            assertThat(expected.getMessage()).contains(context.document().getId());
+        }
+        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -202,6 +202,7 @@ public class PageArtifactTest {
             assertThat(expected.getMessage()).contains(context.document().getId());
         }
         assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        verify(sources).getSource(project, context.document());
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -283,6 +283,8 @@ public class PageArtifactTest {
         assertThat(entry.get("taskInput").get("ocr").asBoolean()).isTrue();
         assertThat(entry.has("contentType")).isFalse();
         assertThat(entry.has("filename")).isFalse();
+        assertThat(entry.has("complete")).isFalse();
+        assertThat(entry.has("terminal")).isFalse();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -7,6 +7,9 @@ import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.apache.tika.exception.TikaConfigException;
+import org.apache.tika.extractor.DocumentSelector;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.Document;
@@ -20,14 +23,19 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import static org.apache.tika.metadata.TikaCoreProperties.EmbeddedResourceType.ATTACHMENT;
+import static org.apache.tika.metadata.TikaCoreProperties.EmbeddedResourceType.INLINE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
 import static org.junit.Assert.fail;
@@ -45,6 +53,8 @@ public class PageArtifactTest {
     // byte). Referenced by its known char count below, not by decoding the written bytes back,
     // since a decode of a wrongly-sliced multi-byte range is corrupted rather than merely shorter.
     private static final String ACCENTED_PAGE = "Pagé un: coût élevé";
+    // The mail's own text, in the fixture that carries an attachment.
+    private static final String MAIL_BODY = "Mail body text.";
 
     @Test
     public void test_type_is_page() {
@@ -103,6 +113,56 @@ public class PageArtifactTest {
             document.save(pdf.toFile());
         }
         return pdf;
+    }
+
+    // A mail carrying the two-page PDF above as an attachment. The attachment is a document of its own
+    // (Tika marks it ATTACHMENT, extract-lib spawns it, indexes it separately and gives it its own page
+    // artifact), so none of its text belongs to the mail. A mail, not a PDF holding a PDF: a PDF's own
+    // page div is closed before its attachments are parsed, while a mail's is still open, which is what
+    // lets an attachment's characters land in it.
+    private Path emlWithAttachedPdf() throws IOException {
+        Path eml = dir.getRoot().toPath().resolve("mail.eml");
+        String attachment = Base64.getMimeEncoder().encodeToString(Files.readAllBytes(twoPagePdf()));
+        Files.writeString(eml, String.join("\r\n",
+                "From: sender@example.org",
+                "To: recipient@example.org",
+                "Subject: Report attached",
+                "MIME-Version: 1.0",
+                "Content-Type: multipart/mixed; boundary=\"BOUND\"",
+                "",
+                "--BOUND",
+                "Content-Type: text/plain; charset=UTF-8",
+                "",
+                MAIL_BODY,
+                "",
+                "--BOUND",
+                "Content-Type: application/pdf; name=\"report.pdf\"",
+                "Content-Disposition: attachment; filename=\"report.pdf\"",
+                "Content-Transfer-Encoding: base64",
+                "",
+                attachment,
+                "--BOUND--",
+                ""));
+        return eml;
+    }
+
+    // What indexing puts in the ES content field for a document: the text extract-lib hands the spewer,
+    // which is the root's own body, since a spawned embed's text goes to its own document's reader.
+    private static String indexedContent(Path source) throws IOException {
+        try (Extractor extractor = new Extractor()) {
+            extractor.disableOcr();
+            StringWriter indexed = new StringWriter();
+            try (Reader reader = extractor.extract(source).getReader()) {
+                reader.transferTo(indexed);
+            }
+            return indexed.toString();
+        }
+    }
+
+    // Page boundaries fall on whitespace Tika emits around the page divs, so the two sides can differ
+    // by a newline without differing by a word. Compared on words: what must not differ is the text.
+    private static String words(String text) {
+        return text.replaceAll("\\s+", " ").strip();
     }
 
     private ArtifactContext rootContext(Path source) {
@@ -372,6 +432,55 @@ public class PageArtifactTest {
         } catch (UnreadableContentException expected) {
             assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
         }
+    }
+
+    @Test
+    public void test_a_containers_pages_hold_the_same_text_as_the_container_document() throws Exception {
+        // What the pages are for: the document's indexed content, paginated. An attachment is indexed as
+        // its own document and paginated as its own artifact, so its text is in neither the container's
+        // content nor the container's pages. Asserted against what indexing puts in the content field
+        // rather than against a literal, since matching that field is the whole contract.
+        Path mail = emlWithAttachedPdf();
+        ArtifactContext context = rootContext(mail, "message/rfc822");
+        String indexed = indexedContent(mail);
+
+        ManifestEntry entry = new PageArtifact(new PropertiesProvider(Map.of("ocr", "false"))).produce(context);
+
+        assertThat(words(indexed)).contains(MAIL_BODY).excludes("Page two text");
+        assertThat(entry.pages().total()).isEqualTo(1);
+        assertThat(words(Files.readString(contentTxt(context)))).isEqualTo(words(indexed));
+    }
+
+    private static Metadata part(String resourceName, String embeddedResourceType, String contentType) {
+        Metadata metadata = new Metadata();
+        if (resourceName != null) {
+            metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, resourceName);
+        }
+        if (embeddedResourceType != null) {
+            metadata.set(TikaCoreProperties.EMBEDDED_RESOURCE_TYPE, embeddedResourceType);
+        }
+        if (contentType != null) {
+            metadata.set(Metadata.CONTENT_TYPE, contentType);
+        }
+        return metadata;
+    }
+
+    @Test
+    public void test_the_selection_keeps_the_document_and_its_inline_parts_and_drops_the_rest() {
+        // The file being parsed has to be selected or the page-splitting handler is never used for it
+        // (ParsingReaderWithContentHandler hands it a plain handler instead) and the document ends up
+        // with no pages at all. A scanned page's image is INLINE and its OCR text is in the content
+        // field, so it stays. A mail's own body can arrive nameless, so it stays. An attachment, a zip
+        // entry and a nameless PST message are documents of their own, indexed and paginated
+        // separately, so they go.
+        DocumentSelector selection = PageArtifact.ownTextOf(Path.of("/corpus/mail.eml"));
+
+        assertThat(selection.select(part("mail.eml", null, "message/rfc822"))).isTrue();
+        assertThat(selection.select(part(null, null, "text/plain; charset=UTF-8"))).isTrue();
+        assertThat(selection.select(part("image0.png", INLINE.toString(), "image/png"))).isTrue();
+        assertThat(selection.select(part("report.pdf", ATTACHMENT.toString(), "application/pdf"))).isFalse();
+        assertThat(selection.select(part("entry.txt", null, "text/plain"))).isFalse();
+        assertThat(selection.select(part(null, null, "message/rfc822"))).isFalse();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -82,10 +82,13 @@ public class PageArtifactTest {
     }
 
     private ArtifactContext rootContext(Path source) {
+        return rootContext(source, "application/pdf");
+    }
+
+    private ArtifactContext rootContext(Path source, String contentType) {
         Document doc = createDoc("6abb96950946b62bb993307c8945c0c096982783bab7fa24901522426840ca3e")
-                .with(source).ofContentType("application/pdf").build();
-        Path docArtifactDir = dir.getRoot().toPath().resolve("docdir");
-        return new ArtifactContext(project, doc, docArtifactDir, mock(SourceExtractor.class));
+                .with(source).ofContentType(contentType).build();
+        return new ArtifactContext(project, doc, dir.getRoot().toPath().resolve("docdir"), mock(SourceExtractor.class));
     }
 
     private Path contentTxt(ArtifactContext context) {
@@ -198,6 +201,21 @@ public class PageArtifactTest {
         } catch (ArtifactException expected) {
             assertThat(expected.getMessage()).contains(context.document().getId());
         }
+        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+    }
+
+    @Test
+    public void test_a_document_with_no_pages_is_recorded_as_empty_with_no_payload() throws Exception {
+        Path txt = dir.getRoot().toPath().resolve("note.txt");
+        Files.writeString(txt, "one line, no page divs");
+        ArtifactContext context = rootContext(txt, "text/plain");
+
+        ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
+
+        assertThat(entry.status()).isEqualTo(ManifestEntryStatus.EMPTY);
+        assertThat(entry.isTerminal()).isTrue();
+        assertThat(entry.pages()).isNull();
+        assertThat(entry.taskInput().get("pipeline")).isEqualTo("tika");
         assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -340,6 +340,41 @@ public class PageArtifactTest {
     }
 
     @Test
+    public void test_a_document_with_no_pages_discards_the_payload_an_earlier_run_left() throws Exception {
+        // Same document, produced twice: a version bump makes the first run's entry stale and the second
+        // run finds no pages. An EMPTY entry records no ranges, so a content.txt surviving it is served by
+        // a reader that lists the directory with nothing left to say how to read it.
+        new PageArtifact(new PropertiesProvider()).produce(rootContext(twoPagePdf()));
+        Path txt = dir.getRoot().toPath().resolve("note.txt");
+        Files.writeString(txt, "one line, no page divs");
+        ArtifactContext context = rootContext(txt, "text/plain");
+
+        ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
+
+        assertThat(entry.status()).isEqualTo(ManifestEntryStatus.EMPTY);
+        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+    }
+
+    @Test
+    public void test_unreadable_content_discards_the_payload_an_earlier_run_left() throws Exception {
+        // The producer records this one as an empty entry too, so the same rule applies to it.
+        new PageArtifact(new PropertiesProvider()).produce(rootContext(twoPagePdf()));
+        Path broken = dir.getRoot().toPath().resolve("broken.docx");
+        byte[] garbage = new byte[1024];
+        new Random(42).nextBytes(garbage);
+        Files.write(broken, garbage);
+        ArtifactContext context = rootContext(broken,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        try {
+            new PageArtifact(new PropertiesProvider()).produce(context);
+            fail("expected an UnreadableContentException");
+        } catch (UnreadableContentException expected) {
+            assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        }
+    }
+
+    @Test
     public void test_a_broken_configuration_ends_the_run_instead_of_failing_one_document() throws Exception {
         // It fails every document the same way, so ArtifactTask rethrows it where it rethrows an Error.
         // Catching it as one more document failure would drain the whole queue one ERROR at a time.

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -6,6 +6,7 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.tika.exception.TikaConfigException;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.Document;
@@ -336,6 +337,25 @@ public class PageArtifactTest {
         assertThat(entry.pages()).isNull();
         assertThat(entry.taskInput().get("pipeline")).isEqualTo("tika");
         assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+    }
+
+    @Test
+    public void test_a_broken_configuration_ends_the_run_instead_of_failing_one_document() throws Exception {
+        // It fails every document the same way, so ArtifactTask rethrows it where it rethrows an Error.
+        // Catching it as one more document failure would drain the whole queue one ERROR at a time.
+        PageArtifact misconfigured = new PageArtifact(new PropertiesProvider()) {
+            @Override
+            List<String> extractPages(Document document, Path source) {
+                throw new ArtifactConfigurationException(new TikaConfigException("no parser for it"));
+            }
+        };
+
+        try {
+            misconfigured.produce(rootContext(twoPagePdf()));
+            fail("expected an ArtifactConfigurationException");
+        } catch (ArtifactConfigurationException expected) {
+            assertThat(expected.getCause()).isInstanceOf(TikaConfigException.class);
+        }
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
@@ -215,6 +216,28 @@ public class PageArtifactTest {
         }
         assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
         verify(sources).getSource(project, doc);
+    }
+
+    @Test
+    public void test_content_no_parser_can_read_is_reported_as_unreadable() throws Exception {
+        // The same shape StructureArtifactTest pins: bytes indexed as a .docx that hold no zip signature
+        // at all, so POI rejects the package outright and always will. extract-lib hands that back as the
+        // cause of an IOException, so recognising it is what keeps the document from failing, logging at
+        // ERROR and re-parsing on every run.
+        Path broken = dir.getRoot().toPath().resolve("broken.docx");
+        byte[] garbage = new byte[1024];
+        new Random(42).nextBytes(garbage);
+        Files.write(broken, garbage);
+        ArtifactContext context = rootContext(broken,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        try {
+            new PageArtifact(new PropertiesProvider()).produce(context);
+            fail("expected an UnreadableContentException");
+        } catch (UnreadableContentException expected) {
+            assertThat(expected.getMessage()).contains(context.document().getId());
+        }
+        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -12,6 +12,7 @@ import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
+import org.icij.datashare.utils.BuildVersions;
 import org.icij.extract.extractor.Extractor;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +59,17 @@ public class PageArtifactTest {
         String version = (String) taskInput.get("version");
         assertThat(version).excludes("Apache");
         assertThat(version.split("\\.").length).isEqualTo(3);
+    }
+
+    @Test
+    public void test_task_input_fingerprints_extract_and_datashare_too() {
+        // Tika's version does not cover the page splitting: extract-lib owns the parser set and the
+        // handler that cuts the pages, and this class decides how they are stored. Without both, a
+        // release that changes either leaves every existing page artifact looking current.
+        Map<String, Object> taskInput = new PageArtifact(new PropertiesProvider()).taskInput();
+
+        assertThat(taskInput.get("extract")).isEqualTo(BuildVersions.EXTRACT);
+        assertThat(taskInput.get("datashare")).isEqualTo(BuildVersions.DATASHARE);
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -375,6 +375,41 @@ public class PageArtifactTest {
     }
 
     @Test
+    public void test_task_input_records_the_ocr_that_paginated_the_document() throws Exception {
+        // The run's flag alone is not what made these pages: a document indexed without OCR is
+        // paginated without OCR whatever the run asks for. Stamping those pages ocr:true is what lets
+        // the same file, re-indexed with OCR on, keep its OCR-free pages forever: same bytes, same
+        // digest, same artifact dir, same fingerprint, so skip-if-current never looks at it again.
+        PageArtifact withOcrRun = new PageArtifact(new PropertiesProvider());
+        Document notOcred = rootContext(twoPagePdf()).document();
+        Document ocred = createDoc(notOcred.getId()).with(notOcred.getPath()).ofContentType("application/pdf")
+                .withOcrParser("org.icij.extract.parser.ocr.OCRParserAdapter").build();
+
+        assertThat(withOcrRun.taskInput(notOcred).get("ocr")).isEqualTo(false);
+        assertThat(withOcrRun.taskInput(ocred).get("ocr")).isEqualTo(true);
+        // The run's flag still counts: with OCR off the extractor has it off, whatever the document says.
+        assertThat(new PageArtifact(new PropertiesProvider(Map.of("ocr", "false"))).taskInput(ocred).get("ocr"))
+                .isEqualTo(false);
+    }
+
+    @Test
+    public void test_a_document_reindexed_with_ocr_is_paginated_again() throws Exception {
+        Path pdf = twoPagePdf();
+        ArtifactContext context = rootContext(pdf);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false);
+        Files.delete(contentTxt(context)); // regenerated only if the second run does not skip
+        Document reindexedWithOcr = createDoc(context.document().getId()).with(pdf).ofContentType("application/pdf")
+                .withOcrParser("org.icij.extract.parser.ocr.OCRParserAdapter").build();
+        ArtifactContext reindexed = new ArtifactContext(project, reindexedWithOcr, context.docArtifactDir(),
+                mock(SourceExtractor.class));
+
+        assertThat(producer.run(List.of(new PageArtifact(new PropertiesProvider())), reindexed, false)).isTrue();
+
+        assertThat(Files.exists(contentTxt(reindexed))).isTrue();
+    }
+
+    @Test
     public void test_a_broken_configuration_ends_the_run_instead_of_failing_one_document() throws Exception {
         // It fails every document the same way, so ArtifactTask rethrows it where it rethrows an Error.
         // Catching it as one more document failure would drain the whole queue one ERROR at a time.
@@ -454,7 +489,9 @@ public class PageArtifactTest {
         assertThat(entry.get("pages").get("pagination").get("type").asText()).isEqualTo("byteRanges");
         assertThat(entry.get("pages").get("pagination").get("ranges").size()).isEqualTo(2);
         assertThat(entry.get("taskInput").get("pipeline").asText()).isEqualTo("tika");
-        assertThat(entry.get("taskInput").get("ocr").asBoolean()).isTrue();
+        // False although the run has OCR on: this document was indexed without it, so that is what
+        // paginated it, and that is what makes the entry stale when the file is re-indexed with OCR.
+        assertThat(entry.get("taskInput").get("ocr").asBoolean()).isFalse();
         assertThat(entry.has("contentType")).isFalse();
         assertThat(entry.has("filename")).isFalse();
         assertThat(entry.has("complete")).isFalse();

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -194,6 +194,30 @@ public class PageArtifactTest {
     }
 
     @Test
+    public void test_a_document_whose_root_labels_disagree_is_read_down_the_embedded_path() throws Exception {
+        // Extraction level says root, rootId says embed. isRootDocument() requires both, as
+        // SourceExtractor and RawArtifact do, so this document must not be paginated from getPath():
+        // that file is its container's, and pagination would cache the whole container under this
+        // document's digest and stamp it complete.
+        SourceExtractor sources = mock(SourceExtractor.class);
+        Document doc = createDoc("1a2b96950946b62bb993307c8945c0c096982783bab7fa24901522426840ca3e")
+                .with(twoPagePdf()).ofContentType("application/pdf")
+                .withExtractionLevel((short) 0).withRootId("another-id").build();
+        ArtifactContext context = new ArtifactContext(project, doc,
+                dir.getRoot().toPath().resolve("docdir"), sources);
+        when(sources.getSource(project, doc)).thenThrow(new java.io.FileNotFoundException("no raw payload"));
+
+        try {
+            new PageArtifact(new PropertiesProvider()).produce(context);
+            fail("expected an ArtifactException");
+        } catch (ArtifactException expected) {
+            assertThat(expected.getMessage()).contains(doc.getId());
+        }
+        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        verify(sources).getSource(project, doc);
+    }
+
+    @Test
     public void test_produce_reads_an_embedded_document_from_its_cached_raw_payload() throws Exception {
         SourceExtractor sources = mock(SourceExtractor.class);
         ArtifactContext context = embeddedContext(sources);

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -1,0 +1,35 @@
+package org.icij.datashare.text.artifact;
+
+import org.icij.datashare.PropertiesProvider;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class PageArtifactTest {
+    @Test
+    public void test_type_is_page() {
+        assertThat(new PageArtifact(new PropertiesProvider()).type()).isEqualTo(ArtifactType.PAGE);
+    }
+
+    @Test
+    public void test_task_input_is_the_tika_pipeline_its_version_and_the_run_ocr_setting() {
+        Map<String, Object> taskInput = new PageArtifact(new PropertiesProvider()).taskInput();
+
+        assertThat(taskInput.get("pipeline")).isEqualTo("tika");
+        assertThat(taskInput.get("ocr")).isEqualTo(true);
+        String version = (String) taskInput.get("version");
+        assertThat(version).excludes("Apache");
+        assertThat(version.split("\\.").length).isEqualTo(3);
+    }
+
+    @Test
+    public void test_task_input_records_ocr_off_when_the_run_disabled_it() {
+        PropertiesProvider properties = new PropertiesProvider(Map.of("ocr", "false"));
+
+        assertThat(new PageArtifact(properties).taskInput().get("ocr")).isEqualTo(false);
+        assertThat(new PageArtifact(properties).taskInput())
+                .isNotEqualTo(new PageArtifact(new PropertiesProvider()).taskInput());
+    }
+}

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -241,4 +241,25 @@ public class PageArtifactTest {
         assertThat(ArtifactPath.pagesDir(good.docArtifactDir()).toFile().list())
                 .isEqualTo(new String[]{"content.txt"}); // no .tmp left behind
     }
+
+    // content.txt as a non-empty directory forces the temp write to finish (there is nothing wrong
+    // with the payload itself) and the move onto content.txt to fail: REPLACE_EXISTING cannot swap a
+    // file in over a non-empty directory. That is the one failure point no other test reaches.
+    @Test
+    public void test_a_move_failure_after_a_complete_write_leaves_no_tmp_file() throws Exception {
+        ArtifactContext context = rootContext(twoPagePdf());
+        Path content = contentTxt(context);
+        Files.createDirectories(content);
+        Files.createFile(content.resolve("blocking-file"));
+
+        try {
+            new PageArtifact(new PropertiesProvider()).produce(context);
+            fail("expected an ArtifactException");
+        } catch (ArtifactException expected) {
+            assertThat(expected.getMessage()).contains(context.document().getId());
+        }
+
+        assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
+                .excludes("content.txt.tmp");
+    }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -113,6 +114,22 @@ public class PageArtifactTest {
         assertThat(Files.readString(contentTxt(context))).contains(ACCENTED_PAGE).contains("Page two text");
         assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
                 .isEqualTo(new String[]{"content.txt"});
+    }
+
+    // The temp file is built by hand rather than with Files.createTempFile, whose restrictive
+    // rw------- mode would otherwise survive the ATOMIC_MOVE onto content.txt. Compared against a
+    // control file written with Files.write in the same directory, so this pins the umask default
+    // rather than a hardcoded mode that a restrictive CI umask would falsify.
+    @Test
+    public void test_produce_writes_the_payload_with_the_directorys_default_permissions() throws Exception {
+        ArtifactContext context = rootContext(twoPagePdf());
+
+        new PageArtifact(new PropertiesProvider()).produce(context);
+
+        Path control = ArtifactPath.pagesDir(context.docArtifactDir()).resolve("control");
+        Files.write(control, new byte[0]);
+        assertThat(Files.getPosixFilePermissions(contentTxt(context)))
+                .isEqualTo(Files.getPosixFilePermissions(control));
     }
 
     @Test
@@ -244,6 +261,7 @@ public class PageArtifactTest {
             assertThat(expected.getMessage()).contains(context.document().getId());
         }
         assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
+        verify(sources).getSource(project, context.document());
     }
 
     @Test
@@ -300,8 +318,11 @@ public class PageArtifactTest {
             assertThat(expected.getMessage()).contains(context.document().getId());
         }
 
-        assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
-                .excludes("content.txt.tmp");
+        // Asserts on the shape, not the old literal name: createTempFile-era ".tmp" names are gone,
+        // but per-attempt UUID names still end in ".tmp", so this still fails if the temp file
+        // survives.
+        assertThat(Arrays.stream(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
+                .anyMatch(name -> name.endsWith(".tmp"))).isFalse();
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -633,10 +633,24 @@ public class PageArtifactTest {
         ArtifactContext context = rootContext(twoPagePdf());
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
         producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false);
-        Files.delete(contentTxt(context)); // if the second run produced again, it would be back
+        // Overwritten, not deleted: skip-if-current re-produces a payload that left the disk
+        // (ArtifactPayload#isMissing), so an absent content.txt would prove nothing about the skip.
+        Files.writeString(contentTxt(context), "kept from the first run");
 
         assertThat(producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false)).isTrue();
 
-        assertThat(Files.exists(contentTxt(context))).isFalse();
+        assertThat(Files.readString(contentTxt(context))).isEqualTo("kept from the first run");
+    }
+
+    @Test
+    public void test_a_second_run_produces_again_when_the_page_payload_left_the_disk() throws Exception {
+        ArtifactContext context = rootContext(twoPagePdf());
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false);
+        Files.delete(contentTxt(context));
+
+        assertThat(producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false)).isTrue();
+
+        assertThat(Files.readString(contentTxt(context))).contains("Page two text");
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -28,7 +28,6 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -190,8 +189,8 @@ public class PageArtifactTest {
                 .isEqualTo(new String[]{"content.txt"});
     }
 
-    // The temp file is built by hand rather than with Files.createTempFile, whose restrictive
-    // rw------- mode would otherwise survive the ATOMIC_MOVE onto content.txt. Compared against a
+    // The payload must carry the umask default every other artifact file gets, not the rw-------
+    // the JDK stamps on a temp file (see AtomicDirectorySwap#createStagingDir). Compared against a
     // control file written with Files.write in the same directory, so this pins the umask default
     // rather than a hardcoded mode that a restrictive CI umask would falsify.
     @Test
@@ -590,28 +589,19 @@ public class PageArtifactTest {
                 .isEqualTo(new String[]{"content.txt"}); // no .tmp left behind
     }
 
-    // content.txt as a non-empty directory forces the temp write to finish (there is nothing wrong
-    // with the payload itself) and the move onto content.txt to fail: REPLACE_EXISTING cannot swap a
-    // file in over a non-empty directory. That is the one failure point no other test reaches.
+    // Whatever an earlier run left at the payload path, including a directory another producer wrote
+    // there: the swap moves it aside rather than trying to replace a file over it.
     @Test
-    public void test_a_move_failure_after_a_complete_write_leaves_no_tmp_file() throws Exception {
+    public void test_produce_replaces_a_payload_path_holding_something_else() throws Exception {
         ArtifactContext context = rootContext(twoPagePdf());
-        Path content = contentTxt(context);
-        Files.createDirectories(content);
-        Files.createFile(content.resolve("blocking-file"));
+        Files.createDirectories(contentTxt(context));
+        Files.createFile(contentTxt(context).resolve("blocking-file"));
 
-        try {
-            new PageArtifact(new PropertiesProvider()).produce(context);
-            fail("expected an ArtifactException");
-        } catch (ArtifactException expected) {
-            assertThat(expected.getMessage()).contains(context.document().getId());
-        }
+        new PageArtifact(new PropertiesProvider()).produce(context);
 
-        // Asserts on the shape, not the old literal name: createTempFile-era ".tmp" names are gone,
-        // but per-attempt UUID names still end in ".tmp", so this still fails if the temp file
-        // survives.
-        assertThat(Arrays.stream(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
-                .anyMatch(name -> name.endsWith(".tmp"))).isFalse();
+        assertThat(Files.readString(contentTxt(context))).contains("Page two text");
+        assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
+                .isEqualTo(new String[]{"content.txt"});
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -1,11 +1,13 @@
 package org.icij.datashare.text.artifact;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
@@ -261,5 +263,37 @@ public class PageArtifactTest {
 
         assertThat(ArtifactPath.pagesDir(context.docArtifactDir()).toFile().list())
                 .excludes("content.txt.tmp");
+    }
+
+    @Test
+    public void test_the_written_manifest_matches_the_convention_shape() throws Exception {
+        ArtifactContext context = rootContext(twoPagePdf());
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+
+        assertThat(producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false)).isTrue();
+
+        JsonNode manifest = JsonObjectMapper.getMapper()
+                .readTree(context.docArtifactDir().resolve(ArtifactPath.MANIFEST_FILE).toFile());
+        JsonNode entry = manifest.get("page");
+        assertThat(entry.get("status").asText()).isEqualTo("complete");
+        assertThat(entry.get("pages").get("total").asInt()).isEqualTo(2);
+        assertThat(entry.get("pages").get("pagination").get("type").asText()).isEqualTo("byteRanges");
+        assertThat(entry.get("pages").get("pagination").get("ranges").size()).isEqualTo(2);
+        assertThat(entry.get("taskInput").get("pipeline").asText()).isEqualTo("tika");
+        assertThat(entry.get("taskInput").get("ocr").asBoolean()).isTrue();
+        assertThat(entry.has("contentType")).isFalse();
+        assertThat(entry.has("filename")).isFalse();
+    }
+
+    @Test
+    public void test_a_second_run_skips_a_document_already_produced_with_the_same_task_input() throws Exception {
+        ArtifactContext context = rootContext(twoPagePdf());
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false);
+        Files.delete(contentTxt(context)); // if the second run produced again, it would be back
+
+        assertThat(producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false)).isTrue();
+
+        assertThat(Files.exists(contentTxt(context))).isFalse();
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -24,7 +24,11 @@ import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 public class PageArtifactTest {
     @Rule public TemporaryFolder dir = new TemporaryFolder();
@@ -137,5 +141,63 @@ public class PageArtifactTest {
         for (int index = 0; index < live.size(); index++) {
             assertThat(slice(content, ranges.get(index))).isEqualTo(live.get(index));
         }
+    }
+
+    // Extraction level 2 = embedded, and the root path deliberately does not exist: a test that
+    // passes proves the root was never parsed.
+    private ArtifactContext embeddedContext(SourceExtractor sources) {
+        Document doc = createDoc("1a2b96950946b62bb993307c8945c0c096982783bab7fa24901522426840ca3e")
+                .with(Path.of("/absent/root.eml")).ofContentType("application/pdf")
+                .withExtractionLevel((short) 2).build();
+        return new ArtifactContext(project, doc, dir.getRoot().toPath().resolve("docdir"), sources);
+    }
+
+    @Test
+    public void test_produce_reads_an_embedded_document_from_its_cached_raw_payload() throws Exception {
+        SourceExtractor sources = mock(SourceExtractor.class);
+        ArtifactContext context = embeddedContext(sources);
+        Files.createDirectories(context.docArtifactDir());
+        Files.copy(twoPagePdf(), context.docArtifactDir().resolve(ArtifactPath.RAW_FILE));
+
+        ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
+
+        assertThat(entry.pages().total()).isEqualTo(2);
+        assertThat(Files.readString(contentTxt(context))).contains("Page one text");
+        verifyNoInteractions(sources); // the payload was already there: no re-extraction
+    }
+
+    @Test
+    public void test_produce_extracts_the_raw_payload_when_it_is_missing() throws Exception {
+        SourceExtractor sources = mock(SourceExtractor.class);
+        ArtifactContext context = embeddedContext(sources);
+        Path pdf = twoPagePdf();
+        // getSource() writes the payload into the document's artifact dir as a side effect, which is
+        // what this stub reproduces.
+        when(sources.getSource(project, context.document())).thenAnswer(invocation -> {
+            Files.createDirectories(context.docArtifactDir());
+            Files.copy(pdf, context.docArtifactDir().resolve(ArtifactPath.RAW_FILE));
+            return Files.newInputStream(pdf);
+        });
+
+        ManifestEntry entry = new PageArtifact(new PropertiesProvider()).produce(context);
+
+        assertThat(entry.pages().total()).isEqualTo(2);
+        verify(sources).getSource(project, context.document());
+    }
+
+    @Test
+    public void test_produce_fails_when_an_embedded_document_has_no_raw_payload() throws Exception {
+        SourceExtractor sources = mock(SourceExtractor.class);
+        ArtifactContext context = embeddedContext(sources);
+        when(sources.getSource(project, context.document()))
+                .thenThrow(new java.io.FileNotFoundException("/absent/root.eml"));
+
+        try {
+            new PageArtifact(new PropertiesProvider()).produce(context);
+            fail("expected an ArtifactException");
+        } catch (ArtifactException expected) {
+            assertThat(expected.getMessage()).contains(context.document().getId());
+        }
+        assertThat(Files.exists(ArtifactPath.pagesDir(context.docArtifactDir()))).isFalse();
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -1,11 +1,13 @@
 package org.icij.datashare.text.artifact;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.tika.exception.TikaConfigException;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.exception.TikaMemoryLimitException;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
+import org.icij.datashare.text.structure.StructureMarkdownExtractor.Page;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
 import org.junit.Rule;
@@ -191,6 +193,25 @@ public class StructureArtifactTest {
             org.junit.Assert.fail("expected an UnreadableContentException");
         } catch (UnreadableContentException expected) {
             assertThat(Files.exists(ArtifactPath.structureDir(dir.getRoot().toPath()))).isFalse();
+        }
+    }
+
+    @Test
+    public void test_a_broken_configuration_ends_the_run_instead_of_failing_one_document() throws Exception {
+        // It fails every document the same way, so ArtifactTask rethrows it where it rethrows an Error.
+        // Catching it as one more document failure would drain the whole queue one ERROR at a time.
+        StructureArtifact misconfigured = new StructureArtifact() {
+            @Override
+            List<Page> parse(java.io.InputStream source, Document document) {
+                throw new ArtifactConfigurationException(new TikaConfigException("no parser for it"));
+            }
+        };
+
+        try {
+            misconfigured.produce(contextFor(HTML));
+            org.junit.Assert.fail("expected an ArtifactConfigurationException");
+        } catch (ArtifactConfigurationException expected) {
+            assertThat(expected.getCause()).isInstanceOf(TikaConfigException.class);
         }
     }
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPathTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ArtifactPathTest.java
@@ -51,4 +51,18 @@ public class ArtifactPathTest {
             Locale.setDefault(previous);
         }
     }
+
+    @Test
+    public void test_pages_dir_is_under_the_node_dir() {
+        Path docDir = ArtifactPath.dir(Path.of("/artifact/prj"), DIGEST);
+        assertThat(ArtifactPath.pagesDir(docDir).toString())
+                .isEqualTo("/artifact/prj/6a/bb/" + DIGEST + "/pages");
+    }
+
+    @Test
+    public void test_pages_content_is_the_single_file_of_the_byte_ranges_scheme() {
+        Path docDir = ArtifactPath.dir(Path.of("/artifact/prj"), DIGEST);
+        assertThat(ArtifactPath.pagesContent(docDir).toString())
+                .isEqualTo("/artifact/prj/6a/bb/" + DIGEST + "/pages/content.txt");
+    }
 }


### PR DESCRIPTION
Adds the `page` artifact: a document's paginated **plain** extracted text, stored under `artifactDir` as a single `pages/content.txt` whose per-page byte ranges live in `manifest.json`. Produced by the ARTIFACT stage. Closes #2227, part of #2229.

Rebased on main after #2299 landed.

- feat(artifacts): declare the `page` artifact type
- feat(artifacts): add byteRanges pagination, deriving the entry's `total` from the offsets
- feat(artifacts): add the `pages/` payload path helpers
- feat(artifacts): add `PageArtifact`, paginating a root document from its own bytes
- feat(artifacts): paginate an embedded document from its cached `raw` payload, so an embed costs one parse of itself instead of one of its root
- feat(artifacts): write the payload through a unique temp file, swapped in, so a failed run keeps the previous pages
- feat(artifacts): register `page` in the ARTIFACT stage catalog, so it runs by default
- fix(artifacts): record a document with no pages as an empty entry, and reject an empty raw payload as a source
- fix(artifacts): keep the convenience predicates out of `manifest.json`
- fix(artifacts): ask `isRootDocument` where the page artifact asked the extraction level
- fix(artifacts): sort a page produce failure into fatal, retryable and terminal
- refactor(artifacts): fingerprint extract and datashare in the page task input

Pagination honours the document's OCR setting, as `/documents/content/pages/:id` does, so the stored pages match the indexed content. That is what keeps this type distinct from `structure`, which disables OCR for byte-determinism.

Serving is #2228.
