### PR TITLE
refactor(tasks): ArtifactTask reads its configuration from the task args

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/PropertiesProvider.java
+++ b/datashare-api/src/main/java/org/icij/datashare/PropertiesProvider.java
@@ -110,14 +110,25 @@ public class PropertiesProvider {
         return fileProperties;
     }
 
+    /**
+     * The DS_DOCKER_* tier alone, as the camelCased keys {@link #getProperties()} folds over the file.
+     * A caller ranking the operator's file against its own defaults needs this tier separately: it sits
+     * above the file, so substituting the file's value without it silently demotes the env var.
+     */
+    public static Properties getEnvProperties() {
+        Properties envProperties = new Properties();
+        envProperties.putAll(getenv().entrySet().stream().filter(entry -> entry.getKey().startsWith(PREFIX)).
+                collect(toMap(k -> camelCasify(k.getKey().replace(PREFIX, "")), Map.Entry::getValue)));
+        return envProperties;
+    }
+
     private void loadEnvVariables(Properties properties) {
-        Map<String, String> envVars = getenv().entrySet().stream().filter(entry -> entry.getKey().startsWith(PREFIX)).
-                collect(toMap(k -> camelCasify(k.getKey().replace(PREFIX, "")), Map.Entry::getValue));
+        Properties envVars = getEnvProperties();
         logger.info("adding properties from env vars {}", envVars);
         properties.putAll(envVars);
     }
 
-    private String camelCasify(String str) {
+    private static String camelCasify(String str) {
         String[] stringParts = str.toLowerCase().split("_");
         return stringParts[0] + stream(stringParts).skip(1).
                 map(s -> toUpperCase(s.charAt(0)) + s.substring(1)).

--- a/datashare-api/src/main/java/org/icij/datashare/PropertiesProvider.java
+++ b/datashare-api/src/main/java/org/icij/datashare/PropertiesProvider.java
@@ -81,14 +81,7 @@ public class PropertiesProvider {
         if (cachedProperties == null) {
             synchronized(this) {
                 if (cachedProperties == null) {
-                    Properties localProperties = new Properties();
-                    try {
-                        InputStream propertiesStream = new FileInputStream(settingsPath.toFile());
-                        logger.info("reading properties from {}", settingsPath);
-                        localProperties.load(propertiesStream);
-                    } catch (IOException | NullPointerException e) {
-                        logger.warn("no {} file found, using default values", settingsPath);
-                    }
+                    Properties localProperties = getFileProperties();
                     loadEnvVariables(localProperties);
                     cachedProperties = localProperties;
                     logger.info("properties set to {}", cachedProperties);
@@ -96,6 +89,25 @@ public class PropertiesProvider {
             }
         }
         return cachedProperties;
+    }
+
+    /**
+     * The settings file's own contents, without the DS_DOCKER_* fold-in {@link #getProperties()} adds.
+     * A caller that ranks the operator's file against its own defaults needs the file alone: the env
+     * vars are a separate, higher tier, and letting them ride along here promotes them silently.
+     */
+    public Properties getFileProperties() {
+        Properties fileProperties = new Properties();
+        if (settingsPath == null) {
+            return fileProperties;
+        }
+        try (InputStream propertiesStream = new FileInputStream(settingsPath.toFile())) {
+            logger.info("reading properties from {}", settingsPath);
+            fileProperties.load(propertiesStream);
+        } catch (IOException e) {
+            logger.warn("no {} file found, using default values", settingsPath);
+        }
+        return fileProperties;
     }
 
     private void loadEnvVariables(Properties properties) {

--- a/datashare-api/src/test/java/org/icij/datashare/PropertiesProviderTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/PropertiesProviderTest.java
@@ -271,6 +271,22 @@ public class PropertiesProviderTest {
     /**
      * see https://stackoverflow.com/questions/318239/how-do-i-set-environment-variables-from-java
      */
+    @Test
+    public void test_file_properties_leave_out_the_ds_env_variables() throws Exception {
+        putEnv("DS_DOCKER_FROM_ENV", "from-env");
+        File settings = folder.newFile("env.conf");
+        Files.write(settings.toPath(), asList("fromFile=from-file"));
+
+        PropertiesProvider provider = new PropertiesProvider(settings.getAbsolutePath());
+
+        // a caller ranking the operator's file against its own defaults must see the file alone:
+        // DS_DOCKER_* is a separate, higher tier and riding along here silently promotes it
+        assertThat(provider.getFileProperties()).includes(entry("fromFile", "from-file"));
+        assertThat(provider.getFileProperties().containsKey("fromEnv")).isFalse();
+        // getProperties() still folds them in, for callers that want the whole picture
+        assertThat(provider.getProperties()).includes(entry("fromEnv", "from-env"));
+    }
+
     private static void putEnv(String name, String value) throws Exception {
       try {
         Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");

--- a/datashare-app/src/main/java/org/icij/datashare/CliApp.java
+++ b/datashare-app/src/main/java/org/icij/datashare/CliApp.java
@@ -178,7 +178,9 @@ class CliApp {
 
         PipelineHelper pipeline = new PipelineHelper(new PropertiesProvider(properties));
         logger.info("executing {}", pipeline);
-        boolean completed = runPipeline(taskManager, pipeline, properties);
+        // the merged provider, not the raw CLI properties: task args are the only config a stage reads,
+        // so they need the DS_DOCKER_* and settings-file tiers CommonMode ranked, not just the typed args.
+        boolean completed = runPipeline(taskManager, pipeline, mode.properties());
         taskManager.shutdown();
         if (!completed) {
             // a partial run must not look like a success: `datashare ... && post-process.sh` would

--- a/datashare-app/src/main/java/org/icij/datashare/Main.java
+++ b/datashare-app/src/main/java/org/icij/datashare/Main.java
@@ -58,6 +58,7 @@ public class Main {
         commandLine.setAbbreviatedSubcommandsAllowed(false);
         commandLine.setCaseInsensitiveEnumValuesAllowed(true);
         applyColorScheme(commandLine, args);
+        DatashareCommand.applySettingsDefaults(commandLine, args);
         // The execution strategy walks the parse-result hierarchy to the deepest subcommand,
         // short-circuiting to RunLast if --help or --version is requested at any level so the
         // right help page is shown. Otherwise it registers the executed subcommand on

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -55,8 +55,8 @@ public class ArtifactTask extends PipelineTask<String> {
     private final ExecutorService executor;
 
     @Inject
-    public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, PropertiesProvider propertiesProvider, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
-        super(Stage.ARTIFACT, taskView.getUser(), factory, propertiesProvider, String.class, gateFactory.forTask(taskView));
+    public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
+        super(Stage.ARTIFACT, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class, gateFactory.forTask(taskView));
         this.indexer = indexer;
         project = Project.project(ArtifactStages.resolveProjectName(propertiesProvider));
         parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactChaosIntTest.java
@@ -80,8 +80,8 @@ public class ArtifactChaosIntTest {
         int realBeforeBlock = 5;
         AtomicInteger callCount = new AtomicInteger(0);
         CountDownLatch blocked = new CountDownLatch(1);
-        ArtifactTask killedTask = new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
-                new Task<>(ArtifactTask.class.getName(), User.local(), map), null) {
+        ArtifactTask killedTask = new ArtifactTask(stringQueueFactory, indexer, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(map), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 SourceExtractor real = new SourceExtractor(props);
@@ -137,8 +137,8 @@ public class ArtifactChaosIntTest {
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
 
         AtomicInteger reproductions = new AtomicInteger(0);
-        ArtifactTask resumeTask = new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
-                new Task<>(ArtifactTask.class.getName(), User.local(), map), null) {
+        ArtifactTask resumeTask = new ArtifactTask(stringQueueFactory, indexer, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(map), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 SourceExtractor real = new SourceExtractor(props);
@@ -191,8 +191,8 @@ public class ArtifactChaosIntTest {
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
-                new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
+        new ArtifactTask(stringQueueFactory, indexer, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(map), null).call();
 
         ArtifactCoverageChecker.Report report = new ArtifactCoverageChecker(indexer, new SourceExtractor(props))
                 .check(Project.project(es.getIndexName()), artifactDir.getRoot().toPath(), 100);
@@ -247,8 +247,8 @@ public class ArtifactChaosIntTest {
 
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
-                new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
+        new ArtifactTask(stringQueueFactory, indexer, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(map), null).call();
 
         ArtifactCoverageChecker.Report report = new ArtifactCoverageChecker(indexer, new SourceExtractor(props))
                 .check(Project.project(es.getIndexName()), artifactDir.getRoot().toPath(), 100);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactCoverageIntTest.java
@@ -62,8 +62,8 @@ public class ArtifactCoverageIntTest {
         // 3. ENQUEUEIDX -> ARTIFACT (queue test:queue:artifact), then the task itself
         new EnqueueFromIndexTask(stringQueueFactory, indexer,
                 new Task<>(EnqueueFromIndexTask.class.getName(), User.local(), map), null).call();
-        new ArtifactTask(stringQueueFactory, indexer, props, new UpstreamGate.Factory(taskRepository),
-                new Task<>(ArtifactTask.class.getName(), User.local(), map), null).call();
+        new ArtifactTask(stringQueueFactory, indexer, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(map), null).call();
 
         // 4. coverage
         ArtifactCoverageChecker.Report report = new ArtifactCoverageChecker(indexer, new SourceExtractor(props))

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskFixture.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskFixture.java
@@ -3,13 +3,11 @@ package org.icij.datashare.tasks;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.user.User;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /** Builds the Task an ArtifactTask reads its configuration from. Shared by the three artifact test classes. */
 class ArtifactTaskFixture {
-    /** Task args are mutable in production (the launcher adds the upstream id), so copy into a HashMap. */
     static Task<Long> taskWith(Map<String, Object> args) {
-        return new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>(args));
+        return new Task<>(ArtifactTask.class.getName(), User.local(), args);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskFixture.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskFixture.java
@@ -1,0 +1,15 @@
+package org.icij.datashare.tasks;
+
+import org.icij.datashare.asynctasks.Task;
+import org.icij.datashare.user.User;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Builds the Task an ArtifactTask reads its configuration from. Shared by the three artifact test classes. */
+class ArtifactTaskFixture {
+    /** Task args are mutable in production (the launcher adds the upstream id), so copy into a HashMap. */
+    static Task<Long> taskWith(Map<String, Object> args) {
+        return new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>(args));
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -61,7 +61,26 @@ public class ArtifactTaskTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_missing_artifact_dir() {
-        new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of()), new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), Map.of()), null);
+        new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(Map.of()), null);
+    }
+
+    @Test(timeout = 10000)
+    public void test_configuration_comes_from_the_task_args() throws Exception {
+        indexEmbeddedDoc();
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_DOC_SHA256);
+
+        // args carry the whole configuration, exactly as IndexTask and every other stage expects.
+        Long numberOfDocuments = new ArtifactTask(factory, mockEs,
+                new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(Map.of(
+                        "artifactDir", artifactDir.getRoot().toString(),
+                        "defaultProject", "prj")), null)
+                .call();
+
+        assertThat(numberOfDocuments).isEqualTo(1);
+        assertThat(artifactDir.getRoot().toPath().resolve("prj/6a/bb").toFile()).isDirectory();
     }
 
     @Test(timeout = 10000)
@@ -145,13 +164,14 @@ public class ArtifactTaskTest {
         queue.add(secondId);
 
         CountDownLatch bothInFlight = new CountDownLatch(2);
-        PropertiesProvider props = new PropertiesProvider(Map.of(
+        Map<String, Object> config = Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "parallelism", "2"));
-        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+                "parallelism", "2");
+        PropertiesProvider props = new PropertiesProvider(config);
+        Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -188,13 +208,13 @@ public class ArtifactTaskTest {
         queue.add(EMBEDDED_DOC_SHA256);
         queue.add(secondId);
 
-        PropertiesProvider props = new PropertiesProvider(Map.of(
+        Map<String, Object> config = Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "parallelism", "2"));
-        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+                "parallelism", "2");
+        Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 throw new IllegalStateException("no extractor");
@@ -215,16 +235,17 @@ public class ArtifactTaskTest {
         queue.add(EMBEDDED_DOC_SHA256);
         queue.add(secondId);
 
-        PropertiesProvider props = new PropertiesProvider(Map.of(
+        Map<String, Object> config = Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "parallelism", "2"));
-        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+                "parallelism", "2");
+        PropertiesProvider props = new PropertiesProvider(config);
+        Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
         // exactly one of the two workers fails to build its extractor and dies; the other survives.
         // the task must still fail, independently of the parallelism.
         AtomicInteger extractorCalls = new AtomicInteger(0);
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 if (extractorCalls.getAndIncrement() == 0) {
@@ -267,12 +288,13 @@ public class ArtifactTaskTest {
         queue.add(failingId);
         queue.add(EMBEDDED_DOC_SHA256);
 
-        PropertiesProvider props = new PropertiesProvider(Map.of(
+        Map<String, Object> config = Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "parallelism", "2"));
-        ArtifactTask task = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository),
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null) {
+                "parallelism", "2");
+        PropertiesProvider props = new PropertiesProvider(config);
+        ArtifactTask task = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(config), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -309,12 +331,13 @@ public class ArtifactTaskTest {
         queue.add(EMBEDDED_DOC_SHA256);
         queue.add(secondId);
 
-        PropertiesProvider props = new PropertiesProvider(Map.of(
+        Map<String, Object> config = Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "parallelism", "1"));
-        ArtifactTask task = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository),
-                new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null) {
+                "parallelism", "1");
+        PropertiesProvider props = new PropertiesProvider(config);
+        ArtifactTask task = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(config), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -340,13 +363,14 @@ public class ArtifactTaskTest {
         queue.add(EMBEDDED_DOC_SHA256);
 
         CountDownLatch started = new CountDownLatch(1);
-        PropertiesProvider props = new PropertiesProvider(Map.of(
+        Map<String, Object> config = Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "parallelism", "1"));
-        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+                "parallelism", "1");
+        PropertiesProvider props = new PropertiesProvider(config);
+        Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -395,15 +419,16 @@ public class ArtifactTaskTest {
 
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch secondStarted = new CountDownLatch(1);
-        PropertiesProvider props = new PropertiesProvider(Map.of(
+        Map<String, Object> config = Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
-                "parallelism", "1"));
-        Task<Long> task = new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>());
+                "parallelism", "1");
+        PropertiesProvider props = new PropertiesProvider(config);
+        Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
         // a single worker, so cancelling while the first document is in flight must stop the worker
         // before it ever polls the second entry off the queue
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, props, new UpstreamGate.Factory(taskRepository), task, null) {
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(props) {
@@ -489,10 +514,10 @@ public class ArtifactTaskTest {
         queue.add(EMBEDDED_DOC_SHA256);
 
         // no "parallelism" key -> ArtifactTask resolves .orElse(1)
-        Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
-                "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj")),
-                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+        Long numberOfDocuments = new ArtifactTask(factory, mockEs,
+                new UpstreamGate.Factory(taskRepository), ArtifactTaskFixture.taskWith(Map.of(
+                        "artifactDir", artifactDir.getRoot().toString(),
+                        "defaultProject", "prj")), null)
                 .call();
 
         assertThat(numberOfDocuments).isEqualTo(1);
@@ -557,13 +582,14 @@ public class ArtifactTaskTest {
             }
         };
         factory.queues.put("extract:queue:artifact", queue);
-        // this task reads its options from the injected properties, so the upstream id set by the
-        // launcher only exists in the task args: the queue must still be drained
-        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
+        // this task reads its options from the task args, so the upstream id set by the
+        // launcher must live alongside the rest of the configuration in that same map
+        Map<String, Object> config = new HashMap<>(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj")),
-                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(),
-                Map.of(UpstreamGate.UPSTREAM_TASK_ID, upstream.id)), null);
+                "defaultProject", "prj"));
+        config.put(UpstreamGate.UPSTREAM_TASK_ID, upstream.id);
+        ArtifactTask artifactTask = new ArtifactTask(factory, mockEs,
+                new UpstreamGate.Factory(taskRepository), ArtifactTaskFixture.taskWith(config), null);
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
@@ -604,13 +630,13 @@ public class ArtifactTaskTest {
         return runArtifactTask(Map.of());
     }
 
-    private Long runArtifactTask(Map<String, Object> extraProperties) throws Exception {
-        Map<String, Object> properties = new HashMap<>(Map.of(
+    private Long runArtifactTask(Map<String, Object> extraArgs) throws Exception {
+        Map<String, Object> args = new HashMap<>(Map.of(
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj"));
-        properties.putAll(extraProperties);
-        return new ArtifactTask(factory, mockEs, new PropertiesProvider(properties),
-                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+        args.putAll(extraArgs);
+        return new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository),
+                ArtifactTaskFixture.taskWith(args), null)
                 .call();
     }
 
@@ -627,10 +653,10 @@ public class ArtifactTaskTest {
         DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
         queue.add(rootSha);
 
-        Long numberOfDocuments = new ArtifactTask(factory, mockEs, new PropertiesProvider(Map.of(
-                "artifactDir", artifactDir.getRoot().toString(),
-                "defaultProject", "prj")),
-                new UpstreamGate.Factory(taskRepository), new Task<>(ArtifactTask.class.getName(), User.local(), new HashMap<>()), null)
+        Long numberOfDocuments = new ArtifactTask(factory, mockEs,
+                new UpstreamGate.Factory(taskRepository), ArtifactTaskFixture.taskWith(Map.of(
+                        "artifactDir", artifactDir.getRoot().toString(),
+                        "defaultProject", "prj")), null)
                 .call();
 
         assertThat(numberOfDocuments).isEqualTo(1);

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -1,7 +1,6 @@
 package org.icij.datashare.tasks;
 
 
-import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.Task;
 import org.icij.datashare.asynctasks.TaskRepositoryMemory;
 import org.icij.datashare.asynctasks.TaskResult;
@@ -168,13 +167,12 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "2");
-        PropertiesProvider props = new PropertiesProvider(config);
         Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
         ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
-                return new SourceExtractor(props) {
+                return new SourceExtractor(propertiesProvider) {
                     @Override
                     public TikaDocument extractEmbeddedSources(Project project, Document document) {
                         bothInFlight.countDown();
@@ -239,7 +237,6 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "2");
-        PropertiesProvider props = new PropertiesProvider(config);
         Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
         // exactly one of the two workers fails to build its extractor and dies; the other survives.
@@ -251,7 +248,7 @@ public class ArtifactTaskTest {
                 if (extractorCalls.getAndIncrement() == 0) {
                     throw new IllegalStateException("one worker has no extractor");
                 }
-                return new SourceExtractor(props) {
+                return new SourceExtractor(propertiesProvider) {
                     @Override
                     public TikaDocument extractEmbeddedSources(Project project, Document document) {
                         return null;
@@ -292,12 +289,11 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "2");
-        PropertiesProvider props = new PropertiesProvider(config);
         ArtifactTask task = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository),
                 ArtifactTaskFixture.taskWith(config), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
-                return new SourceExtractor(props) {
+                return new SourceExtractor(propertiesProvider) {
                     @Override
                     public TikaDocument extractEmbeddedSources(Project project, Document document) throws org.apache.tika.exception.TikaException {
                         if (document.getId().equals(failingId)) {
@@ -335,12 +331,11 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "1");
-        PropertiesProvider props = new PropertiesProvider(config);
         ArtifactTask task = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository),
                 ArtifactTaskFixture.taskWith(config), null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
-                return new SourceExtractor(props) {
+                return new SourceExtractor(propertiesProvider) {
                     @Override
                     public TikaDocument extractEmbeddedSources(Project project, Document document) {
                         throw new OutOfMemoryError("Java heap space");
@@ -367,13 +362,12 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "1");
-        PropertiesProvider props = new PropertiesProvider(config);
         Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
         ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
-                return new SourceExtractor(props) {
+                return new SourceExtractor(propertiesProvider) {
                     @Override
                     public TikaDocument extractEmbeddedSources(Project project, Document document) {
                         started.countDown();
@@ -423,7 +417,6 @@ public class ArtifactTaskTest {
                 "artifactDir", artifactDir.getRoot().toString(),
                 "defaultProject", "prj",
                 "parallelism", "1");
-        PropertiesProvider props = new PropertiesProvider(config);
         Task<Long> task = ArtifactTaskFixture.taskWith(config);
 
         // a single worker, so cancelling while the first document is in flight must stop the worker
@@ -431,7 +424,7 @@ public class ArtifactTaskTest {
         ArtifactTask artifactTask = new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null) {
             @Override
             protected SourceExtractor createSourceExtractor() {
-                return new SourceExtractor(props) {
+                return new SourceExtractor(propertiesProvider) {
                     @Override
                     public TikaDocument extractEmbeddedSources(Project project, Document document) {
                         if (document.getId().equals(secondId)) {

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -226,10 +226,12 @@ public class DatashareCli {
     Properties asProperties(OptionSet options, String prefix) {
         Properties properties = new Properties();
         // Only a file the operator actually asked for may outrank a declared default: passing null here
-        // would resolve a classpath datashare.properties and fold in DS_DOCKER_* env vars, and neither
-        // is their settings file.
+        // would resolve a classpath datashare.properties, which is not their settings file. Read the
+        // file alone, not getProperties(), which also folds in DS_DOCKER_* env vars: those are a
+        // separate tier that CommonMode ranks, and promoting them here would make them beat an option
+        // default only when -s happens to be passed.
         Properties settings = options.has(SETTINGS_OPT)
-                ? new PropertiesProvider(String.valueOf(options.valueOf(SETTINGS_OPT))).getProperties()
+                ? new PropertiesProvider(String.valueOf(options.valueOf(SETTINGS_OPT))).getFileProperties()
                 : new Properties();
         for (Map.Entry<OptionSpec<?>, List<?>> entry : options.asMap().entrySet()) {
             OptionSpec<?> spec = entry.getKey();

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -223,6 +223,11 @@ public class DatashareCli {
         return parser;
     }
 
+    /** Overridden in tests: env vars cannot be set on a running JVM under Java 21. */
+    Properties envProperties() {
+        return PropertiesProvider.getEnvProperties();
+    }
+
     Properties asProperties(OptionSet options, String prefix) {
         Properties properties = new Properties();
         // Only a file the operator actually asked for may outrank a declared default: passing null here
@@ -233,15 +238,18 @@ public class DatashareCli {
         Properties settings = options.has(SETTINGS_OPT)
                 ? new PropertiesProvider(String.valueOf(options.valueOf(SETTINGS_OPT))).getFileProperties()
                 : new Properties();
+        Properties env = envProperties();
         for (Map.Entry<OptionSpec<?>, List<?>> entry : options.asMap().entrySet()) {
             OptionSpec<?> spec = entry.getKey();
             String key = asPropertyKey(prefix, spec);
             boolean typed = options.has(spec);
             // Substituting the file's value, rather than omitting the key, matters for the consumers
             // that read these raw properties without CommonMode's settings fold-in: Main.startApplication
-            // for logLevel, CliApp.start for pluginsDir/extensionsDir, ArtifactTask for artifactDir.
+            // for logLevel and CliApp.start for pluginsDir/extensionsDir. A DS_DOCKER_* var wins over
+            // the file here, because CommonMode's overrideWith is a putAll: substituting the file's
+            // value blindly would let it clobber the env value the merged provider had ranked above it.
             if (!typed && settings.containsKey(key)) {
-                properties.setProperty(key, settings.getProperty(key));
+                properties.setProperty(key, env.getProperty(key, settings.getProperty(key)));
             } else if (typed || !entry.getValue().isEmpty()) {
                 properties.setProperty(key, asPropertyValue(entry.getValue()));
             }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -236,21 +236,15 @@ public class DatashareCli {
         for (Map.Entry<OptionSpec<?>, List<?>> entry : options.asMap().entrySet()) {
             OptionSpec<?> spec = entry.getKey();
             String key = asPropertyKey(prefix, spec);
-            if (!options.has(spec) && settings.containsKey(key)) {
-                // The operator did not type this option and their settings file defines it: the file
-                // wins over the declared default. Substitute rather than omit, and do so before the
-                // empty-value skip below, otherwise an option that declares no default at all never
-                // gets the file's value. Several consumers read these raw properties without
-                // CommonMode's settings fold-in (Main.startApplication for logLevel, CliApp.start for
-                // pluginsDir/extensionsDir, ArtifactTask for artifactDir) and would otherwise silently
-                // drop to their own unrelated fallback.
+            boolean typed = options.has(spec);
+            // Substituting the file's value, rather than omitting the key, matters for the consumers
+            // that read these raw properties without CommonMode's settings fold-in: Main.startApplication
+            // for logLevel, CliApp.start for pluginsDir/extensionsDir, ArtifactTask for artifactDir.
+            if (!typed && settings.containsKey(key)) {
                 properties.setProperty(key, settings.getProperty(key));
-                continue;
+            } else if (typed || !entry.getValue().isEmpty()) {
+                properties.setProperty(key, asPropertyValue(entry.getValue()));
             }
-            if (entry.getValue().isEmpty() && !options.has(spec)) {
-                continue;
-            }
-            properties.setProperty(key, asPropertyValue(entry.getValue()));
         }
         return properties;
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -225,9 +225,12 @@ public class DatashareCli {
 
     Properties asProperties(OptionSet options, String prefix) {
         Properties properties = new Properties();
-        // resolved the same way CommonMode does, so both paths agree on which file is in play
-        Properties settings = new PropertiesProvider(
-                options.has(SETTINGS_OPT) ? String.valueOf(options.valueOf(SETTINGS_OPT)) : null).getProperties();
+        // Only a file the operator actually asked for may outrank a declared default: passing null here
+        // would resolve a classpath datashare.properties and fold in DS_DOCKER_* env vars, and neither
+        // is their settings file.
+        Properties settings = options.has(SETTINGS_OPT)
+                ? new PropertiesProvider(String.valueOf(options.valueOf(SETTINGS_OPT))).getProperties()
+                : new Properties();
         for (Map.Entry<OptionSpec<?>, List<?>> entry : options.asMap().entrySet()) {
             OptionSpec<?> spec = entry.getKey();
             String key = asPropertyKey(prefix, spec);

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -5,6 +5,7 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.icij.datashare.PipelineHelper;
+import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.cli.spi.CliExtension;
 import org.icij.datashare.user.User;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ import java.util.Properties;
 import static java.util.Optional.ofNullable;
 import static org.icij.datashare.PropertiesProvider.DEFAULT_PROJECT_OPT;
 import static org.icij.datashare.PropertiesProvider.DIGEST_PROJECT_NAME_OPT;
+import static org.icij.datashare.PropertiesProvider.SETTINGS_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_DEFAULT_PROJECT;
 import static org.icij.datashare.cli.DatashareCliOptions.NO_DIGEST_PROJECT_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.OAUTH_USER_PROJECTS_KEY_OPT;
@@ -223,13 +225,22 @@ public class DatashareCli {
 
     Properties asProperties(OptionSet options, String prefix) {
         Properties properties = new Properties();
+        // resolved the same way CommonMode does, so both paths agree on which file is in play
+        Properties settings = new PropertiesProvider(
+                options.has(SETTINGS_OPT) ? String.valueOf(options.valueOf(SETTINGS_OPT)) : null).getProperties();
         for (Map.Entry<OptionSpec<?>, List<?>> entry : options.asMap().entrySet()) {
             OptionSpec<?> spec = entry.getKey();
-            if (options.has(spec) || !entry.getValue().isEmpty()) {
-                properties.setProperty(
-                        asPropertyKey(prefix, spec),
-                        asPropertyValue(entry.getValue()));
+            if (entry.getValue().isEmpty() && !options.has(spec)) {
+                continue;
             }
+            String key = asPropertyKey(prefix, spec);
+            // An option the operator did not type carries only its declared default. Emitting it would
+            // shadow the settings file, which sits below the CLI properties in CommonMode. Leaving the
+            // key out is what lets the file value stand.
+            if (!options.has(spec) && settings.containsKey(key)) {
+                continue;
+            }
+            properties.setProperty(key, asPropertyValue(entry.getValue()));
         }
         return properties;
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -234,10 +234,13 @@ public class DatashareCli {
                 continue;
             }
             String key = asPropertyKey(prefix, spec);
-            // An option the operator did not type carries only its declared default. Emitting it would
-            // shadow the settings file, which sits below the CLI properties in CommonMode. Leaving the
-            // key out is what lets the file value stand.
             if (!options.has(spec) && settings.containsKey(key)) {
+                // The operator did not type this option and their settings file defines it: the file
+                // wins over the declared default. Substitute rather than omit. Several consumers read
+                // these raw properties without CommonMode's settings fold-in (Main.startApplication for
+                // logLevel, CliApp.start for pluginsDir/extensionsDir) and would otherwise silently drop
+                // to their own unrelated fallback.
+                properties.setProperty(key, settings.getProperty(key));
                 continue;
             }
             properties.setProperty(key, asPropertyValue(entry.getValue()));

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/DatashareCli.java
@@ -230,17 +230,19 @@ public class DatashareCli {
                 options.has(SETTINGS_OPT) ? String.valueOf(options.valueOf(SETTINGS_OPT)) : null).getProperties();
         for (Map.Entry<OptionSpec<?>, List<?>> entry : options.asMap().entrySet()) {
             OptionSpec<?> spec = entry.getKey();
-            if (entry.getValue().isEmpty() && !options.has(spec)) {
-                continue;
-            }
             String key = asPropertyKey(prefix, spec);
             if (!options.has(spec) && settings.containsKey(key)) {
                 // The operator did not type this option and their settings file defines it: the file
-                // wins over the declared default. Substitute rather than omit. Several consumers read
-                // these raw properties without CommonMode's settings fold-in (Main.startApplication for
-                // logLevel, CliApp.start for pluginsDir/extensionsDir) and would otherwise silently drop
-                // to their own unrelated fallback.
+                // wins over the declared default. Substitute rather than omit, and do so before the
+                // empty-value skip below, otherwise an option that declares no default at all never
+                // gets the file's value. Several consumers read these raw properties without
+                // CommonMode's settings fold-in (Main.startApplication for logLevel, CliApp.start for
+                // pluginsDir/extensionsDir, ArtifactTask for artifactDir) and would otherwise silently
+                // drop to their own unrelated fallback.
                 properties.setProperty(key, settings.getProperty(key));
+                continue;
+            }
+            if (entry.getValue().isEmpty() && !options.has(spec)) {
                 continue;
             }
             properties.setProperty(key, asPropertyValue(entry.getValue()));

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -74,8 +74,10 @@ public class DatashareCommand implements Runnable {
         CommandLine.IDefaultValueProvider fromSettings = new CommandLine.PropertiesDefaultProvider(settings);
         // Arity-0 booleans are excluded: picocli sets a matched flag to !defaultValue, so taking that
         // default from the file inverts the flag, and "resume=true" in the file would make -r mean
-        // "do not resume". They keep their declared default here and CommonMode's overrideWith fold-in
-        // is what applies the file's value, as it did before this provider existed.
+        // "do not resume". They keep their declared default here, and the file's value reaches them
+        // through CommonMode's overrideWith fold-in only where toProperties() omits the key on false
+        // (resume, PipelineOptions:129). noDigestProject (GlobalOptions:150) and browserOpenLink
+        // (ServerOptions:147) write false unconditionally, so the file cannot set them: see #2339.
         commandLine.setDefaultValueProvider(
                 arg -> arg.arity().max() == 0 ? null : fromSettings.defaultValue(arg));
     }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -63,12 +63,14 @@ public class DatashareCommand implements Runnable {
     public static void applySettingsDefaults(CommandLine commandLine, String[] args) {
         String settingsPath = settingsPathFrom(args);
         if (settingsPath == null) {
-            // Not "no file": PropertiesProvider(null) resolves a classpath datashare.properties and
-            // always folds in DS_DOCKER_* env vars. Letting those in would put them above every
-            // option default, which is not what -s asked for and inverts precedence in Docker.
+            // Not "no file": PropertiesProvider(null) resolves a classpath datashare.properties, which
+            // is not what -s asked for.
             return;
         }
-        Properties settings = new PropertiesProvider(settingsPath).getProperties();
+        // The file alone, not getProperties(), which also folds in DS_DOCKER_* env vars: those are a
+        // separate tier that CommonMode ranks, and promoting them here would make them beat an option
+        // default only when -s happens to be passed.
+        Properties settings = new PropertiesProvider(settingsPath).getFileProperties();
         if (settings.isEmpty()) {
             return;
         }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -71,9 +71,6 @@ public class DatashareCommand implements Runnable {
         // separate tier that CommonMode ranks, and promoting them here would make them beat an option
         // default only when -s happens to be passed.
         Properties settings = new PropertiesProvider(settingsPath).getFileProperties();
-        if (settings.isEmpty()) {
-            return;
-        }
         CommandLine.IDefaultValueProvider fromSettings = new CommandLine.PropertiesDefaultProvider(settings);
         // Arity-0 booleans are excluded: picocli sets a matched flag to !defaultValue, so taking that
         // default from the file inverts the flag, and "resume=true" in the file would make -r mean

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -4,6 +4,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
+import org.icij.datashare.PropertiesProvider;
+
 import java.util.Properties;
 
 @Command(name = "datashare",
@@ -50,5 +52,35 @@ public class DatashareCommand implements Runnable {
         DatashareOptions.putAll(props, executedSubcommand);
         DatashareOptions.postProcess(props);
         return props;
+    }
+
+    /**
+     * Puts the settings file above the annotation defaults: picocli consults an IDefaultValueProvider
+     * before an option's declared defaultValue, and an explicitly typed argument still wins over both.
+     * Read from args because the provider has to be installed before parsing, and a no-op on empty
+     * settings so a run with no file behaves exactly as before.
+     */
+    public static void applySettingsDefaults(CommandLine commandLine, String[] args) {
+        Properties settings = new PropertiesProvider(settingsPathFrom(args)).getProperties();
+        if (!settings.isEmpty()) {
+            commandLine.setDefaultValueProvider(new CommandLine.PropertiesDefaultProvider(settings));
+        }
+    }
+
+    /** Reads -s/--settings out of the raw args, in both the "-s value" and "-s=value" forms. */
+    private static String settingsPathFrom(String[] args) {
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if ("-s".equals(arg) || "--settings".equals(arg)) {
+                return i + 1 < args.length ? args[i + 1] : null;
+            }
+            if (arg.startsWith("-s=")) {
+                return arg.substring("-s=".length());
+            }
+            if (arg.startsWith("--settings=")) {
+                return arg.substring("--settings=".length());
+            }
+        }
+        return null;
     }
 }

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -69,9 +69,16 @@ public class DatashareCommand implements Runnable {
             return;
         }
         Properties settings = new PropertiesProvider(settingsPath).getProperties();
-        if (!settings.isEmpty()) {
-            commandLine.setDefaultValueProvider(new CommandLine.PropertiesDefaultProvider(settings));
+        if (settings.isEmpty()) {
+            return;
         }
+        CommandLine.IDefaultValueProvider fromSettings = new CommandLine.PropertiesDefaultProvider(settings);
+        // Arity-0 booleans are excluded: picocli sets a matched flag to !defaultValue, so taking that
+        // default from the file inverts the flag, and "resume=true" in the file would make -r mean
+        // "do not resume". They keep their declared default here and CommonMode's overrideWith fold-in
+        // is what applies the file's value, as it did before this provider existed.
+        commandLine.setDefaultValueProvider(
+                arg -> arg.arity().max() == 0 ? null : fromSettings.defaultValue(arg));
     }
 
     /** Reads -s/--settings out of the raw args, in both the "-s value" and "-s=value" forms. */

--- a/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
+++ b/datashare-cli/src/main/java/org/icij/datashare/cli/command/DatashareCommand.java
@@ -57,11 +57,18 @@ public class DatashareCommand implements Runnable {
     /**
      * Puts the settings file above the annotation defaults: picocli consults an IDefaultValueProvider
      * before an option's declared defaultValue, and an explicitly typed argument still wins over both.
-     * Read from args because the provider has to be installed before parsing, and a no-op on empty
-     * settings so a run with no file behaves exactly as before.
+     * Read from args because the provider has to be installed before parsing, and a no-op unless the
+     * operator passed -s, so a run with no file behaves exactly as before.
      */
     public static void applySettingsDefaults(CommandLine commandLine, String[] args) {
-        Properties settings = new PropertiesProvider(settingsPathFrom(args)).getProperties();
+        String settingsPath = settingsPathFrom(args);
+        if (settingsPath == null) {
+            // Not "no file": PropertiesProvider(null) resolves a classpath datashare.properties and
+            // always folds in DS_DOCKER_* env vars. Letting those in would put them above every
+            // option default, which is not what -s asked for and inverts precedence in Docker.
+            return;
+        }
+        Properties settings = new PropertiesProvider(settingsPath).getProperties();
         if (!settings.isEmpty()) {
             commandLine.setDefaultValueProvider(new CommandLine.PropertiesDefaultProvider(settings));
         }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -9,6 +9,8 @@ import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -431,6 +433,24 @@ public class DatashareCliTest {
         cli.parseArguments(new String[] {"-s", settings.toString(), "--stages", "ARTIFACT"});
 
         assertThat(cli.properties).includes(entry("artifactDir", "/mnt/artifacts"));
+    }
+
+    @Test
+    public void test_a_classpath_properties_file_is_not_consulted_without_a_settings_option() throws Exception {
+        // PropertiesProvider(null) resolves datashare.properties off the context classloader and always
+        // folds in DS_DOCKER_* env vars. Neither is the operator's settings file, so neither may outrank
+        // a declared option default.
+        Files.writeString(tmp.getRoot().toPath().resolve("datashare.properties"), "parallelism=99\n");
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(
+                new URLClassLoader(new URL[] {tmp.getRoot().toURI().toURL()}, previous));
+        try {
+            cli.parseArguments(new String[] {"--stages", "INDEX"});
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
+
+        assertThat(cli.properties).includes(entry("parallelism", String.valueOf(DEFAULT_PARALLELISM)));
     }
 
     private Path settingsFile(String content) throws IOException {

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -437,9 +437,8 @@ public class DatashareCliTest {
 
     @Test
     public void test_a_classpath_properties_file_is_not_consulted_without_a_settings_option() throws Exception {
-        // PropertiesProvider(null) resolves datashare.properties off the context classloader and always
-        // folds in DS_DOCKER_* env vars. Neither is the operator's settings file, so neither may outrank
-        // a declared option default.
+        // PropertiesProvider(null) resolves datashare.properties off the context classloader, which is
+        // not the operator's settings file, so it may not outrank a declared option default.
         Files.writeString(tmp.getRoot().toPath().resolve("datashare.properties"), "parallelism=99\n");
         ClassLoader previous = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -421,6 +421,18 @@ public class DatashareCliTest {
         assertThat(cli.properties).includes(entry("parallelism", String.valueOf(DEFAULT_PARALLELISM)));
     }
 
+    @Test
+    public void test_settings_file_supplies_an_option_that_declares_no_default() throws IOException {
+        // artifactDir is withRequiredArg() with no defaultsTo, so jopt reports an empty value list for
+        // it when it is not typed. ArtifactTask reads only the task args built from these properties,
+        // so dropping the key here fails the ARTIFACT stage outright.
+        Path settings = settingsFile("artifactDir=/mnt/artifacts\n");
+
+        cli.parseArguments(new String[] {"-s", settings.toString(), "--stages", "ARTIFACT"});
+
+        assertThat(cli.properties).includes(entry("artifactDir", "/mnt/artifacts"));
+    }
+
     private Path settingsFile(String content) throws IOException {
         Path file = tmp.newFile("datashare-test.properties").toPath();
         Files.writeString(file, content);

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -375,9 +375,23 @@ public class DatashareCliTest {
         cli.parseArguments(new String[] {"-s", settings.toString()});
 
         // parallelism declares a default (DEFAULT_PARALLELISM). The operator never typed the option,
-        // so it must not shadow the settings file: leaving the key out lets the settings value stand
-        // once CommonMode folds the file in.
-        assertThat(cli.properties.getProperty("parallelism")).isNull();
+        // so the settings value must be the one that lands in the properties, not that default.
+        assertThat(cli.properties).includes(entry("parallelism", "42"));
+    }
+
+    @Test
+    public void test_a_settings_value_is_substituted_not_dropped() throws IOException {
+        // Regression guard for the stranding this replaced: several consumers read these raw
+        // properties without CommonMode's settings fold-in, so an absent key silently falls through
+        // to an unrelated fallback. logLevel is the sharp case: Main.startApplication does
+        // Level.toLevel(getProperty("logLevel")), and Level.toLevel(null) is DEBUG, not the INFO
+        // default. pluginsDir/extensionsDir would drop to cwd-relative ./plugins and ./extensions.
+        Path settings = settingsFile("logLevel=WARN\npluginsDir=/opt/ds/plugins\n");
+
+        cli.parseArguments(new String[] {"-s", settings.toString()});
+
+        assertThat(cli.properties).includes(entry("logLevel", "WARN"));
+        assertThat(cli.properties).includes(entry("pluginsDir", "/opt/ds/plugins"));
     }
 
     @Test
@@ -398,13 +412,13 @@ public class DatashareCliTest {
     }
 
     @Test
-    public void test_a_settings_file_only_suppresses_the_defaults_it_defines() throws IOException {
+    public void test_a_settings_file_only_overrides_the_defaults_it_defines() throws IOException {
         Path settings = settingsFile("artifactsForce=true\n");
 
         cli.parseArguments(new String[] {"-s", settings.toString()});
 
-        // a key the file does not mention keeps its default
-        assertThat(cli.properties.getProperty("parallelism")).isNotNull();
+        // a key the file does not mention keeps its declared default
+        assertThat(cli.properties).includes(entry("parallelism", String.valueOf(DEFAULT_PARALLELISM)));
     }
 
     private Path settingsFile(String content) throws IOException {

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
@@ -449,6 +450,29 @@ public class DatashareCliTest {
             Thread.currentThread().setContextClassLoader(previous);
         }
 
+        assertThat(cli.properties).includes(entry("parallelism", String.valueOf(DEFAULT_PARALLELISM)));
+    }
+
+    @Test
+    public void test_a_docker_env_var_outranks_the_settings_file_value() throws IOException {
+        // CommonMode.overrideWith is a putAll, so a value substituted here lands on top of the merged
+        // provider: substituting the file's artifactDir blindly would demote DS_DOCKER_ARTIFACT_DIR.
+        Path settings = settingsFile("artifactDir=/file/path\n");
+        DatashareCli cli = new DatashareCli() {
+            @Override
+            Properties envProperties() {
+                Properties env = new Properties();
+                env.setProperty("artifactDir", "/env/path");
+                env.setProperty("parallelism", "7");
+                return env;
+            }
+        };
+
+        cli.parseArguments(new String[] {"-s", settings.toString(), "--stages", "ARTIFACT"});
+
+        assertThat(cli.properties).includes(entry("artifactDir", "/env/path"));
+        // scoped to the keys the file declares: an env-only key keeps ranking through CommonMode, so
+        // it does not start outranking a declared option default here
         assertThat(cli.properties).includes(entry("parallelism", String.valueOf(DEFAULT_PARALLELISM)));
     }
 

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/DatashareCliTest.java
@@ -6,17 +6,22 @@ import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.fest.assertions.MapAssert.entry;
+import static org.icij.datashare.cli.DatashareCliOptions.DEFAULT_PARALLELISM;
 
 public class DatashareCliTest {
     private DatashareCli cli = new DatashareCli();
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
 
     @Before
     public void setUp() {
@@ -361,5 +366,50 @@ public class DatashareCliTest {
     public void test_artifacts_opt_bare_flag() {
         cli.parseArguments(new String[] {"--artifacts"});
         assertThat(cli.properties).includes(entry("artifacts", "true"));
+    }
+
+    @Test
+    public void test_settings_file_value_is_not_overridden_by_an_option_default() throws IOException {
+        Path settings = settingsFile("parallelism=42\n");
+
+        cli.parseArguments(new String[] {"-s", settings.toString()});
+
+        // parallelism declares a default (DEFAULT_PARALLELISM). The operator never typed the option,
+        // so it must not shadow the settings file: leaving the key out lets the settings value stand
+        // once CommonMode folds the file in.
+        assertThat(cli.properties.getProperty("parallelism")).isNull();
+    }
+
+    @Test
+    public void test_an_explicit_option_still_beats_the_settings_file() throws IOException {
+        Path settings = settingsFile("artifactsForce=true\n");
+
+        cli.parseArguments(new String[] {"-s", settings.toString(), "--artifactsForce=false"});
+
+        assertThat(cli.properties).includes(entry("artifactsForce", "false"));
+    }
+
+    @Test
+    public void test_option_defaults_are_still_emitted_without_a_settings_file() {
+        cli.parseArguments(new String[] {"--stages", "INDEX"});
+
+        // guards against the settings lookup dropping defaults app-wide
+        assertThat(cli.properties).includes(entry("parallelism", String.valueOf(DEFAULT_PARALLELISM)));
+    }
+
+    @Test
+    public void test_a_settings_file_only_suppresses_the_defaults_it_defines() throws IOException {
+        Path settings = settingsFile("artifactsForce=true\n");
+
+        cli.parseArguments(new String[] {"-s", settings.toString()});
+
+        // a key the file does not mention keeps its default
+        assertThat(cli.properties.getProperty("parallelism")).isNotNull();
+    }
+
+    private Path settingsFile(String content) throws IOException {
+        Path file = tmp.newFile("datashare-test.properties").toPath();
+        Files.writeString(file, content);
+        return file;
     }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/AbstractDatashareCommandTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/AbstractDatashareCommandTest.java
@@ -25,18 +25,18 @@ abstract class AbstractDatashareCommandTest {
 
     protected Properties parse(String... args) {
         DatashareCommand cmd = new DatashareCommand();
-        CommandLine commandLine = configure(cmd);
+        CommandLine commandLine = configure(cmd, args);
         commandLine.execute(args);
         return cmd.collectProperties();
     }
 
     protected int parseExitCode(String... args) {
         DatashareCommand cmd = new DatashareCommand();
-        CommandLine commandLine = configure(cmd);
+        CommandLine commandLine = configure(cmd, args);
         return commandLine.execute(args);
     }
 
-    private static CommandLine configure(DatashareCommand cmd) {
+    private static CommandLine configure(DatashareCommand cmd, String[] args) {
         CommandLine commandLine = new CommandLine(cmd);
         commandLine.setOverwrittenOptionsAllowed(true);
         commandLine.setCaseInsensitiveEnumValuesAllowed(true);
@@ -62,6 +62,7 @@ abstract class AbstractDatashareCommandTest {
             cmd2.getErr().println("error: " + ex.getMessage());
             return 1;
         });
+        DatashareCommand.applySettingsDefaults(commandLine, args);
         return commandLine;
     }
 }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/RetroCompatibilityTest.java
@@ -49,6 +49,7 @@ public class RetroCompatibilityTest {
             }
             return new CommandLine.RunLast().execute(parseResult);
         });
+        DatashareCommand.applySettingsDefaults(commandLine, args);
         commandLine.execute(args);
         return cmd.collectProperties();
     }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
@@ -49,14 +49,6 @@ public class SettingsDefaultsTest extends AbstractDatashareCommandTest {
     }
 
     @Test
-    public void test_annotation_defaults_are_untouched_without_a_settings_file() {
-        Properties props = parse("stage", "run", "--stages", "INDEX");
-
-        assertThat(props).includes(entry("ocr", "true"));
-        assertThat(props).includes(entry("scrollSize", "1000"));
-    }
-
-    @Test
     public void test_a_settings_file_does_not_invert_an_arity_zero_flag() throws IOException {
         // picocli sets an arity-0 boolean to !defaultValue when the flag is present, and it takes that
         // default from the value provider. A file saying resume=true must not turn -r into "do not resume".
@@ -89,7 +81,9 @@ public class SettingsDefaultsTest extends AbstractDatashareCommandTest {
         try {
             Properties props = parse("stage", "run", "--stages", "INDEX");
 
+            // both the key the classpath file names and one it does not keep their annotation defaults
             assertThat(props).includes(entry("ocr", "true"));
+            assertThat(props).includes(entry("scrollSize", "1000"));
         } finally {
             Thread.currentThread().setContextClassLoader(previous);
         }

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -52,6 +54,24 @@ public class SettingsDefaultsTest extends AbstractDatashareCommandTest {
 
         assertThat(props).includes(entry("ocr", "true"));
         assertThat(props).includes(entry("scrollSize", "1000"));
+    }
+
+    @Test
+    public void test_a_classpath_properties_file_is_not_consulted_without_a_settings_option() throws Exception {
+        // PropertiesProvider(null) resolves datashare.properties off the context classloader and always
+        // folds in DS_DOCKER_* env vars. Neither is the operator's settings file, so neither may outrank
+        // a declared option default.
+        Files.writeString(tmp.getRoot().toPath().resolve("datashare.properties"), "ocr=false\n");
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(
+                new URLClassLoader(new URL[] {tmp.getRoot().toURI().toURL()}, previous));
+        try {
+            Properties props = parse("stage", "run", "--stages", "INDEX");
+
+            assertThat(props).includes(entry("ocr", "true"));
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
+        }
     }
 
     private Path settingsFile(String content) throws IOException {

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
@@ -1,0 +1,62 @@
+package org.icij.datashare.cli.command;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
+public class SettingsDefaultsTest extends AbstractDatashareCommandTest {
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void test_settings_file_value_beats_an_annotation_default() throws IOException {
+        // --ocr is declared with defaultValue = "true" in PipelineOptions
+        Path settings = settingsFile("ocr=false\n");
+
+        Properties props = parse("-s", settings.toString(), "stage", "run", "--stages", "INDEX");
+
+        assertThat(props).includes(entry("ocr", "false"));
+    }
+
+    @Test
+    public void test_an_explicit_option_beats_the_settings_file() throws IOException {
+        Path settings = settingsFile("ocr=false\n");
+
+        Properties props = parse("-s", settings.toString(), "stage", "run", "--stages", "INDEX",
+                "--ocr", "true");
+
+        assertThat(props).includes(entry("ocr", "true"));
+    }
+
+    @Test
+    public void test_annotation_default_applies_for_a_key_the_settings_file_omits() throws IOException {
+        Path settings = settingsFile("ocr=false\n");
+
+        Properties props = parse("-s", settings.toString(), "stage", "run", "--stages", "INDEX");
+
+        // scrollSize is declared with defaultValue = "1000" and the file says nothing about it
+        assertThat(props).includes(entry("scrollSize", "1000"));
+    }
+
+    @Test
+    public void test_annotation_defaults_are_untouched_without_a_settings_file() {
+        Properties props = parse("stage", "run", "--stages", "INDEX");
+
+        assertThat(props).includes(entry("ocr", "true"));
+        assertThat(props).includes(entry("scrollSize", "1000"));
+    }
+
+    private Path settingsFile(String content) throws IOException {
+        Path file = tmp.newFile("datashare-test.properties").toPath();
+        Files.writeString(file, content);
+        return file;
+    }
+}

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
@@ -57,6 +57,28 @@ public class SettingsDefaultsTest extends AbstractDatashareCommandTest {
     }
 
     @Test
+    public void test_a_settings_file_does_not_invert_an_arity_zero_flag() throws IOException {
+        // picocli sets an arity-0 boolean to !defaultValue when the flag is present, and it takes that
+        // default from the value provider. A file saying resume=true must not turn -r into "do not resume".
+        Path settings = settingsFile("resume=true\n");
+
+        Properties props = parse("-s", settings.toString(), "stage", "run", "--stages", "ARTIFACT", "-r");
+
+        assertThat(props).includes(entry("resume", "true"));
+    }
+
+    @Test
+    public void test_an_arity_zero_flag_is_left_out_of_the_settings_defaults() throws IOException {
+        // The flag keeps its own meaning instead: an untyped -r stays false here, and CommonMode's
+        // overrideWith fold-in is what applies the file's resume=true, as it did before this provider.
+        Path settings = settingsFile("resume=true\n");
+
+        Properties props = parse("-s", settings.toString(), "stage", "run", "--stages", "ARTIFACT");
+
+        assertThat(props.containsKey("resume")).isFalse();
+    }
+
+    @Test
     public void test_a_classpath_properties_file_is_not_consulted_without_a_settings_option() throws Exception {
         // PropertiesProvider(null) resolves datashare.properties off the context classloader and always
         // folds in DS_DOCKER_* env vars. Neither is the operator's settings file, so neither may outrank

--- a/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
+++ b/datashare-cli/src/test/java/org/icij/datashare/cli/command/SettingsDefaultsTest.java
@@ -80,9 +80,8 @@ public class SettingsDefaultsTest extends AbstractDatashareCommandTest {
 
     @Test
     public void test_a_classpath_properties_file_is_not_consulted_without_a_settings_option() throws Exception {
-        // PropertiesProvider(null) resolves datashare.properties off the context classloader and always
-        // folds in DS_DOCKER_* env vars. Neither is the operator's settings file, so neither may outrank
-        // a declared option default.
+        // PropertiesProvider(null) resolves datashare.properties off the context classloader, which is
+        // not the operator's settings file, so it may not outrank a declared option default.
         Files.writeString(tmp.getRoot().toPath().resolve("datashare.properties"), "ocr=false\n");
         ClassLoader previous = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(


### PR DESCRIPTION
Closes #2298.

ARTIFACT was the only pipeline stage reading process-wide properties instead of its task args. Moving it to task args exposed four bugs in how a `-s` settings file resolves against CLI option defaults, on both the legacy jopt parser and the picocli one, so those are fixed here too.

- refactor: `ArtifactTask` reads its configuration from the task args instead of the injected process-wide `PropertiesProvider`, like every other stage already does
- fix: substitute a settings-file value before skipping an option that declares no default, so a settings-only `artifactDir` reaches the ARTIFACT stage instead of failing it
- fix: consult the settings file only when the operator passed `-s`, so a classpath `datashare.properties` no longer outranks every option default
- fix: exclude arity-0 booleans from the picocli default value provider, so a settings file setting `resume=true` no longer makes `-r` mean "do not resume"
- fix: read the settings file alone via the new `PropertiesProvider.getFileProperties()`, so `DS_DOCKER_*` env vars keep the precedence `CommonMode` gives them instead of beating an option default only when `-s` happens to be passed
- fix: substitute the settings value as env-over-file, so a `DS_DOCKER_*` var keeps outranking the settings file it substitutes
- fix: build the CLI pipeline task args from the merged provider, so an env-only value still reaches a stage
- test: cover the precedence bugs in `DatashareCliTest`, `SettingsDefaultsTest` and `PropertiesProviderTest`

## Not covered

- `-s<path>` (attached short form) is still not parsed by `settingsPathFrom`, so the settings file is ignored on the picocli path for that invocation style.
- `ArtifactTask` reads task args through `java.util.Properties`, so a non-String arg from the API or Temporal is silently dropped.
- Starting a stage through the generic `PUT /task/:id` with a minimal body needs the full config in `args`: `ScanTask` and `IndexTask` already did, so ARTIFACT is now consistent with them rather than falling back to the server's `datashare.conf`.
- A settings file cannot set `noDigestProject` or `browserOpenLink` (#2339): pre-existing, both write `false` unconditionally.
- `DS_DOCKER_*` env vars still lose to any option that declares a default, because `CommonMode` layers the CLI properties on top. That contradicts the precedence documented on `SettingsResource.patchSettings`, but it predates this branch and changing it would affect every Docker deployment, so it is left alone here.

