### PR TITLE
feat(index): authorize a "<project>.entities" index against its base project

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -12,13 +12,17 @@ import java.util.stream.Collectors;
 import static java.util.Arrays.stream;
 
 public class IndexAccessVerifier {
+    /** An index name: dots allowed inside, never leading, so the elasticsearch system indices (.kibana, .security) stay out of reach. */
+    private static final String INDEX_NAME = "[-a-zA-Z0-9_]+(\\.[-a-zA-Z0-9_]+)*";
+    private static final Pattern INDICES = Pattern.compile("^" + INDEX_NAME + "(," + INDEX_NAME + ")*$");
+    /** Suffix of an index derived from a project: "myproject.entities" is granted to whoever is granted "myproject". */
+    private static final String ENTITIES_SUFFIX = ".entities";
 
     static public String checkIndices(String indices) {
         if( indices == null) {
             throw new IllegalArgumentException("indices is null");
         }
-        Pattern pattern = Pattern.compile("^[-a-zA-Z0-9_]+(,[-a-zA-Z0-9_]+)*$");
-        Matcher matcher = pattern.matcher(indices);
+        Matcher matcher = INDICES.matcher(indices);
         if( !matcher.find()) {
             throw new IllegalArgumentException("Bad format for indices : '" + indices+"'");
         }
@@ -71,8 +75,16 @@ public class IndexAccessVerifier {
         boolean isSearchPath = "_search".equals(pathParts[1]);
         boolean isCountPath = "_count".equals(pathParts[1]);
         boolean isAsyncSearchPath = "_async_search".equals(pathParts[1]);
-        boolean areAllIndexesGranted = stream(indexes).allMatch(currentUser::isGranted);
+        boolean areAllIndexesGranted = stream(indexes).map(IndexAccessVerifier::baseProject).allMatch(currentUser::isGranted);
         return areAllIndexesGranted && (isMethodGet || isSearchPath || isCountPath || isAsyncSearchPath);
+    }
+
+    /**
+     * The project an index name authorizes against: itself, or the base project of a known suffix.
+     * Exact match on the remainder, never a prefix match, so "myproject-other" doesn't inherit "myproject".
+     */
+    public static String baseProject(String index) {
+        return index.endsWith(ENTITIES_SUFFIX) ? index.substring(0, index.length() - ENTITIES_SUFFIX.length()) : index;
     }
 
     public static String getUrlString(Context context, String s) {

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -12,10 +12,12 @@ import java.util.stream.Collectors;
 import static java.util.Arrays.stream;
 
 public class IndexAccessVerifier {
-    /** An index name: dots allowed inside, never leading. That alone does not keep the elasticsearch
-     *  system indices (.kibana, .security) out of reach; "_all" and other "_"-leading names still match.
-     *  The grant check downstream of this pattern is what stops those, since none of them is a granted project. */
-    private static final String INDEX_NAME = "[-a-zA-Z0-9_]+(\\.[-a-zA-Z0-9_]+)*";
+    /** An index name: a dot separates namespaced segments, and neither a dot nor an underscore may lead.
+     *  A leading dot names an elasticsearch system index (.kibana, .security) and a leading underscore
+     *  an elasticsearch selector ("_all"), both of which reach far past the one project a caller is
+     *  granted. Refusing them here rather than downstream keeps the refusal independent of who is
+     *  granted what: a project row named "_all" is grantable, so a grant check alone would let it pass. */
+    private static final String INDEX_NAME = "[-a-zA-Z0-9][-a-zA-Z0-9_]*(\\.[-a-zA-Z0-9_]+)*";
     private static final Pattern INDICES = Pattern.compile("^" + INDEX_NAME + "(," + INDEX_NAME + ")*$");
     /** Suffix of an index derived from a project: "myproject.entities" is granted to whoever is granted "myproject". */
     private static final String ENTITIES_SUFFIX = ".entities";

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -23,7 +23,7 @@ public class IndexAccessVerifier {
             throw new IllegalArgumentException("indices is null");
         }
         Matcher matcher = INDICES.matcher(indices);
-        if( !matcher.find()) {
+        if( !matcher.matches()) {
             throw new IllegalArgumentException("Bad format for indices : '" + indices+"'");
         }
         return indices;

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -5,6 +5,7 @@ import net.codestory.http.Query;
 import net.codestory.http.errors.UnauthorizedException;
 import org.icij.datashare.session.DatashareUser;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -12,7 +13,9 @@ import java.util.stream.Collectors;
 import static java.util.Arrays.stream;
 
 public class IndexAccessVerifier {
-    /** An index name: dots allowed inside, never leading, so the elasticsearch system indices (.kibana, .security) stay out of reach. */
+    /** An index name: dots allowed inside, never leading. That alone does not keep the elasticsearch
+     *  system indices (.kibana, .security) out of reach; "_all" and other "_"-leading names still match.
+     *  The grant check downstream of this pattern is what stops those, since none of them is a granted project. */
     private static final String INDEX_NAME = "[-a-zA-Z0-9_]+(\\.[-a-zA-Z0-9_]+)*";
     private static final Pattern INDICES = Pattern.compile("^" + INDEX_NAME + "(," + INDEX_NAME + ")*$");
     /** Suffix of an index derived from a project: "myproject.entities" is granted to whoever is granted "myproject". */
@@ -37,8 +40,8 @@ public class IndexAccessVerifier {
         if (isSearchScrollPath(path)) {
             return getUrlString(context, path);
         }
-        String[] indexes = checkIndices(pathParts[0]).split(",");
-        if (isAuthorizedRequest(context, pathParts, indexes)) {
+        String indexSegment = checkIndices(pathParts[0]);
+        if (isAuthorizedRequest(context, pathParts, indexSegment)) {
             return getUrlString(context, path);
         }
         throw new UnauthorizedException();
@@ -69,13 +72,13 @@ public class IndexAccessVerifier {
         return "_search".equals(pathParts[0]) && "scroll".equals(pathParts[1]);
     }
 
-    static private boolean isAuthorizedRequest(Context context, String[] pathParts, String[] indexes) {
+    static private boolean isAuthorizedRequest(Context context, String[] pathParts, String indexSegment) {
         DatashareUser currentUser = (DatashareUser) context.currentUser();
         boolean isMethodGet = "GET".equalsIgnoreCase(context.method());
         boolean isSearchPath = "_search".equals(pathParts[1]);
         boolean isCountPath = "_count".equals(pathParts[1]);
         boolean isAsyncSearchPath = "_async_search".equals(pathParts[1]);
-        boolean areAllIndexesGranted = stream(indexes).map(IndexAccessVerifier::baseProject).allMatch(currentUser::isGranted);
+        boolean areAllIndexesGranted = baseProjects(indexSegment).stream().allMatch(currentUser::isGranted);
         return areAllIndexesGranted && (isMethodGet || isSearchPath || isCountPath || isAsyncSearchPath);
     }
 
@@ -85,6 +88,12 @@ public class IndexAccessVerifier {
      */
     public static String baseProject(String index) {
         return index.endsWith(ENTITIES_SUFFIX) ? index.substring(0, index.length() - ENTITIES_SUFFIX.length()) : index;
+    }
+
+    /** Maps a comma-separated index list to its base projects, in the same order; the single source of
+     *  truth for both an async-search submit and the poll that must re-check the same project set. */
+    public static List<String> baseProjects(String commaSeparated) {
+        return stream(commaSeparated.split(",")).map(IndexAccessVerifier::baseProject).toList();
     }
 
     public static String getUrlString(Context context, String s) {

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -6,7 +6,6 @@ import net.codestory.http.errors.UnauthorizedException;
 import org.icij.datashare.session.DatashareUser;
 
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -25,8 +24,7 @@ public class IndexAccessVerifier {
         if( indices == null) {
             throw new IllegalArgumentException("indices is null");
         }
-        Matcher matcher = INDICES.matcher(indices);
-        if( !matcher.matches()) {
+        if( !INDICES.matcher(indices).matches()) {
             throw new IllegalArgumentException("Bad format for indices : '" + indices+"'");
         }
         return indices;
@@ -82,18 +80,11 @@ public class IndexAccessVerifier {
         return areAllIndexesGranted && (isMethodGet || isSearchPath || isCountPath || isAsyncSearchPath);
     }
 
-    /**
-     * The project an index name authorizes against: itself, or the base project of a known suffix.
-     * Exact match on the remainder, never a prefix match, so "myproject-other" doesn't inherit "myproject".
-     */
-    public static String baseProject(String index) {
-        return index.endsWith(ENTITIES_SUFFIX) ? index.substring(0, index.length() - ENTITIES_SUFFIX.length()) : index;
-    }
-
-    /** Maps a comma-separated index list to its base projects, in the same order; the single source of
-     *  truth for both an async-search submit and the poll that must re-check the same project set. */
-    public static List<String> baseProjects(String commaSeparated) {
-        return stream(commaSeparated.split(",")).map(IndexAccessVerifier::baseProject).toList();
+    /** The projects a comma-separated index list authorizes against, in the same order: each index itself,
+     *  or the base project it derives from. Suffix match on the whole remainder, never a prefix match,
+     *  so "myproject-other" doesn't inherit "myproject". */
+    public static List<String> baseProjects(String indices) {
+        return stream(indices.split(",")).map(i -> i.endsWith(ENTITIES_SUFFIX) ? i.substring(0, i.length() - ENTITIES_SUFFIX.length()) : i).toList();
     }
 
     public static String getUrlString(Context context, String s) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -289,7 +289,9 @@ public class IndexResource {
             Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
-            String path = IndexAccessVerifier.checkIndices(index) + "/_close";
+            String checkedIndex = IndexAccessVerifier.checkIndices(index);
+            ForbiddenException.requireGranted(context, IndexAccessVerifier.baseProject(checkedIndex));
+            String path = checkedIndex + "/_close";
             return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
@@ -307,7 +309,9 @@ public class IndexResource {
             Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
-            String path = IndexAccessVerifier.checkIndices(index) + "/_open";
+            String checkedIndex = IndexAccessVerifier.checkIndices(index);
+            ForbiddenException.requireGranted(context, IndexAccessVerifier.baseProject(checkedIndex));
+            String path = checkedIndex + "/_open";
             return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -76,7 +76,7 @@ public class IndexResource {
     @Operation(description = "Create the index for the current user if it doesn't exist. Only available in LOCAL and EMBEDDED modes.")
     @ApiResponse(responseCode = "200", description = "returns 200 if the index already exists")
     @ApiResponse(responseCode = "201", description = "returns 201 if the index has been created")
-    @ApiResponse(responseCode = "403", description = "operation not allowed in current mode")
+    @ApiResponse(responseCode = "403", description = "operation not allowed in current mode, or index not granted to the user")
     @Put("/:index")
     public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index, Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
@@ -289,7 +289,7 @@ public class IndexResource {
     @Operation(description = "Close an index. Only available in LOCAL and EMBEDDED modes.")
     @ApiResponse(responseCode = "200", description = "index closed successfully")
     @ApiResponse(responseCode = "400", description = "invalid index name")
-    @ApiResponse(responseCode = "403", description = "operation not allowed in current mode")
+    @ApiResponse(responseCode = "403", description = "operation not allowed in current mode, or index not granted to the user")
     @Post("/:index/_close")
     public Payload closeIndex(
             @Parameter(name = "index", description = "index name to close", in = ParameterIn.PATH)
@@ -307,7 +307,7 @@ public class IndexResource {
     @Operation(description = "Open a closed index. Only available in LOCAL and EMBEDDED modes.")
     @ApiResponse(responseCode = "200", description = "index opened successfully")
     @ApiResponse(responseCode = "400", description = "invalid index name")
-    @ApiResponse(responseCode = "403", description = "operation not allowed in current mode")
+    @ApiResponse(responseCode = "403", description = "operation not allowed in current mode, or index not granted to the user")
     @Post("/:index/_open")
     public Payload openIndex(
             @Parameter(name = "index", description = "index name to open", in = ParameterIn.PATH)

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -23,6 +23,7 @@ import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.utils.IndexAccessVerifier;
 import org.icij.datashare.utils.ModeVerifier;
 import org.icij.datashare.utils.PayloadFormatter;
+import org.icij.datashare.web.errors.ForbiddenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,9 +77,11 @@ public class IndexResource {
     @ApiResponse(responseCode = "200", description = "returns 200 if the index already exists")
     @ApiResponse(responseCode = "201", description = "returns 201 if the index has been created")
     @Put("/:index")
-    public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index) throws IOException {
+    public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index, Context context) throws IOException {
         try{
-            return indexer.createIndex(IndexAccessVerifier.checkIndices(index)) ? created() : ok();
+            String checkedIndex = IndexAccessVerifier.checkIndices(index);
+            ForbiddenException.requireGranted(context, IndexAccessVerifier.baseProject(checkedIndex));
+            return indexer.createIndex(checkedIndex) ? created() : ok();
         } catch (IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.ResponseException;
 
+import static java.util.Arrays.stream;
 import static net.codestory.http.payload.Payload.created;
 import static net.codestory.http.payload.Payload.ok;
 
@@ -167,9 +168,10 @@ public class IndexResource {
             return;
         }
         DatashareUser submitter = (DatashareUser) context.currentUser();
-        // the first path segment holds the comma-separated indices, already validated as granted by checkPath() above
+        // the first path segment holds the comma-separated indices, already validated as granted by checkPath() above.
+        // They are stored as projects, because that is what a later poll re-checks the user's grants against.
         String indexSegment = path.split("/")[0];
-        List<String> grantedProjects = List.of(indexSegment.split(","));
+        List<String> grantedProjects = stream(indexSegment.split(",")).map(IndexAccessVerifier::baseProject).toList();
         Duration keepAlive = EsDuration.parse(context.get("keep_alive"), defaultKeepAlive);
         String asyncSearchId = idNode.asText();
         asyncSearchStore.put(asyncSearchId, new AsyncSearchOwner(submitter.id, grantedProjects), keepAlive);

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -81,9 +81,7 @@ public class IndexResource {
     public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index, Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try{
-            String checkedIndex = IndexAccessVerifier.checkIndices(index);
-            IndexAccessVerifier.baseProjects(checkedIndex).forEach(p -> ForbiddenException.requireGranted(context, p));
-            return indexer.createIndex(checkedIndex) ? created() : ok();
+            return indexer.createIndex(checkGrantedIndices(index, context)) ? created() : ok();
         } catch (IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
@@ -149,6 +147,14 @@ public class IndexResource {
         } catch ( IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
+    }
+
+    // Both gates for an index taken from the path, in one place so a new index-scoped endpoint
+    // cannot pass the format check and forget the grant one.
+    private String checkGrantedIndices(String indices, Context context) {
+        String checkedIndices = IndexAccessVerifier.checkIndices(indices);
+        IndexAccessVerifier.baseProjects(checkedIndices).forEach(project -> ForbiddenException.requireGranted(context, project));
+        return checkedIndices;
     }
 
     // Keep ES's result lifetime in lockstep with our ownership record: when an async-search submit
@@ -291,9 +297,7 @@ public class IndexResource {
             Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
-            String checkedIndex = IndexAccessVerifier.checkIndices(index);
-            IndexAccessVerifier.baseProjects(checkedIndex).forEach(p -> ForbiddenException.requireGranted(context, p));
-            String path = checkedIndex + "/_close";
+            String path = checkGrantedIndices(index, context) + "/_close";
             return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
@@ -311,9 +315,7 @@ public class IndexResource {
             Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
-            String checkedIndex = IndexAccessVerifier.checkIndices(index);
-            IndexAccessVerifier.baseProjects(checkedIndex).forEach(p -> ForbiddenException.requireGranted(context, p));
-            String path = checkedIndex + "/_open";
+            String path = checkGrantedIndices(index, context) + "/_open";
             return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -80,7 +80,7 @@ public class IndexResource {
     public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index, Context context) throws IOException {
         try{
             String checkedIndex = IndexAccessVerifier.checkIndices(index);
-            ForbiddenException.requireGranted(context, IndexAccessVerifier.baseProject(checkedIndex));
+            IndexAccessVerifier.baseProjects(checkedIndex).forEach(p -> ForbiddenException.requireGranted(context, p));
             return indexer.createIndex(checkedIndex) ? created() : ok();
         } catch (IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
@@ -290,7 +290,7 @@ public class IndexResource {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
             String checkedIndex = IndexAccessVerifier.checkIndices(index);
-            ForbiddenException.requireGranted(context, IndexAccessVerifier.baseProject(checkedIndex));
+            IndexAccessVerifier.baseProjects(checkedIndex).forEach(p -> ForbiddenException.requireGranted(context, p));
             String path = checkedIndex + "/_close";
             return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {
@@ -310,7 +310,7 @@ public class IndexResource {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try {
             String checkedIndex = IndexAccessVerifier.checkIndices(index);
-            ForbiddenException.requireGranted(context, IndexAccessVerifier.baseProject(checkedIndex));
+            IndexAccessVerifier.baseProjects(checkedIndex).forEach(p -> ForbiddenException.requireGranted(context, p));
             String path = checkedIndex + "/_open";
             return PayloadFormatter.json(indexer.executeRaw("POST", IndexAccessVerifier.getUrlString(context, path), null));
         } catch (IllegalArgumentException e) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.ResponseException;
 
-import static java.util.Arrays.stream;
 import static net.codestory.http.payload.Payload.created;
 import static net.codestory.http.payload.Payload.ok;
 
@@ -171,7 +170,7 @@ public class IndexResource {
         // the first path segment holds the comma-separated indices, already validated as granted by checkPath() above.
         // They are stored as projects, because that is what a later poll re-checks the user's grants against.
         String indexSegment = path.split("/")[0];
-        List<String> grantedProjects = stream(indexSegment.split(",")).map(IndexAccessVerifier::baseProject).toList();
+        List<String> grantedProjects = IndexAccessVerifier.baseProjects(indexSegment);
         Duration keepAlive = EsDuration.parse(context.get("keep_alive"), defaultKeepAlive);
         String asyncSearchId = idNode.asText();
         asyncSearchStore.put(asyncSearchId, new AsyncSearchOwner(submitter.id, grantedProjects), keepAlive);

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -73,11 +73,13 @@ public class IndexResource {
         return PayloadFormatter.json(indexer.executeRaw("GET", "/", null));
     }
 
-    @Operation(description = "Create the index for the current user if it doesn't exist.")
+    @Operation(description = "Create the index for the current user if it doesn't exist. Only available in LOCAL and EMBEDDED modes.")
     @ApiResponse(responseCode = "200", description = "returns 200 if the index already exists")
     @ApiResponse(responseCode = "201", description = "returns 201 if the index has been created")
+    @ApiResponse(responseCode = "403", description = "operation not allowed in current mode")
     @Put("/:index")
     public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index, Context context) throws IOException {
+        modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try{
             String checkedIndex = IndexAccessVerifier.checkIndices(index);
             IndexAccessVerifier.baseProjects(checkedIndex).forEach(p -> ForbiddenException.requireGranted(context, p));

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -94,7 +94,7 @@
                 requestBody = @RequestBody(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Project.class)))
         )
         @ApiResponse(responseCode = "201", description = "if project and index have been created")
-        @ApiResponse(responseCode = "400", description = "if project name is empty or contains a dot")
+        @ApiResponse(responseCode = "400", description = "if project name is empty, contains a dot, or starts with an underscore")
         @ApiResponse(responseCode = "400", description = "if project path is not allowed for the project")
         @ApiResponse(responseCode = "409", description = "if project exists")
         @ApiResponse(responseCode = "500", description = "project creation in DB or index creation failed")
@@ -107,6 +107,8 @@
                 return PayloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
             } else if (project.getName().contains(".")) {
                 return PayloadFormatter.error("`name` must not contain a dot.", HttpStatus.BAD_REQUEST);
+            } else if (project.getName().startsWith("_")) {
+                return PayloadFormatter.error("`name` must not start with an underscore.", HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(project) ? withDefaultSourcePath(project) : project;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
@@ -139,7 +141,7 @@
         )
         @ApiResponse(responseCode = "200", description = "if project has been updated")
         @ApiResponse(responseCode = "201", description = "if project did not exist and has been created")
-        @ApiResponse(responseCode = "400", description = "if `name` is empty, contains a dot on creation, or `sourcePath` is outside data dir")
+        @ApiResponse(responseCode = "400", description = "if `name` is empty, contains a dot or starts with an underscore on creation, or `sourcePath` is outside data dir")
         @ApiResponse(responseCode = "403", description = "if the user lacks PROJECT_ADMIN+ on the project id")
         @ApiResponse(responseCode = "404", description = "if path id does not match body id, or if existing project is not accessible to the user")
         @ApiResponse(responseCode = "500", description = "if save failed")
@@ -158,6 +160,9 @@
             // Checked here, before dataDirVerifier, to match projectCreate's order.
             if (isCreate && projectPayload.getName().contains(".")) {
                 return PayloadFormatter.error("`name` must not contain a dot.", HttpStatus.BAD_REQUEST);
+            }
+            if (isCreate && projectPayload.getName().startsWith("_")) {
+                return PayloadFormatter.error("`name` must not start with an underscore.", HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(projectPayload) ? withDefaultSourcePath(projectPayload) : projectPayload;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -154,7 +154,7 @@
             if (!Objects.equals(projectPayload.getId(), id)) {
                 return PayloadFormatter.error("Project id mismatch.", HttpStatus.NOT_FOUND);
             }
-            boolean isCreate = !projectExists(projectPayload);
+            boolean isCreate = !projectExists(id);
             // only a new project's name is validated: a legacy project whose name predates this
             // check must still be updatable, so the guard applies to creation only, same as POST.
             // Checked here, before dataDirVerifier, to match projectCreate's order.

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -105,6 +105,8 @@
                 return PayloadFormatter.error("Project already exists.", HttpStatus.CONFLICT);
             } else if (isProjectNameEmpty(project)) {
                 return PayloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
+            } else if (!Project.NAME_PATTERN.matcher(project.getName()).matches()) {
+                return PayloadFormatter.error("project name must match " + Project.NAME_REGEX, HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(project) ? withDefaultSourcePath(project) : project;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
@@ -156,6 +158,9 @@
             }
 
             if (!projectExists(effectiveProject)) {
+                if (!Project.NAME_PATTERN.matcher(effectiveProject.getName()).matches()) {
+                    return PayloadFormatter.error("project name must match " + Project.NAME_REGEX, HttpStatus.BAD_REQUEST);
+                }
                 if (!repository.save(effectiveProject) || !createIndexOnce(effectiveProject.getId())) {
                     return PayloadFormatter.error("Unable to create the project", HttpStatus.INTERNAL_SERVER_ERROR);
                 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -42,6 +42,7 @@
     import java.util.Map;
     import java.util.Objects;
     import java.util.Properties;
+    import java.util.regex.Pattern;
     import java.util.stream.Collectors;
     import java.util.stream.Stream;
 
@@ -56,6 +57,9 @@
     @Singleton
     @Prefix("/api/project")
     public class ProjectResource {
+        private static final Pattern INDEX_SAFE_NAME = Pattern.compile("[a-z0-9][-a-z0-9_]{0,254}");
+        private static final String INDEX_SAFE_NAME_ERROR = "`name` must be a lowercase letter or digit, then letters, digits, `-` or `_`.";
+
         private final Repository repository;
         private final Indexer indexer;
         private final TaskManager taskManager;
@@ -94,7 +98,7 @@
                 requestBody = @RequestBody(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Project.class)))
         )
         @ApiResponse(responseCode = "201", description = "if project and index have been created")
-        @ApiResponse(responseCode = "400", description = "if project name is empty, contains a dot, or starts with an underscore")
+        @ApiResponse(responseCode = "400", description = "if project name is empty or is not usable as an index name")
         @ApiResponse(responseCode = "400", description = "if project path is not allowed for the project")
         @ApiResponse(responseCode = "409", description = "if project exists")
         @ApiResponse(responseCode = "500", description = "project creation in DB or index creation failed")
@@ -105,10 +109,8 @@
                 return PayloadFormatter.error("Project already exists.", HttpStatus.CONFLICT);
             } else if (isProjectNameEmpty(project)) {
                 return PayloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
-            } else if (project.getName().contains(".")) {
-                return PayloadFormatter.error("`name` must not contain a dot.", HttpStatus.BAD_REQUEST);
-            } else if (project.getName().startsWith("_")) {
-                return PayloadFormatter.error("`name` must not start with an underscore.", HttpStatus.BAD_REQUEST);
+            } else if (!isProjectNameIndexSafe(project)) {
+                return PayloadFormatter.error(INDEX_SAFE_NAME_ERROR, HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(project) ? withDefaultSourcePath(project) : project;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
@@ -141,7 +143,7 @@
         )
         @ApiResponse(responseCode = "200", description = "if project has been updated")
         @ApiResponse(responseCode = "201", description = "if project did not exist and has been created")
-        @ApiResponse(responseCode = "400", description = "if `name` is empty, contains a dot or starts with an underscore on creation, or `sourcePath` is outside data dir")
+        @ApiResponse(responseCode = "400", description = "if `name` is empty, is not usable as an index name on creation, or `sourcePath` is outside data dir")
         @ApiResponse(responseCode = "403", description = "if the user lacks PROJECT_ADMIN+ on the project id")
         @ApiResponse(responseCode = "404", description = "if path id does not match body id, or if existing project is not accessible to the user")
         @ApiResponse(responseCode = "500", description = "if save failed")
@@ -156,13 +158,9 @@
             }
             boolean isCreate = !projectExists(id);
             // only a new project's name is validated: a legacy project whose name predates this
-            // check must still be updatable, so the guard applies to creation only, same as POST.
-            // Checked here, before dataDirVerifier, to match projectCreate's order.
-            if (isCreate && projectPayload.getName().contains(".")) {
-                return PayloadFormatter.error("`name` must not contain a dot.", HttpStatus.BAD_REQUEST);
-            }
-            if (isCreate && projectPayload.getName().startsWith("_")) {
-                return PayloadFormatter.error("`name` must not start with an underscore.", HttpStatus.BAD_REQUEST);
+            // check must still be updatable, so the guard applies to creation only, same as POST
+            if (isCreate && !isProjectNameIndexSafe(projectPayload)) {
+                return PayloadFormatter.error(INDEX_SAFE_NAME_ERROR, HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(projectPayload) ? withDefaultSourcePath(projectPayload) : projectPayload;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
@@ -345,6 +343,15 @@
 
         private boolean isProjectNameEmpty(Project project) {
             return isEmpty(project.getName());
+        }
+
+        /** A name elasticsearch accepts as the index name created for the project. Anything else is saved
+         *  to the database first and only then fails at index creation, leaving a project row whose index
+         *  does not exist and which the ES proxy cannot reach. A dot is excluded on top of ES's own rules,
+         *  because {@link IndexAccessVerifier#baseProjects} reads "myproject.entities" as a namespaced
+         *  index of "myproject", so a project literally named that way would inherit another's grants. */
+        private boolean isProjectNameIndexSafe(Project project) {
+            return INDEX_SAFE_NAME.matcher(project.getName()).matches();
         }
 
         private boolean isProjectSourcePathNull(Project project) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -94,7 +94,7 @@
                 requestBody = @RequestBody(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Project.class)))
         )
         @ApiResponse(responseCode = "201", description = "if project and index have been created")
-        @ApiResponse(responseCode = "400", description = "if project name is empty")
+        @ApiResponse(responseCode = "400", description = "if project name is empty or contains a dot")
         @ApiResponse(responseCode = "400", description = "if project path is not allowed for the project")
         @ApiResponse(responseCode = "409", description = "if project exists")
         @ApiResponse(responseCode = "500", description = "project creation in DB or index creation failed")
@@ -105,8 +105,8 @@
                 return PayloadFormatter.error("Project already exists.", HttpStatus.CONFLICT);
             } else if (isProjectNameEmpty(project)) {
                 return PayloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
-            } else if (!Project.NAME_PATTERN.matcher(project.getName()).matches()) {
-                return PayloadFormatter.error("project name must match " + Project.NAME_REGEX, HttpStatus.BAD_REQUEST);
+            } else if (project.getName().contains(".")) {
+                return PayloadFormatter.error("`name` must not contain a dot.", HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(project) ? withDefaultSourcePath(project) : project;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
@@ -139,7 +139,7 @@
         )
         @ApiResponse(responseCode = "200", description = "if project has been updated")
         @ApiResponse(responseCode = "201", description = "if project did not exist and has been created")
-        @ApiResponse(responseCode = "400", description = "if `name` is empty or `sourcePath` is outside data dir")
+        @ApiResponse(responseCode = "400", description = "if `name` is empty, contains a dot on creation, or `sourcePath` is outside data dir")
         @ApiResponse(responseCode = "403", description = "if the user lacks PROJECT_ADMIN+ on the project id")
         @ApiResponse(responseCode = "404", description = "if path id does not match body id, or if existing project is not accessible to the user")
         @ApiResponse(responseCode = "500", description = "if save failed")
@@ -152,15 +152,19 @@
             if (!Objects.equals(projectPayload.getId(), id)) {
                 return PayloadFormatter.error("Project id mismatch.", HttpStatus.NOT_FOUND);
             }
+            boolean isCreate = !projectExists(projectPayload);
+            // only a new project's name is validated: a legacy project whose name predates this
+            // check must still be updatable, so the guard applies to creation only, same as POST.
+            // Checked here, before dataDirVerifier, to match projectCreate's order.
+            if (isCreate && projectPayload.getName().contains(".")) {
+                return PayloadFormatter.error("`name` must not contain a dot.", HttpStatus.BAD_REQUEST);
+            }
             Project effectiveProject = isProjectSourcePathNull(projectPayload) ? withDefaultSourcePath(projectPayload) : projectPayload;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
                 return PayloadFormatter.error(String.format("`sourcePath` must not be outside %s.", dataDirVerifier.value()), HttpStatus.BAD_REQUEST);
             }
 
-            if (!projectExists(effectiveProject)) {
-                if (!Project.NAME_PATTERN.matcher(effectiveProject.getName()).matches()) {
-                    return PayloadFormatter.error("project name must match " + Project.NAME_REGEX, HttpStatus.BAD_REQUEST);
-                }
+            if (isCreate) {
                 if (!repository.save(effectiveProject) || !createIndexOnce(effectiveProject.getId())) {
                     return PayloadFormatter.error("Unable to create the project", HttpStatus.INTERNAL_SERVER_ERROR);
                 }

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -42,7 +42,6 @@
     import java.util.Map;
     import java.util.Objects;
     import java.util.Properties;
-    import java.util.regex.Pattern;
     import java.util.stream.Collectors;
     import java.util.stream.Stream;
 
@@ -57,8 +56,7 @@
     @Singleton
     @Prefix("/api/project")
     public class ProjectResource {
-        private static final Pattern INDEX_SAFE_NAME = Pattern.compile("[a-z0-9][-a-z0-9_]{0,254}");
-        private static final String INDEX_SAFE_NAME_ERROR = "`name` must be a lowercase letter or digit, then letters, digits, `-` or `_`.";
+        private static final String NAME_ERROR = "`name` must match " + Project.NAME_REGEX;
 
         private final Repository repository;
         private final Indexer indexer;
@@ -98,7 +96,7 @@
                 requestBody = @RequestBody(content = @Content(mediaType = "application/json", schema = @Schema(implementation = Project.class)))
         )
         @ApiResponse(responseCode = "201", description = "if project and index have been created")
-        @ApiResponse(responseCode = "400", description = "if project name is empty or is not usable as an index name")
+        @ApiResponse(responseCode = "400", description = "if project name is empty or does not match the project name pattern")
         @ApiResponse(responseCode = "400", description = "if project path is not allowed for the project")
         @ApiResponse(responseCode = "409", description = "if project exists")
         @ApiResponse(responseCode = "500", description = "project creation in DB or index creation failed")
@@ -109,8 +107,8 @@
                 return PayloadFormatter.error("Project already exists.", HttpStatus.CONFLICT);
             } else if (isProjectNameEmpty(project)) {
                 return PayloadFormatter.error("`name` field is required.", HttpStatus.BAD_REQUEST);
-            } else if (!isProjectNameIndexSafe(project)) {
-                return PayloadFormatter.error(INDEX_SAFE_NAME_ERROR, HttpStatus.BAD_REQUEST);
+            } else if (!isProjectNameValid(project)) {
+                return PayloadFormatter.error(NAME_ERROR, HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(project) ? withDefaultSourcePath(project) : project;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
@@ -143,7 +141,7 @@
         )
         @ApiResponse(responseCode = "200", description = "if project has been updated")
         @ApiResponse(responseCode = "201", description = "if project did not exist and has been created")
-        @ApiResponse(responseCode = "400", description = "if `name` is empty, is not usable as an index name on creation, or `sourcePath` is outside data dir")
+        @ApiResponse(responseCode = "400", description = "if `name` is empty, does not match the project name pattern on creation, or `sourcePath` is outside data dir")
         @ApiResponse(responseCode = "403", description = "if the user lacks PROJECT_ADMIN+ on the project id")
         @ApiResponse(responseCode = "404", description = "if path id does not match body id, or if existing project is not accessible to the user")
         @ApiResponse(responseCode = "500", description = "if save failed")
@@ -159,8 +157,8 @@
             boolean isCreate = !projectExists(id);
             // only a new project's name is validated: a legacy project whose name predates this
             // check must still be updatable, so the guard applies to creation only, same as POST
-            if (isCreate && !isProjectNameIndexSafe(projectPayload)) {
-                return PayloadFormatter.error(INDEX_SAFE_NAME_ERROR, HttpStatus.BAD_REQUEST);
+            if (isCreate && !isProjectNameValid(projectPayload)) {
+                return PayloadFormatter.error(NAME_ERROR, HttpStatus.BAD_REQUEST);
             }
             Project effectiveProject = isProjectSourcePathNull(projectPayload) ? withDefaultSourcePath(projectPayload) : projectPayload;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
@@ -345,13 +343,14 @@
             return isEmpty(project.getName());
         }
 
-        /** A name elasticsearch accepts as the index name created for the project. Anything else is saved
-         *  to the database first and only then fails at index creation, leaving a project row whose index
-         *  does not exist and which the ES proxy cannot reach. A dot is excluded on top of ES's own rules,
-         *  because {@link IndexAccessVerifier#baseProjects} reads "myproject.entities" as a namespaced
-         *  index of "myproject", so a project literally named that way would inherit another's grants. */
-        private boolean isProjectNameIndexSafe(Project project) {
-            return INDEX_SAFE_NAME.matcher(project.getName()).matches();
+        /** The name pattern the CLI ({@code Validators.projectName}) and the admin service already enforce.
+         *  A name outside it is saved to the database before index creation fails, or is created and then
+         *  can never be granted, revoked or deleted from the CLI. It excludes a dot, which matters on top
+         *  of ES's own rules because {@link IndexAccessVerifier#baseProjects} reads "myproject.entities"
+         *  as a namespaced index of "myproject", and caps the name at 64 characters, which keeps the
+         *  derived "<name>.entities" inside ES's 255-byte index name limit. */
+        private boolean isProjectNameValid(Project project) {
+            return Project.NAME_PATTERN.matcher(project.getName()).matches();
         }
 
         private boolean isProjectSourcePathNull(Project project) {

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -61,30 +61,37 @@ public class IndexAccessVerifierTest {
 
     @Test
     public void test_check_path_grants_entities_index_of_granted_project() {
-        assertThat(IndexAccessVerifier.checkPath("foo.entities/_search", contextFor("foo"))).isEqualTo("foo.entities/_search");
+        // POST, not GET: proves isSearchPath is what authorizes this, not the isMethodGet short-circuit
+        assertThat(IndexAccessVerifier.checkPath("foo.entities/_search", contextFor("POST", "foo"))).isEqualTo("foo.entities/_search");
     }
 
     @Test
     public void test_check_path_refuses_entities_index_of_other_project() {
-        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("bar.entities/_search", contextFor("foo")));
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("bar.entities/_search", contextFor("GET", "foo")));
     }
 
     @Test
     public void test_check_path_refuses_unknown_suffix_and_prefix_match() {
-        Context context = contextFor("foo");
+        Context context = contextFor("GET", "foo");
         assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo.unknown/_search", context));
         assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foobar/_search", context));
         // "myproject-other.entities" strips to "myproject-other", a different project; a prefix match would wrongly grant this
-        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("myproject-other.entities/_search", contextFor("myproject")));
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("myproject-other.entities/_search", contextFor("GET", "myproject")));
         // a mixed list is refused as soon as one index isn't granted, even alongside one that is
-        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo,bar.entities/_search", contextFor("foo")));
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo,bar.entities/_search", contextFor("GET", "foo")));
     }
 
-    private static Context contextFor(String... grantedProjects) {
+    @Test
+    public void test_check_path_refuses_write_on_granted_index() {
+        // a grant only ever authorizes GET, _search, _count or _async_search; a write path is refused regardless
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo.entities/_bulk", contextFor("POST", "foo")));
+    }
+
+    private static Context contextFor(String method, String... grantedProjects) {
         Context context = mock(Context.class);
         Query query = mock(Query.class);
         when(context.currentUser()).thenReturn(new DatashareUser(User.localUser("cecile", grantedProjects)));
-        when(context.method()).thenReturn("GET");
+        when(context.method()).thenReturn(method);
         when(context.query()).thenReturn(query);
         when(query.keyValues()).thenReturn(new HashMap<>());
         return context;

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -55,6 +55,8 @@ public class IndexAccessVerifierTest {
         assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices(".kibana"));
         assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("foo."));
         assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("foo..entities"));
+        // find() against a ^...$ pattern lets a trailing line terminator slip through; matches() does not
+        assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("foo\n"));
     }
 
     @Test
@@ -72,8 +74,10 @@ public class IndexAccessVerifierTest {
         Context context = contextFor("foo");
         assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo.unknown/_search", context));
         assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foobar/_search", context));
-        // "myproject-other" doesn't end in ".entities" once stripped down to "myproject", it stays its own project
+        // "myproject-other.entities" strips to "myproject-other", a different project; a prefix match would wrongly grant this
         assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("myproject-other.entities/_search", contextFor("myproject")));
+        // a mixed list is refused as soon as one index isn't granted, even alongside one that is
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo,bar.entities/_search", contextFor("foo")));
     }
 
     private static Context contextFor(String... grantedProjects) {

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -1,9 +1,18 @@
 package org.icij.datashare.utils;
 
+import net.codestory.http.Context;
+import net.codestory.http.Query;
+import net.codestory.http.errors.UnauthorizedException;
+import org.icij.datashare.session.DatashareUser;
+import org.icij.datashare.user.User;
 import org.junit.Test;
+
+import java.util.HashMap;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class IndexAccessVerifierTest {
 
@@ -32,6 +41,47 @@ public class IndexAccessVerifierTest {
         assertThrows(IllegalArgumentException.class, () -> {
             IndexAccessVerifier.checkIndices("bar,foo!");
         });
+    }
+
+    @Test
+    public void test_check_namespaced_index() {
+        assertThat(IndexAccessVerifier.checkIndices("foo.entities")).isEqualTo("foo.entities");
+        assertThat(IndexAccessVerifier.checkIndices("bar,foo.entities")).isEqualTo("bar,foo.entities");
+    }
+
+    @Test
+    public void test_check_invalid_dotted_index() {
+        // a leading dot would reach the elasticsearch system indices (.kibana, .security)
+        assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices(".kibana"));
+        assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("foo."));
+        assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("foo..entities"));
+    }
+
+    @Test
+    public void test_check_path_grants_entities_index_of_granted_project() {
+        assertThat(IndexAccessVerifier.checkPath("foo.entities/_search", contextFor("foo"))).isEqualTo("foo.entities/_search");
+    }
+
+    @Test
+    public void test_check_path_refuses_entities_index_of_other_project() {
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("bar.entities/_search", contextFor("foo")));
+    }
+
+    @Test
+    public void test_check_path_refuses_unknown_suffix_and_prefix_match() {
+        Context context = contextFor("foo");
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo.unknown/_search", context));
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foobar/_search", context));
+    }
+
+    private static Context contextFor(String... grantedProjects) {
+        Context context = mock(Context.class);
+        Query query = mock(Query.class);
+        when(context.currentUser()).thenReturn(new DatashareUser(User.localUser("cecile", grantedProjects)));
+        when(context.method()).thenReturn("GET");
+        when(context.query()).thenReturn(query);
+        when(query.keyValues()).thenReturn(new HashMap<>());
+        return context;
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -72,6 +72,8 @@ public class IndexAccessVerifierTest {
         Context context = contextFor("foo");
         assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foo.unknown/_search", context));
         assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("foobar/_search", context));
+        // "myproject-other" doesn't end in ".entities" once stripped down to "myproject", it stays its own project
+        assertThrows(UnauthorizedException.class, () -> IndexAccessVerifier.checkPath("myproject-other.entities/_search", contextFor("myproject")));
     }
 
     private static Context contextFor(String... grantedProjects) {

--- a/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/utils/IndexAccessVerifierTest.java
@@ -60,6 +60,17 @@ public class IndexAccessVerifierTest {
     }
 
     @Test
+    public void test_check_invalid_underscore_leading_index() {
+        // "_all" and its siblings are elasticsearch selectors, not index names: refusing them here
+        // means a project row named "_all" (creatable before the name guards) cannot grant the
+        // whole cluster to whoever holds it
+        assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("_all"));
+        assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("foo,_all"));
+        assertThrows(IllegalArgumentException.class, () -> IndexAccessVerifier.checkIndices("_foo.entities"));
+        assertThat(IndexAccessVerifier.checkIndices("my_project")).isEqualTo("my_project");
+    }
+
+    @Test
     public void test_check_path_grants_entities_index_of_granted_project() {
         // POST, not GET: proves isSearchPath is what authorizes this, not the isMethodGet short-circuit
         assertThat(IndexAccessVerifier.checkPath("foo.entities/_search", contextFor("POST", "foo"))).isEqualTo("foo.entities/_search");

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -11,6 +11,7 @@ import org.icij.datashare.session.DatashareUser;
 import org.icij.datashare.session.LocalUserFilter;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.DocumentBuilder;
+import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 import org.icij.datashare.web.testhelpers.AbstractProdWebServerTest;
 import org.junit.After;
@@ -82,6 +83,8 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
     @Test
     public void test_put_create_local_index_in_local_mode() {
+        // createIndex now requires a grant on the index's base project; "index_name" must be one
+        when(jooqRepository.getProjects()).thenReturn(List.of(new Project("index_name")));
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider)).filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));
         put("/api/index/index_name").should().respond(201);
         put("/api/index/ !!").should().respond(400);
@@ -196,6 +199,22 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         put("/api/index/cecile-datashare").withPreemptiveAuthentication("cecile", "pass").should().respond(201);
         put("/api/index/!!").withPreemptiveAuthentication("cecile", "pass").should().respond(400);
         put("/api/index/ cecile-datashare").withPreemptiveAuthentication("cecile", "pass").should().respond(400);
+    }
+
+    @Test
+    public void test_put_createIndex_allows_own_project_and_its_entities_index() {
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        put("/api/index/cecile-datashare").withPreemptiveAuthentication("cecile", "").should().respond(201);
+        put("/api/index/cecile-datashare.entities").withPreemptiveAuthentication("cecile", "").should().respond(201);
+    }
+
+    @Test
+    public void test_put_createIndex_refuses_ungranted_project() {
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        put("/api/index/victim.entities").withPreemptiveAuthentication("cecile", "").should().respond(403);
+        put("/api/index/victim").withPreemptiveAuthentication("cecile", "").should().respond(403);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -248,6 +248,32 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_close_and_open_index_allowed_for_granted_project() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        indexer.createIndex("cecile-datashare");
+        post("/api/index/cecile-datashare/_close").withPreemptiveAuthentication("cecile", "").should().respond(200);
+        post("/api/index/cecile-datashare/_open").withPreemptiveAuthentication("cecile", "").should().respond(200);
+    }
+
+    @Test
+    public void test_close_and_open_index_refuses_ungranted_project() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        post("/api/index/victim/_close").withPreemptiveAuthentication("cecile", "").should().respond(403);
+        post("/api/index/victim/_open").withPreemptiveAuthentication("cecile", "").should().respond(403);
+    }
+
+    @Test
+    public void test_close_all_indices_is_refused() throws IOException {
+        // "_all" passes the name grammar but is not a granted project, so it can no longer close
+        // (or reach) every index in the cluster including .kibana and .security
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        post("/api/index/_all/_close").withPreemptiveAuthentication("cecile", "").should().respond(403);
+    }
+
+    @Test
     public void test_close_index_with_invalid_name() {
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
                 .filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -220,6 +220,14 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_put_createIndex_forbidden_in_server_mode() {
+        // granted, so a pass here would prove the mode gate is what refuses it, not the grant check
+        configure(routes -> routes.add(new IndexResource(indexer, serverModeProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        put("/api/index/cecile-datashare").withPreemptiveAuthentication("cecile", "").should().respond(403);
+    }
+
+    @Test
     public void test_close_index_in_local_mode() throws IOException {
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
                 .filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -276,11 +276,16 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_close_all_indices_is_refused() throws IOException {
-        // "_all" passes the name grammar but is not a granted project, so it can no longer close
-        // (or reach) every index in the cluster including .kibana and .security
+        // granted "_all" on purpose: the name grammar has to refuse the selector outright, because a
+        // project row named "_all" is grantable and would otherwise close every index in the cluster
+        DatashareUser user = new DatashareUser(new HashMap<>() {{
+            put("uid", "cecile");
+            put("groups_by_applications", Map.of("datashare", List.of("_all")));
+        }});
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
-                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
-        post("/api/index/_all/_close").withPreemptiveAuthentication("cecile", "").should().respond(403);
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser(user))));
+        post("/api/index/_all/_close").withPreemptiveAuthentication("cecile", "").should().respond(400);
+        post("/api/index/_all/_open").withPreemptiveAuthentication("cecile", "").should().respond(400);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -196,6 +196,8 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_put_createIndex() {
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
         put("/api/index/cecile-datashare").withPreemptiveAuthentication("cecile", "pass").should().respond(201);
         put("/api/index/!!").withPreemptiveAuthentication("cecile", "pass").should().respond(400);
         put("/api/index/ cecile-datashare").withPreemptiveAuthentication("cecile", "pass").should().respond(400);

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -457,6 +457,21 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_async_search_on_entities_index_is_polled_by_its_owner() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+        indexer.createIndex("cecile-datashare.entities");
+        indexer.add("cecile-datashare.entities", DocumentBuilder.createDoc("doc-entities-1").build());
+
+        String id = submitAsyncSearchAs("cecile", "cecile-datashare.entities");
+
+        // ownership is recorded against the base project, so a later poll still matches the user's grants
+        assertThat(asyncSearchStore.get(id).get().projects).containsExactly("cecile-datashare");
+        get("/api/index/search/_async_search/" + urlEncode(id))
+                .withPreemptiveAuthentication("cecile", "").should().respond(200).contain("\"is_running\"");
+    }
+
+    @Test
     public void test_async_search_submit_injects_default_keep_alive_when_absent() throws IOException {
         configure(routes -> routes.add(new IndexResource(indexer, asyncSearchStore, propertiesProvider))
                 .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
@@ -483,7 +498,7 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
 
     @After
     public void tearDown() throws Exception {
-        es.delete("cecile-datashare", "index_name");
+        es.delete("cecile-datashare", "cecile-datashare.entities", "index_name");
     }
 }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -293,9 +293,13 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         }});
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
                 .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser(user))));
-        post("/api/index/%s,%s/_close".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
-        // reopen: these indices are shared across the whole test class via @ClassRule
-        post("/api/index/%s,%s/_open".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
+        try {
+            post("/api/index/%s,%s/_close".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
+        } finally {
+            // reopen unconditionally, even if the close assertion above failed: these indices are
+            // shared across the whole test class via @ClassRule, and nothing else restores them
+            post("/api/index/%s,%s/_open".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
+        }
     }
 
     @Test
@@ -309,6 +313,9 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
                 .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser(user))));
         post("/api/index/%s,victim/_close".formatted(granted)).withPreemptiveAuthentication("cecile", "").should().respond(403);
         post("/api/index/%s,victim/_open".formatted(granted)).withPreemptiveAuthentication("cecile", "").should().respond(403);
+        // reversed: the ungranted index first, so a mutation checking only the list's last entry would still be caught
+        post("/api/index/victim,%s/_close".formatted(granted)).withPreemptiveAuthentication("cecile", "").should().respond(403);
+        post("/api/index/victim,%s/_open".formatted(granted)).withPreemptiveAuthentication("cecile", "").should().respond(403);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -83,7 +83,7 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
     @Test
     public void test_put_create_local_index_in_local_mode() {
-        // createIndex now requires a grant on the index's base project; "index_name" must be one
+        // createIndex requires a grant on the index's base project, so "index_name" must be one
         when(jooqRepository.getProjects()).thenReturn(List.of(new Project("index_name")));
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider)).filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));
         put("/api/index/index_name").should().respond(201);
@@ -301,9 +301,10 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         try {
             post("/api/index/%s,%s/_close".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
         } finally {
-            // reopen unconditionally, even if the close assertion above failed: these indices are
-            // shared across the whole test class via @ClassRule, and nothing else restores them
-            post("/api/index/%s,%s/_open".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
+            // reopen through the indexer rather than the route under test, and without asserting:
+            // these indices are shared across the class via @ClassRule, so a failure here would both
+            // mask the close assertion above and leave the rest of the suite searching closed indices
+            indexer.executeRaw("POST", "%s,%s/_open".formatted(idx1, idx2), null);
         }
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -274,6 +274,34 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_close_index_allows_comma_separated_list_of_granted_projects() throws IOException {
+        String idx1 = es.getIndexNames()[1];
+        String idx2 = es.getIndexNames()[2];
+        DatashareUser user = new DatashareUser(new HashMap<>() {{
+            put("uid", "cecile");
+            put("groups_by_applications", Map.of("datashare", List.of(idx1, idx2)));
+        }});
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser(user))));
+        post("/api/index/%s,%s/_close".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
+        // reopen: these indices are shared across the whole test class via @ClassRule
+        post("/api/index/%s,%s/_open".formatted(idx1, idx2)).withPreemptiveAuthentication("cecile", "").should().respond(200);
+    }
+
+    @Test
+    public void test_close_and_open_refuse_comma_separated_list_with_one_ungranted_project() throws IOException {
+        String granted = es.getIndexNames()[1];
+        DatashareUser user = new DatashareUser(new HashMap<>() {{
+            put("uid", "cecile");
+            put("groups_by_applications", Map.of("datashare", List.of(granted)));
+        }});
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser(user))));
+        post("/api/index/%s,victim/_close".formatted(granted)).withPreemptiveAuthentication("cecile", "").should().respond(403);
+        post("/api/index/%s,victim/_open".formatted(granted)).withPreemptiveAuthentication("cecile", "").should().respond(403);
+    }
+
+    @Test
     public void test_close_index_with_invalid_name() {
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
                 .filter(new LocalUserFilter(propertiesProvider, jooqRepository, es.getIndexNames())));

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -226,6 +226,31 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_cannot_create_project_whose_name_is_not_a_usable_index_name() {
+        // each of these reaches createIndexOnce and fails there, after repository.save has already
+        // committed the row: the project is then permanently unreachable through the ES proxy
+        when(repository.getProject(any())).thenReturn(null);
+        when(repository.save((Project) any())).thenReturn(true);
+
+        post("/api/project/", "{ \"name\": \"foo,bar\", \"sourcePath\": \"/vault/foo\" }").should().respond(400);
+        post("/api/project/", "{ \"name\": \"Foo\", \"sourcePath\": \"/vault/foo\" }").should().respond(400);
+        post("/api/project/", "{ \"name\": \"foo bar\", \"sourcePath\": \"/vault/foo\" }").should().respond(400);
+        post("/api/project/", "{ \"name\": \"-foo\", \"sourcePath\": \"/vault/foo\" }").should().respond(400);
+    }
+
+    @Test
+    public void test_can_update_an_existing_project_whose_name_predates_the_name_guard() {
+        // the guard is create-only: a legacy dotted or underscore-leading row must stay updatable
+        Project legacy = new Project("foo.entities", Path.of("/vault/foo"));
+        when(repository.getProject("foo.entities")).thenReturn(legacy);
+        when(repository.getProjects(any())).thenReturn(List.of(legacy));
+        when(repository.save((Project) any())).thenReturn(true);
+
+        String body = "{ \"name\": \"foo.entities\", \"label\": \"Legacy\", \"sourcePath\": \"/vault/foo\"}";
+        put("/api/project/foo.entities", body).should().respond(200);
+    }
+
+    @Test
     public void test_can_create_project_with_underscore_in_name() throws IOException {
         // a dot is the only hazard the suffix rule depends on; the fuller Project.NAME_PATTERN
         // (no underscore, 2-64 chars) is not this endpoint's contract and must not be enforced here

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -218,6 +218,14 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_cannot_create_project_named_with_a_leading_underscore() {
+        // "_all" granted to a user would let them read/close/open every index in the cluster
+        String body = "{ \"name\": \"_all\", \"label\": \"Foo Bar\", \"sourcePath\": \"/vault/foo\" }";
+        when(repository.getProject("_all")).thenReturn(null);
+        post("/api/project/", body).should().respond(400);
+    }
+
+    @Test
     public void test_can_create_project_with_underscore_in_name() throws IOException {
         // a dot is the only hazard the suffix rule depends on; the fuller Project.NAME_PATTERN
         // (no underscore, 2-64 chars) is not this endpoint's contract and must not be enforced here
@@ -316,6 +324,15 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
 
         String body = "{ \"name\": \"my_project\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
         put("/api/project/my_project", body).should().respond(201);
+    }
+
+    @Test
+    public void test_put_create_returns_400_for_a_leading_underscore() {
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject("_all")).thenReturn(null);
+
+        String body = "{ \"name\": \"_all\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
+        put("/api/project/_all", body).should().respond(400);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -211,6 +211,13 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_cannot_create_project_with_invalid_name() {
+        String body = "{ \"name\": \"foo.entities\", \"label\": \"Foo Bar\", \"sourcePath\": \"/vault/foo\" }";
+        when(repository.getProject("foo.entities")).thenReturn(null);
+        post("/api/project/", body).should().respond(400);
+    }
+
+    @Test
     public void test_update_project() {
         Project oldFoo = new Project("foo", "Foo", Path.of("/vault/foo"), "", "", "", "", "*.*.*.*", null, null);
         when(repository.getProjects(any())).thenReturn(List.of(oldFoo));
@@ -278,6 +285,15 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
 
         String body = "{ \"name\": \"\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
         put("/api/project/foo", body).should().respond(400).contain("name");
+    }
+
+    @Test
+    public void test_put_create_returns_400_when_name_invalid() {
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject("foo.entities")).thenReturn(null);
+
+        String body = "{ \"name\": \"foo.entities\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
+        put("/api/project/foo.entities", body).should().respond(400);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -239,6 +239,15 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_cannot_create_project_whose_entities_index_would_exceed_the_name_limit() {
+        // 255 chars is a valid index name on its own, but the derived "<name>.entities" is 264 bytes,
+        // past elasticsearch's 255-byte limit; Project.NAME_PATTERN caps the name at 64
+        when(repository.getProject(any())).thenReturn(null);
+        String body = "{ \"name\": \"" + "a".repeat(255) + "\", \"sourcePath\": \"/vault/foo\" }";
+        post("/api/project/", body).should().respond(400);
+    }
+
+    @Test
     public void test_can_update_an_existing_project_whose_name_predates_the_name_guard() {
         // the guard is create-only: a legacy dotted or underscore-leading row must stay updatable
         Project legacy = new Project("foo.entities", Path.of("/vault/foo"));
@@ -251,14 +260,12 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_can_create_project_with_underscore_in_name() throws IOException {
-        // a dot is the only hazard the suffix rule depends on; the fuller Project.NAME_PATTERN
-        // (no underscore, 2-64 chars) is not this endpoint's contract and must not be enforced here
+    public void test_cannot_create_project_with_underscore_in_name() {
+        // Project.NAME_PATTERN rejects an underscore, so a project created here under one could
+        // never be granted, revoked or deleted through the CLI, nor recreated by the admin service
         String body = "{ \"name\": \"my_project\", \"label\": \"Foo Bar\", \"sourcePath\": \"/vault/foo\" }";
-        when(indexer.createIndex("my_project")).thenReturn(true);
         when(repository.getProject("my_project")).thenReturn(null);
-        when(repository.save((Project) any())).thenReturn(true);
-        post("/api/project/", body).should().respond(201);
+        post("/api/project/", body).should().respond(400).contain("name");
     }
 
     @Test
@@ -341,14 +348,12 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
-    public void test_put_create_allows_underscore_in_name() throws IOException {
+    public void test_put_create_returns_400_for_an_underscore() {
         when(repository.getProjects(any())).thenReturn(new ArrayList<>());
         when(repository.getProject("my_project")).thenReturn(null);
-        when(repository.save((Project) any())).thenReturn(true);
-        when(indexer.createIndex("my_project")).thenReturn(true);
 
         String body = "{ \"name\": \"my_project\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
-        put("/api/project/my_project", body).should().respond(201);
+        put("/api/project/my_project", body).should().respond(400).contain("name");
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -218,6 +218,17 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_can_create_project_with_underscore_in_name() throws IOException {
+        // a dot is the only hazard the suffix rule depends on; the fuller Project.NAME_PATTERN
+        // (no underscore, 2-64 chars) is not this endpoint's contract and must not be enforced here
+        String body = "{ \"name\": \"my_project\", \"label\": \"Foo Bar\", \"sourcePath\": \"/vault/foo\" }";
+        when(indexer.createIndex("my_project")).thenReturn(true);
+        when(repository.getProject("my_project")).thenReturn(null);
+        when(repository.save((Project) any())).thenReturn(true);
+        post("/api/project/", body).should().respond(201);
+    }
+
+    @Test
     public void test_update_project() {
         Project oldFoo = new Project("foo", "Foo", Path.of("/vault/foo"), "", "", "", "", "*.*.*.*", null, null);
         when(repository.getProjects(any())).thenReturn(List.of(oldFoo));
@@ -294,6 +305,17 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
 
         String body = "{ \"name\": \"foo.entities\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
         put("/api/project/foo.entities", body).should().respond(400);
+    }
+
+    @Test
+    public void test_put_create_allows_underscore_in_name() throws IOException {
+        when(repository.getProjects(any())).thenReturn(new ArrayList<>());
+        when(repository.getProject("my_project")).thenReturn(null);
+        when(repository.save((Project) any())).thenReturn(true);
+        when(indexer.createIndex("my_project")).thenReturn(true);
+
+        String body = "{ \"name\": \"my_project\", \"label\": \"Foo\", \"sourcePath\": \"/vault/foo\"}";
+        put("/api/project/my_project", body).should().respond(201);
     }
 
     @Test


### PR DESCRIPTION
Lets a user who can access a project also reach that project's `<project>.entities` index through the search proxy. Part of #2194.

- refactor: allow a dot between index-name segments, never leading, and refuse a leading underscore, so the elasticsearch system indices and `_all` stay unreachable
- refactor: map an index back to its project by stripping a known `.entities` suffix before the grant check, exact match on the remainder
- fix: use `matches()` rather than `find()` in the index-name check, so a trailing line terminator no longer validates
- fix: require a grant on the index's base project to create, close or open it, per index in a comma-separated list
- fix: record async-search ownership against the base project, so a poll re-checks the string its submit authorized
- fix: mode-gate `createIndex` the way `_close` and `_open` already are
- fix: validate a new project name as an index name on both create paths, so a row can't be saved under a name elasticsearch then refuses
- test: a user reaches their own `.entities` index, and is refused another project's, an unknown suffix, a prefix match, and a foreign index piggybacked on a granted one

Known gaps: `esHead`, `esOptions` and `_snapshot/*` still forward caller input no grant check has seen (#2312), and the suffix rule authorizes on name shape rather than proven ownership, so a third-party `<project>.entities` in a shared cluster is readable by anyone granted `<project>`.

Closes #2199
