### PR TITLE
fix(artifacts): check the payload is still on disk before skipping a current entry

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -1,0 +1,32 @@
+package org.icij.datashare.text.artifact;
+
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Whether the payload a manifest entry advertises is still on disk. The single definition of that
+ *  question: skip-if-current, INDEX-time recording and raw's post-extraction verification all ask it
+ *  here, so none of the three can drift from the others. */
+public class ArtifactPayload {
+    private ArtifactPayload() {}
+
+    /** True when the entry advertises a payload that is not there. Takes the entry as it is recorded,
+     *  stamped or not, because two of the three callers ask before {@link ManifestEntry#withTerminalStatus()}
+     *  runs. An EMPTY entry advertises no payload of its own (a root document's raw source is the on-disk
+     *  original, and unreadable content has nothing to write), so there is nothing to check and nothing to
+     *  repair. */
+    public static boolean isMissing(Path docArtifactDir, ArtifactType type, ManifestEntry entry) {
+        if (entry.status() == ManifestEntryStatus.EMPTY) {
+            return false;
+        }
+        return switch (type) {
+            // extract-lib writes raw as a single file next to manifest.json, not as a directory.
+            case RAW -> Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_FILE));
+            // The directory, not its contents: the atomic swap renames a fully written one into place, so
+            // it is either there with its pages or not there at all. Exhaustive over the enum on purpose:
+            // a new type must decide its own shape here rather than default to "present".
+            case STRUCTURE -> Files.notExists(ArtifactPath.structureDir(docArtifactDir));
+        };
+    }
+}

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -27,10 +27,24 @@ public class ArtifactPayload {
             // be re-produced rather than recorded as present.
             case RAW -> Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
                     || Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
-            // The directory, not its contents: the atomic swap renames a fully written one into place, so
-            // it is either there with its pages or not there at all. Exhaustive over the enum on purpose:
+            // The directory and the last page it advertises. The swap renames a fully written directory
+            // into place, so a partial write is impossible, but a partial delete is not: discard() removes
+            // pages one by one and only warns when it stops half way. Exhaustive over the enum on purpose:
             // a new type must decide its own shape here rather than default to "present".
-            case STRUCTURE -> Files.notExists(ArtifactPath.structureDir(docArtifactDir));
+            case STRUCTURE -> Files.notExists(ArtifactPath.structureDir(docArtifactDir))
+                    || lastPageMissing(docArtifactDir, entry);
         };
+    }
+
+    /** Whether the highest-numbered page the entry advertises is gone. Only the last one: pages are
+     *  written in order into a staging directory the swap renames in one move, so a set truncated by a
+     *  failed delete always loses its last page. An entry that advertises no usable page count says
+     *  nothing to check, and manifest.json is read from disk (a Python producer writes it too), so that
+     *  is a state to fall back from rather than re-produce on every run forever. */
+    private static boolean lastPageMissing(Path docArtifactDir, ManifestEntry entry) {
+        if (entry.pages() == null || entry.pages().total() < 1) {
+            return false;
+        }
+        return Files.notExists(ArtifactPath.structurePage(docArtifactDir, entry.pages().total(), "md"));
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -25,15 +25,23 @@ public class ArtifactPayload {
             // sidecar as a second atomic move after it. Both or neither: SourceExtractor only serves the
             // cache when both are readable, so a pair half written by a JVM death is unservable and must
             // be re-produced rather than recorded as present.
-            case RAW -> Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
-                    || Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
+            case RAW -> isAbsent(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
+                    || isAbsent(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
             // The directory and the last page it advertises. The swap renames a fully written directory
             // into place, so a partial write is impossible, but a partial delete is not: discard() removes
             // pages one by one and only warns when it stops half way. Exhaustive over the enum on purpose:
             // a new type must decide its own shape here rather than default to "present".
-            case STRUCTURE -> Files.notExists(ArtifactPath.structureDir(docArtifactDir))
+            case STRUCTURE -> isAbsent(ArtifactPath.structureDir(docArtifactDir))
                     || lastPageMissing(docArtifactDir, entry);
         };
+    }
+
+    /** Absent, or a path the filesystem will not answer for. A stale NFS handle or a revoked permission
+     *  on a shared artifactDir makes both {@code exists} and {@code notExists} false, and the two callers
+     *  that record entries would stamp a COMPLETE one over a payload nobody has confirmed. Re-producing
+     *  costs work that a later run can redo; recording that lie is what leaves a document unrepairable. */
+    private static boolean isAbsent(Path path) {
+        return !Files.exists(path);
     }
 
     /** Whether the highest-numbered page the entry advertises is gone. Only the last one: pages are
@@ -45,6 +53,6 @@ public class ArtifactPayload {
         if (entry.pages() == null || entry.pages().total() < 1) {
             return false;
         }
-        return Files.notExists(ArtifactPath.structurePage(docArtifactDir, entry.pages().total(), "md"));
+        return isAbsent(ArtifactPath.structurePage(docArtifactDir, entry.pages().total(), "md"));
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -21,8 +21,12 @@ public class ArtifactPayload {
             return false;
         }
         return switch (type) {
-            // extract-lib writes raw as a single file next to manifest.json, not as a directory.
-            case RAW -> Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_FILE));
+            // extract-lib writes raw as a single file next to manifest.json, not as a directory, and its
+            // sidecar as a second atomic move after it. Both or neither: SourceExtractor only serves the
+            // cache when both are readable, so a pair half written by a JVM death is unservable and must
+            // be re-produced rather than recorded as present.
+            case RAW -> Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
+                    || Files.notExists(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
             // The directory, not its contents: the atomic swap renames a fully written one into place, so
             // it is either there with its pages or not there at all. Exhaustive over the enum on purpose:
             // a new type must decide its own shape here rather than default to "present".

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -15,7 +15,10 @@ public class ArtifactPayload {
      *  stamped or not, because two of the three callers ask before {@link ManifestEntry#withTerminalStatus()}
      *  runs. An EMPTY entry advertises no payload of its own (a root document's raw source is the on-disk
      *  original, and unreadable content has nothing to write), so there is nothing to check and nothing to
-     *  repair. */
+     *  repair. {@code !exists} rather than {@code notExists}: a path the filesystem will not answer for
+     *  (a stale NFS handle, a revoked permission on a shared artifactDir) makes both false, and re-producing
+     *  costs work a later run can redo while stamping COMPLETE over an unconfirmed payload is what leaves a
+     *  document unrepairable. */
     public static boolean isMissing(Path docArtifactDir, ArtifactType type, ManifestEntry entry) {
         if (entry.status() == ManifestEntryStatus.EMPTY) {
             return false;
@@ -25,34 +28,24 @@ public class ArtifactPayload {
             // sidecar as a second atomic move after it. Both or neither: SourceExtractor only serves the
             // cache when both are readable, so a pair half written by a JVM death is unservable and must
             // be re-produced rather than recorded as present.
-            case RAW -> isAbsent(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
-                    || isAbsent(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
-            // The directory and the last page it advertises. The swap renames a fully written directory
-            // into place, so a partial write is impossible, but a partial delete is not: discard() removes
-            // pages one by one and only warns when it stops half way. Exhaustive over the enum on purpose:
-            // a new type must decide its own shape here rather than default to "present".
-            case STRUCTURE -> isAbsent(ArtifactPath.structureDir(docArtifactDir))
-                    || lastPageMissing(docArtifactDir, entry);
+            // Exhaustive over the enum on purpose: a new type must decide its own shape here rather than
+            // default to "present".
+            case RAW -> !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
+                    || !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
+            case STRUCTURE -> !Files.exists(lastPageOrDir(docArtifactDir, entry));
         };
     }
 
-    /** Absent, or a path the filesystem will not answer for. A stale NFS handle or a revoked permission
-     *  on a shared artifactDir makes both {@code exists} and {@code notExists} false, and the two callers
-     *  that record entries would stamp a COMPLETE one over a payload nobody has confirmed. Re-producing
-     *  costs work that a later run can redo; recording that lie is what leaves a document unrepairable. */
-    private static boolean isAbsent(Path path) {
-        return !Files.exists(path);
-    }
-
-    /** Whether the highest-numbered page the entry advertises is gone. Only the last one: pages are
-     *  written in order into a staging directory the swap renames in one move, so a set truncated by a
-     *  failed delete always loses its last page. An entry that advertises no usable page count says
-     *  nothing to check, and manifest.json is read from disk (a Python producer writes it too), so that
-     *  is a state to fall back from rather than re-produce on every run forever. */
-    private static boolean lastPageMissing(Path docArtifactDir, ManifestEntry entry) {
+    /** The one path that answers for the whole payload: the highest-numbered page the entry advertises.
+     *  Pages are written in order into a staging directory the swap renames in one move, so a partial write
+     *  is impossible and a set truncated by discard()'s page-by-page delete always loses its last page, and
+     *  a missing page implies a missing directory. Falls back to the directory when the entry advertises no
+     *  usable page count: manifest.json is read from disk (a Python producer writes it too), so that is a
+     *  state to fall back from rather than re-produce on every run forever. */
+    private static Path lastPageOrDir(Path docArtifactDir, ManifestEntry entry) {
         if (entry.pages() == null || entry.pages().total() < 1) {
-            return false;
+            return ArtifactPath.structureDir(docArtifactDir);
         }
-        return isAbsent(ArtifactPath.structurePage(docArtifactDir, entry.pages().total(), "md"));
+        return ArtifactPath.structurePage(docArtifactDir, entry.pages().total(), "md");
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactPayload.java
@@ -5,43 +5,34 @@ import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-/** Whether the payload a manifest entry advertises is still on disk. The single definition of that
- *  question: skip-if-current, INDEX-time recording and raw's post-extraction verification all ask it
- *  here, so none of the three can drift from the others. */
+/** Whether the payload a manifest entry advertises is still on disk. Single definition of the question,
+ *  so skip-if-current, INDEX-time recording and raw's post-extraction check cannot drift apart. */
 public class ArtifactPayload {
     private ArtifactPayload() {}
 
-    /** True when the entry advertises a payload that is not there. Takes the entry as it is recorded,
-     *  stamped or not, because two of the three callers ask before {@link ManifestEntry#withTerminalStatus()}
-     *  runs. An EMPTY entry advertises no payload of its own (a root document's raw source is the on-disk
-     *  original, and unreadable content has nothing to write), so there is nothing to check and nothing to
-     *  repair. {@code !exists} rather than {@code notExists}: a path the filesystem will not answer for
-     *  (a stale NFS handle, a revoked permission on a shared artifactDir) makes both false, and re-producing
-     *  costs work a later run can redo while stamping COMPLETE over an unconfirmed payload is what leaves a
-     *  document unrepairable. */
+    /** Takes the entry stamped or not, since two of the three callers ask before
+     *  {@link ManifestEntry#withTerminalStatus()} runs. {@code !exists} rather than {@code notExists}: a
+     *  path the filesystem will not answer for counts as absent, because re-producing is work a later run
+     *  can redo and stamping COMPLETE over an unconfirmed payload is not. */
     public static boolean isMissing(Path docArtifactDir, ArtifactType type, ManifestEntry entry) {
+        // EMPTY advertises no payload of its own: a root's raw source is the on-disk original.
         if (entry.status() == ManifestEntryStatus.EMPTY) {
             return false;
         }
+        // Exhaustive on purpose: a new type must decide its own shape rather than default to "present".
         return switch (type) {
-            // extract-lib writes raw as a single file next to manifest.json, not as a directory, and its
-            // sidecar as a second atomic move after it. Both or neither: SourceExtractor only serves the
-            // cache when both are readable, so a pair half written by a JVM death is unservable and must
-            // be re-produced rather than recorded as present.
-            // Exhaustive over the enum on purpose: a new type must decide its own shape here rather than
-            // default to "present".
+            // Both or neither: SourceExtractor serves the cache only when both are readable, so a pair
+            // half written by a JVM death is unservable.
             case RAW -> !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))
                     || !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE));
             case STRUCTURE -> !Files.exists(lastPageOrDir(docArtifactDir, entry));
         };
     }
 
-    /** The one path that answers for the whole payload: the highest-numbered page the entry advertises.
-     *  Pages are written in order into a staging directory the swap renames in one move, so a partial write
-     *  is impossible and a set truncated by discard()'s page-by-page delete always loses its last page, and
-     *  a missing page implies a missing directory. Falls back to the directory when the entry advertises no
-     *  usable page count: manifest.json is read from disk (a Python producer writes it too), so that is a
-     *  state to fall back from rather than re-produce on every run forever. */
+    /** The one path that answers for the whole payload: pages land in a staging directory renamed in one
+     *  move, so a partial write is impossible and a set truncated by discard()'s page-by-page delete
+     *  always loses its last page. The directory instead when the entry advertises no usable count, since
+     *  manifest.json is read from disk and a Python producer writes it too. */
     private static Path lastPageOrDir(Path docArtifactDir, ManifestEntry entry) {
         if (entry.pages() == null || entry.pages().total() < 1) {
             return ArtifactPath.structureDir(docArtifactDir);

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -142,11 +142,11 @@ public class ArtifactProducer {
         // A terminal entry is not proof the payload survived: a JVM death mid-swap, or a failed restore
         // leaving the pages in a holding pen, takes it out from under a complete entry. Asking the disk is
         // what makes a plain re-run repair that, instead of --artifactsForce over the whole corpus.
-        if (!ArtifactPayload.isMissing(context.docArtifactDir(), type, existing)) {
-            return true;
+        if (ArtifactPayload.isMissing(context.docArtifactDir(), type, existing)) {
+            LOGGER.warn("'{}' entry for document {} is current but its payload is gone: re-producing",
+                    type.token(), context.document().getId());
+            return false;
         }
-        LOGGER.warn("'{}' entry for document {} is current but its payload is gone: re-producing",
-                type.token(), context.document().getId());
-        return false;
+        return true;
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -136,6 +136,17 @@ public class ArtifactProducer {
 
     private boolean isCurrent(ArtifactType type, Artifact artifact, ArtifactContext context) throws IOException {
         ManifestEntry existing = repository.get(context.docArtifactDir(), type.token());
-        return existing != null && existing.isCurrentFor(artifact.taskInput());
+        if (existing == null || !existing.isCurrentFor(artifact.taskInput())) {
+            return false;
+        }
+        // A terminal entry is not proof the payload survived: a JVM death mid-swap, or a failed restore
+        // leaving the pages in a holding pen, takes it out from under a complete entry. Asking the disk is
+        // what makes a plain re-run repair that, instead of --artifactsForce over the whole corpus.
+        if (!ArtifactPayload.isMissing(context.docArtifactDir(), type, existing)) {
+            return true;
+        }
+        LOGGER.warn("'{}' entry for document {} is current but its payload is gone: re-producing",
+                type.token(), context.document().getId());
+        return false;
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -139,9 +139,8 @@ public class ArtifactProducer {
         if (existing == null || !existing.isCurrentFor(artifact.taskInput())) {
             return false;
         }
-        // A terminal entry is not proof the payload survived: a JVM death mid-swap, or a failed restore
-        // leaving the pages in a holding pen, takes it out from under a complete entry. Asking the disk is
-        // what makes a plain re-run repair that, instead of --artifactsForce over the whole corpus.
+        // A terminal entry is not proof the payload survived a JVM death mid-swap or a failed restore.
+        // Asking the disk is what lets a plain re-run repair it, instead of --artifactsForce on the corpus.
         if (ArtifactPayload.isMissing(context.docArtifactDir(), type, existing)) {
             LOGGER.warn("'{}' entry for document {} is current but its payload is gone: re-producing",
                     type.token(), context.document().getId());

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -37,12 +37,9 @@ public class ManifestRecorder {
         }
         Path docArtifactDir = ArtifactPath.dir(projectRoot, document.getId());
         ManifestEntry entry = raw.entryFor(document);
-        // Before skip-if-current, not after, so this stage asks the payload question in the same order
-        // {@link ArtifactProducer#isCurrent} does: an entry is never treated as current until its payload
-        // has been confirmed. Only record a COMPLETE entry once the raw payload extract-lib wrote during
-        // the parse is really on disk. Otherwise skip, so a later ARTIFACT-stage run produces it rather
-        // than leaving a permanent false-COMPLETE. A root advertises no payload in its own dir, so it
-        // always records its EMPTY entry.
+        // Before skip-if-current, as in ArtifactProducer.isCurrent: nothing is current until its payload is
+        // confirmed. Skipping here leaves the document to a later ARTIFACT run rather than recording a
+        // permanent false-COMPLETE.
         if (ArtifactPayload.isMissing(docArtifactDir, ArtifactType.RAW, entry)) {
             return;
         }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -36,19 +36,21 @@ public class ManifestRecorder {
             return;
         }
         Path docArtifactDir = ArtifactPath.dir(projectRoot, document.getId());
+        ManifestEntry entry = raw.entryFor(document);
+        // Before skip-if-current, not after, so this stage asks the payload question in the same order
+        // {@link ArtifactProducer#isCurrent} does: an entry is never treated as current until its payload
+        // has been confirmed. Only record a COMPLETE entry once the raw payload extract-lib wrote during
+        // the parse is really on disk. Otherwise skip, so a later ARTIFACT-stage run produces it rather
+        // than leaving a permanent false-COMPLETE. A root advertises no payload in its own dir, so it
+        // always records its EMPTY entry.
+        if (ArtifactPayload.isMissing(docArtifactDir, ArtifactType.RAW, entry)) {
+            return;
+        }
         if (!force) {
             ManifestEntry existing = repository.get(docArtifactDir, ArtifactType.RAW.token());
             if (existing != null && existing.isCurrentFor(raw.taskInput())) {
                 return;
             }
-        }
-        ManifestEntry entry = raw.entryFor(document);
-        // Only record a COMPLETE entry once the raw payload extract-lib wrote during the parse is really
-        // on disk. Otherwise skip, so a later ARTIFACT-stage run produces it rather than leaving a
-        // permanent false-COMPLETE. A root advertises no payload in its own dir, so it always records its
-        // EMPTY entry.
-        if (ArtifactPayload.isMissing(docArtifactDir, ArtifactType.RAW, entry)) {
-            return;
         }
         repository.put(docArtifactDir, ArtifactType.RAW.token(), entry.withTerminalStatus());
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -4,7 +4,6 @@ import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -43,13 +42,14 @@ public class ManifestRecorder {
                 return;
             }
         }
-        // For an embedded node, only record a COMPLETE entry once its raw payload is
-        // actually on disk (written by extract-lib during the parse). Otherwise skip, so a later
-        // ARTIFACT-stage run produces it rather than leaving a permanent false-COMPLETE. A root has
-        // no payload in its own dir, so it always records its EMPTY entry.
-        if (!document.isRootDocument() && !Files.exists(docArtifactDir.resolve(ArtifactPath.RAW_FILE))) {
+        ManifestEntry entry = raw.entryFor(document);
+        // Only record a COMPLETE entry once the raw payload extract-lib wrote during the parse is really
+        // on disk. Otherwise skip, so a later ARTIFACT-stage run produces it rather than leaving a
+        // permanent false-COMPLETE. A root advertises no payload in its own dir, so it always records its
+        // EMPTY entry.
+        if (ArtifactPayload.isMissing(docArtifactDir, ArtifactType.RAW, entry)) {
             return;
         }
-        repository.put(docArtifactDir, ArtifactType.RAW.token(), raw.entryFor(document).withTerminalStatus());
+        repository.put(docArtifactDir, ArtifactType.RAW.token(), entry.withTerminalStatus());
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
@@ -30,11 +30,9 @@ public class RawArtifact implements Artifact {
             // extract-lib writes the raw/raw.json bytes for the embedded subtree as a side effect.
             context.sources().extractEmbeddedSources(context.project(), document);
             ManifestEntry entry = entryFor(document);
-            // extractAll can return normally without ever writing THIS polled document's bytes: a
-            // per-message parse failure the resilient parser swallows, a mid-walk abort, a corrupt entry,
-            // an OCR-off image... Verify the payload landed before handing back a terminal-able entry, so
-            // a silent miss fails loudly (nbFailed, re-runnable) instead of being recorded as produced. A
-            // root advertises no payload in this dir, so the predicate finds nothing to check for one.
+            // extractAll can return normally without ever writing THIS polled document's bytes: a parse
+            // failure the resilient parser swallows, a mid-walk abort, an OCR-off image... A silent miss
+            // must fail loudly (nbFailed, re-runnable) instead of being recorded as produced.
             if (ArtifactPayload.isMissing(context.docArtifactDir(), TYPE, entry)) {
                 throw new ArtifactException("raw extraction produced no bytes for " + document.getId(), null);
             }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
@@ -1,9 +1,7 @@
 package org.icij.datashare.text.artifact;
 
 import org.icij.datashare.text.Document;
-import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 
-import java.nio.file.Files;
 import java.util.Map;
 
 /** The raw/source-bytes artifact. extract-lib still writes the raw/raw.json bytes via
@@ -32,14 +30,12 @@ public class RawArtifact implements Artifact {
             // extract-lib writes the raw/raw.json bytes for the embedded subtree as a side effect.
             context.sources().extractEmbeddedSources(context.project(), document);
             ManifestEntry entry = entryFor(document);
-            // A root has no payload in this dir, so there is nothing to verify. For an embedded node,
             // extractAll can return normally without ever writing THIS polled document's bytes: a
-            // per-message parse failure the resilient parser swallows, a mid-walk abort, a corrupt
-            // entry, an OCR-off image... Verify the raw payload actually landed before handing back
-            // a terminal-able entry, so a silent miss fails loudly (nbFailed, re-runnable) instead of
-            // being recorded as produced.
-            if (!document.isRootDocument()
-                    && Files.notExists(context.docArtifactDir().resolve(ArtifactPath.RAW_FILE))) {
+            // per-message parse failure the resilient parser swallows, a mid-walk abort, a corrupt entry,
+            // an OCR-off image... Verify the payload landed before handing back a terminal-able entry, so
+            // a silent miss fails loudly (nbFailed, re-runnable) instead of being recorded as produced. A
+            // root advertises no payload in this dir, so the predicate finds nothing to check for one.
+            if (ArtifactPayload.isMissing(context.docArtifactDir(), TYPE, entry)) {
                 throw new ArtifactException("raw extraction produced no bytes for " + document.getId(), null);
             }
             return entry;

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -20,12 +20,10 @@ public class ArtifactPayloadTest {
         return dir.getRoot().toPath();
     }
 
-    // The entry raw records for an embedded node, as ArtifactProducer stores it.
     private ManifestEntry completeSingleFile() {
         return ManifestEntry.singleFile(TASK_INPUT, "image/jpeg", "image2.jpg").withTerminalStatus();
     }
 
-    // What extract-lib leaves behind for an embedded node: the payload and its sidecar, in that order.
     private void writeRawPair() throws Exception {
         Files.createFile(docDir().resolve(ArtifactPath.RAW_FILE));
         Files.createFile(docDir().resolve(ArtifactPath.RAW_SIDECAR_FILE));
@@ -40,9 +38,8 @@ public class ArtifactPayloadTest {
 
     @Test
     public void test_raw_payload_without_its_sidecar_is_missing() throws Exception {
-        // extract-lib moves the payload into place, then the sidecar, so a JVM death between the two
-        // leaves this pair half written. SourceExtractor.hasCachedEmbeddedSource serves a cache hit only
-        // when both are readable, so half a pair is unservable and the document needs re-producing.
+        // SourceExtractor.hasCachedEmbeddedSource needs both, so a pair a JVM death left half written is
+        // unservable and the document needs re-producing.
         Files.createFile(docDir().resolve(ArtifactPath.RAW_FILE));
 
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, completeSingleFile())).isTrue();
@@ -50,8 +47,7 @@ public class ArtifactPayloadTest {
 
     @Test
     public void test_an_unstamped_entry_is_checked_too() {
-        // RawArtifact.produce and ManifestRecorder ask before withTerminalStatus() stamps the entry, so a
-        // status-based test would answer "nothing to check" for every entry on the write side.
+        // The write-side callers ask before withTerminalStatus() stamps the entry.
         ManifestEntry unstamped = ManifestEntry.singleFile(TASK_INPUT, "image/jpeg", "image2.jpg");
 
         assertThat(unstamped.status()).isNull();
@@ -60,8 +56,7 @@ public class ArtifactPayloadTest {
 
     @Test
     public void test_an_empty_entry_advertises_no_payload() {
-        // A root document's raw source is the on-disk original, so nothing is expected in this dir and a
-        // re-run must not treat the absence as damage to repair, forever.
+        // A root's raw source is the on-disk original: absence here is not damage to repair, forever.
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, ManifestEntry.empty(TASK_INPUT))).isFalse();
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE, ManifestEntry.empty(TASK_INPUT))).isFalse();
     }
@@ -74,8 +69,7 @@ public class ArtifactPayloadTest {
 
     @Test
     public void test_structure_payload_missing_the_last_page_it_advertises_is_missing() throws Exception {
-        // AtomicDirectorySwap.discard deletes page by page and only warns when it fails part way, so the
-        // directory can survive holding a subset while the entry still advertises every page.
+        // AtomicDirectorySwap.discard deletes page by page, so the directory can survive holding a subset.
         Files.createDirectories(ArtifactPath.structureDir(docDir()));
         Files.writeString(ArtifactPath.structurePage(docDir(), 1, "md"), "# Title");
 
@@ -85,8 +79,7 @@ public class ArtifactPayloadTest {
 
     @Test
     public void test_a_structure_entry_advertising_no_page_count_falls_back_to_its_directory() throws Exception {
-        // manifest.json is read from disk and a Python producer writes it too, so pages can be absent or
-        // nonsensical. Nothing to compare against then, and re-producing forever is the wrong answer.
+        // A Python producer writes manifest.json too, so the count can be absent or nonsensical.
         Files.createDirectories(ArtifactPath.structureDir(docDir()));
 
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -39,6 +39,16 @@ public class ArtifactPayloadTest {
     }
 
     @Test
+    public void test_raw_payload_without_its_sidecar_is_missing() throws Exception {
+        // extract-lib moves the payload into place, then the sidecar, so a JVM death between the two
+        // leaves this pair half written. SourceExtractor.hasCachedEmbeddedSource serves a cache hit only
+        // when both are readable, so half a pair is unservable and the document needs re-producing.
+        Files.createFile(docDir().resolve(ArtifactPath.RAW_FILE));
+
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, completeSingleFile())).isTrue();
+    }
+
+    @Test
     public void test_raw_payload_gone_is_missing() {
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, completeSingleFile())).isTrue();
     }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -25,9 +25,15 @@ public class ArtifactPayloadTest {
         return ManifestEntry.singleFile(TASK_INPUT, "image/jpeg", "image2.jpg").withTerminalStatus();
     }
 
+    // What extract-lib leaves behind for an embedded node: the payload and its sidecar, in that order.
+    private void writeRawPair() throws Exception {
+        Files.createFile(docDir().resolve(ArtifactPath.RAW_FILE));
+        Files.createFile(docDir().resolve(ArtifactPath.RAW_SIDECAR_FILE));
+    }
+
     @Test
     public void test_raw_payload_on_disk_is_not_missing() throws Exception {
-        Files.createFile(docDir().resolve(ArtifactPath.RAW_FILE));
+        writeRawPair();
 
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, completeSingleFile())).isFalse();
     }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -78,6 +78,27 @@ public class ArtifactPayloadTest {
     }
 
     @Test
+    public void test_structure_payload_missing_the_last_page_it_advertises_is_missing() throws Exception {
+        // AtomicDirectorySwap.discard deletes page by page and only warns when it fails part way, so the
+        // directory can survive holding a subset while the entry still advertises every page.
+        Files.createDirectories(ArtifactPath.structureDir(docDir()));
+        Files.writeString(ArtifactPath.structurePage(docDir(), 1, "md"), "# Title");
+
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
+                ManifestEntry.paginated(TASK_INPUT, 2).withTerminalStatus())).isTrue();
+    }
+
+    @Test
+    public void test_a_structure_entry_advertising_no_page_count_falls_back_to_its_directory() throws Exception {
+        // manifest.json is read from disk and a Python producer writes it too, so pages can be absent or
+        // nonsensical. Nothing to compare against then, and re-producing forever is the wrong answer.
+        Files.createDirectories(ArtifactPath.structureDir(docDir()));
+
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
+                ManifestEntry.singleFile(TASK_INPUT, "text/markdown", "page-1.md").withTerminalStatus())).isFalse();
+    }
+
+    @Test
     public void test_structure_payload_dir_holding_the_pages_it_advertises_is_not_missing() throws Exception {
         Files.createDirectories(ArtifactPath.structureDir(docDir()));
         Files.writeString(ArtifactPath.structurePage(docDir(), 1, "md"), "# Title");

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -78,9 +78,10 @@ public class ArtifactPayloadTest {
     }
 
     @Test
-    public void test_structure_payload_dir_holding_a_page_is_not_missing() throws Exception {
+    public void test_structure_payload_dir_holding_the_pages_it_advertises_is_not_missing() throws Exception {
         Files.createDirectories(ArtifactPath.structureDir(docDir()));
         Files.writeString(ArtifactPath.structurePage(docDir(), 1, "md"), "# Title");
+        Files.writeString(ArtifactPath.structurePage(docDir(), 2, "md"), "# Second");
 
         assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
                 ManifestEntry.paginated(TASK_INPUT, 2).withTerminalStatus())).isFalse();

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -49,11 +49,6 @@ public class ArtifactPayloadTest {
     }
 
     @Test
-    public void test_raw_payload_gone_is_missing() {
-        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, completeSingleFile())).isTrue();
-    }
-
-    @Test
     public void test_an_unstamped_entry_is_checked_too() {
         // RawArtifact.produce and ManifestRecorder ask before withTerminalStatus() stamps the entry, so a
         // status-based test would answer "nothing to check" for every entry on the write side.

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactPayloadTest.java
@@ -1,0 +1,72 @@
+package org.icij.datashare.text.artifact;
+
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ArtifactPayloadTest {
+    @Rule public TemporaryFolder dir = new TemporaryFolder();
+
+    private static final Map<String, Object> TASK_INPUT = Map.of("type", "raw", "version", 1);
+
+    private Path docDir() {
+        return dir.getRoot().toPath();
+    }
+
+    // The entry raw records for an embedded node, as ArtifactProducer stores it.
+    private ManifestEntry completeSingleFile() {
+        return ManifestEntry.singleFile(TASK_INPUT, "image/jpeg", "image2.jpg").withTerminalStatus();
+    }
+
+    @Test
+    public void test_raw_payload_on_disk_is_not_missing() throws Exception {
+        Files.createFile(docDir().resolve(ArtifactPath.RAW_FILE));
+
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, completeSingleFile())).isFalse();
+    }
+
+    @Test
+    public void test_raw_payload_gone_is_missing() {
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, completeSingleFile())).isTrue();
+    }
+
+    @Test
+    public void test_an_unstamped_entry_is_checked_too() {
+        // RawArtifact.produce and ManifestRecorder ask before withTerminalStatus() stamps the entry, so a
+        // status-based test would answer "nothing to check" for every entry on the write side.
+        ManifestEntry unstamped = ManifestEntry.singleFile(TASK_INPUT, "image/jpeg", "image2.jpg");
+
+        assertThat(unstamped.status()).isNull();
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, unstamped)).isTrue();
+    }
+
+    @Test
+    public void test_an_empty_entry_advertises_no_payload() {
+        // A root document's raw source is the on-disk original, so nothing is expected in this dir and a
+        // re-run must not treat the absence as damage to repair, forever.
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.RAW, ManifestEntry.empty(TASK_INPUT))).isFalse();
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE, ManifestEntry.empty(TASK_INPUT))).isFalse();
+    }
+
+    @Test
+    public void test_structure_payload_dir_absent_is_missing() {
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
+                ManifestEntry.paginated(TASK_INPUT, 2).withTerminalStatus())).isTrue();
+    }
+
+    @Test
+    public void test_structure_payload_dir_holding_a_page_is_not_missing() throws Exception {
+        Files.createDirectories(ArtifactPath.structureDir(docDir()));
+        Files.writeString(ArtifactPath.structurePage(docDir(), 1, "md"), "# Title");
+
+        assertThat(ArtifactPayload.isMissing(docDir(), ArtifactType.STRUCTURE,
+                ManifestEntry.paginated(TASK_INPUT, 2).withTerminalStatus())).isFalse();
+    }
+}

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.text.artifact;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+import org.icij.datashare.utils.AtomicDirectorySwap;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -90,6 +91,18 @@ public class ArtifactProducerTest {
         CountingArtifact v2 = new CountingArtifact("raw", 2);
         producer.run(List.of(v2), ctx(), false);
         assertThat(v2.produced.get()).isEqualTo(1);
+    }
+
+    @Test public void test_regenerates_when_the_recorded_structure_payload_is_gone() throws Exception {
+        // A JVM death between AtomicDirectorySwap's two renames, or a failed restore, leaves the payload
+        // missing under a complete entry. A plain re-run must repair it, not skip it forever (#2300).
+        CountingArtifact structure = new CountingArtifact("structure", 1);
+        producer.run(List.of(structure), ctx(), false);
+        AtomicDirectorySwap.discard(ArtifactPath.structureDir(dir.getRoot().toPath()));
+
+        producer.run(List.of(structure), ctx(), false);
+
+        assertThat(structure.produced.get()).isEqualTo(2);
     }
 
     @Test public void test_isolates_failing_type() throws Exception {

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
@@ -2,12 +2,15 @@ package org.icij.datashare.text.artifact;
 
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,7 +38,24 @@ public class ArtifactProducerTest {
         public ManifestEntry produce(ArtifactContext ctx) throws ArtifactException {
             if (fail) { throw new ArtifactException("boom", null); }
             produced.incrementAndGet();
-            return producesEmpty ? ManifestEntry.empty(taskInput) : ManifestEntry.singleFile(taskInput, "text/plain", "a.txt");
+            if (producesEmpty) { return ManifestEntry.empty(taskInput); }
+            writePayload(ctx.docArtifactDir());
+            return ManifestEntry.singleFile(taskInput, "text/plain", "a.txt");
+        }
+        // A real producer writes its payload before the entry is recorded, and skip-if-current now checks
+        // the payload is still there: a fake that records without writing would be re-produced every run.
+        private void writePayload(Path docArtifactDir) throws ArtifactException {
+            try {
+                if (type == ArtifactType.RAW) {
+                    Files.createDirectories(docArtifactDir);
+                    Files.write(docArtifactDir.resolve(ArtifactPath.RAW_FILE), new byte[]{1});
+                } else {
+                    Files.createDirectories(ArtifactPath.structureDir(docArtifactDir));
+                    Files.writeString(ArtifactPath.structurePage(docArtifactDir, 1, "md"), "page");
+                }
+            } catch (IOException cannotWrite) {
+                throw new ArtifactException("cannot write the fake payload", cannotWrite);
+            }
         }
     }
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
@@ -50,6 +50,7 @@ public class ArtifactProducerTest {
                 if (type == ArtifactType.RAW) {
                     Files.createDirectories(docArtifactDir);
                     Files.write(docArtifactDir.resolve(ArtifactPath.RAW_FILE), new byte[]{1});
+                    Files.write(docArtifactDir.resolve(ArtifactPath.RAW_SIDECAR_FILE), "{}".getBytes());
                 } else {
                     Files.createDirectories(ArtifactPath.structureDir(docArtifactDir));
                     Files.writeString(ArtifactPath.structurePage(docArtifactDir, 1, "md"), "page");

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
@@ -43,8 +43,7 @@ public class ArtifactProducerTest {
             writePayload(ctx.docArtifactDir());
             return ManifestEntry.singleFile(taskInput, "text/plain", "a.txt");
         }
-        // A real producer writes its payload before the entry is recorded, and skip-if-current now checks
-        // the payload is still there: a fake that records without writing would be re-produced every run.
+        // skip-if-current now checks the payload, so a fake that records without writing is never skipped.
         private void writePayload(Path docArtifactDir) throws ArtifactException {
             try {
                 if (type == ArtifactType.RAW) {
@@ -95,8 +94,7 @@ public class ArtifactProducerTest {
     }
 
     @Test public void test_regenerates_when_the_recorded_structure_payload_is_gone() throws Exception {
-        // A JVM death between AtomicDirectorySwap's two renames, or a failed restore, leaves the payload
-        // missing under a complete entry. A plain re-run must repair it, not skip it forever (#2300).
+        // A payload gone from under a complete entry must be repaired by a plain re-run, not skipped (#2300).
         CountingArtifact structure = new CountingArtifact("structure", 1);
         producer.run(List.of(structure), ctx(), false);
         AtomicDirectorySwap.discard(ArtifactPath.structureDir(dir.getRoot().toPath()));

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
@@ -35,6 +35,7 @@ public class ManifestRecorderTest {
     private void writePayload(String docId) throws Exception {
         Files.createDirectories(ArtifactPath.dir(projectRoot(), docId));
         Files.write(ArtifactPath.dir(projectRoot(), docId).resolve("raw"), new byte[]{1, 2, 3});
+        Files.write(ArtifactPath.dir(projectRoot(), docId).resolve("raw.json"), "{}".getBytes());
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
@@ -72,8 +72,7 @@ public class RawArtifactTest {
         Project project = Project.project("prj");
         Document doc = createDoc("doc-id").with(Path.of("/path/to/report.pdf")).ofContentType("application/pdf").withExtractionLevel((short) 1).build();
         Path docDir = dir.getRoot().toPath();
-        // Mirror extract-lib's side effect: extractEmbeddedSources writes the polled doc's raw bytes
-        // and their sidecar, the pair the read path needs.
+        // Mirror extract-lib's side effect: extractEmbeddedSources writes the raw bytes and their sidecar.
         doAnswer(invocation -> {
             Files.createFile(docDir.resolve("raw"));
             Files.createFile(docDir.resolve("raw.json"));

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
@@ -72,9 +72,11 @@ public class RawArtifactTest {
         Project project = Project.project("prj");
         Document doc = createDoc("doc-id").with(Path.of("/path/to/report.pdf")).ofContentType("application/pdf").withExtractionLevel((short) 1).build();
         Path docDir = dir.getRoot().toPath();
-        // Mirror extract-lib's side effect: extractEmbeddedSources writes the polled doc's raw bytes.
+        // Mirror extract-lib's side effect: extractEmbeddedSources writes the polled doc's raw bytes
+        // and their sidecar, the pair the read path needs.
         doAnswer(invocation -> {
             Files.createFile(docDir.resolve("raw"));
+            Files.createFile(docDir.resolve("raw.json"));
             return null;
         }).when(sources).extractEmbeddedSources(project, doc);
         ArtifactContext ctx = new ArtifactContext(project, doc, docDir, sources);

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -265,8 +265,7 @@ public class StructureArtifactTest {
     public void test_second_producer_run_skips_a_document_whose_payload_is_still_there() throws Exception {
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
         producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
-        // Overwrite the payload rather than delete it: a re-render would replace this sentinel, and a
-        // deleted page is now a repair trigger rather than proof of a skip.
+        // Overwrite rather than delete: a deleted page is now a repair trigger, not proof of a skip.
         Files.writeString(page(1, "md"), "sentinel");
 
         producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
@@ -278,8 +277,8 @@ public class StructureArtifactTest {
     public void test_a_re_run_repairs_pages_stranded_in_a_holding_pen() throws Exception {
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
         producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
-        // What a failed AtomicDirectorySwap.restore leaves behind: the only copy of the pages sitting in a
-        // holding pen while the target is gone, until now recoverable only by hand (#2300).
+        // What a failed AtomicDirectorySwap.restore leaves behind: the only copy of the pages in a holding
+        // pen while the target is gone, until now recoverable only by hand (#2300).
         Path pen = dir.getRoot().toPath().resolve(".structure-" + UUID.randomUUID() + ".replaced");
         Files.move(ArtifactPath.structureDir(dir.getRoot().toPath()), pen);
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -261,14 +262,31 @@ public class StructureArtifactTest {
     }
 
     @Test
-    public void test_second_producer_run_skips_a_document_that_is_already_current() throws Exception {
+    public void test_second_producer_run_skips_a_document_whose_payload_is_still_there() throws Exception {
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
         producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
-        // Delete the payload: if the second run regenerated, the page would come back.
-        Files.delete(page(1, "md"));
+        // Overwrite the payload rather than delete it: a re-render would replace this sentinel, and a
+        // deleted page is now a repair trigger rather than proof of a skip.
+        Files.writeString(page(1, "md"), "sentinel");
 
         producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
 
-        assertThat(Files.exists(page(1, "md"))).isFalse();
+        assertThat(Files.readString(page(1, "md"))).isEqualTo("sentinel");
+    }
+
+    @Test
+    public void test_a_re_run_repairs_pages_stranded_in_a_holding_pen() throws Exception {
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
+        // What a failed AtomicDirectorySwap.restore leaves behind: the only copy of the pages sitting in a
+        // holding pen while the target is gone, until now recoverable only by hand (#2300).
+        Path pen = dir.getRoot().toPath().resolve(".structure-" + UUID.randomUUID() + ".replaced");
+        Files.move(ArtifactPath.structureDir(dir.getRoot().toPath()), pen);
+
+        producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
+
+        assertThat(Files.readString(page(1, "md"))).contains("# Title");
+        // reclaimHoldingPens swept the stale pen on the way through, so the repair costs no extra copy.
+        assertThat(Files.exists(pen)).isFalse();
     }
 }


### PR DESCRIPTION
Closes #2300.

`isCurrentFor` only asked the manifest entry, never the disk, so a document whose payload went missing after its entry was recorded stayed skipped until an `--artifactsForce` run over the whole corpus. Skip-if-current now asks the artifact whether its payload is still there, so a plain re-run repairs it.

- feat(artifacts): one predicate for whether an entry's payload is still on disk
- fix(artifacts): re-produce a current entry whose payload left the disk
- fix(artifacts): count a raw payload missing when its sidecar did not land
- fix(artifacts): verify the pages a structure entry advertises, not just their directory
- fix(artifacts): treat a payload path the filesystem will not answer for as absent
- refactor(artifacts): read the payload check in isCurrent as a guard clause
