### PR TITLE
feat(artifacts): search a document's structure pages

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
+++ b/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
@@ -33,7 +33,8 @@ public class ArtifactRegistry {
      *  such rival producer: the pages/ payload is Java's alone. */
     public static ArtifactRegistry withDefaults(PropertiesProvider propertiesProvider) {
         return new ArtifactRegistry(
-                List.of(new RawArtifact(), new StructureArtifact(propertiesProvider), new PageArtifact(propertiesProvider)));
+                List.of(new RawArtifact(), new StructureArtifact(propertiesProvider),
+                        new PageArtifact(propertiesProvider)));
     }
 
     public List<Artifact> select(String flagValue) {

--- a/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
+++ b/datashare-app/src/main/java/org/icij/datashare/text/artifact/ArtifactRegistry.java
@@ -33,7 +33,7 @@ public class ArtifactRegistry {
      *  such rival producer: the pages/ payload is Java's alone. */
     public static ArtifactRegistry withDefaults(PropertiesProvider propertiesProvider) {
         return new ArtifactRegistry(
-                List.of(new RawArtifact(), new StructureArtifact(), new PageArtifact(propertiesProvider)));
+                List.of(new RawArtifact(), new StructureArtifact(propertiesProvider), new PageArtifact(propertiesProvider)));
     }
 
     public List<Artifact> select(String flagValue) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -149,33 +149,38 @@ public class ArtifactResource {
                 : payload;
     }
 
-    @Operation(description = "Counts a query's occurrences in a document's structure pages, per page.",
+    @Operation(description = "Counts a query's occurrences in a document's Markdown structure pages, per page. "
+            + "Markdown only: the XHTML the page route serves is markup, so counting over it reports tag "
+            + "names, class names and link targets as occurrences of the user's term. Counts the document's "
+            + "original language: structure pages are rendered from the source bytes, so unlike "
+            + "/documents/searchContent this route has no targetLanguage and never counts a translation.",
             parameters = {
                     @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
                     @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
                     @Parameter(name = "query", description = "the term to count, matched literally", in = ParameterIn.QUERY),
-                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY),
-                    @Parameter(name = "format", description = "md (default) or xhtml", in = ParameterIn.QUERY)
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY)
             }
     )
-    @ApiResponse(responseCode = "200", description = "JSON {\"count\": N, \"hits\": [{\"page\": P, \"count\": N}]}")
-    @ApiResponse(responseCode = "400", description = "if the query is blank, or format is not one of md, xhtml")
+    @ApiResponse(responseCode = "200", description = "JSON {\"count\": N, \"pages\": P, \"scanned\": S, "
+            + "\"hits\": [{\"page\": P, \"count\": N}]}. scanned below pages means the artifact lost pages "
+            + "between its manifest and disk, so the counts are a floor rather than a total.")
+    @ApiResponse(responseCode = "400", description = "if the query is blank")
     @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project")
-    @ApiResponse(responseCode = "404", description = "if the document, the artifact, or that format is not found")
-    @Get("/:project/artifacts/structure/:id/search?query=:query&routing=:routing&format=:format")
-    public Payload structureSearch(final String project, final String id, final String query, final String routing,
-                                   final String format, final Context context) throws IOException {
+    @ApiResponse(responseCode = "404", description = "if the document, the artifact, or its markdown is not found")
+    // The verb before the id, as /documents/searchContent/:id has it, so this cannot collide with the
+    // :page route. Under that route's shape it would win only on a tie-break: fluent-http's UriParser
+    // orders on the count of :params across the whole pattern, query string included, and both hold
+    // five. A sixth would sort this second, :page would match "search", and every search would 404.
+    @Get("/:project/artifacts/structure/search/:id?query=:query&routing=:routing")
+    public Payload structureSearch(final String project, final String id, final String query,
+                                   final String routing, final Context context) throws IOException {
         requireGranted(context, project);
         if (query == null || query.isBlank()) {
             // Not the 404 /documents/searchContent gives an empty query: a missing parameter is a
             // malformed request, and a whitespace query would scan every page to match every space.
             return PayloadFormatter.error("a non-blank query is required", HttpStatus.BAD_REQUEST);
         }
-        String extension = structureExtension(format);
-        if (extension == null) {
-            return unsupportedFormat(format);
-        }
-        return search(docArtifactDir(project, id, routing), extension, query);
+        return search(project, id, routing, query);
     }
 
     @Operation(description = "Fetches a document's raw (embedded or source) bytes. Same access rules as /documents/src: project membership, the project's download restriction, and the root-document size limit.",
@@ -276,11 +281,14 @@ public class ArtifactResource {
         return new Payload(contentType, bytes).withHeader("X-Content-Type-Options", "nosniff");
     }
 
-    private Payload search(final Path docArtifactDir, final String extension, final String query) throws IOException {
+    // Same (project, id, routing) shape as manifest() and payload(), so all three routes read alike.
+    private Payload search(final String project, final String id, final String routing,
+                           final String query) throws IOException {
+        Path docArtifactDir = docArtifactDir(project, id, routing);
         if (docArtifactDir == null) {
             return Payload.notFound();
         }
-        StructureSearch.Hits hits = new StructureSearch(reader, docArtifactDir, extension).search(query);
+        StructureSearch.Hits hits = new StructureSearch(reader, docArtifactDir, MARKDOWN).search(query);
         return hits == null ? Payload.notFound() : PayloadFormatter.json(hits);
     }
 

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -235,7 +235,9 @@ public class ArtifactResource {
     }
 
     // The extension a ?format= value asks for, defaulted, or null when it is not one this resource
-    // serves. Shared by the page route and the search route so their whitelists cannot drift.
+    // serves. The page route's whitelist alone: the search route takes no ?format= and counts the
+    // Markdown deliberately, since counting over the XHTML would report tag names, class names and
+    // link targets as occurrences of the user's term (see structureSearch).
     private static String structureExtension(final String format) {
         String extension = ofNullable(format).filter(value -> !value.isBlank()).orElse(MARKDOWN);
         return STRUCTURE_CONTENT_TYPES.containsKey(extension) ? extension : null;

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -18,6 +18,7 @@ import org.icij.datashare.text.artifact.ArtifactReader;
 import org.icij.datashare.text.artifact.ArtifactType;
 import org.icij.datashare.text.artifact.FilesystemManifestRepository;
 import org.icij.datashare.text.artifact.ManifestEntry;
+import org.icij.datashare.text.artifact.StructureSearch;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.utils.DocumentSourceAccess;
@@ -134,19 +135,47 @@ public class ArtifactResource {
         // Membership gates before format validation, same as every other route here: a non-member
         // must see 403 regardless of what else is wrong with the request.
         requireGranted(context, project);
-        String extension = ofNullable(format).filter(value -> !value.isBlank()).orElse(MARKDOWN);
-        String contentType = STRUCTURE_CONTENT_TYPES.get(extension);
-        if (contentType == null) {
+        String extension = structureExtension(format);
+        if (extension == null) {
             // A bad format is a request error: 404 on this route means "no such page".
-            return PayloadFormatter.error("unsupported format '" + extension + "'; supported formats: "
-                    + String.join(", ", STRUCTURE_CONTENT_TYPES.keySet()), HttpStatus.BAD_REQUEST);
+            return unsupportedFormat(format);
         }
-        Payload payload = payload(project, id, page, routing, ArtifactType.STRUCTURE, extension, contentType);
+        Payload payload = payload(project, id, page, routing, ArtifactType.STRUCTURE, extension,
+                STRUCTURE_CONTENT_TYPES.get(extension));
         // The on-disk XHTML is written pre-sanitized by the structure producer; this is the serving
         // side's defense in depth for a payload written by another producer.
         return XHTML.equals(extension)
                 ? payload.withHeader("Content-Security-Policy", "default-src 'none'; sandbox")
                 : payload;
+    }
+
+    @Operation(description = "Counts a query's occurrences in a document's structure pages, per page.",
+            parameters = {
+                    @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
+                    @Parameter(name = "id", description = "the document id", in = ParameterIn.PATH),
+                    @Parameter(name = "query", description = "the term to count, matched literally", in = ParameterIn.QUERY),
+                    @Parameter(name = "routing", description = "routing key if not a root document", in = ParameterIn.QUERY),
+                    @Parameter(name = "format", description = "md (default) or xhtml", in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "JSON {\"count\": N, \"hits\": [{\"page\": P, \"count\": N}]}")
+    @ApiResponse(responseCode = "400", description = "if the query is blank, or format is not one of md, xhtml")
+    @ApiResponse(responseCode = "403", description = "forbidden if the user doesn't have access to the project")
+    @ApiResponse(responseCode = "404", description = "if the document, the artifact, or that format is not found")
+    @Get("/:project/artifacts/structure/:id/search?query=:query&routing=:routing&format=:format")
+    public Payload structureSearch(final String project, final String id, final String query, final String routing,
+                                   final String format, final Context context) throws IOException {
+        requireGranted(context, project);
+        if (query == null || query.isBlank()) {
+            // Not the 404 /documents/searchContent gives an empty query: a missing parameter is a
+            // malformed request, and a whitespace query would scan every page to match every space.
+            return PayloadFormatter.error("a non-blank query is required", HttpStatus.BAD_REQUEST);
+        }
+        String extension = structureExtension(format);
+        if (extension == null) {
+            return unsupportedFormat(format);
+        }
+        return search(docArtifactDir(project, id, routing), extension, query);
     }
 
     @Operation(description = "Fetches a document's raw (embedded or source) bytes. Same access rules as /documents/src: project membership, the project's download restriction, and the root-document size limit.",
@@ -196,6 +225,18 @@ public class ArtifactResource {
         return unmodifiableMap(contentTypes);
     }
 
+    // The extension a ?format= value asks for, defaulted, or null when it is not one this resource
+    // serves. Shared by the page route and the search route so their whitelists cannot drift.
+    private static String structureExtension(final String format) {
+        String extension = ofNullable(format).filter(value -> !value.isBlank()).orElse(MARKDOWN);
+        return STRUCTURE_CONTENT_TYPES.containsKey(extension) ? extension : null;
+    }
+
+    private static Payload unsupportedFormat(final String format) {
+        return PayloadFormatter.error("unsupported format '" + format + "'; supported formats: "
+                + String.join(", ", STRUCTURE_CONTENT_TYPES.keySet()), HttpStatus.BAD_REQUEST);
+    }
+
     private Payload manifest(final String project, final String id, final String routing,
                              final ArtifactType type, final Collection<String> formats) throws IOException {
         Path docArtifactDir = docArtifactDir(project, id, routing);
@@ -233,6 +274,14 @@ public class ArtifactResource {
         // Every artifact payload is text derived from an ingested document, served from this origin:
         // a browser that sniffs its way to another type could execute a malicious document.
         return new Payload(contentType, bytes).withHeader("X-Content-Type-Options", "nosniff");
+    }
+
+    private Payload search(final Path docArtifactDir, final String extension, final String query) throws IOException {
+        if (docArtifactDir == null) {
+            return Payload.notFound();
+        }
+        StructureSearch.Hits hits = new StructureSearch(reader, docArtifactDir, extension).search(query);
+        return hits == null ? Payload.notFound() : PayloadFormatter.json(hits);
     }
 
     private static int parsePageNumber(String page) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ArtifactResource.java
@@ -171,6 +171,10 @@ public class ArtifactResource {
     // :page route. Under that route's shape it would win only on a tie-break: fluent-http's UriParser
     // orders on the count of :params across the whole pattern, query string included, and both hold
     // five. A sixth would sort this second, :page would match "search", and every search would 404.
+    //
+    // Past the four-parameter limit, as every route here is: fluent-http binds the URL template's
+    // params positionally, so the count is set by the URL and not by this signature. Bundling them
+    // would only move the binding problem into a factory.
     @Get("/:project/artifacts/structure/search/:id?query=:query&routing=:routing")
     public Payload structureSearch(final String project, final String id, final String query,
                                    final String routing, final Context context) throws IOException {

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -271,21 +271,38 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         Path docDir = indexedDocDir(DIGEST);
         writePages(docDir, ArtifactType.STRUCTURE, "md", "data and data", "nothing here", "data");
         writeManifest(docDir, filesystemManifest("structure", 3));
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should()
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=data").should()
                 .respond(200).haveType("application/json")
-                .contain("{\"count\":3,\"hits\":[{\"page\":1,\"count\":2},{\"page\":3,\"count\":1}]}");
+                .contain("{\"count\":3,\"pages\":3,\"scanned\":3,"
+                        + "\"hits\":[{\"page\":1,\"count\":2},{\"page\":3,\"count\":1}]}");
     }
 
     @Test
-    public void test_structure_search_route_is_matched_before_the_page_route() throws Exception {
+    public void test_structure_search_reports_the_pages_it_could_not_read() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "data", "data", "data");
+        Files.delete(ArtifactPath.payloadPage(docDir, ArtifactType.STRUCTURE, 2, "md"));
+        writeManifest(docDir, filesystemManifest("structure", 3));
+        // scanned below pages is the only thing separating this from a healthy document that really
+        // holds two occurrences, and without it the client shows an authoritative count for a
+        // degraded artifact.
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=data").should()
+                .respond(200).contain("\"count\":2,\"pages\":3,\"scanned\":2");
+    }
+
+    @Test
+    public void test_structure_search_does_not_collide_with_the_page_route() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
         writePages(docDir, ArtifactType.STRUCTURE, "md", "data");
         writeManifest(docDir, filesystemManifest("structure", 1));
-        // Both routes carry the same segment count, and only fluent-http's UriParser ordering
-        // (a literal segment sorts before a :param) puts this one first. Had :page won,
-        // parsePageNumber("search") would give 0 and the answer would be 404, so this 200 is the
-        // whole assertion.
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should().respond(200);
+        // The verb sits before the id, so the two patterns differ by a literal segment and no
+        // ordering rule is involved. Sharing the :page route's shape would have worked only on a
+        // tie-break: fluent-http's UriParser sorts on the number of :params across the whole
+        // pattern, query string included, and one more query parameter would have sorted this
+        // route second, matched :page, and turned every search into a 404.
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=data").should().respond(200);
+        // And the page route still owns its own shape.
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1").should().respond(200);
     }
 
     @Test
@@ -295,8 +312,8 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writeManifest(docDir, filesystemManifest("structure", 1));
         // 200 with an empty result, not 404: the client's counter shows "0 of 0", it does not
         // fall back to plain text.
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should()
-                .respond(200).contain("{\"count\":0,\"hits\":[]}");
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=data").should()
+                .respond(200).contain("{\"count\":0,\"pages\":1,\"scanned\":1,\"hits\":[]}");
     }
 
     @Test
@@ -304,46 +321,40 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         Path docDir = indexedDocDir(DIGEST);
         writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
         writeManifest(docDir, filesystemManifest("structure", 1));
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search").should().respond(400);
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=").should().respond(400);
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "").should().respond(400);
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=").should().respond(400);
         // Whitespace-only is not empty, so /documents/searchContent runs it and matches every
         // space on every page. Rejected here instead.
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=%20%20").should().respond(400);
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=%20%20").should().respond(400);
     }
 
     @Test
-    public void test_structure_search_rejects_an_unsupported_format() throws Exception {
+    public void test_structure_search_counts_markdown_only() throws Exception {
         Path docDir = indexedDocDir(DIGEST);
-        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
+        // Only the xhtml is on disk, so a search that could fall back to it would answer 200. It must
+        // 404 instead: counting over markup reports every tag name and link target as an occurrence
+        // of the user's term, and "html" would match a page whose only text is "AT&T".
+        writePages(docDir, ArtifactType.STRUCTURE, "xhtml",
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>data</p></body></html>");
         writeManifest(docDir, filesystemManifest("structure", 1));
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=one&format=pdf").should()
-                .respond(400).contain("'pdf'").contain("md").contain("xhtml");
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=data").should().respond(404);
+        // The format is not a parameter at all, so asking for one changes nothing.
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=html&format=xhtml")
+                .should().respond(404);
     }
 
     @Test
     public void test_structure_search_not_found_without_a_structure_artifact() throws Exception {
         indexedDocDir(DIGEST);
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should().respond(404);
-    }
-
-    @Test
-    public void test_structure_search_not_found_for_a_format_absent_on_disk() throws Exception {
-        Path docDir = indexedDocDir(DIGEST);
-        writePages(docDir, ArtifactType.STRUCTURE, "md", "data");
-        writeManifest(docDir, filesystemManifest("structure", 1));
-        // Same document and manifest, only the format differs: 404 rather than a zero count, so
-        // the client cannot read "no xhtml here" as "your term appears nowhere".
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data&format=md").should().respond(200);
-        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data&format=xhtml").should().respond(404);
+        get("/api/local-datashare/artifacts/structure/search/" + DIGEST + "?query=data").should().respond(404);
     }
 
     @Test
     public void test_structure_search_forbidden_for_non_member_project() {
-        get("/api/foo_index/artifacts/structure/" + DIGEST + "/search?query=data").should().respond(403);
-        // Membership gates before the query and format checks: a non-member must not learn that
-        // their query was blank or their format unsupported before they learn they are not a member.
-        get("/api/foo_index/artifacts/structure/" + DIGEST + "/search").should().respond(403);
-        get("/api/foo_index/artifacts/structure/" + DIGEST + "/search?query=data&format=pdf").should().respond(403);
+        get("/api/foo_index/artifacts/structure/search/" + DIGEST + "?query=data").should().respond(403);
+        // Membership gates before the query check: a non-member must not learn that their query was
+        // blank before they learn they are not a member.
+        get("/api/foo_index/artifacts/structure/search/" + DIGEST + "").should().respond(403);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -267,6 +267,86 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_structure_search_counts_occurrences_across_pages() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "data and data", "nothing here", "data");
+        writeManifest(docDir, filesystemManifest("structure", 3));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should()
+                .respond(200).haveType("application/json")
+                .contain("{\"count\":3,\"hits\":[{\"page\":1,\"count\":2},{\"page\":3,\"count\":1}]}");
+    }
+
+    @Test
+    public void test_structure_search_route_is_matched_before_the_page_route() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "data");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        // Both routes carry the same segment count, and only fluent-http's UriParser ordering
+        // (a literal segment sorts before a :param) puts this one first. Had :page won,
+        // parsePageNumber("search") would give 0 and the answer would be 404, so this 200 is the
+        // whole assertion.
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should().respond(200);
+    }
+
+    @Test
+    public void test_structure_search_answers_zero_for_a_document_with_no_match() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        // 200 with an empty result, not 404: the client's counter shows "0 of 0", it does not
+        // fall back to plain text.
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should()
+                .respond(200).contain("{\"count\":0,\"hits\":[]}");
+    }
+
+    @Test
+    public void test_structure_search_rejects_a_blank_query() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search").should().respond(400);
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=").should().respond(400);
+        // Whitespace-only is not empty, so /documents/searchContent runs it and matches every
+        // space on every page. Rejected here instead.
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=%20%20").should().respond(400);
+    }
+
+    @Test
+    public void test_structure_search_rejects_an_unsupported_format() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=one&format=pdf").should()
+                .respond(400).contain("md").contain("xhtml");
+    }
+
+    @Test
+    public void test_structure_search_not_found_without_a_structure_artifact() throws Exception {
+        indexedDocDir(DIGEST);
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data").should().respond(404);
+    }
+
+    @Test
+    public void test_structure_search_not_found_for_a_format_absent_on_disk() throws Exception {
+        Path docDir = indexedDocDir(DIGEST);
+        writePages(docDir, ArtifactType.STRUCTURE, "md", "data");
+        writeManifest(docDir, filesystemManifest("structure", 1));
+        // Same document and manifest, only the format differs: 404 rather than a zero count, so
+        // the client cannot read "no xhtml here" as "your term appears nowhere".
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data&format=md").should().respond(200);
+        get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=data&format=xhtml").should().respond(404);
+    }
+
+    @Test
+    public void test_structure_search_forbidden_for_non_member_project() {
+        get("/api/foo_index/artifacts/structure/" + DIGEST + "/search?query=data").should().respond(403);
+        // Membership gates before the query and format checks: a non-member must not learn that
+        // their query was blank or their format unsupported before they learn they are not a member.
+        get("/api/foo_index/artifacts/structure/" + DIGEST + "/search").should().respond(403);
+        get("/api/foo_index/artifacts/structure/" + DIGEST + "/search?query=data&format=pdf").should().respond(403);
+    }
+
+    @Test
     public void test_raw_serves_the_source_bytes_as_an_attachment() throws Exception {
         File file = new File(temp.getRoot(), "raw-source.txt");
         MockIndexer.write(file, "source bytes");

--- a/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ArtifactResourceTest.java
@@ -243,7 +243,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
         writeManifest(docDir, filesystemManifest("structure", 1));
         get("/api/local-datashare/artifacts/structure/" + DIGEST + "/1?format=pdf").should()
-                .respond(400).contain("md").contain("xhtml");
+                .respond(400).contain("'pdf'").contain("md").contain("xhtml");
     }
 
     @Test
@@ -317,7 +317,7 @@ public class ArtifactResourceTest extends AbstractProdWebServerTest {
         writePages(docDir, ArtifactType.STRUCTURE, "md", "# one");
         writeManifest(docDir, filesystemManifest("structure", 1));
         get("/api/local-datashare/artifacts/structure/" + DIGEST + "/search?query=one&format=pdf").should()
-                .respond(400).contain("md").contain("xhtml");
+                .respond(400).contain("'pdf'").contain("md").contain("xhtml");
     }
 
     @Test

--- a/datashare-index/src/main/java/org/icij/datashare/text/ContentOccurrences.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/ContentOccurrences.java
@@ -14,23 +14,32 @@ public class ContentOccurrences {
     /**
      * Below this, a char is NFKD-stable and carries no diacritic, so both branches of the script's
      * fold produce the char itself: skipping the Normalizer there is a speed-up, not a change of
-     * meaning. It does not reach Cyrillic or Greek, whose letters are all LOWERCASE_LETTER, so a
-     * large document in those scripts still pays one Normalizer call per letter. Bounded by
-     * StructureMarkdownExtractor's 16M-char output cap, and the first thing to measure if an
-     * in-document search ever feels slow.
+     * meaning, and it is the branch nearly every character of a Latin-script page takes.
      */
     private static final char ASCII_LIMIT = 0x80;
 
+    // Latin Extended, Greek and Cyrillic all sit below this and are all LOWERCASE_LETTER, so they miss
+    // the fast path: a full Russian page costs 17x an ASCII one without the memo. Racy on purpose, no
+    // lock: a String is safely published by its final fields, so a reader sees null or the same value.
+    private static final int MEMO_LIMIT = 0x600;
+    private static final String[] MEMO = new String[MEMO_LIMIT];
+
     private ContentOccurrences() {}
 
-    /** Non-overlapping occurrences of {@code query} in {@code content}, both folded first. */
+    /**
+     * Occurrences of {@code query} in {@code content}, both folded first. Stepping by the raw query's
+     * length, as the script does, means matches may overlap when the fold expands the query (a
+     * ligature): {@code count("afffb", "ﬀ")} is 2, and the two share a character.
+     */
     public static int count(String content, String query) {
-        // The script's loop never advances on an empty query, so it would spin forever. Serving
-        // code rejects a blank query before calling, but a hang is too sharp an edge to leave here.
-        if (query.isEmpty()) {
+        // On the folded query, which is what drives the loop: indexOf never returns -1 for an empty
+        // needle, so an empty one spins forever rather than miscounting. Nothing folds to empty today,
+        // so guarding the raw query would leave termination resting on that, one edit away.
+        String foldedQuery = fold(query);
+        if (foldedQuery.isEmpty()) {
             return 0;
         }
-        return occurrences(fold(content), fold(query), query.length());
+        return occurrences(fold(content), foldedQuery, query.length());
     }
 
     /**
@@ -63,14 +72,22 @@ public class ContentOccurrences {
             folded.append(character);
             return;
         }
-        appendWithoutMarks(folded, Normalizer.normalize(String.valueOf(character), Normalizer.Form.NFKD));
+        if (character >= MEMO_LIMIT) {
+            folded.append(withoutMarks(character));
+            return;
+        }
+        String memoized = MEMO[character];
+        folded.append(memoized != null ? memoized : (MEMO[character] = withoutMarks(character)));
     }
 
-    private static void appendWithoutMarks(StringBuilder folded, String normalized) {
+    private static String withoutMarks(char original) {
+        String normalized = Normalizer.normalize(String.valueOf(original), Normalizer.Form.NFKD);
+        StringBuilder kept = new StringBuilder(normalized.length());
         for (char character : normalized.toCharArray()) {
             if (Character.getType(character) != Character.NON_SPACING_MARK) {
-                folded.append(character);
+                kept.append(character);
             }
         }
+        return kept.toString();
     }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/ContentOccurrences.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/ContentOccurrences.java
@@ -1,0 +1,76 @@
+package org.icij.datashare.text;
+
+import java.text.Normalizer;
+import java.util.Locale;
+
+/**
+ * Counts a query's occurrences the way {@code /documents/searchContent} does, so a search over
+ * artifacts folds text exactly as Elasticsearch folds it. Every rule here is a port of
+ * {@code datashare-index/src/main/resources/searchOccurrences.painless.java}, quirks included:
+ * the two search the same documents in the same UI, so a rule improved on one side alone shows up
+ * as two counters disagreeing about one word. Each quirk is pinned by a test.
+ */
+public class ContentOccurrences {
+    /**
+     * Below this, a char is NFKD-stable and carries no diacritic, so both branches of the script's
+     * fold produce the char itself: skipping the Normalizer there is a speed-up, not a change of
+     * meaning. It does not reach Cyrillic or Greek, whose letters are all LOWERCASE_LETTER, so a
+     * large document in those scripts still pays one Normalizer call per letter. Bounded by
+     * StructureMarkdownExtractor's 16M-char output cap, and the first thing to measure if an
+     * in-document search ever feels slow.
+     */
+    private static final char ASCII_LIMIT = 0x80;
+
+    private ContentOccurrences() {}
+
+    /** Non-overlapping occurrences of {@code query} in {@code content}, both folded first. */
+    public static int count(String content, String query) {
+        // The script's loop never advances on an empty query, so it would spin forever. Serving
+        // code rejects a blank query before calling, but a hang is too sharp an edge to leave here.
+        if (query.isEmpty()) {
+            return 0;
+        }
+        return occurrences(fold(content), fold(query), query.length());
+    }
+
+    /**
+     * Lowercased, then NFKD-normalized and stripped of non-spacing marks for {@code LOWERCASE_LETTER}
+     * chars only. Everything else passes through, which is why a decomposed accent survives and a
+     * caseless script is untouched: {@code normalizeLetters} tests that one type and nothing else.
+     * {@link Locale#ROOT} rather than the default, so folding cannot depend on where the JVM runs;
+     * the script's own {@code toLowerCase()} takes the Elasticsearch node's default.
+     */
+    static String fold(String input) {
+        StringBuilder folded = new StringBuilder(input.length());
+        for (char character : input.toLowerCase(Locale.ROOT).toCharArray()) {
+            appendFolded(folded, character);
+        }
+        return folded.toString();
+    }
+
+    // Steps by the raw query's length, as the script does, not by the folded one: a query whose
+    // fold expands (a ligature) then finds overlapping matches, in Elasticsearch today and here.
+    private static int occurrences(String content, String query, int step) {
+        int count = 0;
+        for (int at = content.indexOf(query); at != -1; at = content.indexOf(query, at + step)) {
+            count++;
+        }
+        return count;
+    }
+
+    private static void appendFolded(StringBuilder folded, char character) {
+        if (character < ASCII_LIMIT || Character.getType(character) != Character.LOWERCASE_LETTER) {
+            folded.append(character);
+            return;
+        }
+        appendWithoutMarks(folded, Normalizer.normalize(String.valueOf(character), Normalizer.Form.NFKD));
+    }
+
+    private static void appendWithoutMarks(StringBuilder folded, String normalized) {
+        for (char character : normalized.toCharArray()) {
+            if (Character.getType(character) != Character.NON_SPACING_MARK) {
+                folded.append(character);
+            }
+        }
+    }
+}

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/Artifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/Artifact.java
@@ -1,8 +1,11 @@
 package org.icij.datashare.text.artifact;
 
+import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 
 import java.util.Map;
+
+import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
 
 /** A derived representation of a document, produced alongside it and stored under its artifact dir.
  *  Implementations write payload files only and MUST NOT touch manifest.json. */
@@ -23,6 +26,14 @@ public interface Artifact {
      *  config, so the same doc in two different batches compares equal. */
     default Map<String, Object> taskInput(Document document) {
         return taskInput();
+    }
+
+    /** Whether this run enables OCR, defaulting to on as extract-lib's --ocr does. Shared because
+     *  more than one artifact renders a document with it and both have to read the option the same
+     *  way: two copies would let a change to how --ocr is parsed reach one artifact and not the other,
+     *  which shows up as two artifacts of the same document disagreeing about a scanned page. */
+    static boolean ocrEnabled(PropertiesProvider propertiesProvider) {
+        return propertiesProvider.get(OCR_OPT).map(Boolean::parseBoolean).orElse(true);
     }
 
     /** Produce payload files under context.docArtifactDir() and return the entry to record (without

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -17,6 +17,12 @@ import java.util.List;
  *  servable, where a page lives, and what a missing payload means. */
 public class ArtifactReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactReader.class);
+
+    /** Beyond this a total is a corrupt manifest, not a long document. It matters because {@link
+     *  StructureSearch} turns a total written by another producer into a loop bound, and unbounded,
+     *  {@code Integer.MAX_VALUE} never terminates at all: the counter wraps to MIN_VALUE, still in range. */
+    public static final int MAX_SERVABLE_PAGES = 100_000;
+
     private final ManifestRepository manifests;
 
     public ArtifactReader(ManifestRepository manifests) {
@@ -42,17 +48,19 @@ public class ArtifactReader {
     /**
      * The page count a servable entry advertises, or null when its pages block cannot be trusted:
      * absent, renamed by a producer whose manifest shape differs (unknown properties are ignored on
-     * read), or non-positive because Pages.total is a primitive that an absent field fills with 0.
-     * Warned rather than silent: such a manifest is otherwise indistinguishable from a document
-     * that has no artifact of this type at all, and the strict-store contract says it is not found.
+     * read), non-positive because Pages.total is a primitive that an absent field fills with 0, or
+     * past {@link #MAX_SERVABLE_PAGES}. Warned rather than silent: such a manifest is otherwise
+     * indistinguishable from a document that has no artifact of this type at all, and the
+     * strict-store contract says it is not found.
      */
     public Integer servableTotal(Path docArtifactDir, ArtifactType type, ManifestEntry entry) {
         Pages pages = entry.pages();
-        if (pages != null && pages.total() > 0) {
+        if (pages != null && pages.total() > 0 && pages.total() <= MAX_SERVABLE_PAGES) {
             return pages.total();
         }
         LOGGER.warn("complete '{}' entry in {} advertises no usable page count: its pages block is "
-                + "absent, renamed, or carries a non-positive total", type.token(), docArtifactDir);
+                + "absent, renamed, or carries a total outside 1..{}", type.token(), docArtifactDir,
+                MAX_SERVABLE_PAGES);
         return null;
     }
 
@@ -72,9 +80,10 @@ public class ArtifactReader {
         // them (same hazard as SourceExtractor#hasCachedEmbeddedSource), and reading one this
         // process cannot open would throw an IOException the serving side turns into a 500.
         if (!Files.isReadable(file)) {
-            // In range per the manifest but absent on disk: the two disagree, which is worth
-            // seeing in the logs rather than reshaping the advertised page count silently.
-            LOGGER.warn("manifest advertises {} page(s) for '{}' but {} is missing or unreadable", total, type.token(), file);
+            // In range per the manifest but absent on disk. DEBUG, not WARN: a caller walking every
+            // page would turn one disagreement into one line per page, replayable by any project
+            // member, so StructureSearch reports it once per scan and the page route answers 404.
+            LOGGER.debug("manifest advertises {} page(s) for '{}' but {} is missing or unreadable", total, type.token(), file);
             return null;
         }
         return Files.readAllBytes(file);

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -7,7 +7,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -76,17 +78,21 @@ public class ArtifactReader {
                     byteRanges.ranges(), page, type, total);
         }
         Path file = ArtifactPath.payloadPage(docArtifactDir, type, page, extension);
-        // Readable, not merely present: payloads are written 0600 by whichever process produced
-        // them (same hazard as SourceExtractor#hasCachedEmbeddedSource), and reading one this
-        // process cannot open would throw an IOException the serving side turns into a 500.
-        if (!Files.isReadable(file)) {
-            // In range per the manifest but absent on disk. DEBUG, not WARN: a caller walking every
-            // page would turn one disagreement into one line per page, replayable by any project
-            // member, so StructureSearch reports it once per scan and the page route answers 404.
+        // Read and let it fail, rather than stat then read: on the shared artifactDir this is
+        // deployed on, each is a network round trip, and StructureSearch walks every page, so the
+        // pre-check doubled the round trips of a whole scan to learn what the read reports anyway.
+        try {
+            return Files.readAllBytes(file);
+        } catch (NoSuchFileException | AccessDeniedException unreadable) {
+            // Absent on disk though the manifest advertises it, or written 0600 by a producer
+            // running under another uid (the hazard SourceExtractor#hasCachedEmbeddedSource has):
+            // both read as "not found" here rather than as the 500 an IOException would become.
+            // DEBUG, not WARN: a caller walking every page would turn one disagreement into one
+            // line per page, replayable by any project member, so StructureSearch reports it once
+            // per scan and the single-page route answers 404.
             LOGGER.debug("manifest advertises {} page(s) for '{}' but {} is missing or unreadable", total, type.token(), file);
             return null;
         }
-        return Files.readAllBytes(file);
     }
 
     /** Which extensions are actually on disk, in the candidate order given. Probes per scheme,

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -20,11 +20,6 @@ import java.util.List;
 public class ArtifactReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactReader.class);
 
-    /** Beyond this a total is a corrupt manifest, not a long document. It matters because {@link
-     *  StructureSearch} turns a total written by another producer into a loop bound, and unbounded,
-     *  {@code Integer.MAX_VALUE} never terminates at all: the counter wraps to MIN_VALUE, still in range. */
-    public static final int MAX_SERVABLE_PAGES = 100_000;
-
     private final ManifestRepository manifests;
 
     public ArtifactReader(ManifestRepository manifests) {
@@ -50,19 +45,20 @@ public class ArtifactReader {
     /**
      * The page count a servable entry advertises, or null when its pages block cannot be trusted:
      * absent, renamed by a producer whose manifest shape differs (unknown properties are ignored on
-     * read), non-positive because Pages.total is a primitive that an absent field fills with 0, or
-     * past {@link #MAX_SERVABLE_PAGES}. Warned rather than silent: such a manifest is otherwise
-     * indistinguishable from a document that has no artifact of this type at all, and the
-     * strict-store contract says it is not found.
+     * read), or non-positive because Pages.total is a primitive that an absent field fills with 0.
+     * Any positive total is served, however large: nothing here loops over it, and a merged archive
+     * or a bulk-exported log really does run to six figures, so bounding a scan belongs to the one
+     * caller that walks every page ({@link StructureSearch}) rather than to every artifact route.
+     * Warned rather than silent: such a manifest is otherwise indistinguishable from a document that
+     * has no artifact of this type at all, and the strict-store contract says it is not found.
      */
     public Integer servableTotal(Path docArtifactDir, ArtifactType type, ManifestEntry entry) {
         Pages pages = entry.pages();
-        if (pages != null && pages.total() > 0 && pages.total() <= MAX_SERVABLE_PAGES) {
+        if (pages != null && pages.total() > 0) {
             return pages.total();
         }
         LOGGER.warn("complete '{}' entry in {} advertises no usable page count: its pages block is "
-                + "absent, renamed, or carries a total outside 1..{}", type.token(), docArtifactDir,
-                MAX_SERVABLE_PAGES);
+                + "absent, renamed, or carries a total below 1", type.token(), docArtifactDir);
         return null;
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -111,11 +111,7 @@ public class ArtifactReader {
 
     // Half-open [start, end). A range outside the file means manifest and payload disagree, which
     // is a 404 for that page rather than a truncated body.
-    private byte[] slice(Path content, List<long[]> ranges, int page, ArtifactType type, int total) throws IOException {
-        if (!Files.isReadable(content)) {
-            LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but {} is missing or unreadable", total, type.token(), content);
-            return null;
-        }
+    private byte[] slice(Path content, List<long[]> ranges, int page, ArtifactType type, int total) {
         if (ranges == null || ranges.size() < page || ranges.get(page - 1).length != 2) {
             LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but range {} is malformed", total, type.token(), page);
             return null;
@@ -123,14 +119,23 @@ public class ArtifactReader {
         long[] range = ranges.get(page - 1);
         long start = range[0];
         long end = range[1];
-        if (start < 0 || end < start || end > Files.size(content) || end - start > Integer.MAX_VALUE) {
-            LOGGER.warn("byte range [{}, {}) for '{}' is outside {}", start, end, type.token(), content);
+        // What the bytes themselves cannot answer: a negative or inverted range, and a length no
+        // byte[] can hold. Whether the range fits the file is left to the read below.
+        if (start < 0 || end < start || end - start > Integer.MAX_VALUE) {
+            LOGGER.warn("byte range [{}, {}) for '{}' is malformed in {}", start, end, type.token(), content);
             return null;
         }
         byte[] slice = new byte[(int) (end - start)];
+        // Read and let it fail, as the filesystem branch above does: an isReadable() stat and a
+        // Files.size() bound check were two more round trips on a shared artifactDir to learn what
+        // the read reports anyway, and neither holds over the window between the check and the read.
         try (RandomAccessFile file = new RandomAccessFile(content.toFile(), "r")) {
             file.seek(start);
-            file.readFully(slice);   // handles the partial-read loop
+            file.readFully(slice);   // handles the partial-read loop; EOF means the range runs past the file
+        } catch (IOException unreadable) {
+            LOGGER.warn("manifest advertises {} byte-range page(s) for '{}' but [{}, {}) of {} could not be read",
+                    total, type.token(), start, end, content);
+            return null;
         }
         return slice;
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactReader.java
@@ -7,9 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -79,10 +77,12 @@ public class ArtifactReader {
         // pre-check doubled the round trips of a whole scan to learn what the read reports anyway.
         try {
             return Files.readAllBytes(file);
-        } catch (NoSuchFileException | AccessDeniedException unreadable) {
-            // Absent on disk though the manifest advertises it, or written 0600 by a producer
-            // running under another uid (the hazard SourceExtractor#hasCachedEmbeddedSource has):
-            // both read as "not found" here rather than as the 500 an IOException would become.
+        } catch (IOException unreadable) {
+            // Absent on disk though the manifest advertises it, written 0600 by a producer running
+            // under another uid (the hazard SourceExtractor#hasCachedEmbeddedSource has), or a
+            // directory or symlink loop where a page file belongs. Every one of them is a payload
+            // the manifest promised and disk cannot give: the Files.isReadable() pre-check this
+            // replaced answered false for all of them, so all of them stay a 404 rather than a 500.
             // DEBUG, not WARN: a caller walking every page would turn one disagreement into one
             // line per page, replayable by any project member, so StructureSearch reports it once
             // per scan and the single-page route answers 404.

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
 
 /** The page artifact: a document's paginated PLAIN extracted text, written as a single
  *  pages/content.txt whose per-page half-open byte ranges live in the manifest entry. */
@@ -55,7 +54,7 @@ public class PageArtifact implements Artifact {
         // text, extract-lib owns the parser set and the page splitting, and the datashare version covers
         // what this class decides. The run's OCR setting is the best this document-less overload can do;
         // what actually paginated a document is the overload below.
-        return taskInput(ocrEnabled());
+        return taskInput(Artifact.ocrEnabled(propertiesProvider));
     }
 
     @Override
@@ -65,7 +64,7 @@ public class PageArtifact implements Artifact {
         // that file with OCR on and nothing the fingerprint sees changes (same bytes, same digest, same
         // artifact dir), so skip-if-current serves the OCR-free pages forever. Still config, not data:
         // the same document under the same run config compares equal in any batch.
-        return taskInput(ocrEnabled() && document.getOcrParser() != null);
+        return taskInput(Artifact.ocrEnabled(propertiesProvider) && document.getOcrParser() != null);
     }
 
     private static Map<String, Object> taskInput(boolean ocr) {
@@ -256,7 +255,4 @@ public class PageArtifact implements Artifact {
         AtomicDirectorySwap.discard(ArtifactPath.payloadDir(docArtifactDir, TYPE));
     }
 
-    private boolean ocrEnabled() {
-        return propertiesProvider.get(OCR_OPT).map(Boolean::parseBoolean).orElse(true);
-    }
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
@@ -4,9 +4,12 @@ import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaConfigException;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.exception.TikaMemoryLimitException;
+import org.apache.tika.parser.pdf.PDFParserConfig;
+import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.text.structure.StructureMarkdownExtractor;
+import org.icij.datashare.text.structure.StructureMarkdownExtractor.OcrSettings;
 import org.icij.datashare.text.structure.StructureMarkdownExtractor.Page;
 import org.icij.datashare.utils.AtomicDirectorySwap;
 import org.icij.datashare.utils.BuildVersions;
@@ -18,8 +21,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
+import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
+import static org.icij.datashare.cli.DatashareCliOptions.OCR_STRATEGY_OPT;
 import static org.icij.datashare.text.nlp.DocumentMetadataConstants.RESOURCE_NAME_KEY;
 
 /** The structure artifact: a per-page Tika rendering written as page-N.xhtml (sanitized, the
@@ -34,6 +40,11 @@ public class StructureArtifact implements Artifact {
     private static final String ZIP_BOMB_MESSAGE = "Zip bomb detected!";
 
     private final StructureMarkdownExtractor extractor = new StructureMarkdownExtractor();
+    private final PropertiesProvider propertiesProvider;
+
+    public StructureArtifact(PropertiesProvider propertiesProvider) {
+        this.propertiesProvider = propertiesProvider;
+    }
 
     @Override
     public ArtifactType type() {
@@ -42,24 +53,62 @@ public class StructureArtifact implements Artifact {
 
     @Override
     public Map<String, Object> taskInput() {
+        // The run's OCR setting is the best this document-less overload can do; what actually rendered
+        // a document is the overload below. Same split as PageArtifact.
+        return taskInput(runOcrSettings());
+    }
+
+    @Override
+    public Map<String, Object> taskInput(Document document) {
+        // The OCR that made these pages, not the one the run asked for, or re-indexing with OCR on
+        // would change nothing the fingerprint sees and skip-if-current would serve the OCR-free pages
+        // forever. Same reasoning as {@link PageArtifact#taskInput(Document)}.
+        return taskInput(ocrSettings(document));
+    }
+
+    private static Map<String, Object> taskInput(OcrSettings ocr) {
         // A fingerprint of the code that made the bytes, so skip-if-current sees pages an earlier release
         // rendered as stale: Tika renders the XHTML, extract-lib owns the parser set (the resilient PST
         // one), and the datashare version covers what this class decides (page grouping, safelist,
         // flexmark options), which no dependency version tracks. Deliberately conservative: any datashare
         // release makes every structure artifact stale, so the next ARTIFACT run re-extracts a corpus.
         return Map.of("pipeline", "tika", "version", TIKA_VERSION,
+                "ocr", ocr.images(), "ocrStrategy", ocr.pdfStrategy().name(),
                 "extract", BuildVersions.EXTRACT, "datashare", BuildVersions.DATASHARE);
+    }
+
+    // What the INDEX stage applied to this document, so the pages hold the text the content field holds.
+    // getOcrParser() is set only when OCR actually ran for it, and it is one-way here as disableOcr() is
+    // in PageArtifact: the run can turn OCR off, it cannot turn it on for a document indexed without it.
+    private OcrSettings ocrSettings(Document document) {
+        return document.getOcrParser() == null ? OcrSettings.NONE : runOcrSettings();
+    }
+
+    private OcrSettings runOcrSettings() {
+        boolean images = propertiesProvider.get(OCR_OPT).map(Boolean::parseBoolean).orElse(true);
+        return new OcrSettings(images, images ? pdfOcrStrategy() : PDFParserConfig.OCR_STRATEGY.NO_OCR);
+    }
+
+    // Unset or unparseable means NO_OCR, both as extract-lib resolves --ocrStrategy: a scanned PDF
+    // renders empty here exactly when the INDEX stage extracted nothing from it either.
+    private PDFParserConfig.OCR_STRATEGY pdfOcrStrategy() {
+        try {
+            return PDFParserConfig.OCR_STRATEGY.valueOf(
+                    propertiesProvider.get(OCR_STRATEGY_OPT).orElse("NO_OCR").toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException unknown) {
+            return PDFParserConfig.OCR_STRATEGY.NO_OCR;
+        }
     }
 
     @Override
     public ManifestEntry produce(ArtifactContext context) throws ArtifactException {
         try (InputStream source = context.sources().getSource(context.project(), context.document())) {
-            // The parser's output is served as it comes, blank pages included: with OCR off a scanned page
-            // renders empty, and "the parser found no text here" is a different thing from the EMPTY of a
-            // raw entry, which means there is nothing at this path to serve at all.
+            // The parser's output is served as it comes, blank pages included: a document indexed without
+            // OCR renders its scanned pages empty here too, and "the parser found no text here" is a
+            // different thing from the EMPTY of a raw entry, which means there is nothing to serve at all.
             List<Page> pages = parse(source, context.document());
             writePages(context.docArtifactDir(), pages);
-            return ManifestEntry.paginated(taskInput(), pages.size());
+            return ManifestEntry.paginated(taskInput(context.document()), pages.size());
         } catch (ArtifactConfigurationException fatal) {
             // Unchecked, and not an ArtifactException, so the catch-all below would otherwise demote the
             // fatal bucket to one more per-document failure and drain the queue instead of ending the run.
@@ -98,7 +147,8 @@ public class StructureArtifact implements Artifact {
      */
     List<Page> parse(InputStream source, Document document) throws IOException, ArtifactException {
         try {
-            return extractor.extract(source, document.getContentType(), resourceName(document));
+            return extractor.extract(source, document.getContentType(), resourceName(document),
+                    ocrSettings(document));
         } catch (TikaConfigException fatal) {
             throw new ArtifactConfigurationException(fatal);
         } catch (TikaException | SAXException failure) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.icij.datashare.cli.DatashareCliOptions.OCR_OPT;
 import static org.icij.datashare.cli.DatashareCliOptions.OCR_STRATEGY_OPT;
 import static org.icij.datashare.text.nlp.DocumentMetadataConstants.RESOURCE_NAME_KEY;
 
@@ -85,7 +84,7 @@ public class StructureArtifact implements Artifact {
     }
 
     private OcrSettings runOcrSettings() {
-        boolean images = propertiesProvider.get(OCR_OPT).map(Boolean::parseBoolean).orElse(true);
+        boolean images = Artifact.ocrEnabled(propertiesProvider);
         return new OcrSettings(images, images ? pdfOcrStrategy() : PDFParserConfig.OCR_STRATEGY.NO_OCR);
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
@@ -6,6 +6,7 @@ import org.apache.tika.exception.TikaException;
 import org.apache.tika.exception.TikaMemoryLimitException;
 import org.apache.tika.parser.pdf.PDFParserConfig;
 import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.cli.OcrStrategy;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 import org.icij.datashare.text.structure.StructureMarkdownExtractor;
@@ -88,12 +89,16 @@ public class StructureArtifact implements Artifact {
         return new OcrSettings(images, images ? pdfOcrStrategy() : PDFParserConfig.OCR_STRATEGY.NO_OCR);
     }
 
-    // Unset or unparseable means NO_OCR, both as extract-lib resolves --ocrStrategy: a scanned PDF
-    // renders empty here exactly when the INDEX stage extracted nothing from it either.
+    // Read as the CLI's own OcrStrategy and mapped by name into Tika's, so this accepts exactly what
+    // --ocrStrategy accepts rather than a second vocabulary that happens to agree today. Unset or
+    // unparseable means NO_OCR, as extract-lib resolves it: a scanned PDF renders empty here exactly
+    // when the INDEX stage extracted nothing from it either. A member renamed on either side lands in
+    // that same fallback rather than in a strategy nobody asked for.
     private PDFParserConfig.OCR_STRATEGY pdfOcrStrategy() {
         try {
-            return PDFParserConfig.OCR_STRATEGY.valueOf(
+            OcrStrategy strategy = OcrStrategy.valueOf(
                     propertiesProvider.get(OCR_STRATEGY_OPT).orElse("NO_OCR").toUpperCase(Locale.ROOT));
+            return PDFParserConfig.OCR_STRATEGY.valueOf(strategy.name());
         } catch (IllegalArgumentException unknown) {
             return PDFParserConfig.OCR_STRATEGY.NO_OCR;
         }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -1,0 +1,85 @@
+package org.icij.datashare.text.artifact;
+
+import org.icij.datashare.text.ContentOccurrences;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * In-document search over one document's persisted structure pages, the read-side counterpart of
+ * {@link StructureArtifact}. Built per request rather than shared, because the document's dir and
+ * the requested format are fixed for a whole scan and holding them keeps every helper inside the
+ * four-parameter limit. Pages are read one at a time, so a document's whole markdown is never
+ * resident at once.
+ */
+public class StructureSearch {
+    private static final ArtifactType TYPE = ArtifactType.STRUCTURE;
+
+    private final ArtifactReader reader;
+    private final Path docArtifactDir;
+    private final String extension;
+
+    public StructureSearch(ArtifactReader reader, Path docArtifactDir, String extension) {
+        this.reader = reader;
+        this.docArtifactDir = docArtifactDir;
+        this.extension = extension;
+    }
+
+    /** Per-page occurrence counts in page order, pages with none omitted, or null when this
+     *  document has nothing servable to search. Callers map null to 404 the way they map the
+     *  reader's own nulls, so "not found" keeps one definition across the artifact routes. */
+    public Hits search(String query) throws IOException {
+        ManifestEntry entry = searchableEntry();
+        if (entry == null) {
+            return null;
+        }
+        return scan(entry, query);
+    }
+
+    // The entry only when a servable structure artifact carries this format on disk. Without the
+    // formats probe, a document whose page-N.md files are gone would answer "no occurrences"
+    // instead of "no markdown here", contradicting what the manifest route told the client.
+    private ManifestEntry searchableEntry() throws IOException {
+        ManifestEntry entry = reader.servableEntry(docArtifactDir, TYPE);
+        if (entry == null || reader.servableTotal(docArtifactDir, TYPE, entry) == null) {
+            return null;
+        }
+        return reader.formats(docArtifactDir, TYPE, entry, List.of(extension)).isEmpty() ? null : entry;
+    }
+
+    private Hits scan(ManifestEntry entry, String query) throws IOException {
+        List<PageHits> hits = new ArrayList<>();
+        int total = reader.servableTotal(docArtifactDir, TYPE, entry);
+        for (int page = 1; page <= total; page++) {
+            addPage(hits, entry, page, query);
+        }
+        return new Hits(hits.stream().mapToInt(PageHits::count).sum(), hits);
+    }
+
+    private void addPage(List<PageHits> hits, ManifestEntry entry, int page, String query) throws IOException {
+        int count = countPage(entry, page, query);
+        if (count > 0) {
+            hits.add(new PageHits(page, count));
+        }
+    }
+
+    private int countPage(ManifestEntry entry, int page, String query) throws IOException {
+        byte[] payload = reader.page(docArtifactDir, TYPE, entry, page, extension);
+        // A page the manifest advertises but disk no longer has: the reader has already logged it
+        // and the page route 404s that one page, so here it simply holds no occurrence. Failing a
+        // nine-hundred-page search over one missing file would be strictly worse.
+        if (payload == null) {
+            return 0;
+        }
+        return ContentOccurrences.count(new String(payload, UTF_8), query);
+    }
+
+    /** The response body: the document total, then only the pages carrying an occurrence. */
+    public record Hits(int count, List<PageHits> hits) {}
+
+    public record PageHits(int page, int count) {}
+}

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -29,12 +29,22 @@ public class StructureSearch {
 
     /**
      * Wall clock a single scan may spend before it answers with what it has. Deliberately far above
-     * any real document, which the {@link ArtifactReader#MAX_SERVABLE_PAGES} cap is not: that cap
-     * still allows a manifest to hold one of the ten HTTP worker threads for minutes. Generous
-     * enough never to fire on a real corpus, so the answer stays reproducible in practice, and
-     * {@code scanned} below {@code pages} tells the client the count is a floor when it does.
+     * any real document, which the {@link #MAX_SCANNED_PAGES} cap is not: that cap still allows a
+     * manifest to hold one of the ten HTTP worker threads for minutes. Generous enough never to fire
+     * on a real corpus, so the answer stays reproducible in practice, and {@code scanned} below
+     * {@code pages} tells the client the count is a floor when it does.
      */
     private static final Duration SCAN_BUDGET = Duration.ofSeconds(10);
+
+    /**
+     * The most pages one scan walks, however many the manifest advertises. Past this a total is
+     * hostile input rather than a long document: manifest.json is written by other producers, and an
+     * unbounded loop over {@code Integer.MAX_VALUE} never terminates at all, since the counter wraps
+     * to MIN_VALUE and stays in range. It bounds this loop and nothing else, which is why it lives
+     * here rather than in {@link ArtifactReader}: a merged archive or a bulk-exported log really can
+     * run past a hundred thousand pages, and the manifest and page routes serve it page by page.
+     */
+    private static final int MAX_SCANNED_PAGES = 100_000;
 
     private final ArtifactReader reader;
     private final Path docArtifactDir;
@@ -76,9 +86,10 @@ public class StructureSearch {
         List<PageHits> hits = new ArrayList<>();
         // Subtraction rather than a plain comparison, so a nanoTime wrap cannot end the scan early.
         long deadline = System.nanoTime() + scanBudget.toNanos();
+        int last = Math.min(total, MAX_SCANNED_PAGES);
         int scanned = 0;
         int page = 1;
-        for (; page <= total && System.nanoTime() - deadline < 0; page++) {
+        for (; page <= last && System.nanoTime() - deadline < 0; page++) {
             Integer count = countPage(entry, page, query);
             if (count == null) {
                 continue;
@@ -88,17 +99,22 @@ public class StructureSearch {
                 hits.add(new PageHits(page, count));
             }
         }
-        reportIncompleteScan(scanned, page - 1, total);
+        reportIncompleteScan(scanned, page - 1, last, total);
         return new Hits(hits.stream().mapToInt(PageHits::count).sum(), total, scanned, hits);
     }
 
-    // Two ways to come back short, and the log has to tell them apart: pages the scan reached and
-    // could not read, versus pages it never reached because the budget ran out. Once per scan, not
-    // once per page: the reader logs each unreadable page at DEBUG precisely so this stays one line.
-    private void reportIncompleteScan(int scanned, int reached, int total) {
-        if (reached < total) {
+    // Three ways to come back short, and the log has to tell them apart: pages the budget never let
+    // the scan reach, pages past the cap it will not walk at all, and pages it reached and could not
+    // read. Once per scan, not once per page: the reader logs each unreadable page at DEBUG
+    // precisely so this stays one line.
+    private void reportIncompleteScan(int scanned, int reached, int last, int total) {
+        if (reached < last) {
             LOGGER.warn("stopped searching '{}' in {} after {} of {} page(s): the {}s scan budget ran out",
                     TYPE.token(), docArtifactDir, reached, total, scanBudget.toSeconds());
+        } else if (last < total) {
+            LOGGER.warn("searched the first {} of the {} page(s) the '{}' manifest advertises in {}: one "
+                    + "scan walks at most {} page(s)", last, total, TYPE.token(), docArtifactDir,
+                    MAX_SCANNED_PAGES);
         } else if (scanned < total) {
             LOGGER.warn("searched {} of the {} page(s) the '{}' manifest advertises in {}: the rest are "
                     + "missing or unreadable", scanned, total, TYPE.token(), docArtifactDir);

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -51,6 +51,9 @@ public class StructureSearch {
         return scan(entry, total, query);
     }
 
+    // Over five lines on purpose: the loop accumulates two values and skips a third case, so the only
+    // way under the limit is a one-caller helper taking the accumulators as parameters, which hides
+    // the algorithm rather than shortening it. Sibling serving code here runs to the same length.
     private Hits scan(ManifestEntry entry, int total, String query) {
         List<PageHits> hits = new ArrayList<>();
         int scanned = 0;

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -73,31 +73,26 @@ public class StructureSearch {
         if (total == null) {
             return null;
         }
-        // Page 1 is counted here rather than probed. A formats() probe stats the very file the first
-        // loop iteration then reads, which is the stat-then-read round trip ArtifactReader#page was
-        // just changed to drop, reintroduced once per request. Null carries the same meaning the
-        // empty probe did: without a page 1 in this format the document has "no markdown here"
-        // rather than "no occurrences", which the route turns into 404. A gap further in is reported
-        // through scanned() instead, as the manifest route reports it.
-        Integer first = countPage(entry, 1, query);
-        return first == null ? null : scan(entry, total, query, first);
+        // "No markdown here" is not "no occurrences", and only the 404 the first says is right for a
+        // document whose page-N.md files are all gone. It is the whole scan that decides, never page
+        // 1 alone: one unreadable page costs its own count and nothing else, so a document whose
+        // first page is missing still answers for the pages after it, and scanned() carries the gap
+        // out. No probe either, since a stat asks what these reads already report.
+        Hits hits = scan(entry, total, query);
+        return hits.scanned() == 0 ? null : hits;
     }
 
     // Over five lines on purpose: the loop accumulates three values and skips a fourth case, so the
     // only way under the limit is a one-caller helper taking the accumulators as parameters, which
     // hides the algorithm rather than shortening it. Sibling serving code here runs to the same length.
-    private Hits scan(ManifestEntry entry, int total, String query, int firstPage) {
+    private Hits scan(ManifestEntry entry, int total, String query) {
         List<PageHits> hits = new ArrayList<>();
-        int matches = firstPage;
-        if (firstPage > 0) {
-            hits.add(new PageHits(1, firstPage));
-        }
+        int matches = 0;
         // Subtraction rather than a plain comparison, so a nanoTime wrap cannot end the scan early.
         long deadline = System.nanoTime() + scanBudget.toNanos();
         int last = Math.min(total, MAX_SCANNED_PAGES);
-        // One already: search() read page 1 to learn whether there is anything here to search.
-        int scanned = 1;
-        int page = 2;
+        int scanned = 0;
+        int page = 1;
         for (; page <= last && System.nanoTime() - deadline < 0; page++) {
             Integer count = countPage(entry, page, query);
             if (count == null) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,14 +27,31 @@ public class StructureSearch {
     private static final Logger LOGGER = LoggerFactory.getLogger(StructureSearch.class);
     private static final ArtifactType TYPE = ArtifactType.STRUCTURE;
 
+    /**
+     * Wall clock a single scan may spend before it answers with what it has. Deliberately far above
+     * any real document, which the {@link ArtifactReader#MAX_SERVABLE_PAGES} cap is not: that cap
+     * still allows a manifest to hold one of the ten HTTP worker threads for minutes. Generous
+     * enough never to fire on a real corpus, so the answer stays reproducible in practice, and
+     * {@code scanned} below {@code pages} tells the client the count is a floor when it does.
+     */
+    private static final Duration SCAN_BUDGET = Duration.ofSeconds(10);
+
     private final ArtifactReader reader;
     private final Path docArtifactDir;
     private final String extension;
+    private final Duration scanBudget;
 
     public StructureSearch(ArtifactReader reader, Path docArtifactDir, String extension) {
+        this(reader, docArtifactDir, extension, SCAN_BUDGET);
+    }
+
+    // Package-private: the budget is fixed in production, and no test can wait ten seconds to prove
+    // the loop consults it at all.
+    StructureSearch(ArtifactReader reader, Path docArtifactDir, String extension, Duration scanBudget) {
         this.reader = reader;
         this.docArtifactDir = docArtifactDir;
         this.extension = extension;
+        this.scanBudget = scanBudget;
     }
 
     /** Per-page occurrence counts in page order, pages with none omitted, or null when this
@@ -56,8 +74,11 @@ public class StructureSearch {
     // the algorithm rather than shortening it. Sibling serving code here runs to the same length.
     private Hits scan(ManifestEntry entry, int total, String query) {
         List<PageHits> hits = new ArrayList<>();
+        // Subtraction rather than a plain comparison, so a nanoTime wrap cannot end the scan early.
+        long deadline = System.nanoTime() + scanBudget.toNanos();
         int scanned = 0;
-        for (int page = 1; page <= total; page++) {
+        int page = 1;
+        for (; page <= total && System.nanoTime() - deadline < 0; page++) {
             Integer count = countPage(entry, page, query);
             if (count == null) {
                 continue;
@@ -67,13 +88,21 @@ public class StructureSearch {
                 hits.add(new PageHits(page, count));
             }
         }
-        if (scanned < total) {
-            // Once per scan, not once per page: the reader logs each miss at DEBUG precisely so this
-            // stays one line however many pages a degraded artifact has lost.
+        reportIncompleteScan(scanned, page - 1, total);
+        return new Hits(hits.stream().mapToInt(PageHits::count).sum(), total, scanned, hits);
+    }
+
+    // Two ways to come back short, and the log has to tell them apart: pages the scan reached and
+    // could not read, versus pages it never reached because the budget ran out. Once per scan, not
+    // once per page: the reader logs each unreadable page at DEBUG precisely so this stays one line.
+    private void reportIncompleteScan(int scanned, int reached, int total) {
+        if (reached < total) {
+            LOGGER.warn("stopped searching '{}' in {} after {} of {} page(s): the {}s scan budget ran out",
+                    TYPE.token(), docArtifactDir, reached, total, scanBudget.toSeconds());
+        } else if (scanned < total) {
             LOGGER.warn("searched {} of the {} page(s) the '{}' manifest advertises in {}: the rest are "
                     + "missing or unreadable", scanned, total, TYPE.token(), docArtifactDir);
         }
-        return new Hits(hits.stream().mapToInt(PageHits::count).sum(), total, scanned, hits);
     }
 
     // null when the page could not be read: missing on disk, or a read that throws (the window between

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -70,25 +70,34 @@ public class StructureSearch {
     public Hits search(String query) throws IOException {
         ManifestEntry entry = reader.servableEntry(docArtifactDir, TYPE);
         Integer total = entry == null ? null : reader.servableTotal(docArtifactDir, TYPE, entry);
-        // Without the formats probe, a document whose page-N.md files are gone would answer "no
-        // occurrences" instead of "no markdown here". The probe checks page 1 only, as the manifest
-        // route does; a gap further in is reported through scanned().
-        if (total == null || reader.formats(docArtifactDir, TYPE, entry, List.of(extension)).isEmpty()) {
+        if (total == null) {
             return null;
         }
-        return scan(entry, total, query);
+        // Page 1 is counted here rather than probed. A formats() probe stats the very file the first
+        // loop iteration then reads, which is the stat-then-read round trip ArtifactReader#page was
+        // just changed to drop, reintroduced once per request. Null carries the same meaning the
+        // empty probe did: without a page 1 in this format the document has "no markdown here"
+        // rather than "no occurrences", which the route turns into 404. A gap further in is reported
+        // through scanned() instead, as the manifest route reports it.
+        Integer first = countPage(entry, 1, query);
+        return first == null ? null : scan(entry, total, query, first);
     }
 
-    // Over five lines on purpose: the loop accumulates two values and skips a third case, so the only
-    // way under the limit is a one-caller helper taking the accumulators as parameters, which hides
-    // the algorithm rather than shortening it. Sibling serving code here runs to the same length.
-    private Hits scan(ManifestEntry entry, int total, String query) {
+    // Over five lines on purpose: the loop accumulates three values and skips a fourth case, so the
+    // only way under the limit is a one-caller helper taking the accumulators as parameters, which
+    // hides the algorithm rather than shortening it. Sibling serving code here runs to the same length.
+    private Hits scan(ManifestEntry entry, int total, String query, int firstPage) {
         List<PageHits> hits = new ArrayList<>();
+        int matches = firstPage;
+        if (firstPage > 0) {
+            hits.add(new PageHits(1, firstPage));
+        }
         // Subtraction rather than a plain comparison, so a nanoTime wrap cannot end the scan early.
         long deadline = System.nanoTime() + scanBudget.toNanos();
         int last = Math.min(total, MAX_SCANNED_PAGES);
-        int scanned = 0;
-        int page = 1;
+        // One already: search() read page 1 to learn whether there is anything here to search.
+        int scanned = 1;
+        int page = 2;
         for (; page <= last && System.nanoTime() - deadline < 0; page++) {
             Integer count = countPage(entry, page, query);
             if (count == null) {
@@ -96,11 +105,12 @@ public class StructureSearch {
             }
             scanned++;
             if (count > 0) {
+                matches += count;
                 hits.add(new PageHits(page, count));
             }
         }
         reportIncompleteScan(scanned, page - 1, last, total);
-        return new Hits(hits.stream().mapToInt(PageHits::count).sum(), total, scanned, hits);
+        return new Hits(matches, total, scanned, hits);
     }
 
     // Three ways to come back short, and the log has to tell them apart: pages the budget never let
@@ -121,9 +131,9 @@ public class StructureSearch {
         }
     }
 
-    // null when the page could not be read: missing on disk, or a read that throws (the window between
-    // isReadable and readAllBytes, a permission change mid-scan, a stalled mount). Failing a
-    // nine-hundred-page search over one page would be worse, and scanned() carries the fact out.
+    // null when the page could not be read: missing on disk, unreadable (the reader maps every read
+    // failure to null), or a read that throws where even that cannot reach, such as a stalled mount.
+    // Failing a nine-hundred-page search over one page would be worse, and scanned() carries it out.
     private Integer countPage(ManifestEntry entry, int page, String query) {
         byte[] payload;
         try {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.text.artifact;
 
 import org.icij.datashare.text.ContentOccurrences;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -13,10 +15,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * In-document search over one document's persisted structure pages, the read-side counterpart of
  * {@link StructureArtifact}. Built per request rather than shared, because the document's dir and
  * the requested format are fixed for a whole scan and holding them keeps every helper inside the
- * four-parameter limit. Pages are read one at a time, so a document's whole markdown is never
- * resident at once.
+ * four-parameter limit.
+ * <p>
+ * Two things it does not promise. Reading one page at a time is not a memory bound: a format Tika
+ * emits no {@code div.page} for is one page holding the whole document, the same page the single-page
+ * route already serves in one response. And a match is counted within a page, so a phrase split by a
+ * page break counts zero here and one in the Elasticsearch content search.
  */
 public class StructureSearch {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StructureSearch.class);
     private static final ArtifactType TYPE = ArtifactType.STRUCTURE;
 
     private final ArtifactReader reader;
@@ -33,56 +40,56 @@ public class StructureSearch {
      *  document has nothing servable to search. Callers map null to 404 the way they map the
      *  reader's own nulls, so "not found" keeps one definition across the artifact routes. */
     public Hits search(String query) throws IOException {
-        ManifestEntry entry = searchableEntry();
-        if (entry == null) {
-            return null;
-        }
-        return scan(entry, query);
-    }
-
-    // The entry only when a servable structure artifact carries this format on disk. Without the
-    // formats probe, a document whose page-N.md files are gone would answer "no occurrences"
-    // instead of "no markdown here", contradicting what the manifest route told the client. The
-    // probe itself only checks page 1 (ArtifactReader#formats), matching what the manifest route
-    // advertises: a document missing page-1.md reads as "no markdown here", while a gap further in
-    // is just a page with no occurrence.
-    private ManifestEntry searchableEntry() throws IOException {
         ManifestEntry entry = reader.servableEntry(docArtifactDir, TYPE);
-        if (entry == null || reader.servableTotal(docArtifactDir, TYPE, entry) == null) {
+        Integer total = entry == null ? null : reader.servableTotal(docArtifactDir, TYPE, entry);
+        // Without the formats probe, a document whose page-N.md files are gone would answer "no
+        // occurrences" instead of "no markdown here". The probe checks page 1 only, as the manifest
+        // route does; a gap further in is reported through scanned().
+        if (total == null || reader.formats(docArtifactDir, TYPE, entry, List.of(extension)).isEmpty()) {
             return null;
         }
-        return reader.formats(docArtifactDir, TYPE, entry, List.of(extension)).isEmpty() ? null : entry;
+        return scan(entry, total, query);
     }
 
-    private Hits scan(ManifestEntry entry, String query) throws IOException {
+    private Hits scan(ManifestEntry entry, int total, String query) {
         List<PageHits> hits = new ArrayList<>();
-        int total = reader.servableTotal(docArtifactDir, TYPE, entry);
+        int scanned = 0;
         for (int page = 1; page <= total; page++) {
-            addPage(hits, entry, page, query);
+            Integer count = countPage(entry, page, query);
+            if (count == null) {
+                continue;
+            }
+            scanned++;
+            if (count > 0) {
+                hits.add(new PageHits(page, count));
+            }
         }
-        return new Hits(hits.stream().mapToInt(PageHits::count).sum(), hits);
+        if (scanned < total) {
+            // Once per scan, not once per page: the reader logs each miss at DEBUG precisely so this
+            // stays one line however many pages a degraded artifact has lost.
+            LOGGER.warn("searched {} of the {} page(s) the '{}' manifest advertises in {}: the rest are "
+                    + "missing or unreadable", scanned, total, TYPE.token(), docArtifactDir);
+        }
+        return new Hits(hits.stream().mapToInt(PageHits::count).sum(), total, scanned, hits);
     }
 
-    private void addPage(List<PageHits> hits, ManifestEntry entry, int page, String query) throws IOException {
-        int count = countPage(entry, page, query);
-        if (count > 0) {
-            hits.add(new PageHits(page, count));
+    // null when the page could not be read: missing on disk, or a read that throws (the window between
+    // isReadable and readAllBytes, a permission change mid-scan, a stalled mount). Failing a
+    // nine-hundred-page search over one page would be worse, and scanned() carries the fact out.
+    private Integer countPage(ManifestEntry entry, int page, String query) {
+        byte[] payload;
+        try {
+            payload = reader.page(docArtifactDir, TYPE, entry, page, extension);
+        } catch (IOException unreadable) {
+            LOGGER.debug("page {} of '{}' in {} could not be read", page, TYPE.token(), docArtifactDir, unreadable);
+            return null;
         }
+        return payload == null ? null : ContentOccurrences.count(new String(payload, UTF_8), query);
     }
 
-    private int countPage(ManifestEntry entry, int page, String query) throws IOException {
-        byte[] payload = reader.page(docArtifactDir, TYPE, entry, page, extension);
-        // A page the manifest advertises but disk no longer has: the reader has already logged it
-        // and the page route 404s that one page, so here it simply holds no occurrence. Failing a
-        // nine-hundred-page search over one missing file would be strictly worse.
-        if (payload == null) {
-            return 0;
-        }
-        return ContentOccurrences.count(new String(payload, UTF_8), query);
-    }
-
-    /** The response body: the document total, then only the pages carrying an occurrence. */
-    public record Hits(int count, List<PageHits> hits) {}
+    /** The response body. {@code scanned} is below {@code pages} when the artifact lost pages between
+     *  the manifest and disk: the counts are then a floor, not a total, and only this field says so. */
+    public record Hits(int count, int pages, int scanned, List<PageHits> hits) {}
 
     public record PageHits(int page, int count) {}
 }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureSearch.java
@@ -42,7 +42,10 @@ public class StructureSearch {
 
     // The entry only when a servable structure artifact carries this format on disk. Without the
     // formats probe, a document whose page-N.md files are gone would answer "no occurrences"
-    // instead of "no markdown here", contradicting what the manifest route told the client.
+    // instead of "no markdown here", contradicting what the manifest route told the client. The
+    // probe itself only checks page 1 (ArtifactReader#formats), matching what the manifest route
+    // advertises: a document missing page-1.md reads as "no markdown here", while a gap further in
+    // is just a page with no occurrence.
     private ManifestEntry searchableEntry() throws IOException {
         ManifestEntry entry = reader.servableEntry(docArtifactDir, TYPE);
         if (entry == null || reader.servableTotal(docArtifactDir, TYPE, entry) == null) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -39,11 +39,19 @@ import java.util.regex.Pattern;
 
 /**
  * Converts a document's source bytes into a per-page rendering of its structure. Pipeline: Tika XHTML
- * -> split on {@code <div class="page">} -> per-page sanitize -> flexmark html2md. OCR is disabled and
- * embedded documents contribute no pages, so the same bytes always yield byte-identical output, which
- * the content-addressed cache relies on.
+ * -> split on {@code <div class="page">} -> per-page sanitize -> flexmark html2md. Embedded documents
+ * contribute no pages, so the same bytes under the same {@link OcrSettings} always yield byte-identical
+ * output, which the content-addressed cache relies on: OCR is the one input that is not the bytes, so
+ * the caller passes it and records it in the artifact's fingerprint.
  */
 public class StructureMarkdownExtractor {
+
+    /** The OCR the INDEX stage applied to this document, so a page holds the text the content field
+     *  holds. Two knobs because two parsers are, as extract-lib splits them: {@code --ocr} for a
+     *  standalone image, {@code --ocrStrategy} for a scanned PDF (whose default really is NO_OCR). */
+    public record OcrSettings(boolean images, PDFParserConfig.OCR_STRATEGY pdfStrategy) {
+        public static final OcrSettings NONE = new OcrSettings(false, PDFParserConfig.OCR_STRATEGY.NO_OCR);
+    }
 
     private static final String GENERIC_CONTENT_TYPE = "application/octet-stream";
 
@@ -142,11 +150,11 @@ public class StructureMarkdownExtractor {
      * caller owns {@code source}: this method reads but does not close it. {@code contentType} and
      * {@code filename} are detection hints, either of which may be null.
      */
-    public List<Page> extract(InputStream source, String contentType, String filename)
+    public List<Page> extract(InputStream source, String contentType, String filename, OcrSettings ocr)
             throws IOException, SAXException, TikaException {
         // Kept rather than built inside toXhtml: the parse fills it with the type Tika detected.
         Metadata metadata = buildMetadata(contentType, filename);
-        org.jsoup.nodes.Document document = Jsoup.parse(toXhtml(source, metadata));
+        org.jsoup.nodes.Document document = Jsoup.parse(toXhtml(source, metadata, ocr));
         if (isMarkdown(metadata)) {
             document = parseAsMarkdown(document);
         }
@@ -232,12 +240,12 @@ public class StructureMarkdownExtractor {
         return page.html();
     }
 
-    String toXhtml(InputStream source, Metadata metadata)
+    String toXhtml(InputStream source, Metadata metadata, OcrSettings ocr)
             throws IOException, SAXException, TikaException {
         ToXMLContentHandler xhtmlHandler = new ToXMLContentHandler();
         new AutoDetectParser(RESILIENT_PARSER).parse(source,
                 new WriteOutContentHandler(xhtmlHandler, maxOutputChars),
-                metadata, buildParseContext());
+                metadata, buildParseContext(ocr));
         return xhtmlHandler.toString();
     }
 
@@ -261,18 +269,19 @@ public class StructureMarkdownExtractor {
         return contentType != null && !contentType.isBlank() && !GENERIC_CONTENT_TYPE.equalsIgnoreCase(contentType);
     }
 
-    // No OCR, no recursion into embedded parts, and IdentityHtmlMapper so inline formatting survives
-    // instead of being dropped by the DefaultHtmlMapper. Disabling OCR takes both configs: PDFParserConfig
+    // The caller's OCR, no recursion into embedded parts, and IdentityHtmlMapper so inline formatting
+    // survives instead of being dropped by the DefaultHtmlMapper. OCR takes both configs: PDFParserConfig
     // only governs a scanned PDF page, while a standalone image goes through TesseractOCRParser, which it
-    // does not reach. Output would otherwise depend on the tesseract build and langpacks, which taskInput
-    // does not record.
-    static ParseContext buildParseContext() {
+    // does not reach. With OCR on, output depends on the tesseract build and langpacks, which taskInput
+    // does not record: the same exposure PageArtifact already accepts, and the price of pages that hold
+    // what the content field holds.
+    static ParseContext buildParseContext(OcrSettings ocr) {
         ParseContext context = new ParseContext();
         PDFParserConfig pdfConfig = new PDFParserConfig();
-        pdfConfig.setOcrStrategy(PDFParserConfig.OCR_STRATEGY.NO_OCR);
+        pdfConfig.setOcrStrategy(ocr.pdfStrategy());
         context.set(PDFParserConfig.class, pdfConfig);
         TesseractOCRConfig tesseractConfig = new TesseractOCRConfig();
-        tesseractConfig.setSkipOcr(true);
+        tesseractConfig.setSkipOcr(!ocr.images());
         context.set(TesseractOCRConfig.class, tesseractConfig);
         context.set(HtmlMapper.class, new IdentityHtmlMapper());
         // Tika otherwise appends every embedded part's XHTML into this document's handler, buffering a

--- a/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
@@ -1,0 +1,90 @@
+package org.icij.datashare.text;
+
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/** Pins the folding and counting rules ContentOccurrences ports from
+ *  searchOccurrences.painless.java: every test here fails if the two drift apart. */
+public class ContentOccurrencesTest {
+    @Test
+    public void test_matching_ignores_case() {
+        assertThat(ContentOccurrences.count("Data and DATA", "data")).isEqualTo(2);
+    }
+
+    // Escapes rather than literal accented characters throughout this class: these tests turn
+    // on whether an accent is precomposed or decomposed, which a literal does not show and an
+    // editor can silently renormalize, inverting the next test without touching its source.
+    @Test
+    public void test_a_precomposed_accent_folds_to_its_base_letter() {
+        // "é" as U+00E9 is a LOWERCASE_LETTER, so the script normalizes it and drops the mark.
+        assertThat(ContentOccurrences.count("r\u00e9sum\u00e9", "resume")).isEqualTo(1);
+    }
+
+    @Test
+    public void test_a_decomposed_accent_does_not_fold() {
+        // The same word written "e" + U+0301: the combining acute is NON_SPACING_MARK, not
+        // LOWERCASE_LETTER, so the script's else branch keeps it and the mark breaks the match.
+        // Wrong on its face, and load-bearing: "fixing" it makes this search disagree with
+        // /documents/searchContent on the same document.
+        assertThat(ContentOccurrences.count("re\u0301sume", "resume")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_a_caseless_script_is_left_untouched() {
+        // Arabic letters are OTHER_LETTER, so no NFKD runs: alef-with-hamza (U+0623) never
+        // decomposes into a bare alef (U+0627), so the two spellings of "ahmad" stay as
+        // distinct here as they are in Elasticsearch.
+        assertThat(ContentOccurrences.count("\u0623\u062d\u0645\u062f", "\u0623\u062d\u0645\u062f")).isEqualTo(1);
+        assertThat(ContentOccurrences.count("\u0623\u062d\u0645\u062f", "\u0627\u062d\u0645\u062f")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_matches_do_not_overlap() {
+        // The script steps by the query's length, so "aaaa" holds two "aa", not three.
+        assertThat(ContentOccurrences.count("aaaa", "aa")).isEqualTo(2);
+    }
+
+    @Test
+    public void test_the_query_is_matched_literally_not_as_a_regex() {
+        // A regex would match "abc" too, and every user typing a dot would get a wrong count.
+        assertThat(ContentOccurrences.count("a.c and abc", "a.c")).isEqualTo(1);
+    }
+
+    @Test
+    public void test_a_compatibility_ligature_expands_when_folded() {
+        // NFKD is the compatibility form, so "ﬁ" (U+FB01) becomes "fi" and the folded string
+        // outgrows its source. Harmless for a count, and exactly why the script's offsets drift,
+        // which is why offsets are not part of this endpoint's contract.
+        assertThat(ContentOccurrences.count("of\ufb01ce", "office")).isEqualTo(1);
+    }
+
+    @Test
+    public void test_an_empty_query_counts_nothing_instead_of_hanging() {
+        // The script's loop never advances on an empty query. Serving code rejects a blank one,
+        // so this guards the library against its next caller, not the route.
+        assertThat(ContentOccurrences.count("anything", "")).isEqualTo(0);
+    }
+
+    @Test
+    public void test_ascii_folds_to_lowercase_and_nothing_else() {
+        // The ASCII fast path must produce exactly what the script's two branches produce.
+        assertThat(ContentOccurrences.fold("Hello, World! 42")).isEqualTo("hello, world! 42");
+    }
+
+    @Test
+    public void test_folding_ignores_the_jvm_default_locale() {
+        Locale previous = Locale.getDefault();
+        try {
+            // Under tr-TR, "I".toLowerCase() is the dotless "ı", which would stop INDEX from
+            // matching index. Locale.ROOT pins the fold so a deployment's locale cannot change
+            // what a search finds.
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertThat(ContentOccurrences.count("INDEX", "index")).isEqualTo(1);
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+}

--- a/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
@@ -1,7 +1,8 @@
 package org.icij.datashare.text;
 
-import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 import org.junit.Test;
+
+import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 
 import java.io.IOException;
 import java.util.Locale;

--- a/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
@@ -1,7 +1,9 @@
 package org.icij.datashare.text;
 
+import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Locale;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -9,6 +11,19 @@ import static org.fest.assertions.Assertions.assertThat;
 /** Pins the folding and counting rules ContentOccurrences ports from
  *  searchOccurrences.painless.java: every test here fails if the two drift apart. */
 public class ContentOccurrencesTest {
+    @Test
+    public void test_the_ported_script_still_carries_the_rules_this_class_mirrors() throws IOException {
+        // Every other test here asserts the port against hardcoded expectations, so editing the script
+        // alone leaves them all green while the two counters start disagreeing. Substrings rather than
+        // a checksum: reformatting the script should not fail the build, changing its rules should.
+        String script = ElasticsearchIndexer.getScriptStringFromFile("searchOccurrences.painless.java");
+        assertThat(script).contains("Character.getType(c) == Character.LOWERCASE_LETTER");
+        assertThat(script).contains("Normalizer.normalize(Character.toString(c) , Normalizer.Form.NFKD)");
+        assertThat(script).contains("Character.getType(c) != Character.NON_SPACING_MARK");
+        assertThat(script).contains("int queryLength = query.length();");
+        assertThat(script).contains("contentInLower.indexOf(queryInLower, lastIndex + queryLength)");
+    }
+
     @Test
     public void test_matching_ignores_case() {
         assertThat(ContentOccurrences.count("Data and DATA", "data")).isEqualTo(2);

--- a/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/ContentOccurrencesTest.java
@@ -87,4 +87,13 @@ public class ContentOccurrencesTest {
             Locale.setDefault(previous);
         }
     }
+
+    @Test
+    public void test_the_step_uses_the_raw_query_length_not_the_folded_one() {
+        // U+FB00 is a LOWERCASE_LETTER whose NFKD form is "ff", so the folded query is twice the
+        // raw one. The script steps by the raw length (line 45), which finds the two overlapping
+        // matches here; stepping by the folded length would report 1 and diverge from
+        // Elasticsearch on any query holding a ligature.
+        assertThat(ContentOccurrences.count("afffb", "\ufb00")).isEqualTo(2);
+    }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -142,6 +142,18 @@ public class ArtifactReaderTest {
     }
 
     @Test
+    public void test_page_is_null_when_a_directory_sits_where_the_page_file_belongs() throws Exception {
+        Path node = withFilesystemPages(1, "page one");
+        Path file = ArtifactPath.payloadPage(node, ArtifactType.PAGE, 1, "txt");
+        Files.delete(file);
+        // Neither NoSuchFile nor AccessDenied: a plain FileSystemException, which the isReadable
+        // pre-check used to answer false for. It has to stay a 404 rather than escape as a 500.
+        Files.createDirectory(file);
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.page(node, ArtifactType.PAGE, entry, 1, "txt")).isNull();
+    }
+
+    @Test
     public void test_page_reads_the_filesystem_page() throws Exception {
         Path node = withFilesystemPages(2, "page one", "page two");
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -129,6 +129,19 @@ public class ArtifactReaderTest {
     }
 
     @Test
+    public void test_a_total_past_a_hundred_thousand_is_still_servable() throws Exception {
+        Path node = dir.getRoot().toPath();
+        // A merged archive or a bulk-exported log really can run past a hundred thousand pages, and
+        // nothing here loops over the total: bounding a scan is the searcher's business, not the
+        // reader's, so a big document must not 404 on the manifest and page routes.
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE),
+                "{\"page\": {\"status\": \"complete\", \"taskInput\": {}, "
+                        + "\"pages\": {\"total\": 150000, \"pagination\": {\"type\": \"filesystem\"}}}}");
+        ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);
+        assertThat(reader.servableTotal(node, ArtifactType.PAGE, entry)).isEqualTo(150000);
+    }
+
+    @Test
     public void test_page_reads_the_filesystem_page() throws Exception {
         Path node = withFilesystemPages(2, "page one", "page two");
         ManifestEntry entry = reader.servableEntry(node, ArtifactType.PAGE);

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -1,10 +1,10 @@
 package org.icij.datashare.text.artifact;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.icij.datashare.PropertiesProvider;
 import org.apache.tika.exception.TikaConfigException;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.exception.TikaMemoryLimitException;
+import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
@@ -199,7 +199,8 @@ public class StructureArtifactTest {
         when(sources.getSource(project, doc)).thenThrow(new java.io.FileNotFoundException("gone"));
 
         try {
-            new StructureArtifact(new PropertiesProvider()).produce(new ArtifactContext(project, doc, dir.getRoot().toPath(), sources));
+            new StructureArtifact(new PropertiesProvider())
+                    .produce(new ArtifactContext(project, doc, dir.getRoot().toPath(), sources));
             org.junit.Assert.fail("expected an ArtifactException");
         } catch (ArtifactException expected) {
             // the directory must not be created before the source is known to be readable
@@ -219,7 +220,8 @@ public class StructureArtifactTest {
         when(sources.getSource(project, broken)).thenAnswer(invocation -> new ByteArrayInputStream(garbage));
 
         try {
-            new StructureArtifact(new PropertiesProvider()).produce(new ArtifactContext(project, broken, dir.getRoot().toPath(), sources));
+            new StructureArtifact(new PropertiesProvider())
+                    .produce(new ArtifactContext(project, broken, dir.getRoot().toPath(), sources));
             org.junit.Assert.fail("expected an UnreadableContentException");
         } catch (UnreadableContentException expected) {
             assertThat(Files.exists(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE))).isFalse();

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.text.artifact;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.icij.datashare.PropertiesProvider;
 import org.apache.tika.exception.TikaConfigException;
 import org.apache.tika.exception.TikaException;
 import org.apache.tika.exception.TikaMemoryLimitException;
@@ -23,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -76,8 +78,36 @@ public class StructureArtifactTest {
     }
 
     @Test
+    public void test_task_input_records_the_ocr_that_rendered_the_document() {
+        // A document indexed without OCR is rendered without it whatever the run asks, so the run's flag
+        // alone would stamp OCR-free pages as OCR'd: re-indexing with OCR on then changes nothing the
+        // fingerprint sees, and skip-if-current serves the OCR-free pages forever.
+        StructureArtifact withOcrRun = new StructureArtifact(
+                new PropertiesProvider(Map.of("ocrStrategy", "OCR_AND_TEXT_EXTRACTION")));
+        Document ocred = createDoc("ocr-id").with(Path.of("/path/to/scan.pdf")).ofContentType("application/pdf")
+                .withOcrParser("org.icij.extract.parser.ocr.OCRParserAdapter").build();
+
+        assertThat(withOcrRun.taskInput(doc).get("ocr")).isEqualTo(false);
+        assertThat(withOcrRun.taskInput(doc).get("ocrStrategy")).isEqualTo("NO_OCR");
+        assertThat(withOcrRun.taskInput(ocred).get("ocr")).isEqualTo(true);
+        assertThat(withOcrRun.taskInput(ocred).get("ocrStrategy")).isEqualTo("OCR_AND_TEXT_EXTRACTION");
+        // The run's switch still wins downward: it cannot OCR when the run turned OCR off.
+        assertThat(new StructureArtifact(new PropertiesProvider(Map.of("ocr", "false"))).taskInput(ocred).get("ocr"))
+                .isEqualTo(false);
+        // A fingerprint that does not move is the bug, so the two must not compare equal.
+        assertThat(withOcrRun.taskInput(ocred)).isNotEqualTo(withOcrRun.taskInput(doc));
+    }
+
+    @Test
+    public void test_an_unknown_ocr_strategy_degrades_to_no_ocr_as_extract_does() {
+        StructureArtifact misconfigured = new StructureArtifact(
+                new PropertiesProvider(Map.of("ocrStrategy", "NOPE")));
+        assertThat(misconfigured.taskInput().get("ocrStrategy")).isEqualTo("NO_OCR");
+    }
+
+    @Test
     public void test_type_and_task_input() {
-        StructureArtifact structure = new StructureArtifact();
+        StructureArtifact structure = new StructureArtifact(new PropertiesProvider());
         assertThat(structure.type()).isEqualTo(ArtifactType.STRUCTURE);
         assertThat(structure.taskInput().get("pipeline")).isEqualTo("tika");
         String version = (String) structure.taskInput().get("version");
@@ -100,7 +130,7 @@ public class StructureArtifactTest {
     // confirm the change was intended, then update the expectation.
     @Test
     public void test_the_stored_page_set_is_pinned() throws Exception {
-        new StructureArtifact().produce(contextFor(PINNED_HTML));
+        new StructureArtifact(new PropertiesProvider()).produce(contextFor(PINNED_HTML));
 
         assertThat(storedPageNames()).isEqualTo(
                 List.of("page-1.md", "page-1.xhtml", "page-2.md", "page-2.xhtml"));
@@ -133,7 +163,7 @@ public class StructureArtifactTest {
 
     @Test
     public void test_produce_writes_both_formats_for_page_one() throws Exception {
-        new StructureArtifact().produce(contextFor(HTML));
+        new StructureArtifact(new PropertiesProvider()).produce(contextFor(HTML));
 
         assertThat(Files.readString(page(1, "md"))).contains("# Title");
         assertThat(Files.readString(page(1, "xhtml"))).contains("<h1>Title</h1>");
@@ -142,7 +172,7 @@ public class StructureArtifactTest {
 
     @Test
     public void test_produce_returns_a_filesystem_paginated_entry() throws Exception {
-        ManifestEntry entry = new StructureArtifact().produce(contextFor(HTML));
+        ManifestEntry entry = new StructureArtifact(new PropertiesProvider()).produce(contextFor(HTML));
 
         assertThat(entry.pages().total()).isEqualTo(1);
         assertThat(entry.pages().pagination().type()).isEqualTo("filesystem");
@@ -153,11 +183,11 @@ public class StructureArtifactTest {
 
     @Test
     public void test_produce_is_byte_deterministic() throws Exception {
-        new StructureArtifact().produce(contextFor(HTML));
+        new StructureArtifact(new PropertiesProvider()).produce(contextFor(HTML));
         byte[] firstMd = Files.readAllBytes(page(1, "md"));
         byte[] firstXhtml = Files.readAllBytes(page(1, "xhtml"));
 
-        new StructureArtifact().produce(contextFor(HTML));
+        new StructureArtifact(new PropertiesProvider()).produce(contextFor(HTML));
 
         assertThat(Files.readAllBytes(page(1, "md"))).isEqualTo(firstMd);
         assertThat(Files.readAllBytes(page(1, "xhtml"))).isEqualTo(firstXhtml);
@@ -169,7 +199,7 @@ public class StructureArtifactTest {
         when(sources.getSource(project, doc)).thenThrow(new java.io.FileNotFoundException("gone"));
 
         try {
-            new StructureArtifact().produce(new ArtifactContext(project, doc, dir.getRoot().toPath(), sources));
+            new StructureArtifact(new PropertiesProvider()).produce(new ArtifactContext(project, doc, dir.getRoot().toPath(), sources));
             org.junit.Assert.fail("expected an ArtifactException");
         } catch (ArtifactException expected) {
             // the directory must not be created before the source is known to be readable
@@ -189,7 +219,7 @@ public class StructureArtifactTest {
         when(sources.getSource(project, broken)).thenAnswer(invocation -> new ByteArrayInputStream(garbage));
 
         try {
-            new StructureArtifact().produce(new ArtifactContext(project, broken, dir.getRoot().toPath(), sources));
+            new StructureArtifact(new PropertiesProvider()).produce(new ArtifactContext(project, broken, dir.getRoot().toPath(), sources));
             org.junit.Assert.fail("expected an UnreadableContentException");
         } catch (UnreadableContentException expected) {
             assertThat(Files.exists(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE))).isFalse();
@@ -200,7 +230,7 @@ public class StructureArtifactTest {
     public void test_a_broken_configuration_ends_the_run_instead_of_failing_one_document() throws Exception {
         // It fails every document the same way, so ArtifactTask rethrows it where it rethrows an Error.
         // Catching it as one more document failure would drain the whole queue one ERROR at a time.
-        StructureArtifact misconfigured = new StructureArtifact() {
+        StructureArtifact misconfigured = new StructureArtifact(new PropertiesProvider()) {
             @Override
             List<Page> parse(java.io.InputStream source, Document document) {
                 throw new ArtifactConfigurationException(new TikaConfigException("no parser for it"));
@@ -238,7 +268,7 @@ public class StructureArtifactTest {
         Document scan = createDoc("scan-id").with(Path.of("/path/to/scan.png"))
                 .ofContentType("image/png").build();
 
-        ManifestEntry entry = new StructureArtifact().produce(contextFor(blankPng(), scan));
+        ManifestEntry entry = new StructureArtifact(new PropertiesProvider()).produce(contextFor(blankPng(), scan));
 
         assertThat(entry.status()).isNull(); // the producer loop stamps complete
         assertThat(entry.pages().total()).isEqualTo(1);
@@ -257,7 +287,7 @@ public class StructureArtifactTest {
         // an ARTIFACT run over a fresh artifactDir has to create it here or fail on every document.
         Path docArtifactDir = dir.getRoot().toPath().resolve("6a/bb/6abbdigest");
 
-        ManifestEntry entry = new StructureArtifact().produce(contextFor(HTML, docArtifactDir));
+        ManifestEntry entry = new StructureArtifact(new PropertiesProvider()).produce(contextFor(HTML, docArtifactDir));
 
         assertThat(entry.pages().total()).isEqualTo(1);
         assertThat(Files.readString(ArtifactPath.payloadPage(docArtifactDir, ArtifactType.STRUCTURE, 1, "md"))).contains("# Title");
@@ -269,7 +299,7 @@ public class StructureArtifactTest {
     @Test
     public void test_manifest_written_by_the_real_producer_loop_matches_the_convention() throws Exception {
         boolean produced = new ArtifactProducer(new FilesystemManifestRepository(), () -> false)
-                .run(List.of(new StructureArtifact()), contextFor(HTML), false);
+                .run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
 
         assertThat(produced).isTrue();
         // The repository pretty-prints the manifest, so assert on the parsed tree rather than raw bytes.
@@ -285,11 +315,11 @@ public class StructureArtifactTest {
     @Test
     public void test_second_producer_run_skips_a_document_whose_payload_is_still_there() throws Exception {
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
-        producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
+        producer.run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
         // Overwrite rather than delete: a deleted page is now a repair trigger, not proof of a skip.
         Files.writeString(page(1, "md"), "sentinel");
 
-        producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
+        producer.run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
 
         assertThat(Files.readString(page(1, "md"))).isEqualTo("sentinel");
     }
@@ -297,13 +327,13 @@ public class StructureArtifactTest {
     @Test
     public void test_a_re_run_repairs_pages_stranded_in_a_holding_pen() throws Exception {
         ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
-        producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
+        producer.run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
         // What a failed AtomicDirectorySwap.restore leaves behind: the only copy of the pages in a holding
         // pen while the target is gone, until now recoverable only by hand (#2300).
         Path pen = dir.getRoot().toPath().resolve(".structure-" + UUID.randomUUID() + ".replaced");
         Files.move(ArtifactPath.payloadDir(dir.getRoot().toPath(), ArtifactType.STRUCTURE), pen);
 
-        producer.run(List.of(new StructureArtifact()), contextFor(HTML), false);
+        producer.run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
 
         assertThat(Files.readString(page(1, "md"))).contains("# Title");
         // reclaimHoldingPens swept the stale pen on the way through, so the repair costs no extra copy.

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
@@ -1,0 +1,124 @@
+package org.icij.datashare.text.artifact;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/** Covers one invariant: a search answers only for a document whose structure artifact is servable
+ *  in the requested format, and then counts every page that manifest advertises. */
+public class StructureSearchTest {
+    @Rule public TemporaryFolder dir = new TemporaryFolder();
+    private final ManifestRepository manifests = new FilesystemManifestRepository();
+    private final ArtifactReader reader = new ArtifactReader(manifests);
+
+    private StructureSearch markdownSearch() {
+        return new StructureSearch(reader, dir.getRoot().toPath(), "md");
+    }
+
+    // Written through ArtifactPath, never through an inline page-N format: a duplicated format
+    // string would let writer and reader drift together and hide a naming bug from these tests.
+    private Path writePages(String extension, String... pages) throws Exception {
+        Path node = dir.getRoot().toPath();
+        Files.createDirectories(ArtifactPath.payloadDir(node, ArtifactType.STRUCTURE));
+        for (int page = 1; page <= pages.length; page++) {
+            Files.writeString(ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, page, extension), pages[page - 1]);
+        }
+        return node;
+    }
+
+    // Advertises `total` pages regardless of how many were written, so a test can claim more.
+    private void completeManifest(int total) throws Exception {
+        manifests.put(dir.getRoot().toPath(), ArtifactType.STRUCTURE.token(),
+                ManifestEntry.paginated(Map.of(), total).withStatus(ManifestEntryStatus.COMPLETE));
+    }
+
+    @Test
+    public void test_search_is_null_without_a_manifest() throws Exception {
+        writePages("md", "data");
+        assertThat(markdownSearch().search("data")).isNull();
+    }
+
+    @Test
+    public void test_search_is_null_when_the_entry_is_never_stamped_complete() throws Exception {
+        Path node = writePages("md", "data");
+        // Paginated and on disk, but no status: the strict store reads a half-written artifact as
+        // absent rather than serving what a crashed producer happened to leave behind.
+        manifests.put(node, ArtifactType.STRUCTURE.token(), ManifestEntry.paginated(Map.of(), 1));
+        assertThat(markdownSearch().search("data")).isNull();
+    }
+
+    @Test
+    public void test_search_is_null_when_the_pages_block_has_no_usable_total() throws Exception {
+        Path node = writePages("md", "data");
+        // Pages.total is a primitive, so an absent total deserializes to 0: complete, but malformed.
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE),
+                "{\"structure\": {\"status\": \"complete\", \"taskInput\": {}, "
+                        + "\"pages\": {\"pagination\": {\"type\": \"filesystem\"}}}}");
+        assertThat(markdownSearch().search("data")).isNull();
+    }
+
+    @Test
+    public void test_search_is_null_when_the_format_is_absent_from_disk() throws Exception {
+        writePages("md", "data");
+        completeManifest(1);
+        // Same document, same manifest, only the requested format differs, so the null below can
+        // come from nothing but the missing format.
+        assertThat(markdownSearch().search("data")).isNotNull();
+        assertThat(new StructureSearch(reader, dir.getRoot().toPath(), "xhtml").search("data")).isNull();
+    }
+
+    @Test
+    public void test_search_counts_every_page_in_order_and_omits_the_empty_ones() throws Exception {
+        writePages("md", "data and data", "nothing here", "data");
+        completeManifest(3);
+        StructureSearch.Hits hits = markdownSearch().search("data");
+        assertThat(hits.count()).isEqualTo(3);
+        assertThat(hits.hits()).hasSize(2);
+        assertThat(hits.hits().get(0).page()).isEqualTo(1);
+        assertThat(hits.hits().get(0).count()).isEqualTo(2);
+        assertThat(hits.hits().get(1).page()).isEqualTo(3);
+        assertThat(hits.hits().get(1).count()).isEqualTo(1);
+    }
+
+    @Test
+    public void test_a_document_with_no_match_answers_zero_rather_than_nothing() throws Exception {
+        writePages("md", "# one", "# two");
+        completeManifest(2);
+        // The distinction the route turns into 200 versus 404: "searched, found none" is not
+        // "there is nothing here to search".
+        StructureSearch.Hits hits = markdownSearch().search("data");
+        assertThat(hits.count()).isEqualTo(0);
+        assertThat(hits.hits()).isEmpty();
+    }
+
+    @Test
+    public void test_a_page_missing_on_disk_holds_no_occurrence_and_the_scan_goes_on() throws Exception {
+        Path node = writePages("md", "data", "data", "data");
+        // A gap in the middle, not a truncated tail: the manifest still promises page 2, and the
+        // scan has to carry on to page 3 rather than stopping or failing at the missing file.
+        Files.delete(ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, 2, "md"));
+        completeManifest(3);
+        StructureSearch.Hits hits = markdownSearch().search("data");
+        assertThat(hits.count()).isEqualTo(2);
+        assertThat(hits.hits()).hasSize(2);
+        assertThat(hits.hits().get(0).page()).isEqualTo(1);
+        assertThat(hits.hits().get(1).page()).isEqualTo(3);
+    }
+
+    @Test
+    public void test_a_page_is_folded_like_the_elasticsearch_content_search() throws Exception {
+        writePages("md", "R\u00e9sum\u00e9 of DATA");
+        completeManifest(1);
+        // Delegation smoke test only: ContentOccurrencesTest owns the full rule set.
+        assertThat(markdownSearch().search("resume").count()).isEqualTo(1);
+        assertThat(markdownSearch().search("data").count()).isEqualTo(1);
+    }
+}

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
@@ -8,6 +8,7 @@ import org.icij.datashare.text.indexing.elasticsearch.ArtifactPath;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -93,13 +94,28 @@ public class StructureSearchTest {
         Path node = writePages("md", "data", "data", "data");
         Path page = ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, 2, "md");
         Files.delete(page);
-        // A directory where a page file belongs: isReadable passes and readAllBytes throws, standing in
-        // for the mid-scan permission change a unit test cannot stage. Unhandled, one page 500s the lot.
+        // A directory where a page file belongs: readAllBytes throws a plain IOException rather than
+        // the NoSuchFile/AccessDenied the reader maps to null, standing in for the stalled mount a unit
+        // test cannot stage. Unhandled, one such page turns a nine-hundred-page search into a 500.
         Files.createDirectory(page);
         completeManifest(3);
         StructureSearch.Hits hits = markdownSearch().search("data");
         assertThat(hits.count()).isEqualTo(2);
         assertThat(hits.scanned()).isEqualTo(2);
+    }
+
+    @Test(timeout = 10_000)
+    public void test_a_scan_stops_at_its_budget_and_reports_the_pages_it_never_reached() throws Exception {
+        writePages("md", "data", "data", "data");
+        completeManifest(3);
+        // A zero budget fails the very first deadline check, so nothing is scanned. The production
+        // budget is ten seconds precisely so it never fires on a real document, which is also why no
+        // test can reach it: this proves the loop consults the budget at all.
+        StructureSearch.Hits hits =
+                new StructureSearch(reader, dir.getRoot().toPath(), "md", Duration.ZERO).search("data");
+        assertThat(hits.pages()).isEqualTo(3);
+        assertThat(hits.scanned()).isEqualTo(0);
+        assertThat(hits.count()).isEqualTo(0);
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
@@ -115,14 +115,16 @@ public class StructureSearchTest {
     public void test_a_scan_stops_at_its_budget_and_reports_the_pages_it_never_reached() throws Exception {
         writePages("md", "data", "data", "data");
         completeManifest(3);
-        // A zero budget fails the very first deadline check, so nothing is scanned. The production
-        // budget is ten seconds precisely so it never fires on a real document, which is also why no
-        // test can reach it: this proves the loop consults the budget at all.
+        // A zero budget fails the very first deadline check, so the loop scans nothing. Page 1 is
+        // counted regardless: reading it is how the search tells "no markdown here" (404) from "no
+        // occurrences" (200), which it has to answer before any budget applies. The production budget
+        // is ten seconds precisely so it never fires on a real document, which is also why no test
+        // can reach it: this proves the loop consults the budget at all.
         StructureSearch.Hits hits =
                 new StructureSearch(reader, dir.getRoot().toPath(), "md", Duration.ZERO).search("data");
         assertThat(hits.pages()).isEqualTo(3);
-        assertThat(hits.scanned()).isEqualTo(0);
-        assertThat(hits.count()).isEqualTo(0);
+        assertThat(hits.scanned()).isEqualTo(1);
+        assertThat(hits.count()).isEqualTo(1);
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
@@ -112,19 +112,29 @@ public class StructureSearchTest {
     }
 
     @Test(timeout = 10_000)
-    public void test_a_scan_stops_at_its_budget_and_reports_the_pages_it_never_reached() throws Exception {
+    public void test_a_scan_stops_at_its_budget() throws Exception {
         writePages("md", "data", "data", "data");
         completeManifest(3);
-        // A zero budget fails the very first deadline check, so the loop scans nothing. Page 1 is
-        // counted regardless: reading it is how the search tells "no markdown here" (404) from "no
-        // occurrences" (200), which it has to answer before any budget applies. The production budget
-        // is ten seconds precisely so it never fires on a real document, which is also why no test
-        // can reach it: this proves the loop consults the budget at all.
-        StructureSearch.Hits hits =
-                new StructureSearch(reader, dir.getRoot().toPath(), "md", Duration.ZERO).search("data");
-        assertThat(hits.pages()).isEqualTo(3);
-        assertThat(hits.scanned()).isEqualTo(1);
+        // A zero budget fails the very first deadline check, so nothing is scanned, and a scan that
+        // read no page cannot tell "no markdown here" from "budget gone": both answer 404, as a scan
+        // whose every page is unreadable does. Ignoring the budget would answer the three pages
+        // instead, which is what this pins. The production budget is ten seconds precisely so it
+        // never fires on a real document, which is also why no test can reach it.
+        assertThat(new StructureSearch(reader, dir.getRoot().toPath(), "md", Duration.ZERO)
+                .search("data")).isNull();
+    }
+
+    @Test
+    public void test_an_unreadable_first_page_does_not_hide_the_pages_after_it() throws Exception {
+        Path node = writePages("md", "data", "data");
+        Files.delete(ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, 1, "md"));
+        completeManifest(2);
+        // Page 1 is read like any other page: one unreadable page costs its own count and nothing
+        // else, or a malformed first byte range would 404 a document whose later pages are fine.
+        StructureSearch.Hits hits = markdownSearch().search("data");
         assertThat(hits.count()).isEqualTo(1);
+        assertThat(hits.scanned()).isEqualTo(1);
+        assertThat(hits.hits().get(0).page()).isEqualTo(2);
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
@@ -66,15 +66,22 @@ public class StructureSearchTest {
         assertThat(markdownSearch().search("data")).isNull();
     }
 
-    @Test(timeout = 10_000)
-    public void test_search_is_null_when_the_manifest_advertises_an_impossible_page_count() throws Exception {
+    // Under the scan cap a hundred thousand absent pages take a fraction of a second, so this fails
+    // well before the ten-second budget could end the loop instead: it pins the cap, not the budget.
+    @Test(timeout = 5_000)
+    public void test_a_wild_page_total_is_answered_but_scanned_only_up_to_the_cap() throws Exception {
         Path node = writePages("md", "data");
         // manifest.json is written by other producers, so a wild total is hostile input, not a big
-        // document. Unbounded it never terminates: the counter wraps to MIN_VALUE and stays <= total.
+        // document. Unbounded the loop never ends: the counter wraps to MIN_VALUE and stays <= total.
         Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE),
                 "{\"structure\": {\"status\": \"complete\", \"taskInput\": {}, \"pages\": "
                         + "{\"total\": 2147483647, \"pagination\": {\"type\": \"filesystem\"}}}}");
-        assertThat(markdownSearch().search("data")).isNull();
+        StructureSearch.Hits hits = markdownSearch().search("data");
+        // The total is reported as the manifest states it and only one page is on disk, so scanned
+        // below pages is what tells the client the count is a floor.
+        assertThat(hits.pages()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(hits.scanned()).isEqualTo(1);
+        assertThat(hits.count()).isEqualTo(1);
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureSearchTest.java
@@ -65,6 +65,52 @@ public class StructureSearchTest {
         assertThat(markdownSearch().search("data")).isNull();
     }
 
+    @Test(timeout = 10_000)
+    public void test_search_is_null_when_the_manifest_advertises_an_impossible_page_count() throws Exception {
+        Path node = writePages("md", "data");
+        // manifest.json is written by other producers, so a wild total is hostile input, not a big
+        // document. Unbounded it never terminates: the counter wraps to MIN_VALUE and stays <= total.
+        Files.writeString(node.resolve(ArtifactPath.MANIFEST_FILE),
+                "{\"structure\": {\"status\": \"complete\", \"taskInput\": {}, \"pages\": "
+                        + "{\"total\": 2147483647, \"pagination\": {\"type\": \"filesystem\"}}}}");
+        assertThat(markdownSearch().search("data")).isNull();
+    }
+
+    @Test
+    public void test_a_page_missing_on_disk_is_reported_as_unscanned() throws Exception {
+        Path node = writePages("md", "data", "data", "data");
+        Files.delete(ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, 2, "md"));
+        completeManifest(3);
+        // Without this the client cannot tell a genuine 2 from a 3 that lost a page: both answer 200
+        // with the same body, so a degraded artifact reads as an authoritative count.
+        StructureSearch.Hits hits = markdownSearch().search("data");
+        assertThat(hits.pages()).isEqualTo(3);
+        assertThat(hits.scanned()).isEqualTo(2);
+    }
+
+    @Test
+    public void test_a_page_that_cannot_be_read_does_not_fail_the_whole_search() throws Exception {
+        Path node = writePages("md", "data", "data", "data");
+        Path page = ArtifactPath.payloadPage(node, ArtifactType.STRUCTURE, 2, "md");
+        Files.delete(page);
+        // A directory where a page file belongs: isReadable passes and readAllBytes throws, standing in
+        // for the mid-scan permission change a unit test cannot stage. Unhandled, one page 500s the lot.
+        Files.createDirectory(page);
+        completeManifest(3);
+        StructureSearch.Hits hits = markdownSearch().search("data");
+        assertThat(hits.count()).isEqualTo(2);
+        assertThat(hits.scanned()).isEqualTo(2);
+    }
+
+    @Test
+    public void test_every_page_read_counts_as_scanned() throws Exception {
+        writePages("md", "data", "nothing here");
+        completeManifest(2);
+        StructureSearch.Hits hits = markdownSearch().search("data");
+        assertThat(hits.pages()).isEqualTo(2);
+        assertThat(hits.scanned()).isEqualTo(2);
+    }
+
     @Test
     public void test_search_is_null_when_the_format_is_absent_from_disk() throws Exception {
         writePages("md", "data");

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -350,7 +350,8 @@ public class StructureMarkdownExtractorTest {
         // The exact metadata shapes Tika hands shouldParseEmbedded: a mail's own text part carries no
         // resourceName, while an attachment, a zip entry and a PST mail item are documents in their own
         // right.
-        DocumentSelector selector = StructureMarkdownExtractor.buildParseContext(OcrSettings.NONE).get(DocumentSelector.class);
+        DocumentSelector selector =
+                StructureMarkdownExtractor.buildParseContext(OcrSettings.NONE).get(DocumentSelector.class);
 
         assertThat(selector.select(partMetadata(null, "text/plain"))).isTrue();
         assertThat(selector.select(partMetadata(null, "text/html; charset=UTF-8"))).isTrue();

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -20,6 +20,7 @@ import org.apache.tika.metadata.TikaCoreProperties;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.ocr.TesseractOCRConfig;
 import org.apache.tika.parser.pdf.PDFParserConfig;
+import org.icij.datashare.text.structure.StructureMarkdownExtractor.OcrSettings;
 import org.icij.datashare.text.structure.StructureMarkdownExtractor.Page;
 import org.jsoup.Jsoup;
 import org.jsoup.parser.Parser;
@@ -50,7 +51,7 @@ public class StructureMarkdownExtractorTest {
 
     private List<Page> extract(StructureMarkdownExtractor extractor, InputStream source, String contentType)
             throws Exception {
-        return extractor.extract(source, contentType, null);
+        return extractor.extract(source, contentType, null, OcrSettings.NONE);
     }
 
     private ByteArrayInputStream stream(String s) {
@@ -104,7 +105,7 @@ public class StructureMarkdownExtractorTest {
     // Both hints a real Markdown document carries: the content type Tika detected at INDEX time and
     // the resource name from its metadata.
     private Page markdownPage(String source) throws Exception {
-        return extractor.extract(stream(source), "text/x-web-markdown", "README.md").get(0);
+        return extractor.extract(stream(source), "text/x-web-markdown", "README.md", OcrSettings.NONE).get(0);
     }
 
     @Test
@@ -349,7 +350,7 @@ public class StructureMarkdownExtractorTest {
         // The exact metadata shapes Tika hands shouldParseEmbedded: a mail's own text part carries no
         // resourceName, while an attachment, a zip entry and a PST mail item are documents in their own
         // right.
-        DocumentSelector selector = StructureMarkdownExtractor.buildParseContext().get(DocumentSelector.class);
+        DocumentSelector selector = StructureMarkdownExtractor.buildParseContext(OcrSettings.NONE).get(DocumentSelector.class);
 
         assertThat(selector.select(partMetadata(null, "text/plain"))).isTrue();
         assertThat(selector.select(partMetadata(null, "text/html; charset=UTF-8"))).isTrue();
@@ -516,11 +517,24 @@ public class StructureMarkdownExtractorTest {
 
     @Test
     public void test_parse_context_disables_ocr_for_both_pdf_and_standalone_images() {
-        ParseContext context = StructureMarkdownExtractor.buildParseContext();
+        ParseContext context = StructureMarkdownExtractor.buildParseContext(OcrSettings.NONE);
 
         assertThat(context.get(PDFParserConfig.class).getOcrStrategy())
                 .isEqualTo(PDFParserConfig.OCR_STRATEGY.NO_OCR);
         assertThat(context.get(TesseractOCRConfig.class).isSkipOcr()).isTrue();
+    }
+
+    @Test
+    public void test_parse_context_applies_the_ocr_the_caller_asks_for() {
+        // Both configs, because two parsers are involved: PDFParserConfig governs a scanned PDF page and
+        // TesseractOCRConfig governs a standalone image, which the PDF one never reaches. A document
+        // indexed with OCR whose pages render empty is the whole reason this is a parameter.
+        ParseContext context = StructureMarkdownExtractor.buildParseContext(
+                new OcrSettings(true, PDFParserConfig.OCR_STRATEGY.OCR_AND_TEXT_EXTRACTION));
+
+        assertThat(context.get(PDFParserConfig.class).getOcrStrategy())
+                .isEqualTo(PDFParserConfig.OCR_STRATEGY.OCR_AND_TEXT_EXTRACTION);
+        assertThat(context.get(TesseractOCRConfig.class).isSkipOcr()).isFalse();
     }
 
     @Test
@@ -537,8 +551,8 @@ public class StructureMarkdownExtractorTest {
             throws Exception {
         // isMarkdown reads the type Tika detected, not the caller's hint: a mismatched or generic hint
         // (an embedded .md arriving with its container's type, for instance) must not turn the branch off.
-        Page page = extractor.extract(stream("Some **bold** text.\n"), "application/octet-stream", "README.md")
-                .get(0);
+        Page page = extractor.extract(stream("Some **bold** text.\n"), "application/octet-stream", "README.md",
+                OcrSettings.NONE).get(0);
 
         assertThat(page.markdown()).contains("**bold**");
     }


### PR DESCRIPTION
Adds an in-document search over a document's persisted structure pages, counting a query's occurrences per page the way `/documents/searchContent` counts them over the indexed content.

- feat: add `GET /:project/artifacts/structure/search/:id`, answering `{count, pages, scanned, hits}`
- feat: port the `searchOccurrences.painless.java` folding rules to Java, with a test pinning the script so the two counters cannot drift apart
- fix: render structure pages with the OCR the document was indexed with, and record it in the artifact fingerprint
- fix: bound the page total a manifest can advertise, so a total written by another producer cannot become an unbounded loop
- fix: count an unreadable page as unscanned rather than failing the whole search, and log it once per scan instead of once per page
- chore: the OCR fingerprint gains `ocr` and `ocrStrategy`, so every existing structure artifact is stale and the next ARTIFACT run re-extracts


### How it works, and what it does not do

The scan reads one `page-N.md` at a time and folds it with the rules ported from `searchOccurrences.painless.java`, so the endpoint and `/documents/searchContent` fold text identically. Occurrences are counted per page with `indexOf` stepping by the raw query length, and summed. Work is linear in pages, capped by a 10s budget: `scanned` below `pages` means the count is a floor, not a total.

Known limits, all deliberate:

- Counts the stored Markdown, not the indexed content, so flexmark escaping, table pipes and link URLs are part of the searched text. XHTML is rejected for this reason.
- A match straddling a page break counts zero here and one in Elasticsearch, which scans the concatenated `content` field.
- Original language only: structure pages are rendered from the source bytes, so there is no `targetLanguage`.
- A scanned PDF renders empty unless the run passes `--ocrStrategy`, which is the same condition under which INDEX extracted nothing from it.
