### PR TITLE
fix(artifacts): parse a Markdown source as Markdown

### DIFF
--- a/datashare-index/pom.xml
+++ b/datashare-index/pom.xml
@@ -46,6 +46,18 @@
             <artifactId>flexmark-html2md-converter</artifactId>
         </dependency>
         <dependency>
+            <!-- Used directly by StructureMarkdownExtractor to parse a Markdown source before the
+                 html2md pass; only pulled in transitively today via flexmark-html2md-converter, so
+                 declare it explicitly. No version: the root dependencyManagement pin governs it. -->
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark</artifactId>
+        </dependency>
+        <dependency>
+            <!-- GFM tables in a Markdown source. Same transitive-but-used case as flexmark above. -->
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-ext-tables</artifactId>
+        </dependency>
+        <dependency>
             <!-- Used directly by StructureMarkdownExtractor; only pulled in transitively today via
                  flexmark, so declare it explicitly. No version: the root dependencyManagement pin
                  (1.22.1, matching Tika's expected jsoup) governs it. -->

--- a/datashare-index/pom.xml
+++ b/datashare-index/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>flexmark-ext-tables</artifactId>
         </dependency>
         <dependency>
+            <!-- GFM strikethrough in a Markdown source. Same transitive-but-used case. -->
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-ext-gfm-strikethrough</artifactId>
+        </dependency>
+        <dependency>
             <!-- Used directly by StructureMarkdownExtractor; only pulled in transitively today via
                  flexmark, so declare it explicitly. No version: the root dependencyManagement pin
                  (1.22.1, matching Tika's expected jsoup) governs it. -->

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -105,6 +105,7 @@ public class StructureMarkdownExtractor {
     private static final FlexmarkHtmlConverter MARKDOWN_CONVERTER = FlexmarkHtmlConverter.builder(
             new MutableDataSet()
                     .set(FlexmarkHtmlConverter.SETEXT_HEADINGS, false)
+                    .set(FlexmarkHtmlConverter.UNORDERED_LIST_DELIMITER, '-')
                     .set(FlexmarkHtmlConverter.MAX_BLANK_LINES, 1)).build();
 
     // Tika has no Markdown parser: a Markdown document goes through TextAndCSVParser, which hands back

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -60,7 +60,11 @@ public class StructureMarkdownExtractor {
     // image ("//host/pixel.png" passes). A link target stays, since rendering a page does not follow it.
     // A <del> is added because a Markdown source's "~~struck~~" parses to one and Safelist.relaxed()
     // has no del: it carries no attributes and no active content, and the client's own sanitizer allows it.
+    // "class" on a <code> only, so a fenced block keeps the language the converter needs to write
+    // the fence back. A class name is inert without an attacker-supplied stylesheet, and jsoup cannot
+    // filter attribute values, so this admits any class name on that one tag.
     private static final Safelist SAFELIST = Safelist.relaxed().removeTags("u").addTags("del")
+            .addAttributes("code", "class")
             .removeAttributes("img", "src").preserveRelativeLinks(true);
 
     // Pretty-printing would bake jsoup's indentation into the stored XHTML, so the page bytes would

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Converts a document's source bytes into a per-page rendering of its structure. Pipeline: Tika XHTML
@@ -59,11 +60,14 @@ public class StructureMarkdownExtractor {
     // reader's IP and which document they opened, and no protocol allowlist can tell one from a benign
     // image ("//host/pixel.png" passes). A link target stays, since rendering a page does not follow it.
     // A <del> is added because a Markdown source's "~~struck~~" parses to one and Safelist.relaxed()
-    // has no del: it carries no attributes and no active content, and the client's own sanitizer allows it.
-    // "class" on a <code> only, so a fenced block keeps the language the converter needs to write
-    // the fence back. A class name is inert without an attacker-supplied stylesheet, and jsoup cannot
-    // filter attribute values, so this admits any class name on that one tag.
-    private static final Safelist SAFELIST = Safelist.relaxed().removeTags("u").addTags("del")
+    // has no del. An <hr> is added for the same reason a "---" thematic break parses to: like <del>,
+    // it is formatting-only, carries no attributes and no active content, and is common in real
+    // READMEs. Both are allowed because the client's own sanitizer allows them too.
+    // "class" on a <code> only, so a fenced block keeps the language the converter needs to write the
+    // fence back. jsoup cannot filter attribute values, and html2md writes this one straight into the
+    // markdown fence info string with no re-sanitization after (see keepOnlyLanguageClass), so what
+    // reaches Jsoup.clean is already reduced to a single recognized language token or nothing.
+    private static final Safelist SAFELIST = Safelist.relaxed().removeTags("u").addTags("del", "hr")
             .addAttributes("code", "class")
             .removeAttributes("img", "src").preserveRelativeLinks(true);
 
@@ -102,17 +106,21 @@ public class StructureMarkdownExtractor {
     }
 
     // Stateless once built; build once rather than per page.
+    // THEMATIC_BREAK is pinned to "---" for the same reason as the list delimiter below: the default
+    // ("*** ** * ** ***") is not what a "---" in a Markdown source round-trips to otherwise.
     private static final FlexmarkHtmlConverter MARKDOWN_CONVERTER = FlexmarkHtmlConverter.builder(
             new MutableDataSet()
                     .set(FlexmarkHtmlConverter.SETEXT_HEADINGS, false)
                     .set(FlexmarkHtmlConverter.UNORDERED_LIST_DELIMITER, '-')
+                    .set(FlexmarkHtmlConverter.THEMATIC_BREAK, "---")
                     .set(FlexmarkHtmlConverter.MAX_BLANK_LINES, 1)).build();
 
     // Tika has no Markdown parser: a Markdown document goes through TextAndCSVParser, which hands back
     // the whole file as a single literal text node, so every "**" reaching the converter above is text
     // and comes out escaped as "\*\*". Parsing that text as Markdown first makes it real elements, which
-    // the converter then writes back unescaped. Tables are on because the converter renders them back as
-    // GFM tables and would otherwise see a wall of escaped pipes.
+    // the converter then writes back unescaped. Tables and strikethrough are both on because the
+    // converter renders them back as GFM syntax (a table, "~~struck~~") and would otherwise see a wall
+    // of escaped pipes or literal tildes.
     private static final MutableDataSet MARKDOWN_OPTIONS = new MutableDataSet()
             .set(com.vladsch.flexmark.parser.Parser.EXTENSIONS,
                     List.of(TablesExtension.create(), StrikethroughExtension.create()));
@@ -295,11 +303,14 @@ public class StructureMarkdownExtractor {
     }
 
     /**
-     * Sanitizes one page (live jsoup DOM) to a safe Markdown-ready HTML subset (see SAFELIST). Empty
-     * paragraphs are removed first so they do not survive conversion as stray "<br />" noise.
+     * Sanitizes one page (live jsoup DOM) to a safe Markdown-ready HTML subset (see SAFELIST). Two
+     * pre-passes run before Jsoup.clean: empty paragraphs are removed so they do not survive conversion
+     * as stray "<br />" noise, and a code block's class is reduced to a single language token so nothing
+     * jsoup lets through unfiltered reaches the fence info string html2md writes from it.
      */
     String sanitize(Element page) {
         removeEmptyParagraphs(page);
+        keepOnlyLanguageClass(page);
         // A detached page has no output settings of its own and would serialize with jsoup's
         // pretty-printing defaults. Moving rather than copying: the nodes are not held twice, at the
         // cost of emptying the argument, which each page is only handed to once.
@@ -316,6 +327,21 @@ public class StructureMarkdownExtractor {
             if (isBlankParagraph(paragraph)) {
                 paragraph.remove();
             }
+        }
+    }
+
+    // A code class is an unsanitized channel: jsoup cannot filter an attribute's value, and html2md
+    // writes this one verbatim into the markdown fence info string with no re-sanitization afterward.
+    // A value holding a newline and a closing fence would otherwise close the fence early and drop the
+    // rest of the value in as a raw HTML block at the top level. classNames() splits on whitespace, so
+    // a newline inside the value cannot survive into a kept token.
+    private static final Pattern LANGUAGE_CLASS = Pattern.compile("language-[\\w.+#-]+");
+
+    private static void keepOnlyLanguageClass(Element page) {
+        for (Element code : page.select("code[class]")) {
+            String language = code.classNames().stream().filter(c -> LANGUAGE_CLASS.matcher(c).matches())
+                    .findFirst().orElse(null);
+            if (language == null) code.removeAttr("class"); else code.attr("class", language);
         }
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text.structure;
 
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
@@ -57,7 +58,9 @@ public class StructureMarkdownExtractor {
     // everything but its src: a stored page is rendered, so a remote image is a beacon reporting the
     // reader's IP and which document they opened, and no protocol allowlist can tell one from a benign
     // image ("//host/pixel.png" passes). A link target stays, since rendering a page does not follow it.
-    private static final Safelist SAFELIST = Safelist.relaxed().removeTags("u")
+    // A <del> is added because a Markdown source's "~~struck~~" parses to one and Safelist.relaxed()
+    // has no del: it carries no attributes and no active content, and the client's own sanitizer allows it.
+    private static final Safelist SAFELIST = Safelist.relaxed().removeTags("u").addTags("del")
             .removeAttributes("img", "src").preserveRelativeLinks(true);
 
     // Pretty-printing would bake jsoup's indentation into the stored XHTML, so the page bytes would
@@ -106,7 +109,8 @@ public class StructureMarkdownExtractor {
     // the converter then writes back unescaped. Tables are on because the converter renders them back as
     // GFM tables and would otherwise see a wall of escaped pipes.
     private static final MutableDataSet MARKDOWN_OPTIONS = new MutableDataSet()
-            .set(com.vladsch.flexmark.parser.Parser.EXTENSIONS, List.of(TablesExtension.create()));
+            .set(com.vladsch.flexmark.parser.Parser.EXTENSIONS,
+                    List.of(TablesExtension.create(), StrikethroughExtension.create()));
 
     private static final com.vladsch.flexmark.parser.Parser MARKDOWN_PARSER =
             com.vladsch.flexmark.parser.Parser.builder(MARKDOWN_OPTIONS).build();

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.text.structure;
 
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
 import com.vladsch.flexmark.util.data.MutableDataSet;
 import org.apache.tika.config.TikaConfig;
@@ -98,6 +100,24 @@ public class StructureMarkdownExtractor {
                     .set(FlexmarkHtmlConverter.SETEXT_HEADINGS, false)
                     .set(FlexmarkHtmlConverter.MAX_BLANK_LINES, 1)).build();
 
+    // Tika has no Markdown parser: a Markdown document goes through TextAndCSVParser, which hands back
+    // the whole file as a single literal text node, so every "**" reaching the converter above is text
+    // and comes out escaped as "\*\*". Parsing that text as Markdown first makes it real elements, which
+    // the converter then writes back unescaped. Tables are on because the converter renders them back as
+    // GFM tables and would otherwise see a wall of escaped pipes.
+    private static final MutableDataSet MARKDOWN_OPTIONS = new MutableDataSet()
+            .set(com.vladsch.flexmark.parser.Parser.EXTENSIONS, List.of(TablesExtension.create()));
+
+    private static final com.vladsch.flexmark.parser.Parser MARKDOWN_PARSER =
+            com.vladsch.flexmark.parser.Parser.builder(MARKDOWN_OPTIONS).build();
+
+    private static final HtmlRenderer MARKDOWN_RENDERER = HtmlRenderer.builder(MARKDOWN_OPTIONS).build();
+
+    // Tika 3.3.0 detects Markdown as text/x-web-markdown; the other two are the IANA name (RFC 7763)
+    // and its legacy alias, so a rename upstream does not silently switch this off.
+    private static final Set<String> MARKDOWN_TYPES =
+            Set.of("text/x-web-markdown", "text/markdown", "text/x-markdown");
+
     private static final Set<String> INLINE_BODY_TYPES = Set.of("text/plain", "text/html");
 
     public record Page(String xhtml, String markdown) {}
@@ -109,7 +129,12 @@ public class StructureMarkdownExtractor {
      */
     public List<Page> extract(InputStream source, String contentType, String filename)
             throws IOException, SAXException, TikaException {
-        org.jsoup.nodes.Document document = Jsoup.parse(toXhtml(source, contentType, filename));
+        // Kept rather than built inside toXhtml: the parse fills it with the type Tika detected.
+        Metadata metadata = buildMetadata(contentType, filename);
+        org.jsoup.nodes.Document document = Jsoup.parse(toXhtml(source, metadata));
+        if (isMarkdown(metadata)) {
+            document = parseAsMarkdown(document);
+        }
         List<Page> pages = new ArrayList<>();
         for (Element page : selectRootPages(document)) {
             // Both formats come from the same DOM, so they can never disagree about a page's content.
@@ -118,6 +143,21 @@ public class StructureMarkdownExtractor {
             pages.add(new Page(serializeAsXhtml(sanitized), markdown));
         }
         return pages;
+    }
+
+    // The type Tika settled on rather than the caller's hint: AutoDetectParser writes what it detected
+    // into the metadata it is given, so an embedded .md arriving with its container's generic type is
+    // recognised here too.
+    private static boolean isMarkdown(Metadata metadata) {
+        return MARKDOWN_TYPES.contains(baseContentType(metadata));
+    }
+
+    // Replaces Tika's single-text-node rendering with a DOM parsed from the Markdown that node holds.
+    // Nothing downstream knows the difference: page selection, the safelist and the converter run on it
+    // exactly as they run on a parser's own XHTML.
+    private static org.jsoup.nodes.Document parseAsMarkdown(org.jsoup.nodes.Document tikaOutput) {
+        Element body = tikaOutput.body() != null ? tikaOutput.body() : tikaOutput;
+        return Jsoup.parse(MARKDOWN_RENDERER.render(MARKDOWN_PARSER.parse(body.wholeText())));
     }
 
     /**
@@ -178,18 +218,20 @@ public class StructureMarkdownExtractor {
         return page.html();
     }
 
-    String toXhtml(InputStream source, String contentType, String filename)
+    String toXhtml(InputStream source, Metadata metadata)
             throws IOException, SAXException, TikaException {
         ToXMLContentHandler xhtmlHandler = new ToXMLContentHandler();
         new AutoDetectParser(RESILIENT_PARSER).parse(source,
                 new WriteOutContentHandler(xhtmlHandler, maxOutputChars),
-                buildMetadata(contentType, filename), buildParseContext());
+                metadata, buildParseContext());
         return xhtmlHandler.toString();
     }
 
     // The two hints Tika's detector takes, both as deterministic as the bytes themselves. A generic
     // application/octet-stream type (common for embedded nodes) would mislead detection rather than help
-    // it, so only a specific one is passed on; the filename is passed as it is.
+    // it, so only a specific one is passed on; the filename is passed as it is. The caller keeps the
+    // instance: AutoDetectParser writes the type it detected into it, which is what decides whether the
+    // Markdown branch above applies.
     static Metadata buildMetadata(String contentType, String filename) {
         Metadata metadata = new Metadata();
         if (isSpecificContentType(contentType)) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -59,10 +59,8 @@ public class StructureMarkdownExtractor {
     // everything but its src: a stored page is rendered, so a remote image is a beacon reporting the
     // reader's IP and which document they opened, and no protocol allowlist can tell one from a benign
     // image ("//host/pixel.png" passes). A link target stays, since rendering a page does not follow it.
-    // A <del> is added because a Markdown source's "~~struck~~" parses to one and Safelist.relaxed()
-    // has no del. An <hr> is added for the same reason a "---" thematic break parses to: like <del>,
-    // it is formatting-only, carries no attributes and no active content, and is common in real
-    // READMEs. Both are allowed because the client's own sanitizer allows them too.
+    // A Markdown source's "~~struck~~" and "---" parse to <del> and <hr>, which relaxed() has neither
+    // of: both are formatting-only, carry no attributes and no active content, so both are added.
     // "class" on a <code> only, so a fenced block keeps the language the converter needs to write the
     // fence back. jsoup cannot filter attribute values, and html2md writes this one straight into the
     // markdown fence info string with no re-sanitization after (see keepOnlyLanguageClass), so what
@@ -105,9 +103,9 @@ public class StructureMarkdownExtractor {
         this.maxOutputChars = maxOutputChars;
     }
 
-    // Stateless once built; build once rather than per page.
-    // THEMATIC_BREAK is pinned to "---" for the same reason as the list delimiter below: the default
-    // ("*** ** * ** ***") is not what a "---" in a Markdown source round-trips to otherwise.
+    // Stateless once built; build once rather than per page. The list delimiter and thematic break are
+    // pinned to what a Markdown source writes them as, since flexmark's defaults ("*", and
+    // "*** ** * ** ***") would rewrite a README's own syntax on the way back out.
     private static final FlexmarkHtmlConverter MARKDOWN_CONVERTER = FlexmarkHtmlConverter.builder(
             new MutableDataSet()
                     .set(FlexmarkHtmlConverter.SETEXT_HEADINGS, false)
@@ -130,10 +128,10 @@ public class StructureMarkdownExtractor {
 
     private static final HtmlRenderer MARKDOWN_RENDERER = HtmlRenderer.builder(MARKDOWN_OPTIONS).build();
 
-    // Tika 3.3.0 detects Markdown as text/x-web-markdown; the other two are the IANA name (RFC 7763)
-    // and its legacy alias, so a rename upstream does not silently switch this off.
-    private static final Set<String> MARKDOWN_TYPES =
-            Set.of("text/x-web-markdown", "text/markdown", "text/x-markdown");
+    // What Tika 3.3.0 detects Markdown as. The IANA name (text/markdown, RFC 7763) is deliberately not
+    // listed too: Tika never emits it, so it would be an untested branch standing in for a rename that
+    // has not happened.
+    private static final String MARKDOWN_TYPE = "text/x-web-markdown";
 
     private static final Set<String> INLINE_BODY_TYPES = Set.of("text/plain", "text/html");
 
@@ -166,15 +164,14 @@ public class StructureMarkdownExtractor {
     // into the metadata it is given, so an embedded .md arriving with its container's generic type is
     // recognised here too.
     private static boolean isMarkdown(Metadata metadata) {
-        return MARKDOWN_TYPES.contains(baseContentType(metadata));
+        return MARKDOWN_TYPE.equals(baseContentType(metadata));
     }
 
     // Replaces Tika's single-text-node rendering with a DOM parsed from the Markdown that node holds.
     // Nothing downstream knows the difference: page selection, the safelist and the converter run on it
     // exactly as they run on a parser's own XHTML.
     private static org.jsoup.nodes.Document parseAsMarkdown(org.jsoup.nodes.Document tikaOutput) {
-        Element body = tikaOutput.body() != null ? tikaOutput.body() : tikaOutput;
-        return Jsoup.parse(MARKDOWN_RENDERER.render(MARKDOWN_PARSER.parse(body.wholeText())));
+        return Jsoup.parse(MARKDOWN_RENDERER.render(MARKDOWN_PARSER.parse(tikaOutput.body().wholeText())));
     }
 
     /**

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -112,7 +112,7 @@ public class StructureArtifactTest {
                 + "<ul>\t<li>one</li>\n\t<li>two</li>\n</ul>\n"
                 + "<p><a href=\"page2.html\">next</a></p>\n\n<p>clean</p>\n</body></html>");
         assertThat(readPage(1, "md")).isEqualTo("# Title\n\nplain **bold** and *it* and under\n\n"
-                + "* one\n* two\n\n[next](page2.html)\n\nclean");
+                + "- one\n- two\n\n[next](page2.html)\n\nclean");
         assertThat(readPage(2, "xhtml")).isEqualTo("<html xmlns=\"http://www.w3.org/1999/xhtml\">"
                 + "<head></head><body><table><tbody><tr>\t<th>head</th></tr>\n"
                 + "<tr>\t<td>cell</td></tr>\n</tbody></table>\n\n\n</body></html>");

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -133,7 +133,7 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
-    public void test_unordered_lists_keep_the_dash_marker_a_markdown_source_used() throws Exception {
+    public void test_unordered_lists_keep_the_dash_marker_of_the_markdown_source() throws Exception {
         Page page = markdownPage("- one\n- two\n");
 
         assertThat(page.markdown()).contains("- one");
@@ -182,6 +182,29 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
+    public void test_an_unsanitized_code_class_cannot_break_out_of_the_markdown_fence() throws Exception {
+        // jsoup cannot filter an attribute's value, and html2md writes a <code> class verbatim into the
+        // fence info string with no re-sanitization after: a class holding a newline, a closing fence and
+        // markup closes the fence early and drops the rest in as a raw HTML block.
+        Page page = extract(stream(
+                "<pre><code class=\"js&#10;```&#10;&lt;img src=x onerror=alert(1)&gt;&#10;\">code</code></pre>"),
+                "text/html").get(0);
+
+        assertThat(page.markdown()).excludes("onerror");
+        assertThat(page.markdown()).excludes("<img");
+    }
+
+    @Test
+    public void test_a_multi_class_highlighter_does_not_produce_a_garbage_fence_info_string() throws Exception {
+        // A real highlighter class (hljs, sourceCode, a language name) has no "language-" prefix, so kept
+        // verbatim it would produce a fence info string no renderer understands.
+        Page page = extract(stream("<pre><code class=\"hljs sourceCode python\">code</code></pre>"),
+                "text/html").get(0);
+
+        assertThat(page.markdown()).excludes("hljs sourceCode python");
+    }
+
+    @Test
     public void test_a_gfm_table_in_a_markdown_source_survives_the_round_trip() throws Exception {
         Page page = markdownPage("| a | b |\n|---|---|\n| 1 | 2 |\n");
 
@@ -196,6 +219,14 @@ public class StructureMarkdownExtractorTest {
 
         assertThat(page.xhtml()).contains("<del>struck</del>");
         assertThat(page.markdown()).contains("~~struck~~");
+    }
+
+    @Test
+    public void test_a_thematic_break_in_a_markdown_source_survives_the_round_trip() throws Exception {
+        Page page = markdownPage("a\n\n---\n\nb\n");
+
+        assertThat(page.xhtml()).contains("<hr");
+        assertThat(page.markdown()).contains("---");
     }
 
     @Test
@@ -518,6 +549,17 @@ public class StructureMarkdownExtractorTest {
         List<Page> pages = extract(
                 stream("<html><body><h1>Detected</h1></body></html>"), "application/octet-stream");
         assertThat(pages.get(0).markdown()).contains("# Detected");
+    }
+
+    @Test
+    public void test_a_generic_content_type_hint_with_a_markdown_filename_still_takes_the_markdown_branch()
+            throws Exception {
+        // isMarkdown reads the type Tika detected, not the caller's hint: a mismatched or generic hint
+        // (an embedded .md arriving with its container's type, for instance) must not turn the branch off.
+        Page page = extractor.extract(stream("Some **bold** text.\n"), "application/octet-stream", "README.md")
+                .get(0);
+
+        assertThat(page.markdown()).contains("**bold**");
     }
 
     private byte[] zipContaining(String entryName, String content) throws Exception {

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -175,6 +175,14 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
+    public void test_strikethrough_in_a_markdown_source_survives_as_markup() throws Exception {
+        Page page = markdownPage("~~struck~~ and kept.\n");
+
+        assertThat(page.xhtml()).contains("<del>struck</del>");
+        assertThat(page.markdown()).contains("~~struck~~");
+    }
+
+    @Test
     public void test_plain_text_still_escapes_markdown_metacharacters() throws Exception {
         // Not a markup language: a literal "**" in a .txt must stay literal, so the branch above it
         // must not widen to every text/* type.

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -101,6 +101,97 @@ public class StructureMarkdownExtractorTest {
         assertThat(page.markdown()).excludes("alert");
     }
 
+    // Both hints a real Markdown document carries: the content type Tika detected at INDEX time and
+    // the resource name from its metadata.
+    private Page markdownPage(String source) throws Exception {
+        return extractor.extract(stream(source), "text/x-web-markdown", "README.md").get(0);
+    }
+
+    @Test
+    public void test_a_markdown_source_is_parsed_as_markdown_not_as_literal_text() throws Exception {
+        Page page = markdownPage("# Title\n\nSome **bold** and `code`.\n");
+
+        assertThat(page.markdown()).contains("# Title");
+        assertThat(page.markdown()).contains("**bold**");
+        assertThat(page.markdown()).contains("`code`");
+        // The bug: a Markdown source reaches the converter as one text node, so every metacharacter
+        // in it comes back backslash-escaped.
+        assertThat(page.markdown()).excludes("\\*");
+        assertThat(page.markdown()).excludes("\\`");
+        assertThat(page.xhtml()).contains("<h1>Title</h1>");
+        assertThat(page.xhtml()).contains("<strong>bold</strong>");
+    }
+
+    @Test
+    public void test_markdown_lists_and_links_survive_without_escaping() throws Exception {
+        Page page = markdownPage("- item one\n- item two\n\nA [link](http://example.com).\n");
+
+        assertThat(page.markdown()).contains("item one");
+        assertThat(page.markdown()).contains("[link](http://example.com)");
+        assertThat(page.markdown()).excludes("\\[");
+        assertThat(page.xhtml()).contains("<li>item one</li>");
+    }
+
+    @Test
+    public void test_raw_html_in_a_markdown_source_is_sanitized_out_of_both_formats() throws Exception {
+        Page page = markdownPage("Real text.\n\n<script>alert(1)</script>\n");
+
+        // Today this survives as "\<script\>alert(1)\</script\>", inert only because of the escaping
+        // this change removes, so the safelist has to be what drops it.
+        assertThat(page.markdown()).excludes("alert");
+        assertThat(page.markdown()).excludes("script");
+        assertThat(page.xhtml()).excludes("script");
+        assertThat(page.markdown()).contains("Real text.");
+    }
+
+    @Test
+    public void test_a_markdown_image_and_a_javascript_link_lose_their_targets() throws Exception {
+        Page page = markdownPage("![shot](http://remote/x.png)\n\nA [bad](javascript:alert(1)) link.\n");
+
+        assertThat(page.xhtml()).excludes("http://remote/x.png");
+        assertThat(page.xhtml()).excludes("javascript:");
+        assertThat(page.markdown()).excludes("javascript:");
+        assertThat(page.markdown()).contains("bad");
+    }
+
+    @Test
+    public void test_a_fenced_code_block_keeps_its_content_including_html() throws Exception {
+        Page page = markdownPage("```bash\nls -l\n<script>in a fence</script>\n```\n");
+
+        // A code sample is content, not markup: it survives as text on both sides.
+        assertThat(page.markdown()).contains("ls -l");
+        assertThat(page.markdown()).contains("<script>in a fence</script>");
+        assertThat(page.xhtml()).contains("<pre>");
+        assertThat(page.xhtml()).contains("&lt;script&gt;in a fence&lt;/script&gt;");
+    }
+
+    @Test
+    public void test_a_gfm_table_in_a_markdown_source_survives_the_round_trip() throws Exception {
+        Page page = markdownPage("| a | b |\n|---|---|\n| 1 | 2 |\n");
+
+        assertThat(page.xhtml()).contains("<table>");
+        assertThat(page.markdown()).contains("| a | b |");
+        assertThat(page.markdown()).excludes("\\|");
+    }
+
+    @Test
+    public void test_plain_text_still_escapes_markdown_metacharacters() throws Exception {
+        // Not a markup language: a literal "**" in a .txt must stay literal, so the branch above it
+        // must not widen to every text/* type.
+        Page page = extract(stream("a **b** c"), "text/plain").get(0);
+
+        assertThat(page.markdown()).contains("\\*");
+        assertThat(page.xhtml()).excludes("<strong>");
+    }
+
+    @Test
+    public void test_markdown_extraction_is_deterministic() throws Exception {
+        String source = "# Title\n\n- one\n- two\n\n`code`\n";
+
+        assertThat(markdownPage(source).markdown()).isEqualTo(markdownPage(source).markdown());
+        assertThat(markdownPage(source).xhtml()).isEqualTo(markdownPage(source).xhtml());
+    }
+
     @Test
     public void test_underline_is_normalized_to_plain_text() throws Exception {
         Page page = extract(

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -166,6 +166,14 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
+    public void test_a_fenced_code_block_keeps_its_language() throws Exception {
+        Page page = markdownPage("```bash\nls -l\n```\n");
+
+        assertThat(page.xhtml()).contains("class=\"language-bash\"");
+        assertThat(page.markdown()).contains("```bash");
+    }
+
+    @Test
     public void test_a_gfm_table_in_a_markdown_source_survives_the_round_trip() throws Exception {
         Page page = markdownPage("| a | b |\n|---|---|\n| 1 | 2 |\n");
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -126,18 +126,12 @@ public class StructureMarkdownExtractorTest {
     public void test_markdown_lists_and_links_survive_without_escaping() throws Exception {
         Page page = markdownPage("- item one\n- item two\n\nA [link](http://example.com).\n");
 
-        assertThat(page.markdown()).contains("item one");
+        // The dash marker is the source's own: flexmark writes "*" unless it is pinned.
+        assertThat(page.markdown()).contains("- item one");
+        assertThat(page.markdown()).excludes("* item one");
         assertThat(page.markdown()).contains("[link](http://example.com)");
         assertThat(page.markdown()).excludes("\\[");
         assertThat(page.xhtml()).contains("<li>item one</li>");
-    }
-
-    @Test
-    public void test_unordered_lists_keep_the_dash_marker_of_the_markdown_source() throws Exception {
-        Page page = markdownPage("- one\n- two\n");
-
-        assertThat(page.markdown()).contains("- one");
-        assertThat(page.markdown()).excludes("* one");
     }
 
     @Test
@@ -163,22 +157,15 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
-    public void test_a_fenced_code_block_keeps_its_content_including_html() throws Exception {
+    public void test_a_fenced_code_block_keeps_its_language_and_its_content() throws Exception {
         Page page = markdownPage("```bash\nls -l\n<script>in a fence</script>\n```\n");
 
+        assertThat(page.markdown()).contains("```bash");
+        assertThat(page.xhtml()).contains("class=\"language-bash\"");
         // A code sample is content, not markup: it survives as text on both sides.
         assertThat(page.markdown()).contains("ls -l");
         assertThat(page.markdown()).contains("<script>in a fence</script>");
-        assertThat(page.xhtml()).contains("<pre>");
         assertThat(page.xhtml()).contains("&lt;script&gt;in a fence&lt;/script&gt;");
-    }
-
-    @Test
-    public void test_a_fenced_code_block_keeps_its_language() throws Exception {
-        Page page = markdownPage("```bash\nls -l\n```\n");
-
-        assertThat(page.xhtml()).contains("class=\"language-bash\"");
-        assertThat(page.markdown()).contains("```bash");
     }
 
     @Test
@@ -192,16 +179,6 @@ public class StructureMarkdownExtractorTest {
 
         assertThat(page.markdown()).excludes("onerror");
         assertThat(page.markdown()).excludes("<img");
-    }
-
-    @Test
-    public void test_a_multi_class_highlighter_does_not_produce_a_garbage_fence_info_string() throws Exception {
-        // A real highlighter class (hljs, sourceCode, a language name) has no "language-" prefix, so kept
-        // verbatim it would produce a fence info string no renderer understands.
-        Page page = extract(stream("<pre><code class=\"hljs sourceCode python\">code</code></pre>"),
-                "text/html").get(0);
-
-        assertThat(page.markdown()).excludes("hljs sourceCode python");
     }
 
     @Test
@@ -241,10 +218,14 @@ public class StructureMarkdownExtractorTest {
 
     @Test
     public void test_markdown_extraction_is_deterministic() throws Exception {
+        // The Markdown parser and renderer are shared statics, so this pins that they hold no state
+        // between documents, which the content-addressed cache depends on.
         String source = "# Title\n\n- one\n- two\n\n`code`\n";
+        Page first = markdownPage(source);
+        Page second = markdownPage(source);
 
-        assertThat(markdownPage(source).markdown()).isEqualTo(markdownPage(source).markdown());
-        assertThat(markdownPage(source).xhtml()).isEqualTo(markdownPage(source).xhtml());
+        assertThat(first.markdown()).isEqualTo(second.markdown());
+        assertThat(first.xhtml()).isEqualTo(second.xhtml());
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -133,6 +133,14 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
+    public void test_unordered_lists_keep_the_dash_marker_a_markdown_source_used() throws Exception {
+        Page page = markdownPage("- one\n- two\n");
+
+        assertThat(page.markdown()).contains("- one");
+        assertThat(page.markdown()).excludes("* one");
+    }
+
+    @Test
     public void test_raw_html_in_a_markdown_source_is_sanitized_out_of_both_formats() throws Exception {
         Page page = markdownPage("Real text.\n\n<script>alert(1)</script>\n");
 

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,18 @@
                 <version>${flexmark.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.vladsch.flexmark</groupId>
+                <artifactId>flexmark</artifactId>
+                <version>${flexmark.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.vladsch.flexmark</groupId>
+                <artifactId>flexmark-ext-tables</artifactId>
+                <version>${flexmark.version}</version>
+            </dependency>
+
             <!-- flexmark-html2md transitively pulls jsoup 1.15.4, which wins Maven mediation and
                  downgrades the jsoup that Tika 3.3.0 manages (1.22.1, per tika-parent). The older
                  jsoup lacks org.jsoup.parser.TagSet, so Tika's JSoupParser fails to instantiate, its

--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,12 @@
                 <version>${flexmark.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.vladsch.flexmark</groupId>
+                <artifactId>flexmark-ext-gfm-strikethrough</artifactId>
+                <version>${flexmark.version}</version>
+            </dependency>
+
             <!-- flexmark-html2md transitively pulls jsoup 1.15.4, which wins Maven mediation and
                  downgrades the jsoup that Tika 3.3.0 manages (1.22.1, per tika-parent). The older
                  jsoup lacks org.jsoup.parser.TagSet, so Tika's JSoupParser fails to instantiate, its


### PR DESCRIPTION
A document whose source is already Markdown produced a structure artifact full of backslashes (`\*\*bold\*\*`, `` \`code\` ``): Tika has no Markdown parser, so a `.md` file goes through `TextAndCSVParser` and arrives as one literal text node in a single `<p>`, which forces the html2md pass to escape every metacharacter in it. It now gets parsed as Markdown before the existing pipeline runs, so sanitization rather than escaping is what keeps the payload inert.

- fix: parse a Markdown source as Markdown instead of as literal text, keyed on the type Tika detected rather than the caller's hint
- fix: keep strikethrough as markup (`del` on the safelist, GFM strikethrough on the parser)
- fix: keep a fenced code block's language, and normalize `code[class]` so a crafted class cannot break out of the fence info string into raw HTML
- fix: keep thematic breaks, which the safelist was dropping silently
- refactor: write unordered lists with the dash marker
- test: 43 tests in `StructureMarkdownExtractorTest`, covering the escaping, the sanitization of raw HTML in a Markdown source, and the fence injection