### PR TITLE
fix: make the path banner DELETE and GET by path actually match stored banners

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/PathBannerResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/PathBannerResource.java
@@ -18,6 +18,7 @@ import org.icij.datashare.policies.Policy;
 import org.icij.datashare.policies.Role;
 import org.icij.datashare.session.DatashareUser;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -86,7 +87,7 @@ public class PathBannerResource {
     public List<PathBanner> getPathBanners(String project, String documentPath, Context context) {
         DatashareUser user = (DatashareUser) context.currentUser();
         forbiddenIfNotGranted(user.isGranted(project));
-        return repository.getPathBanners(project(project), documentPath);
+        return repository.getPathBanners(project(project), bannerPath(documentPath).toString());
     }
 
     @Operation(description = "Gets the list of notes for a project.",
@@ -115,7 +116,7 @@ public class PathBannerResource {
     public Payload savePathBanner(String project, String documentPath, PathBanner body, Context context) {
         DatashareUser user = (DatashareUser) context.currentUser();
         forbiddenIfNotGranted(user.isGranted(project));
-        PathBanner pathBanner = new PathBanner(project(project), Paths.get("/" + documentPath), body.note, body.variant, body.blurSensitiveMedia);
+        PathBanner pathBanner = new PathBanner(project(project), bannerPath(documentPath), body.note, body.variant, body.blurSensitiveMedia);
         return repository.save(pathBanner) ? created() : ok();
     }
 
@@ -123,9 +124,9 @@ public class PathBannerResource {
             Deletes path banners for a given project and path.
             
             By default, deletes the banner whose path matches exactly.
-            With `?greedy=true`, deletes every banner whose path starts with the given prefix
+            With `?greedy=true`, deletes the banner at the given path and every banner below it
             (subtree delete). For example, `DELETE /api/p1/pathBanners/a/b?greedy=true` removes
-            banners at `a/b`, `a/b/doc1`, `a/b/sub/doc2`, etc.
+            banners at `a/b`, `a/b/doc1`, `a/b/sub/doc2`, etc, but not the one at `a/bcd`.
             """,
             parameters = {
                     @Parameter(name = "project", description = "the project id", in = ParameterIn.PATH),
@@ -142,9 +143,9 @@ public class PathBannerResource {
         forbiddenIfNotGranted(user.isGranted(project));
         boolean isGreedy = "true".equals(context.query().get("greedy"));
         if (isGreedy) {
-            repository.deleteGreedyPathBanner(project(project), documentPath);
+            repository.deleteGreedyPathBanner(project(project), bannerPath(documentPath).toString());
         } else {
-            repository.deletePathBanner(project(project), documentPath);
+            repository.deletePathBanner(project(project), bannerPath(documentPath).toString());
         }
         return new Payload(NO_CONTENT);
     }
@@ -163,5 +164,10 @@ public class PathBannerResource {
         forbiddenIfNotGranted(user.isGranted(project));
         repository.deleteProjectPathBanners(project(project));
         return new Payload(NO_CONTENT);
+    }
+
+    // greedy route params never carry the leading slash, banners are stored with an absolute path
+    private static Path bannerPath(String documentPath) {
+        return Paths.get("/" + documentPath);
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/web/PathBannerResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/PathBannerResourceTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Paths;
 
 import static java.util.Collections.singletonList;
 import static org.icij.datashare.text.Project.project;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PathBannerResourceTest extends AbstractProdWebServerTest {
@@ -37,7 +38,7 @@ public class PathBannerResourceTest extends AbstractProdWebServerTest {
     @Test
     public void test_get_notes_for_path() {
         PathBanner pathBanner = new PathBanner(project("local-datashare"), Paths.get("/path/to/note"), "this is a note");
-        when(jooqRepository.getPathBanners(project("local-datashare"), "url")).thenReturn(singletonList(pathBanner));
+        when(jooqRepository.getPathBanners(project("local-datashare"), "/url")).thenReturn(singletonList(pathBanner));
         get("/api/local-datashare/pathBanners/url").should().respond(200).
                 contain("\"path\":\"/path/to/note\"").
                 contain("\"variant\":\"info\"").
@@ -91,20 +92,23 @@ public class PathBannerResourceTest extends AbstractProdWebServerTest {
 
     @Test
     public void test_delete_path_banner() {
-        when(jooqRepository.deletePathBanner(project("local-datashare"), "path/to/note")).thenReturn(true);
+        when(jooqRepository.deletePathBanner(project("local-datashare"), "/path/to/note")).thenReturn(true);
         delete("/api/local-datashare/pathBanners/path/to/note").should().respond(204);
+        verify(jooqRepository).deletePathBanner(project("local-datashare"), "/path/to/note");
     }
 
     @Test
     public void test_delete_greedy_path_banner() {
-        when(jooqRepository.deleteGreedyPathBanner(project("local-datashare"), "path/to/note")).thenReturn(true);
+        when(jooqRepository.deleteGreedyPathBanner(project("local-datashare"), "/path/to/note")).thenReturn(true);
         delete("/api/local-datashare/pathBanners/path/to/note?greedy=true").should().respond(204);
+        verify(jooqRepository).deleteGreedyPathBanner(project("local-datashare"), "/path/to/note");
     }
 
     @Test
     public void test_delete_project_path_banners() {
         when(jooqRepository.deleteProjectPathBanners(project("local-datashare"))).thenReturn(true);
-        delete("/api/local-datashare/pathBanners/path/to/note").should().respond(204);
+        delete("/api/local-datashare/pathBanners").should().respond(204);
+        verify(jooqRepository).deleteProjectPathBanners(project("local-datashare"));
     }
 
     @Before

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -479,7 +479,7 @@ public class JooqRepository implements Repository {
     public boolean deleteGreedyPathBanner(Project project, String path) {
         return using(connectionProvider, dialect).deleteFrom(PATH_BANNER)
                 .where(PATH_BANNER.PROJECT_ID.eq(project.getId()))
-                .and(PATH_BANNER.PATH.like(value(path).concat('%')))
+                .and(PATH_BANNER.PATH.eq(value(path)).or(PATH_BANNER.PATH.like(value(path).concat("/%"))))
                 .execute() > 0;
     }
 

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -526,6 +526,18 @@ public class JooqRepositoryTest {
     }
 
     @Test
+    public void test_delete_greedy_path_banner_stops_at_a_path_separator() {
+        repository.save(new PathBanner(project("project"), Paths.get("/path/to"), "this is note 1"));
+        repository.save(new PathBanner(project("project"), Paths.get("/path/to/note"), "this is note 2"));
+        repository.save(new PathBanner(project("project"), Paths.get("/path/toother"), "this is note 3"));
+
+        assertThat(repository.deleteGreedyPathBanner(project("project"), "/path/to")).isEqualTo(true);
+
+        assertThat(repository.getProjectPathBanners(project("project"))).
+                containsExactly(new PathBanner(project("project"), Paths.get("/path/toother"), "this is note 3"));
+    }
+
+    @Test
     public void test_delete_path_banners() {
         PathBanner pathBanner1 = new PathBanner(project("project"), Paths.get("/path"), "this is note 1");
         PathBanner pathBanner2 = new PathBanner(project("project"), Paths.get("/path/to/note"), "this is note 2");


### PR DESCRIPTION
PUT stored the banner path with a leading slash while GET and DELETE queried the raw route param, so neither ever matched. Closes #2334.

- fix(api): prepend the leading slash to the path banner route param in GET and DELETE, via a single `bannerPath` helper used by all three routes
- fix(db): stop the greedy delete at a path separator, so deleting `/a/b` no longer takes `/a/bcd` with it
- test(api): assert the path passed to the repository, the previous stubs only checked the status code, which is unconditional
- test(db): cover the greedy delete boundary with a sibling banner
- test(api): point `test_delete_project_path_banners` at the project route it names
- docs(api): describe the narrowed greedy delete