### PR TITLE
fix(redis): honour the rediss scheme when building the pool

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
@@ -3,6 +3,8 @@ package org.icij.datashare.session;
 import org.icij.datashare.PropertiesProvider;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
+import redis.clients.util.JedisURIHelper;
 
 import java.net.URI;
 
@@ -11,6 +13,7 @@ import static org.icij.datashare.cli.DatashareCliOptions.REDIS_ADDRESS_OPT;
 
 final class RedisPoolFactory {
     private static final long EVICTION_RUN_INTERVAL_MILLIS = 30_000;
+    private static final String SSL_SCHEME = "rediss";
 
     private RedisPoolFactory() {}
 
@@ -25,6 +28,15 @@ final class RedisPoolFactory {
         poolConfig.setTestWhileIdle(true);
         poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_RUN_INTERVAL_MILLIS);
         String redisAddress = propertiesProvider.get(REDIS_ADDRESS_OPT).orElse(DEFAULT_REDIS_ADDRESS);
-        return new JedisPool(poolConfig, URI.create(redisAddress));
+        URI uri = URI.create(redisAddress);
+        // Take the host and port apart rather than passing the URI. JedisPool's URI constructors
+        // hand JedisFactory a hardcoded ssl=false and never look at the scheme, so a rediss://
+        // address would connect in plaintext and every command would time out against a TLS-only
+        // server. JedisPool(String) reads the scheme, but it accepts no pool config, and the
+        // settings above are the point of this factory.
+        boolean ssl = SSL_SCHEME.equalsIgnoreCase(uri.getScheme());
+        int port = uri.getPort() == -1 ? Protocol.DEFAULT_PORT : uri.getPort();
+        return new JedisPool(poolConfig, uri.getHost(), port, Protocol.DEFAULT_TIMEOUT,
+                JedisURIHelper.getPassword(uri), JedisURIHelper.getDBIndex(uri), null, ssl);
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
@@ -28,8 +28,6 @@ final class RedisPoolFactory {
         poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_RUN_INTERVAL_MILLIS);
         String redisAddress = propertiesProvider.get(REDIS_ADDRESS_OPT).orElse(DEFAULT_REDIS_ADDRESS);
         URI uri = URI.create(redisAddress);
-        // JedisPool's URI constructors hardcode ssl=false, so a rediss:// address would connect
-        // in plaintext. Pass host and port instead, with ssl taken from the scheme.
         boolean ssl = "rediss".equalsIgnoreCase(uri.getScheme());
         int port = uri.getPort() == -1 ? Protocol.DEFAULT_PORT : uri.getPort();
         return new JedisPool(poolConfig, uri.getHost(), port, Protocol.DEFAULT_TIMEOUT,

--- a/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
@@ -4,6 +4,7 @@ import org.icij.datashare.PropertiesProvider;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.util.JedisURIHelper;
 
 import java.net.URI;
@@ -28,6 +29,9 @@ final class RedisPoolFactory {
         poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_RUN_INTERVAL_MILLIS);
         String redisAddress = propertiesProvider.get(REDIS_ADDRESS_OPT).orElse(DEFAULT_REDIS_ADDRESS);
         URI uri = URI.create(redisAddress);
+        if (uri.getHost() == null) {
+            throw new InvalidURIException("Cannot open Redis connection due invalid URI. " + redisAddress);
+        }
         boolean ssl = "rediss".equalsIgnoreCase(uri.getScheme());
         int port = uri.getPort() == -1 ? Protocol.DEFAULT_PORT : uri.getPort();
         return new JedisPool(poolConfig, uri.getHost(), port, Protocol.DEFAULT_TIMEOUT,

--- a/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
+++ b/datashare-app/src/main/java/org/icij/datashare/session/RedisPoolFactory.java
@@ -13,7 +13,6 @@ import static org.icij.datashare.cli.DatashareCliOptions.REDIS_ADDRESS_OPT;
 
 final class RedisPoolFactory {
     private static final long EVICTION_RUN_INTERVAL_MILLIS = 30_000;
-    private static final String SSL_SCHEME = "rediss";
 
     private RedisPoolFactory() {}
 
@@ -29,12 +28,9 @@ final class RedisPoolFactory {
         poolConfig.setTimeBetweenEvictionRunsMillis(EVICTION_RUN_INTERVAL_MILLIS);
         String redisAddress = propertiesProvider.get(REDIS_ADDRESS_OPT).orElse(DEFAULT_REDIS_ADDRESS);
         URI uri = URI.create(redisAddress);
-        // Take the host and port apart rather than passing the URI. JedisPool's URI constructors
-        // hand JedisFactory a hardcoded ssl=false and never look at the scheme, so a rediss://
-        // address would connect in plaintext and every command would time out against a TLS-only
-        // server. JedisPool(String) reads the scheme, but it accepts no pool config, and the
-        // settings above are the point of this factory.
-        boolean ssl = SSL_SCHEME.equalsIgnoreCase(uri.getScheme());
+        // JedisPool's URI constructors hardcode ssl=false, so a rediss:// address would connect
+        // in plaintext. Pass host and port instead, with ssl taken from the scheme.
+        boolean ssl = "rediss".equalsIgnoreCase(uri.getScheme());
         int port = uri.getPort() == -1 ? Protocol.DEFAULT_PORT : uri.getPort();
         return new JedisPool(poolConfig, uri.getHost(), port, Protocol.DEFAULT_TIMEOUT,
                 JedisURIHelper.getPassword(uri), JedisURIHelper.getDBIndex(uri), null, ssl);


### PR DESCRIPTION
Fixes #2346.

`JedisPool`'s URI constructors pass `JedisFactory` a hardcoded `ssl=false` and never read the scheme, so a `rediss://` address connects in plaintext and every command fails. `JedisPool(String)` does read the scheme but takes no pool config, which is what this factory exists to set, so this passes host and port with `ssl` explicit.

Verified against a TLS-required Redis, driving an unmodified `RedisSessionIdStore` with only this class replaced:

```
get(absent)     -> null
put then get    -> probe-user
remove then get -> null
```

`ssl` resolves to `false` for `redis://`, so plaintext deployments are unaffected. A missing port falls back to `Protocol.DEFAULT_PORT`, and password and database index still come from `JedisURIHelper`.