### PR TITLE
fix(search): route async search per index distribution

### DIFF
--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.web;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,6 +41,11 @@ import static net.codestory.http.payload.Payload.ok;
 @Prefix("/api/index")
 public class IndexResource {
     private static final Logger logger = LoggerFactory.getLogger(IndexResource.class);
+    private static final String OPENSEARCH_DISTRIBUTION = "opensearch";
+    private static final String ES_ASYNC_SEARCH_PATH = "_async_search";
+    private static final String OPENSEARCH_ASYNC_SEARCH_PATH = "_plugins/_asynchronous_search";
+    private static final String OPENSEARCH_RUNNING_STATE = "RUNNING";
+    private volatile Boolean openSearchBackend;
     private final Indexer indexer;
     private final AsyncSearchStore asyncSearchStore;
     private final ModeVerifier modeVerifier;
@@ -131,7 +137,14 @@ public class IndexResource {
     public Payload esPost(@Parameter(name = "index", description = "elasticsearch path", in = ParameterIn.PATH) final String path, Context context, final net.codestory.http.Request request) throws IOException {
         try {
             String esUrl = withInjectedKeepAlive(IndexAccessVerifier.checkPath(path, context), path, context);
+            boolean translateAsyncSearch = IndexAccessVerifier.isAsyncSearchSubmit(path) && isOpenSearch();
+            if (translateAsyncSearch) {
+                esUrl = toOpenSearchAsyncSubmitUrl(esUrl);
+            }
             String response = indexer.executeRaw("POST", esUrl, new String(request.contentAsBytes()));
+            if (translateAsyncSearch) {
+                response = toElasticsearchAsyncEnvelope(response);
+            }
             if (IndexAccessVerifier.isAsyncSearchSubmit(path)) {
                 try {
                     recordAsyncSearchOwnership(path, context, response);
@@ -206,7 +219,14 @@ public class IndexResource {
             return PayloadFormatter.error("async search not found", HttpStatus.NOT_FOUND);
         }
         try {
-            String response = indexer.executeRaw(method, IndexAccessVerifier.getUrlString(context, path), null);
+            String statusUrl = IndexAccessVerifier.getUrlString(context, path);
+            if (isOpenSearch()) {
+                statusUrl = toOpenSearchAsyncStatusUrl(statusUrl);
+            }
+            String response = indexer.executeRaw(method, statusUrl, null);
+            if (isOpenSearch() && !"DELETE".equalsIgnoreCase(method)) {
+                response = toElasticsearchAsyncEnvelope(response);
+            }
             if ("DELETE".equalsIgnoreCase(method)) {
                 // ES already cancelled the search; a store failure (e.g. Redis down) shouldn't surface
                 // as a 500 to the user. The TTL will reap the orphaned record on its own.
@@ -233,6 +253,54 @@ public class IndexResource {
                     ? EntityUtils.toString(e.getResponse().getEntity()) : "";
             return PayloadFormatter.json(body).withCode(status);
         }
+    }
+
+    // OpenSearch implements async search as a plugin rather than a core API, so the same capability
+    // sits behind a different contract: the indices move from the path into an "index" parameter, and
+    // a completed search is discarded unless keep_on_completion asks for it. Elasticsearch retains a
+    // result as soon as it issues an id, so passing keep_on_completion=true is what makes the two
+    // behave alike -- without it a search that outlives wait_for_completion_timeout returns an id and
+    // then 404s on the first poll.
+    private String toOpenSearchAsyncSubmitUrl(String esUrl) {
+        String[] pathAndQuery = esUrl.split("\\?", 2);
+        String indices = pathAndQuery[0].split("/")[0];
+        StringBuilder url = new StringBuilder(OPENSEARCH_ASYNC_SEARCH_PATH).append("?");
+        if (pathAndQuery.length > 1 && !pathAndQuery[1].isEmpty()) {
+            url.append(pathAndQuery[1]).append("&");
+        }
+        return url.append("index=").append(indices).append("&keep_on_completion=true").toString();
+    }
+
+    private String toOpenSearchAsyncStatusUrl(String esUrl) {
+        return OPENSEARCH_ASYNC_SEARCH_PATH + esUrl.substring(ES_ASYNC_SEARCH_PATH.length());
+    }
+
+    // OpenSearch reports progress as a "state" string; the client reads Elasticsearch's booleans.
+    // Only RUNNING means the search is still going, so every other state is a finished search.
+    private String toElasticsearchAsyncEnvelope(String openSearchResponse) throws IOException {
+        JsonNode parsed = JsonObjectMapper.getMapper().readTree(openSearchResponse);
+        if (!parsed.isObject() || parsed.get("state") == null || parsed.get("state").isNull()) {
+            return openSearchResponse;
+        }
+        ObjectNode envelope = (ObjectNode) parsed;
+        boolean isRunning = OPENSEARCH_RUNNING_STATE.equalsIgnoreCase(envelope.remove("state").asText());
+        envelope.put("is_running", isRunning);
+        envelope.put("is_partial", isRunning);
+        return JsonObjectMapper.getMapper().writeValueAsString(envelope);
+    }
+
+    // The distribution cannot change while the process runs, and getVersion() is a call to the
+    // cluster, so resolve it once rather than on every async search.
+    private boolean isOpenSearch() {
+        if (openSearchBackend == null) {
+            try {
+                openSearchBackend = OPENSEARCH_DISTRIBUTION.equalsIgnoreCase(indexer.getVersion().get("distribution"));
+            } catch (Exception e) {
+                logger.warn("could not read the index distribution, assuming elasticsearch: {}", e.getMessage());
+                openSearchBackend = false;
+            }
+        }
+        return openSearchBackend;
     }
 
     // The current user owns the async search only if they submitted it AND still hold a grant on


### PR DESCRIPTION
Fixes #2349. This is option 1 from that issue — keep async search working on both distributions. Happy to switch to option 2 (synchronous fallback on OpenSearch) if you would rather not carry the translation.

`submitAsyncSearch` targets the Elasticsearch API unconditionally, so on OpenSearch every search returns 500. OpenSearch has the same capability as the `opensearch-asynchronous-search` plugin, with the indices in an `index` parameter and progress in a `state` field.

`IndexResource` already owns async-search behaviour (`isAsyncSearchSubmit`, `withInjectedKeepAlive`, `recordAsyncSearchOwnership`, `asyncSearchStatus`), and `RootResource` already resolves `index.distribution`, so the translation goes there. The client, `IndexAccessVerifier` and `AsyncSearchStore` are unchanged — keeping distribution differences out of `IndexAccessVerifier` matters, because it validates granted indices from `pathParts[0]` and moving the indices into a query parameter would push that variance into the authorization path.

Three adaptations, all no-ops on Elasticsearch:

| | Elasticsearch | OpenSearch |
| --- | --- | --- |
| submit | `POST /{indices}/_async_search` | `POST /_plugins/_asynchronous_search?index={indices}` |
| poll, cancel | `/_async_search/{id}` | `/_plugins/_asynchronous_search/{id}` |
| progress | `is_running`, `is_partial` | `state` |
| retain on completion | implicit once an id is issued | needs `keep_on_completion=true` |

The last row is the one that is easy to miss. Elasticsearch keeps a result as soon as it hands out an id. OpenSearch discards it on completion unless asked. Without `keep_on_completion=true`, a search that outlives `wait_for_completion_timeout` returns an id and then 404s on the first poll — which would be worse than the current failure, because it loses results quietly.

`getVersion()` is a call to the cluster and the distribution cannot change while the process runs, so it is resolved once. If it cannot be read, the code assumes Elasticsearch and logs a warning, so existing deployments keep their current behaviour.

## Verification

Datashare 21.18.0 in Docker against Elasticsearch 8.15.0 and OpenSearch 2.11.1, testing through `/api/index/search/...` rather than against the engines directly. The patched class was placed in `dist/`, which precedes the distribution jar on the entrypoint classpath.

| | before | after |
| --- | --- | --- |
| OpenSearch: submit | 500 `Unable to apply route` | 200, `is_running:false`, `is_partial:false`, no `state` |
| OpenSearch: poll | — | 200, with hits |
| OpenSearch: cancel | — | 200 `{"acknowledged":true}` |
| Elasticsearch: submit | 200 | 200, unchanged |

The poll returning 200 is what shows `keep_on_completion` is being applied; without it OpenSearch answers 404.

Also measured, to confirm this is the only divergence — every endpoint `IndexResource` exposes, same build, both engines: `GET /`, `PUT /{index}`, `HEAD /{index}`, `_search`, `_count`, `_search/scroll`, `_close`, `_open`, `_snapshot`, `_nodes`, `_nodes/settings`, `_cluster/settings`, `DELETE /{index}` all return 200 on both. Only `_async_search` differed.

**What I have not done:** run the project's Maven test suite, and I have not added tests. If you want them, tell me where they belong — `IndexResourceTest` looked like the natural home, and I would rather match your conventions than guess. I observed `RUNNING`, `CLOSED` and `STORE_RESIDENT` from OpenSearch; the code treats only `RUNNING` as in-flight, so the documented `FAILED` and `PERSIST_*` states are handled as finished, with errors surfaced from the response body.