### PR TITLE
feat(tabular): tabular source reader

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
@@ -2,9 +2,11 @@ package org.icij.datashare.tabular;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * One data row. {@code number} is the 1-based ordinal of the emitted row, not the row's position in
@@ -16,22 +18,36 @@ public record Row(long number, Map<String, String> values) {
     /**
      * Applies the one header rule every reader shares: a blank name means the column is dropped
      * (represented by a null entry the caller skips), a duplicate name is a mapping the reader
-     * cannot honour unambiguously and so fails.
+     * cannot honour unambiguously and so fails, and a header row with no name at all is not a header
+     * row: importing every data row as an empty map would report a total loss as a success.
      */
     public static List<String> headers(List<String> rawNames) {
         List<String> headers = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
         for (String rawName : rawNames) {
-            String name = rawName == null ? "" : rawName.strip();
+            String name = rawName == null ? "" : strip(rawName);
             if (name.isEmpty()) {
                 headers.add(null);
                 continue;
             }
-            if (headers.contains(name)) {
+            if (!seen.add(name)) {
                 throw new IllegalArgumentException("duplicate column name in header: " + name);
             }
             headers.add(name);
         }
+        if (seen.isEmpty()) {
+            throw new IllegalArgumentException("no column name in the header row: every name is blank, "
+                    + "so the row above the data is a title or a spacer rather than a header");
+        }
         return headers;
+    }
+
+    // String.strip leaves a UTF-8 byte order mark in place, because U+FEFF is not whitespace. It can
+    // only ever precede the first name, and Excel writes one on every "CSV UTF-8" export, so without
+    // this the first column is named BOM + "id" and no mapping can address it.
+    private static String strip(String rawName) {
+        String name = rawName.strip();
+        return name.startsWith("\uFEFF") ? name.substring(1).strip() : name;
     }
 
     /**

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
@@ -53,10 +53,13 @@ public record Row(long number, Map<String, String> values) {
     /**
      * The same mapping, refusing a row carrying more fields than the header declares: that is the
      * signature of a wrong delimiter or of a separator inside an unquoted value, and importing such a
-     * row would silently misalign every value in it.
+     * row would silently misalign every value in it. Only a surplus cell that is not blank counts,
+     * because both of those signatures put content in it: a trailing delimiter in a csv and a styled
+     * or previously emptied cell past the last filled column in a workbook produce an empty surplus
+     * that carries no data and cannot misalign anything.
      */
     public static Map<String, String> values(List<String> headers, List<String> cells, long number) {
-        if (cells.size() > headers.size()) {
+        if (cells.stream().skip(headers.size()).anyMatch(cell -> !cell.isBlank())) {
             throw new IllegalArgumentException("row " + number + " has " + cells.size()
                     + " fields but the header declares " + headers.size());
         }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
@@ -1,0 +1,30 @@
+package org.icij.datashare.tabular;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** One data row. {@code number} is 1-based and excludes the header row. */
+public record Row(long number, Map<String, String> values) {
+
+    /**
+     * Applies the one header rule every reader shares: a blank name means the column is dropped
+     * (represented by a null entry the caller skips), a duplicate name is a mapping the reader
+     * cannot honour unambiguously and so fails.
+     */
+    public static List<String> headers(List<String> rawNames) {
+        List<String> headers = new ArrayList<>();
+        for (String rawName : rawNames) {
+            String name = rawName == null ? "" : rawName.strip();
+            if (name.isEmpty()) {
+                headers.add(null);
+                continue;
+            }
+            if (headers.contains(name)) {
+                throw new IllegalArgumentException("duplicate column name in header: " + name);
+            }
+            headers.add(name);
+        }
+        return headers;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
@@ -1,10 +1,16 @@
 package org.icij.datashare.tabular;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/** One data row. {@code number} is 1-based and excludes the header row. */
+/**
+ * One data row. {@code number} is the 1-based ordinal of the emitted row, not the row's position in
+ * the file: the header row and the rows a reader skips, an entirely blank one for instance, consume
+ * no number.
+ */
 public record Row(long number, Map<String, String> values) {
 
     /**
@@ -26,5 +32,34 @@ public record Row(long number, Map<String, String> values) {
             headers.add(name);
         }
         return headers;
+    }
+
+    /**
+     * Maps a row's cells onto the header names, in header order. Every column the header declares is
+     * present, padded with an empty string when the row is short, so a consumer never has to tell a
+     * missing cell from an empty one. A column whose header name is blank is dropped, and cells past
+     * the last declared column are ignored.
+     */
+    public static Map<String, String> values(List<String> headers, List<String> cells) {
+        Map<String, String> values = new LinkedHashMap<>();
+        for (int column = 0; column < headers.size(); column++) {
+            if (headers.get(column) != null) {
+                values.put(headers.get(column), column < cells.size() ? cells.get(column) : "");
+            }
+        }
+        return Collections.unmodifiableMap(values);
+    }
+
+    /**
+     * The same mapping, refusing a row carrying more fields than the header declares: that is the
+     * signature of a wrong delimiter or of a separator inside an unquoted value, and importing such a
+     * row would silently misalign every value in it.
+     */
+    public static Map<String, String> values(List<String> headers, List<String> cells, long number) {
+        if (cells.size() > headers.size()) {
+            throw new IllegalArgumentException("row " + number + " has " + cells.size()
+                    + " fields but the header declares " + headers.size());
+        }
+        return values(headers, cells);
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/Row.java
@@ -25,7 +25,7 @@ public record Row(long number, Map<String, String> values) {
         List<String> headers = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         for (String rawName : rawNames) {
-            String name = rawName == null ? "" : strip(rawName);
+            String name = rawName == null ? "" : rawName.strip();
             if (name.isEmpty()) {
                 headers.add(null);
                 continue;
@@ -40,14 +40,6 @@ public record Row(long number, Map<String, String> values) {
                     + "so the row above the data is a title or a spacer rather than a header");
         }
         return headers;
-    }
-
-    // String.strip leaves a UTF-8 byte order mark in place, because U+FEFF is not whitespace. It can
-    // only ever precede the first name, and Excel writes one on every "CSV UTF-8" export, so without
-    // this the first column is named BOM + "id" and no mapping can address it.
-    private static String strip(String rawName) {
-        String name = rawName.strip();
-        return name.startsWith("\uFEFF") ? name.substring(1).strip() : name;
     }
 
     /**

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/RowSource.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/RowSource.java
@@ -1,0 +1,16 @@
+package org.icij.datashare.tabular;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+/**
+ * Streams the rows of a tabular source with its columns intact. Implementations are stateless and
+ * reusable; each call to {@link #rows} owns the stream it is given and releases it when the returned
+ * stream is closed, so callers must use try-with-resources.
+ */
+public interface RowSource {
+    boolean supports(String contentType);
+
+    Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException;
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/RowSourceOptions.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/RowSourceOptions.java
@@ -1,0 +1,29 @@
+package org.icij.datashare.tabular;
+
+import java.nio.charset.Charset;
+
+/**
+ * Per-read knobs, every one nullable, a null meaning the reader's own default. A reader ignores the
+ * fields it has no use for: {@code delimiter} and {@code quote} are delimited-text only, {@code
+ * sheet} is Excel only, {@code table} is the Tika fallback only, and {@code charset} does not reach
+ * the fallback, which lets Tika resolve encoding itself.
+ */
+public record RowSourceOptions(String contentType, Charset charset, Character delimiter,
+                               Character quote, String sheet, Integer table) {
+
+    public static RowSourceOptions defaults() {
+        return new RowSourceOptions(null, null, null, null, null, null);
+    }
+
+    public RowSourceOptions withContentType(String newContentType) {
+        return new RowSourceOptions(newContentType, charset, delimiter, quote, sheet, table);
+    }
+
+    public RowSourceOptions withCharset(Charset newCharset) {
+        return new RowSourceOptions(contentType, newCharset, delimiter, quote, sheet, table);
+    }
+
+    public RowSourceOptions withDelimiter(Character newDelimiter) {
+        return new RowSourceOptions(contentType, charset, newDelimiter, quote, sheet, table);
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/RowSourceOptions.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/RowSourceOptions.java
@@ -26,4 +26,16 @@ public record RowSourceOptions(String contentType, Charset charset, Character de
     public RowSourceOptions withDelimiter(Character newDelimiter) {
         return new RowSourceOptions(contentType, charset, newDelimiter, quote, sheet, table);
     }
+
+    public RowSourceOptions withQuote(Character newQuote) {
+        return new RowSourceOptions(contentType, charset, delimiter, newQuote, sheet, table);
+    }
+
+    public RowSourceOptions withSheet(String newSheet) {
+        return new RowSourceOptions(contentType, charset, delimiter, quote, newSheet, table);
+    }
+
+    public RowSourceOptions withTable(Integer newTable) {
+        return new RowSourceOptions(contentType, charset, delimiter, quote, sheet, newTable);
+    }
 }

--- a/datashare-app/pom.xml
+++ b/datashare-app/pom.xml
@@ -31,6 +31,26 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-scratchpad</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>

--- a/datashare-app/pom.xml
+++ b/datashare-app/pom.xml
@@ -41,6 +41,16 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
+            <exclusions>
+                <!-- poi-ooxml-lite is a strict subset of the poi-ooxml-full that tika-parser-microsoft
+                     already brings, so shipping both only duplicates ~6MB of identical schema classes
+                     into both fat jars and puts two copies of the same automatic module on a module
+                     path. POI's own guidance is to depend on exactly one of the two. -->
+                <exclusion>
+                    <groupId>org.apache.poi</groupId>
+                    <artifactId>poi-ooxml-lite</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -9,10 +9,8 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -59,13 +57,26 @@ public class DelimitedRowSource implements RowSource {
     private static Stream<Row> stream(Iterator<CSVRecord> records, List<String> headers) {
         Iterator<Row> rows = new Iterator<>() {
             private long number = 0;
+            private List<String> pending;
 
             @Override
             public boolean hasNext() {
-                // commons-csv's iterator prefetches the next record here, so a malformed record (an
-                // unterminated quote, for instance) surfaces as an UncheckedIOException or an
-                // IllegalStateException from this call rather than from next(); naming the row number
-                // is what makes it actionable to whoever wrote the file.
+                // A record whose every field is empty is skipped, as it is in every other reader, and
+                // consumes no row number; commons-csv already drops a truly blank line.
+                while (pending == null && hasNextRecord()) {
+                    List<String> cells = records.next().toList();
+                    if (!cells.stream().allMatch(String::isEmpty)) {
+                        pending = cells;
+                    }
+                }
+                return pending != null;
+            }
+
+            // commons-csv's iterator prefetches the next record, so a malformed record (an
+            // unterminated quote, for instance) surfaces as an UncheckedIOException or an
+            // IllegalStateException from hasNext() rather than from next(); naming the row number is
+            // what makes it actionable to whoever wrote the file.
+            private boolean hasNextRecord() {
                 try {
                     return records.hasNext();
                 } catch (UncheckedIOException | IllegalStateException e) {
@@ -75,22 +86,15 @@ public class DelimitedRowSource implements RowSource {
 
             @Override
             public Row next() {
-                return new Row(++number, values(records.next(), headers));
+                List<String> cells = pending;
+                pending = null;
+                number++;
+                return new Row(number, Row.values(headers, cells, number));
             }
         };
         return StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(rows, Spliterator.ORDERED | Spliterator.NONNULL),
                 false);
-    }
-
-    private static Map<String, String> values(CSVRecord record, List<String> headers) {
-        Map<String, String> values = new HashMap<>();
-        for (int column = 0; column < headers.size() && column < record.size(); column++) {
-            if (headers.get(column) != null) {
-                values.put(headers.get(column), record.get(column));
-            }
-        }
-        return values;
     }
 
     private static void close(CSVParser parser) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -16,6 +16,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -53,7 +54,7 @@ public class DelimitedRowSource implements RowSource {
             if (!records.hasNext()) {
                 throw new IllegalArgumentException("no header row: the source is empty");
             }
-            List<String> headers = Row.headers(records.next().toList());
+            List<String> headers = Row.headers(withoutBom(records.next().toList()));
             return stream(records, headers).onClose(() -> close(parser));
         } catch (RuntimeException failure) {
             closeQuietly(parser);
@@ -100,6 +101,19 @@ public class DelimitedRowSource implements RowSource {
         CoderResult result = decoder.decode(
                 ByteBuffer.wrap(head), CharBuffer.allocate(head.length + 1), false);
         return !result.isError();
+    }
+
+    // A byte order mark survives decoding, because U+FEFF is not whitespace, and Excel writes one on
+    // every "CSV UTF-8" export: without this the first column is named BOM + "id" and no mapping can
+    // address it. Stripped after decoding rather than off the byte stream, because a charset like
+    // bare UTF-16 needs the BOM bytes to pick its endianness.
+    private static List<String> withoutBom(List<String> header) {
+        if (header.isEmpty() || !header.get(0).startsWith("﻿")) {
+            return header;
+        }
+        List<String> stripped = new ArrayList<>(header);
+        stripped.set(0, stripped.get(0).substring(1));
+        return stripped;
     }
 
     private static CSVFormat format(RowSourceOptions options) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -1,0 +1,98 @@
+package org.icij.datashare.tabular;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class DelimitedRowSource implements RowSource {
+    private static final Set<String> SUPPORTED =
+            Set.of("text/csv", "text/tab-separated-values", "text/plain");
+
+    private static final char DEFAULT_DELIMITER = ',';
+
+    @Override
+    public boolean supports(String contentType) {
+        return SUPPORTED.contains(contentType);
+    }
+
+    @Override
+    public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
+        Charset charset = options.charset() == null ? StandardCharsets.UTF_8 : options.charset();
+        // CSVParser.parse over CSVParser.builder(): the builder's setReader is inherited from
+        // commons-io and returns the supertype, so the fluent chain does not typecheck.
+        CSVParser parser = CSVParser.parse(source, charset, format(options));
+
+        Iterator<CSVRecord> records = parser.iterator();
+        if (!records.hasNext()) {
+            parser.close();
+            throw new IllegalArgumentException("no header row: the source is empty");
+        }
+        List<String> headers = Row.headers(records.next().toList());
+
+        return stream(records, headers).onClose(() -> close(parser));
+    }
+
+    private static CSVFormat format(RowSourceOptions options) {
+        CSVFormat.Builder builder = CSVFormat.DEFAULT.builder()
+                .setDelimiter(options.delimiter() == null ? DEFAULT_DELIMITER : options.delimiter());
+        if (options.quote() != null) {
+            builder.setQuote(options.quote());
+        }
+        return builder.get();
+    }
+
+    private static Stream<Row> stream(Iterator<CSVRecord> records, List<String> headers) {
+        Iterator<Row> rows = new Iterator<>() {
+            private long number = 0;
+
+            @Override
+            public boolean hasNext() {
+                return records.hasNext();
+            }
+
+            @Override
+            public Row next() {
+                return new Row(++number, values(records.next(), headers, number));
+            }
+        };
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(rows, Spliterator.ORDERED | Spliterator.NONNULL),
+                false);
+    }
+
+    // A malformed record surfaces as an UncheckedIOException from commons-csv's own iterator; the row
+    // number is added because that is the only thing making the message actionable to whoever wrote
+    // the file. A Spliterator cannot throw a checked IOException, so unchecked is the only option.
+    private static Map<String, String> values(CSVRecord record, List<String> headers, long number) {
+        Map<String, String> values = new HashMap<>();
+        for (int column = 0; column < headers.size() && column < record.size(); column++) {
+            if (headers.get(column) != null) {
+                values.put(headers.get(column), record.get(column));
+            }
+        }
+        return values;
+    }
+
+    private static void close(CSVParser parser) {
+        try {
+            parser.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException("closing the delimited source failed", e);
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -62,12 +62,20 @@ public class DelimitedRowSource implements RowSource {
 
             @Override
             public boolean hasNext() {
-                return records.hasNext();
+                // commons-csv's iterator prefetches the next record here, so a malformed record (an
+                // unterminated quote, for instance) surfaces as an UncheckedIOException or an
+                // IllegalStateException from this call rather than from next(); naming the row number
+                // is what makes it actionable to whoever wrote the file.
+                try {
+                    return records.hasNext();
+                } catch (UncheckedIOException | IllegalStateException e) {
+                    throw new IllegalArgumentException("malformed row " + (number + 1) + ": " + e.getMessage(), e);
+                }
             }
 
             @Override
             public Row next() {
-                return new Row(++number, values(records.next(), headers, number));
+                return new Row(++number, values(records.next(), headers));
             }
         };
         return StreamSupport.stream(
@@ -75,10 +83,7 @@ public class DelimitedRowSource implements RowSource {
                 false);
     }
 
-    // A malformed record surfaces as an UncheckedIOException from commons-csv's own iterator; the row
-    // number is added because that is the only thing making the message actionable to whoever wrote
-    // the file. A Spliterator cannot throw a checked IOException, so unchecked is the only option.
-    private static Map<String, String> values(CSVRecord record, List<String> headers, long number) {
+    private static Map<String, String> values(CSVRecord record, List<String> headers) {
         Map<String, String> values = new HashMap<>();
         for (int column = 0; column < headers.size() && column < record.size(); column++) {
             if (headers.get(column) != null) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class DelimitedRowSource implements RowSource {
-    private static final Set<String> SUPPORTED =
+    public static final Set<String> SUPPORTED =
             Set.of("text/csv", "text/tab-separated-values", "text/plain");
 
     private static final char DEFAULT_DELIMITER = ',';

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -48,7 +48,7 @@ public class DelimitedRowSource implements RowSource {
 
     @Override
     public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
-        CSVParser parser = open(source, options);
+        CSVParser parser = parse(source, options);
         try {
             Iterator<CSVRecord> records = parser.iterator();
             if (!records.hasNext()) {
@@ -64,7 +64,7 @@ public class DelimitedRowSource implements RowSource {
 
     // Releases the source itself when the parser cannot be built, since no stream reaches the caller
     // to be closed on that path.
-    private static CSVParser open(InputStream source, RowSourceOptions options) throws IOException {
+    private static CSVParser parse(InputStream source, RowSourceOptions options) throws IOException {
         BufferedInputStream buffered = new BufferedInputStream(source);
         try {
             // CSVParser.parse over CSVParser.builder(): the builder's setReader is inherited from

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -4,10 +4,17 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
+import java.io.BufferedInputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
@@ -18,10 +25,20 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class DelimitedRowSource implements RowSource {
+    /** text/tsv is the type Tika 3.3.0 writes when its sniffer finds a tab delimiter in a file whose
+     *  name does not end in .tsv; text/tab-separated-values is the one it keeps for the extension. */
     public static final Set<String> SUPPORTED =
-            Set.of("text/csv", "text/tab-separated-values", "text/plain");
+            Set.of("text/csv", "text/tab-separated-values", "text/tsv", "text/plain");
+
+    private static final Set<String> TAB_SEPARATED_TYPES =
+            Set.of("text/tab-separated-values", "text/tsv");
 
     private static final char DEFAULT_DELIMITER = ',';
+
+    // Thousands of rows, so the first accented character of a realistic export falls inside it. A file
+    // that is pure ascii this far and latin-1 afterwards decodes as utf-8 and shows replacement
+    // characters, which is a visible failure rather than the silent mojibake this probe prevents.
+    private static final int CHARSET_PROBE_BYTES = 64 * 1024;
 
     @Override
     public boolean supports(String contentType) {
@@ -30,28 +47,78 @@ public class DelimitedRowSource implements RowSource {
 
     @Override
     public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
-        Charset charset = options.charset() == null ? StandardCharsets.UTF_8 : options.charset();
-        // CSVParser.parse over CSVParser.builder(): the builder's setReader is inherited from
-        // commons-io and returns the supertype, so the fluent chain does not typecheck.
-        CSVParser parser = CSVParser.parse(source, charset, format(options));
-
-        Iterator<CSVRecord> records = parser.iterator();
-        if (!records.hasNext()) {
-            parser.close();
-            throw new IllegalArgumentException("no header row: the source is empty");
+        CSVParser parser = open(source, options);
+        try {
+            Iterator<CSVRecord> records = parser.iterator();
+            if (!records.hasNext()) {
+                throw new IllegalArgumentException("no header row: the source is empty");
+            }
+            List<String> headers = Row.headers(records.next().toList());
+            return stream(records, headers).onClose(() -> close(parser));
+        } catch (RuntimeException failure) {
+            closeQuietly(parser);
+            throw failure;
         }
-        List<String> headers = Row.headers(records.next().toList());
+    }
 
-        return stream(records, headers).onClose(() -> close(parser));
+    // Releases the source itself when the parser cannot be built, since no stream reaches the caller
+    // to be closed on that path.
+    private static CSVParser open(InputStream source, RowSourceOptions options) throws IOException {
+        BufferedInputStream buffered = new BufferedInputStream(source);
+        try {
+            // CSVParser.parse over CSVParser.builder(): the builder's setReader is inherited from
+            // commons-io and returns the supertype, so the fluent chain does not typecheck.
+            return CSVParser.parse(buffered, charset(buffered, options.charset()), format(options));
+        } catch (IOException | RuntimeException failure) {
+            closeQuietly(buffered);
+            throw failure;
+        }
+    }
+
+    /**
+     * A UTF-8 file read as a single-byte charset never reports a decoding error, so Tika's charset
+     * detector settling on ISO-8859-1 for a large mostly-ASCII export would mojibake every accented
+     * value in silence. The reverse does report, so probing the head for valid UTF-8 is what tells the
+     * two apart; the detected charset is kept only when that probe fails.
+     */
+    private static Charset charset(BufferedInputStream source, Charset detected) throws IOException {
+        if (detected == null || StandardCharsets.UTF_8.equals(detected)) {
+            return StandardCharsets.UTF_8;
+        }
+        source.mark(CHARSET_PROBE_BYTES);
+        byte[] head = source.readNBytes(CHARSET_PROBE_BYTES);
+        source.reset();
+        return decodesAsUtf8(head) ? StandardCharsets.UTF_8 : detected;
+    }
+
+    private static boolean decodesAsUtf8(byte[] head) {
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        // endOfInput false, so a multi-byte sequence cut in half by the probe boundary underflows
+        // instead of counting as malformed.
+        CoderResult result = decoder.decode(
+                ByteBuffer.wrap(head), CharBuffer.allocate(head.length + 1), false);
+        return !result.isError();
     }
 
     private static CSVFormat format(RowSourceOptions options) {
-        CSVFormat.Builder builder = CSVFormat.DEFAULT.builder()
-                .setDelimiter(options.delimiter() == null ? DEFAULT_DELIMITER : options.delimiter());
+        CSVFormat.Builder builder = CSVFormat.DEFAULT.builder().setDelimiter(delimiter(options));
         if (options.quote() != null) {
             builder.setQuote(options.quote());
         }
         return builder.get();
+    }
+
+    // Tika records csv:delimiter only for the files its sniffer typed, and it never types a .tsv that
+    // way, so without this the one format whose delimiter its content type already states is the one
+    // parsed with a comma.
+    private static char delimiter(RowSourceOptions options) {
+        if (options.delimiter() != null) {
+            return options.delimiter();
+        }
+        return options.contentType() != null && TAB_SEPARATED_TYPES.contains(options.contentType())
+                ? '\t' : DEFAULT_DELIMITER;
     }
 
     private static Stream<Row> stream(Iterator<CSVRecord> records, List<String> headers) {
@@ -102,6 +169,14 @@ public class DelimitedRowSource implements RowSource {
             parser.close();
         } catch (IOException e) {
             throw new UncheckedIOException("closing the delimited source failed", e);
+        }
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        try {
+            closeable.close();
+        } catch (IOException ignored) {
+            // the read already failed; the close failure adds nothing the caller can act on
         }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -28,7 +28,7 @@ public class JsonRowSource implements RowSource {
      *  the internal token connecting an extension to this reader. It never appears on a document. */
     public static final String NDJSON_CONTENT_TYPE = "application/x-ndjson";
 
-    private static final Set<String> SUPPORTED = Set.of("application/json", NDJSON_CONTENT_TYPE);
+    public static final Set<String> SUPPORTED = Set.of("application/json", NDJSON_CONTENT_TYPE);
 
     private static final String SCALAR_ARRAY_SEPARATOR = "|";
 

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -9,8 +9,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.Spliterator;
@@ -22,6 +23,10 @@ import java.util.stream.StreamSupport;
  * Reads flat records out of JSON. One reader covers both shapes a dump comes in: peeking the first
  * token tells an array of objects apart from line-delimited or concatenated objects, and Jackson
  * iterates both identically once positioned.
+ *
+ * A record carries its own column names, so the header rules the other readers share do not reach
+ * here: a blank key becomes a column named "", keys are not stripped, a duplicate key is
+ * last-write-wins, and {@code {"addr.city":"X","addr":{"city":"Y"}}} collides silently.
  */
 public class JsonRowSource implements RowSource {
     /** Tika 3.3.0 has no mimetype for jsonl or ndjson, so this is the de facto type, used only as
@@ -60,9 +65,17 @@ public class JsonRowSource implements RowSource {
 
             @Override
             public Row next() {
-                Map<String, String> values = new HashMap<>();
-                flatten("", records.next(), values);
-                return new Row(++number, values);
+                JsonNode record = records.next();
+                number++;
+                // A scalar or an array has no keys to map onto columns, so it would yield a row with
+                // no values at all: refusing beats reporting an empty import as a success.
+                if (!record.isObject()) {
+                    throw new IllegalArgumentException(
+                            "row " + number + " is not a json object but a " + record.getNodeType());
+                }
+                Map<String, String> values = new LinkedHashMap<>();
+                flatten("", record, values);
+                return new Row(number, Collections.unmodifiableMap(values));
             }
         };
         return StreamSupport.stream(

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -47,20 +48,62 @@ public class JsonRowSource implements RowSource {
     @Override
     public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
         JsonParser parser = mapper.createParser(source);
-        // Positioning inside a root array is what makes readValues yield its elements rather than the
-        // array as a single value; for NDJSON the parser is already where it needs to be.
-        if (parser.nextToken() == JsonToken.START_ARRAY && parser.nextToken() == JsonToken.END_ARRAY) {
-            close(parser);
-            return Stream.empty();
+        MappingIterator<JsonNode> records;
+        try {
+            // Positioning inside a root array is what makes readValues yield its elements rather than
+            // the array as a single value; for NDJSON the parser is already where it needs to be.
+            // An empty source is a failed export, not an empty one: every sibling reader refuses it,
+            // and importing zero rows out of a truncated file would report the loss as a success. An
+            // explicitly empty array is different, and stays a successful read of nothing.
+            JsonToken first = parser.nextToken();
+            if (first == null) {
+                throw new IllegalArgumentException("no records: the source is empty");
+            }
+            if (first == JsonToken.START_ARRAY && parser.nextToken() == JsonToken.END_ARRAY) {
+                close(parser);
+                return Stream.empty();
+            }
+            records = mapper.readerFor(JsonNode.class).readValues(parser);
+        } catch (IOException | RuntimeException failure) {
+            // The parser does not own a stream it was handed, so releasing it is not enough.
+            closeQuietly(parser);
+            closeQuietly(source);
+            throw failure;
         }
-        MappingIterator<JsonNode> records = mapper.readerFor(JsonNode.class).readValues(parser);
 
         Iterator<Row> rows = new Iterator<>() {
             private long number = 0;
 
             @Override
             public boolean hasNext() {
-                return records.hasNext();
+                // MappingIterator stops at the root array's closing bracket, so anything after it
+                // would be dropped without a word: two dumps concatenated by cat would import the
+                // first and report success.
+                boolean more = hasNextRecord();
+                if (!more) {
+                    refuseTrailingContent();
+                }
+                return more;
+            }
+
+            private boolean hasNextRecord() {
+                try {
+                    return records.hasNext();
+                } catch (RuntimeException malformed) {
+                    throw new IllegalArgumentException(
+                            "malformed record " + (number + 1) + ": " + malformed.getMessage(), malformed);
+                }
+            }
+
+            private void refuseTrailingContent() {
+                try {
+                    if (parser.nextToken() != null) {
+                        throw new IllegalArgumentException(
+                                "content after the end of the json array, at " + parser.currentLocation());
+                    }
+                } catch (IOException unreadable) {
+                    throw new UncheckedIOException("reading past the json array failed", unreadable);
+                }
             }
 
             @Override
@@ -105,11 +148,15 @@ public class JsonRowSource implements RowSource {
      */
     private static void joinScalars(String column, JsonNode array, Map<String, String> values) {
         StringBuilder joined = new StringBuilder();
-        for (JsonNode element : array) {
+        // The separator goes before every element but the first, keyed on the position rather than on
+        // whether anything has been written yet: an empty leading element would otherwise vanish and
+        // shift every value a splitting consumer reads.
+        for (int index = 0; index < array.size(); index++) {
+            JsonNode element = array.get(index);
             if (element.isContainerNode()) {
                 return;
             }
-            if (!joined.isEmpty()) {
+            if (index > 0) {
                 joined.append(SCALAR_ARRAY_SEPARATOR);
             }
             joined.append(element.isNull() ? "" : element.asText());
@@ -122,6 +169,14 @@ public class JsonRowSource implements RowSource {
             parser.close();
         } catch (IOException e) {
             throw new UncheckedIOException("closing the json source failed", e);
+        }
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        try {
+            closeable.close();
+        } catch (IOException ignored) {
+            // the read already failed; the close failure adds nothing the caller can act on
         }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -44,8 +44,9 @@ public class JsonRowSource implements RowSource {
         JsonParser parser = mapper.createParser(source);
         // Positioning inside a root array is what makes readValues yield its elements rather than the
         // array as a single value; for NDJSON the parser is already where it needs to be.
-        if (parser.nextToken() == JsonToken.START_ARRAY) {
-            parser.nextToken();
+        if (parser.nextToken() == JsonToken.START_ARRAY && parser.nextToken() == JsonToken.END_ARRAY) {
+            close(parser);
+            return Stream.empty();
         }
         MappingIterator<JsonNode> records = mapper.readerFor(JsonNode.class).readValues(parser);
 

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -36,8 +36,6 @@ public class JsonRowSource implements RowSource {
 
     public static final Set<String> SUPPORTED = Set.of("application/json", NDJSON_CONTENT_TYPE);
 
-    private static final String SCALAR_ARRAY_SEPARATOR = "|";
-
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Override
@@ -117,7 +115,11 @@ public class JsonRowSource implements RowSource {
                             "row " + number + " is not a json object but a " + record.getNodeType());
                 }
                 Map<String, String> values = new LinkedHashMap<>();
-                flatten("", record, values);
+                try {
+                    flatten("", record, values);
+                } catch (IllegalArgumentException notTabular) {
+                    throw new IllegalArgumentException("row " + number + ": " + notTabular.getMessage(), notTabular);
+                }
                 return new Row(number, Collections.unmodifiableMap(values));
             }
         };
@@ -127,6 +129,9 @@ public class JsonRowSource implements RowSource {
                 .onClose(() -> close(parser));
     }
 
+    // An array is refused rather than joined or skipped: a joined array is a delimited file inside a
+    // cell, whose separator can collide with the data, and a skipped one loses values in silence. If
+    // multi-valued properties turn out to matter, the fix is a multi-value seam in Row.
     private static void flatten(String prefix, JsonNode node, Map<String, String> values) {
         node.properties().forEach(field -> {
             String column = prefix.isEmpty() ? field.getKey() : prefix + "." + field.getKey();
@@ -134,34 +139,12 @@ public class JsonRowSource implements RowSource {
             if (value.isObject()) {
                 flatten(column, value, values);
             } else if (value.isArray()) {
-                joinScalars(column, value, values);
+                throw new IllegalArgumentException(
+                        "column " + column + " holds an array, which no table cell can carry");
             } else {
                 values.put(column, value.isNull() ? "" : value.asText());
             }
         });
-    }
-
-    /**
-     * An array of scalars joins on a fixed separator so a mapping can rely on splitting it. An array
-     * of objects is skipped: there is no column name that would describe it. If multi-valued
-     * properties turn out to matter, the fix is a multi-value seam in Row, not a cleverer separator.
-     */
-    private static void joinScalars(String column, JsonNode array, Map<String, String> values) {
-        StringBuilder joined = new StringBuilder();
-        // The separator goes before every element but the first, keyed on the position rather than on
-        // whether anything has been written yet: an empty leading element would otherwise vanish and
-        // shift every value a splitting consumer reads.
-        for (int index = 0; index < array.size(); index++) {
-            JsonNode element = array.get(index);
-            if (element.isContainerNode()) {
-                return;
-            }
-            if (index > 0) {
-                joined.append(SCALAR_ARRAY_SEPARATOR);
-            }
-            joined.append(element.isNull() ? "" : element.asText());
-        }
-        values.put(column, joined.toString());
     }
 
     private static void close(JsonParser parser) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -1,0 +1,113 @@
+package org.icij.datashare.tabular;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Reads flat records out of JSON. One reader covers both shapes a dump comes in: peeking the first
+ * token tells an array of objects apart from line-delimited or concatenated objects, and Jackson
+ * iterates both identically once positioned.
+ */
+public class JsonRowSource implements RowSource {
+    /** Tika 3.3.0 has no mimetype for jsonl or ndjson, so this is the de facto type, used only as
+     *  the internal token connecting an extension to this reader. It never appears on a document. */
+    public static final String NDJSON_CONTENT_TYPE = "application/x-ndjson";
+
+    private static final Set<String> SUPPORTED = Set.of("application/json", NDJSON_CONTENT_TYPE);
+
+    private static final String SCALAR_ARRAY_SEPARATOR = "|";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public boolean supports(String contentType) {
+        return SUPPORTED.contains(contentType);
+    }
+
+    @Override
+    public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
+        JsonParser parser = mapper.createParser(source);
+        // Positioning inside a root array is what makes readValues yield its elements rather than the
+        // array as a single value; for NDJSON the parser is already where it needs to be.
+        if (parser.nextToken() == JsonToken.START_ARRAY) {
+            parser.nextToken();
+        }
+        MappingIterator<JsonNode> records = mapper.readerFor(JsonNode.class).readValues(parser);
+
+        Iterator<Row> rows = new Iterator<>() {
+            private long number = 0;
+
+            @Override
+            public boolean hasNext() {
+                return records.hasNext();
+            }
+
+            @Override
+            public Row next() {
+                Map<String, String> values = new HashMap<>();
+                flatten("", records.next(), values);
+                return new Row(++number, values);
+            }
+        };
+        return StreamSupport.stream(
+                        Spliterators.spliteratorUnknownSize(rows,
+                                Spliterator.ORDERED | Spliterator.NONNULL), false)
+                .onClose(() -> close(parser));
+    }
+
+    private static void flatten(String prefix, JsonNode node, Map<String, String> values) {
+        node.properties().forEach(field -> {
+            String column = prefix.isEmpty() ? field.getKey() : prefix + "." + field.getKey();
+            JsonNode value = field.getValue();
+            if (value.isObject()) {
+                flatten(column, value, values);
+            } else if (value.isArray()) {
+                joinScalars(column, value, values);
+            } else {
+                values.put(column, value.isNull() ? "" : value.asText());
+            }
+        });
+    }
+
+    /**
+     * An array of scalars joins on a fixed separator so a mapping can rely on splitting it. An array
+     * of objects is skipped: there is no column name that would describe it. If multi-valued
+     * properties turn out to matter, the fix is a multi-value seam in Row, not a cleverer separator.
+     */
+    private static void joinScalars(String column, JsonNode array, Map<String, String> values) {
+        StringBuilder joined = new StringBuilder();
+        for (JsonNode element : array) {
+            if (element.isContainerNode()) {
+                return;
+            }
+            if (!joined.isEmpty()) {
+                joined.append(SCALAR_ARRAY_SEPARATOR);
+            }
+            joined.append(element.isNull() ? "" : element.asText());
+        }
+        values.put(column, joined.toString());
+    }
+
+    private static void close(JsonParser parser) {
+        try {
+            parser.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException("closing the json source failed", e);
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
@@ -1,0 +1,162 @@
+package org.icij.datashare.tabular;
+
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Turns the document a mapping names into rows. Addressing the source by document id rather than by
+ * path is what buys embedded sources (a CSV inside a ZIP, a workbook attached to an email) through
+ * SourceExtractor, plus the content type and charset Tika already detected at index time. It also
+ * means no user-supplied path reaches the filesystem, so this route has no traversal surface at all.
+ *
+ * Authorization on the project is not checked here: it belongs to the callers wiring the REST and CLI
+ * triggers, not to a reader.
+ */
+public class TabularRowReader {
+    private static final Set<String> GENERIC_TYPES =
+            Set.of("text/plain", "application/octet-stream");
+
+    // Only the formats a reader claims. Tika 3.3.0 types a .csv named .txt, and every .jsonl, as
+    // text/plain, so without this the delimited reader would claim NDJSON files.
+    private static final Map<String, String> TYPE_BY_EXTENSION = Map.of(
+            "csv", "text/csv",
+            "tsv", "text/tab-separated-values",
+            "psv", "text/csv",
+            "txt", "text/plain",
+            "json", "application/json",
+            "jsonl", JsonRowSource.NDJSON_CONTENT_TYPE,
+            "ndjson", JsonRowSource.NDJSON_CONTENT_TYPE);
+
+    private static final String DELIMITER_METADATA_KEY = "tika_metadata_csv_delimiter";
+
+    private static final Map<String, Character> DELIMITER_BY_TIKA_NAME = Map.of(
+            "comma", ',', "tab", '\t', "pipe", '|', "semicolon", ';');
+
+    private static final List<String> SUPPORTED_CONTENT_TYPES = Stream.of(
+                    DelimitedRowSource.SUPPORTED, WorkbookRowSource.SUPPORTED, JsonRowSource.SUPPORTED,
+                    TikaTableRowSource.SUPPORTED)
+            .flatMap(Set::stream)
+            .sorted()
+            .toList();
+
+    private final Indexer indexer;
+    private final SourceExtractor sourceExtractor;
+    private final List<RowSource> readers;
+    private final RowSource fallback;
+
+    public TabularRowReader(Indexer indexer, SourceExtractor sourceExtractor) {
+        this(indexer, sourceExtractor,
+                List.of(new DelimitedRowSource(), new WorkbookRowSource(), new JsonRowSource()),
+                new TikaTableRowSource());
+    }
+
+    TabularRowReader(Indexer indexer, SourceExtractor sourceExtractor, List<RowSource> readers,
+                     RowSource fallback) {
+        this.indexer = indexer;
+        this.sourceExtractor = sourceExtractor;
+        this.readers = readers;
+        this.fallback = fallback;
+    }
+
+    /**
+     * @param rootId the container the document was extracted from, or null for a root document. ES
+     *               routes an embedded document by its root, so this cannot be derived here.
+     */
+    public Stream<Row> rows(Project project, String documentId, String rootId,
+                            RowSourceOptions options) throws IOException {
+        Document document = indexer.get(project.getName(), documentId,
+                rootId == null ? documentId : rootId);
+        if (document == null) {
+            throw new IllegalArgumentException("no such document in " + project.getName() + ": " + documentId);
+        }
+        RowSourceOptions resolved = resolve(document, options);
+        RowSource reader = select(resolved.contentType());
+        InputStream source = sourceExtractor.getSource(project, document);
+        try {
+            return reader.rows(source, resolved).onClose(() -> closeQuietly(source));
+        } catch (IOException | RuntimeException failure) {
+            closeQuietly(source);
+            throw failure;
+        }
+    }
+
+    private RowSourceOptions resolve(Document document, RowSourceOptions options) {
+        RowSourceOptions resolved = options.withContentType(effectiveContentType(
+                options.contentType(), document.getContentType(), document.getName()));
+        if (resolved.charset() == null && document.getContentEncoding() != null) {
+            resolved = resolved.withCharset(document.getContentEncoding());
+        }
+        if (resolved.delimiter() == null) {
+            resolved = resolved.withDelimiter(delimiterFrom(document.getMetadata()));
+        }
+        return resolved;
+    }
+
+    private RowSource select(String contentType) {
+        for (RowSource reader : readers) {
+            if (reader.supports(contentType)) {
+                return reader;
+            }
+        }
+        if (fallback.supports(contentType)) {
+            return fallback;
+        }
+        throw new IllegalArgumentException(
+                "no reader supports " + contentType + ", supported content types: " + SUPPORTED_CONTENT_TYPES);
+    }
+
+    /**
+     * The mapping's override wins; otherwise a generic stored type is refined by extension, because
+     * Tika has no mimetype for jsonl or ndjson and types a .csv without the extension as text/plain.
+     */
+    static String effectiveContentType(String override, String storedType, String filename) {
+        if (override != null) {
+            return override;
+        }
+        if (!GENERIC_TYPES.contains(storedType)) {
+            return storedType;
+        }
+        return Optional.ofNullable(TYPE_BY_EXTENSION.get(extension(filename))).orElse(storedType);
+    }
+
+    private static String extension(String filename) {
+        if (filename == null) {
+            return "";
+        }
+        int dot = filename.lastIndexOf('.');
+        return dot < 0 ? "" : filename.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Tika's TextAndCSVParser sniffs the delimiter at index time and records its name under
+     * csv:delimiter, which reaches the metadata map as tika_metadata_csv_delimiter. Reading it beats
+     * sniffing again here: it costs nothing and it cannot disagree with the delimiter Tika used to
+     * produce the document's indexed text.
+     */
+    static Character delimiterFrom(Map<String, Object> metadata) {
+        if (metadata == null) {
+            return null;
+        }
+        Object name = metadata.get(DELIMITER_METADATA_KEY);
+        return name == null ? null : DELIMITER_BY_TIKA_NAME.get(name.toString().toLowerCase(Locale.ROOT));
+    }
+
+    private static void closeQuietly(InputStream source) {
+        try {
+            source.close();
+        } catch (IOException ignored) {
+            // the read already failed or already finished; the close failure adds nothing actionable
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
@@ -27,8 +27,10 @@ import java.util.stream.Stream;
  * several times over.
  */
 public class TabularRowReader {
+    // "unknown" is what Document.getContentTypeOrDefault returns, and what the spewer stores, when
+    // Tika detected no type at all: the document that most needs refining by extension.
     private static final Set<String> GENERIC_TYPES =
-            Set.of("text/plain", "application/octet-stream");
+            Set.of("text/plain", "application/octet-stream", "unknown");
 
     // Only the formats a reader claims. Tika 3.3.0 types a .csv named .txt, and every .jsonl, as
     // text/plain, so without this the delimited reader would claim NDJSON files.
@@ -43,8 +45,17 @@ public class TabularRowReader {
 
     private static final String DELIMITER_METADATA_KEY = "tika_metadata_csv_delimiter";
 
+    private static final String RESOURCE_NAME_METADATA_KEY = "tika_metadata_resourcename";
+
+    // Below its sniffer's confidence threshold Tika types every delimited file as text/plain and
+    // records no delimiter, so for the two extensions that name one, the extension is the only thing
+    // left that does.
+    private static final Map<String, Character> DELIMITER_BY_EXTENSION = Map.of("tsv", '\t', "psv", '|');
+
     private static final Map<String, Character> DELIMITER_BY_TIKA_NAME = Map.of(
             "comma", ',', "tab", '\t', "pipe", '|', "semicolon", ';');
+
+    private static final List<String> CONTENT_FIELDS = List.of("content", "content_translated");
 
     private static final List<String> SUPPORTED_CONTENT_TYPES = Stream.of(
                     DelimitedRowSource.SUPPORTED, WorkbookRowSource.SUPPORTED, JsonRowSource.SUPPORTED,
@@ -78,8 +89,10 @@ public class TabularRowReader {
      */
     public Stream<Row> rows(Project project, String documentId, String rootId,
                             RowSourceOptions options) throws IOException {
+        // Excluding the extracted text, as DocumentSourceAccess does: only four metadata fields are
+        // read here, and a large tabular document's content would be a second full copy in heap.
         Document document = indexer.get(project.getName(), documentId,
-                rootId == null ? documentId : rootId);
+                rootId == null ? documentId : rootId, CONTENT_FIELDS);
         if (document == null) {
             throw new IllegalArgumentException("no such document in " + project.getName() + ": " + documentId);
         }
@@ -95,15 +108,29 @@ public class TabularRowReader {
     }
 
     private RowSourceOptions resolve(Document document, RowSourceOptions options) {
+        String filename = filename(document);
         RowSourceOptions resolved = options.withContentType(effectiveContentType(
-                options.contentType(), document.getContentTypeOrDefault(), document.getName()));
+                options.contentType(), document.getContentTypeOrDefault(), filename));
         if (resolved.charset() == null && document.getContentEncoding() != null) {
             resolved = resolved.withCharset(document.getContentEncoding());
         }
         if (resolved.delimiter() == null) {
-            resolved = resolved.withDelimiter(delimiterFrom(document.getMetadata()));
+            resolved = resolved.withDelimiter(Optional
+                    .ofNullable(delimiterFrom(document.getMetadata()))
+                    .orElseGet(() -> delimiterByExtension(filename)));
         }
         return resolved;
+    }
+
+    /**
+     * The name Tika recorded, not the path: an embedded document carries its container's path, so
+     * Document.getName would hand records.jsonl inside archive.zip the name of the archive and the
+     * extension refinement would go inert on exactly the embedded sources this class exists to reach.
+     */
+    static String filename(Document document) {
+        Map<String, Object> metadata = document.getMetadata();
+        Object resourceName = metadata == null ? null : metadata.get(RESOURCE_NAME_METADATA_KEY);
+        return resourceName == null ? document.getName() : resourceName.toString();
     }
 
     private RowSource select(String contentType) {
@@ -131,6 +158,10 @@ public class TabularRowReader {
             return storedType;
         }
         return Optional.ofNullable(TYPE_BY_EXTENSION.get(extension(filename))).orElse(storedType);
+    }
+
+    static Character delimiterByExtension(String filename) {
+        return DELIMITER_BY_EXTENSION.get(extension(filename));
     }
 
     private static String extension(String filename) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
@@ -20,8 +20,11 @@ import java.util.stream.Stream;
  * SourceExtractor, plus the content type and charset Tika already detected at index time. It also
  * means no user-supplied path reaches the filesystem, so this route has no traversal surface at all.
  *
- * Authorization on the project is not checked here: it belongs to the callers wiring the REST and CLI
- * triggers, not to a reader.
+ * Authorization on the project is not checked here: the REST and CLI triggers must route through
+ * DocumentSourceAccess, the single decision for serving a document's source bytes, and wiring them to
+ * it belongs to #2206. Its DocumentVerifier.isRootDocumentSizeAllowed check is a size guard this
+ * class does not apply either, which matters because the tier-2 fallback buffers a whole document
+ * several times over.
  */
 public class TabularRowReader {
     private static final Set<String> GENERIC_TYPES =
@@ -33,7 +36,6 @@ public class TabularRowReader {
             "csv", "text/csv",
             "tsv", "text/tab-separated-values",
             "psv", "text/csv",
-            "txt", "text/plain",
             "json", "application/json",
             "jsonl", JsonRowSource.NDJSON_CONTENT_TYPE,
             "ndjson", JsonRowSource.NDJSON_CONTENT_TYPE);

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
@@ -93,7 +93,7 @@ public class TabularRowReader {
 
     private RowSourceOptions resolve(Document document, RowSourceOptions options) {
         RowSourceOptions resolved = options.withContentType(effectiveContentType(
-                options.contentType(), document.getContentType(), document.getName()));
+                options.contentType(), document.getContentTypeOrDefault(), document.getName()));
         if (resolved.charset() == null && document.getContentEncoding() != null) {
             resolved = resolved.withCharset(document.getContentEncoding());
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
@@ -36,6 +36,7 @@ public class TabularRowReader {
             "csv", "text/csv",
             "tsv", "text/tab-separated-values",
             "psv", "text/csv",
+            "txt", "text/plain",
             "json", "application/json",
             "jsonl", JsonRowSource.NDJSON_CONTENT_TYPE,
             "ndjson", JsonRowSource.NDJSON_CONTENT_TYPE);

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
@@ -39,6 +39,10 @@ import java.util.stream.Stream;
 public class TikaTableRowSource implements RowSource {
     private static final Logger LOGGER = LoggerFactory.getLogger(TikaTableRowSource.class);
 
+    /** Rows of this table only: a table nested inside a cell keeps its own rows, and thead, tbody and
+     *  tfoot survive the sanitizer, so a row is either a direct child or one level down. */
+    private static final String ROW_SELECTOR = ">tr, >thead>tr, >tbody>tr, >tfoot>tr";
+
     /** Only the types whose Tika parser was confirmed to emit table markup. Deliberately not a
      *  catch-all: claiming every unclaimed type would make this reader own application/pdf and force
      *  a future PDF table extractor to displace an incumbent. */
@@ -60,7 +64,7 @@ public class TikaTableRowSource implements RowSource {
     @Override
     public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
         Element table = selectTable(tables(source, options), options.table());
-        Elements tableRows = table.select("tr");
+        Elements tableRows = table.select(ROW_SELECTOR);
         if (tableRows.isEmpty()) {
             throw new IllegalArgumentException("no header row: the table is empty");
         }
@@ -122,7 +126,7 @@ public class TikaTableRowSource implements RowSource {
      */
     private static List<String> cells(Element tableRow) {
         List<String> values = new ArrayList<>();
-        for (Element cell : tableRow.select("th, td")) {
+        for (Element cell : tableRow.select(">th, >td")) {
             if (cell.hasAttr("colspan") || cell.hasAttr("rowspan")) {
                 throw new IllegalArgumentException(
                         "merged cells make the columns ambiguous: remove the colspan or rowspan");

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
@@ -7,15 +7,15 @@ import org.icij.datashare.text.structure.StructureMarkdownExtractor.Page;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -31,8 +31,14 @@ import java.util.stream.Stream;
  * mapping's own date format has to handle it. And the extractor's output cap means an oversized
  * document throws rather than importing a truncated table, which is the behaviour a data import
  * needs; large files belong on tier 1.
+ *
+ * Cell text is stripped here while tier 1 leaves values untouched: Tika's XHTML rendering introduces
+ * its own indentation and newlines inside a cell, so the whitespace being removed is the renderer's
+ * rather than the document's.
  */
 public class TikaTableRowSource implements RowSource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TikaTableRowSource.class);
+
     /** Only the types whose Tika parser was confirmed to emit table markup. Deliberately not a
      *  catch-all: claiming every unclaimed type would make this reader own application/pdf and force
      *  a future PDF table extractor to displace an incumbent. */
@@ -61,12 +67,21 @@ public class TikaTableRowSource implements RowSource {
         List<String> headers = Row.headers(cells(tableRows.get(0)));
 
         List<Row> rows = new ArrayList<>();
+        long surplus = 0;
         for (int index = 1; index < tableRows.size(); index++) {
             List<String> values = cells(tableRows.get(index));
             if (values.stream().allMatch(String::isEmpty)) {
                 continue;
             }
-            rows.add(new Row(rows.size() + 1L, map(headers, values)));
+            if (values.size() > headers.size()) {
+                surplus++;
+            }
+            // Tolerated rather than refused, unlike tier 1: a stray trailing cell is common in
+            // real-world markup, and the rest of the row still lines up with the header.
+            rows.add(new Row(rows.size() + 1L, Row.values(headers, values)));
+        }
+        if (surplus > 0) {
+            LOGGER.info("dropped the cells past the {} declared columns in {} rows", headers.size(), surplus);
         }
         return rows.stream().onClose(() -> close(source));
     }
@@ -115,16 +130,6 @@ public class TikaTableRowSource implements RowSource {
             values.add(cell.text().strip());
         }
         return values;
-    }
-
-    private static Map<String, String> map(List<String> headers, List<String> values) {
-        Map<String, String> mapped = new HashMap<>();
-        for (int column = 0; column < headers.size(); column++) {
-            if (headers.get(column) != null) {
-                mapped.put(headers.get(column), column < values.size() ? values.get(column) : "");
-            }
-        }
-        return mapped;
     }
 
     private static void close(InputStream source) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
@@ -11,6 +11,7 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -67,7 +68,7 @@ public class TikaTableRowSource implements RowSource {
             }
             rows.add(new Row(rows.size() + 1L, map(headers, values)));
         }
-        return rows.stream();
+        return rows.stream().onClose(() -> close(source));
     }
 
     // OCR off: a tabular source does not need it, and leaving it off keeps the parse cheap and its
@@ -124,5 +125,13 @@ public class TikaTableRowSource implements RowSource {
             }
         }
         return mapped;
+    }
+
+    private static void close(InputStream source) {
+        try {
+            source.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException("closing the tabular source failed", e);
+        }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
@@ -1,0 +1,128 @@
+package org.icij.datashare.tabular;
+
+import org.apache.tika.exception.TikaException;
+import org.icij.datashare.text.structure.StructureMarkdownExtractor;
+import org.icij.datashare.text.structure.StructureMarkdownExtractor.OcrSettings;
+import org.icij.datashare.text.structure.StructureMarkdownExtractor.Page;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * The tier-2 fallback: rows out of the tables Tika renders, covering every format whose parser emits
+ * table markup. Reuses StructureMarkdownExtractor rather than setting up its own parse, because that
+ * class already owns the resilient PST parser swap, the output cap, the page splitting and the
+ * sanitizer. Its Markdown rendering is ignored here; if that shows up in a profile, the fix is an
+ * xhtml-only method on that class rather than a parser in this one.
+ *
+ * Two things differ from tier 1, by nature rather than by omission. Cell values arrive already
+ * formatted with the cell type discarded, so a date is whatever the source rendered it as and the
+ * mapping's own date format has to handle it. And the extractor's output cap means an oversized
+ * document throws rather than importing a truncated table, which is the behaviour a data import
+ * needs; large files belong on tier 1.
+ */
+public class TikaTableRowSource implements RowSource {
+    /** Only the types whose Tika parser was confirmed to emit table markup. Deliberately not a
+     *  catch-all: claiming every unclaimed type would make this reader own application/pdf and force
+     *  a future PDF table extractor to displace an incumbent. */
+    public static final Set<String> SUPPORTED = Set.of(
+            "application/vnd.oasis.opendocument.spreadsheet",
+            "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/msword",
+            "text/html",
+            "application/vnd.apple.numbers");
+
+    private final StructureMarkdownExtractor extractor = new StructureMarkdownExtractor();
+
+    @Override
+    public boolean supports(String contentType) {
+        return SUPPORTED.contains(contentType);
+    }
+
+    @Override
+    public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
+        Element table = selectTable(tables(source, options), options.table());
+        Elements tableRows = table.select("tr");
+        if (tableRows.isEmpty()) {
+            throw new IllegalArgumentException("no header row: the table is empty");
+        }
+        List<String> headers = Row.headers(cells(tableRows.get(0)));
+
+        List<Row> rows = new ArrayList<>();
+        for (int index = 1; index < tableRows.size(); index++) {
+            List<String> values = cells(tableRows.get(index));
+            if (values.stream().allMatch(String::isEmpty)) {
+                continue;
+            }
+            rows.add(new Row(rows.size() + 1L, map(headers, values)));
+        }
+        return rows.stream();
+    }
+
+    // OCR off: a tabular source does not need it, and leaving it off keeps the parse cheap and its
+    // output deterministic.
+    private List<Element> tables(InputStream source, RowSourceOptions options) throws IOException {
+        List<Page> pages;
+        try {
+            pages = extractor.extract(source, options.contentType(), null, OcrSettings.NONE);
+        } catch (SAXException | TikaException parseFailure) {
+            throw new IOException("parsing the tabular source failed", parseFailure);
+        }
+        List<Element> tables = new ArrayList<>();
+        for (Page page : pages) {
+            tables.addAll(Jsoup.parse(page.xhtml()).select("table"));
+        }
+        return tables;
+    }
+
+    private static Element selectTable(List<Element> tables, Integer requested) {
+        if (tables.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "the source holds no table, so it has no rows to read");
+        }
+        int index = requested == null ? 1 : requested;
+        if (index < 1 || index > tables.size()) {
+            throw new IllegalArgumentException(
+                    "no table at index " + index + ": the source holds " + tables.size());
+        }
+        return tables.get(index - 1);
+    }
+
+    /**
+     * A merged cell makes column alignment undefined, and silently misaligning every value under a
+     * header is worse than refusing the file, so a span anywhere in a row is rejected. Both th and td
+     * count as cells: a header row uses either depending on who wrote the document.
+     */
+    private static List<String> cells(Element tableRow) {
+        List<String> values = new ArrayList<>();
+        for (Element cell : tableRow.select("th, td")) {
+            if (cell.hasAttr("colspan") || cell.hasAttr("rowspan")) {
+                throw new IllegalArgumentException(
+                        "merged cells make the columns ambiguous: remove the colspan or rowspan");
+            }
+            values.add(cell.text().strip());
+        }
+        return values;
+    }
+
+    private static Map<String, String> map(List<String> headers, List<String> values) {
+        Map<String, String> mapped = new HashMap<>();
+        for (int column = 0; column < headers.size(); column++) {
+            if (headers.get(column) != null) {
+                mapped.put(headers.get(column), column < values.size() ? values.get(column) : "");
+            }
+        }
+        return mapped;
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TikaTableRowSource.java
@@ -6,7 +6,6 @@ import org.icij.datashare.text.structure.StructureMarkdownExtractor.OcrSettings;
 import org.icij.datashare.text.structure.StructureMarkdownExtractor.Page;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -40,8 +39,14 @@ public class TikaTableRowSource implements RowSource {
     private static final Logger LOGGER = LoggerFactory.getLogger(TikaTableRowSource.class);
 
     /** Rows of this table only: a table nested inside a cell keeps its own rows, and thead, tbody and
-     *  tfoot survive the sanitizer, so a row is either a direct child or one level down. */
-    private static final String ROW_SELECTOR = ">tr, >thead>tr, >tbody>tr, >tfoot>tr";
+     *  tfoot survive the sanitizer, so a row is either a direct child or one level down. Selected in
+     *  four passes rather than as one comma group, because a group returns document order and a tfoot
+     *  written before its tbody is legal html that several exporters emit. */
+    private static final List<String> ROW_SELECTORS = List.of(">thead>tr", ">tr", ">tbody>tr", ">tfoot>tr");
+
+    /** Excel's column limit, used only to stop a hostile or corrupt span from expanding a row without
+     *  bound; a real sheet cannot exceed it. */
+    private static final int MAX_CELLS_PER_ROW = 16384;
 
     /** Only the types whose Tika parser was confirmed to emit table markup. Deliberately not a
      *  catch-all: claiming every unclaimed type would make this reader own application/pdf and force
@@ -52,7 +57,10 @@ public class TikaTableRowSource implements RowSource {
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/msword",
             "text/html",
-            "application/vnd.apple.numbers");
+            // Tika types Numbers by format generation, and only the pre-2013 one keeps the bare name.
+            "application/vnd.apple.numbers",
+            "application/vnd.apple.numbers.13",
+            "application/vnd.apple.numbers.18");
 
     private final StructureMarkdownExtractor extractor = new StructureMarkdownExtractor();
 
@@ -63,8 +71,18 @@ public class TikaTableRowSource implements RowSource {
 
     @Override
     public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
+        // Nothing here is lazy: the extractor has consumed the source to exhaustion before the first
+        // row is built, so the source is released on the way out rather than by the returned stream.
+        try {
+            return read(source, options).stream();
+        } finally {
+            close(source);
+        }
+    }
+
+    private List<Row> read(InputStream source, RowSourceOptions options) throws IOException {
         Element table = selectTable(tables(source, options), options.table());
-        Elements tableRows = table.select(ROW_SELECTOR);
+        List<Element> tableRows = tableRows(table);
         if (tableRows.isEmpty()) {
             throw new IllegalArgumentException("no header row: the table is empty");
         }
@@ -87,7 +105,15 @@ public class TikaTableRowSource implements RowSource {
         if (surplus > 0) {
             LOGGER.info("dropped the cells past the {} declared columns in {} rows", headers.size(), surplus);
         }
-        return rows.stream().onClose(() -> close(source));
+        return rows;
+    }
+
+    private static List<Element> tableRows(Element table) {
+        List<Element> tableRows = new ArrayList<>();
+        for (String selector : ROW_SELECTORS) {
+            tableRows.addAll(table.select(selector));
+        }
+        return tableRows;
     }
 
     // OCR off: a tabular source does not need it, and leaving it off keeps the parse cheap and its
@@ -121,19 +147,49 @@ public class TikaTableRowSource implements RowSource {
 
     /**
      * A merged cell makes column alignment undefined, and silently misaligning every value under a
-     * header is worse than refusing the file, so a span anywhere in a row is rejected. Both th and td
+     * header is worse than refusing the file, so a cell that carries content across more than one
+     * column is rejected. A span of exactly one is not a merge, and Word, TinyMCE and CKEditor write
+     * colspan="1" on every cell they emit. An empty span is not a merge either: Tika renders ODF's
+     * table:number-columns-repeated as a colspan, and LibreOffice writes it on the trailing empty
+     * cells of every sheet, so those expand back into the empty columns they stand for. Both th and td
      * count as cells: a header row uses either depending on who wrote the document.
      */
     private static List<String> cells(Element tableRow) {
         List<String> values = new ArrayList<>();
         for (Element cell : tableRow.select(">th, >td")) {
-            if (cell.hasAttr("colspan") || cell.hasAttr("rowspan")) {
+            String text = text(cell);
+            int columns = span(cell, "colspan");
+            if (!text.isEmpty() && (columns > 1 || span(cell, "rowspan") > 1)) {
                 throw new IllegalArgumentException(
                         "merged cells make the columns ambiguous: remove the colspan or rowspan");
             }
-            values.add(cell.text().strip());
+            if (values.size() + columns > MAX_CELLS_PER_ROW) {
+                throw new IllegalArgumentException(
+                        "a row spans more than " + MAX_CELLS_PER_ROW + " columns, so the table is not a table");
+            }
+            values.add(text);
+            for (int repeat = 1; repeat < columns; repeat++) {
+                values.add("");
+            }
         }
         return values;
+    }
+
+    private static int span(Element cell, String attribute) {
+        try {
+            String declared = cell.attr(attribute).strip();
+            return declared.isEmpty() ? 1 : Math.max(1, Integer.parseInt(declared));
+        } catch (NumberFormatException notANumber) {
+            return 1;
+        }
+    }
+
+    // A nested table keeps its own rows, so its text must not be folded into the cell that holds it:
+    // Element.text() walks every descendant and would return "ACME inner nested" for one cell.
+    private static String text(Element cell) {
+        Element withoutNestedTables = cell.clone();
+        withoutNestedTables.select("table").remove();
+        return withoutNestedTables.text().strip();
     }
 
     private static void close(InputStream source) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 public class WorkbookRowSource implements RowSource {
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkbookRowSource.class);
 
-    private static final Set<String> SUPPORTED = Set.of(
+    public static final Set<String> SUPPORTED = Set.of(
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             "application/vnd.ms-excel",
             "application/vnd.ms-excel.sheet.macroenabled.12");

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
@@ -39,8 +39,6 @@ public class WorkbookRowSource implements RowSource {
             "application/vnd.ms-excel",
             "application/vnd.ms-excel.sheet.macroenabled.12");
 
-    private final DataFormatter formatter = new DataFormatter();
-
     @Override
     public boolean supports(String contentType) {
         return SUPPORTED.contains(contentType);
@@ -52,7 +50,8 @@ public class WorkbookRowSource implements RowSource {
         try {
             Sheet sheet = selectSheet(workbook, options.sheet());
             FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
-            return read(sheet, evaluator).stream().onClose(() -> close(workbook));
+            DataFormatter formatter = new DataFormatter();
+            return read(sheet, evaluator, formatter).stream().onClose(() -> close(workbook));
         } catch (RuntimeException failure) {
             close(workbook);
             throw failure;
@@ -80,17 +79,17 @@ public class WorkbookRowSource implements RowSource {
 
     // Materialized rather than lazily streamed: the workbook is already fully in memory, so a lazy
     // spliterator over it would buy nothing and would keep the workbook open for the caller to leak.
-    private List<Row> read(Sheet sheet, FormulaEvaluator evaluator) {
+    private static List<Row> read(Sheet sheet, FormulaEvaluator evaluator, DataFormatter formatter) {
         java.util.Iterator<org.apache.poi.ss.usermodel.Row> sheetRows = sheet.iterator();
         if (!sheetRows.hasNext()) {
             throw new IllegalArgumentException("no header row: the sheet is empty");
         }
-        List<String> headers = Row.headers(cells(sheetRows.next(), evaluator));
+        List<String> headers = Row.headers(cells(sheetRows.next(), evaluator, formatter));
 
         List<Row> rows = new ArrayList<>();
         long blank = 0;
         while (sheetRows.hasNext()) {
-            List<String> values = cells(sheetRows.next(), evaluator);
+            List<String> values = cells(sheetRows.next(), evaluator, formatter);
             if (values.stream().allMatch(String::isEmpty)) {
                 blank++;
                 continue;
@@ -103,10 +102,10 @@ public class WorkbookRowSource implements RowSource {
         return rows;
     }
 
-    private List<String> cells(org.apache.poi.ss.usermodel.Row row, FormulaEvaluator evaluator) {
+    private static List<String> cells(org.apache.poi.ss.usermodel.Row row, FormulaEvaluator evaluator, DataFormatter formatter) {
         List<String> values = new ArrayList<>();
         for (int column = 0; column < row.getLastCellNum(); column++) {
-            values.add(value(row.getCell(column), evaluator));
+            values.add(value(row.getCell(column), evaluator, formatter));
         }
         return values;
     }
@@ -116,7 +115,7 @@ public class WorkbookRowSource implements RowSource {
      * mapping's date format depend on how somebody styled the file. Date cells are therefore rendered
      * ISO-8601 instead, dropping the time part when it is midnight.
      */
-    private String value(Cell cell, FormulaEvaluator evaluator) {
+    private static String value(Cell cell, FormulaEvaluator evaluator, DataFormatter formatter) {
         if (cell == null) {
             return "";
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
@@ -18,9 +18,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -73,7 +71,7 @@ public class WorkbookRowSource implements RowSource {
         try {
             return workbook.getSheetAt(Integer.parseInt(requested.strip()) - 1);
         } catch (IllegalArgumentException notAnIndex) {
-            throw new IllegalArgumentException("no such sheet: " + requested);
+            throw new IllegalArgumentException("no such sheet: " + requested, notAnIndex);
         }
     }
 
@@ -94,7 +92,8 @@ public class WorkbookRowSource implements RowSource {
                 blank++;
                 continue;
             }
-            rows.add(new Row(rows.size() + 1L, map(headers, values)));
+            long number = rows.size() + 1L;
+            rows.add(new Row(number, Row.values(headers, values, number)));
         }
         if (blank > 0) {
             LOGGER.info("skipped {} blank rows in sheet {}", blank, sheet.getSheetName());
@@ -133,16 +132,6 @@ public class WorkbookRowSource implements RowSource {
                 ? evaluator.evaluateFormulaCell(cell)
                 : cell.getCellType();
         return type == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell);
-    }
-
-    private static Map<String, String> map(List<String> headers, List<String> values) {
-        Map<String, String> mapped = new HashMap<>();
-        for (int column = 0; column < headers.size(); column++) {
-            if (headers.get(column) != null) {
-                mapped.put(headers.get(column), column < values.size() ? values.get(column) : "");
-            }
-        }
-        return mapped;
     }
 
     private static void close(Workbook workbook) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
@@ -1,0 +1,156 @@
+package org.icij.datashare.tabular;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Reads a workbook with POI. The whole workbook is loaded in memory, roughly 5 to 10 times the file
+ * size in heap: streaming would mean two Excel code paths, since HSSF has no practical streaming
+ * equivalent, plus hand-wiring StylesTable and SharedStrings to reproduce cell formatting. The
+ * RowSource contract is stream-shaped, so replacing this with an XSSFReader implementation later
+ * touches neither the interface nor its callers.
+ */
+public class WorkbookRowSource implements RowSource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkbookRowSource.class);
+
+    private static final Set<String> SUPPORTED = Set.of(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+            "application/vnd.ms-excel.sheet.macroenabled.12");
+
+    private final DataFormatter formatter = new DataFormatter();
+
+    @Override
+    public boolean supports(String contentType) {
+        return SUPPORTED.contains(contentType);
+    }
+
+    @Override
+    public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
+        Workbook workbook = WorkbookFactory.create(source);
+        try {
+            Sheet sheet = selectSheet(workbook, options.sheet());
+            FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
+            return read(sheet, evaluator).stream().onClose(() -> close(workbook));
+        } catch (RuntimeException failure) {
+            close(workbook);
+            throw failure;
+        }
+    }
+
+    /**
+     * By name first, so a sheet literally named "2" wins over position 2, and only then as a 1-based
+     * index when the name matches nothing and parses as an integer.
+     */
+    private static Sheet selectSheet(Workbook workbook, String requested) {
+        if (requested == null) {
+            return workbook.getSheetAt(0);
+        }
+        Sheet byName = workbook.getSheet(requested);
+        if (byName != null) {
+            return byName;
+        }
+        try {
+            return workbook.getSheetAt(Integer.parseInt(requested.strip()) - 1);
+        } catch (IllegalArgumentException notAnIndex) {
+            throw new IllegalArgumentException("no such sheet: " + requested);
+        }
+    }
+
+    // Materialized rather than lazily streamed: the workbook is already fully in memory, so a lazy
+    // spliterator over it would buy nothing and would keep the workbook open for the caller to leak.
+    private List<Row> read(Sheet sheet, FormulaEvaluator evaluator) {
+        java.util.Iterator<org.apache.poi.ss.usermodel.Row> sheetRows = sheet.iterator();
+        if (!sheetRows.hasNext()) {
+            throw new IllegalArgumentException("no header row: the sheet is empty");
+        }
+        List<String> headers = Row.headers(cells(sheetRows.next(), evaluator));
+
+        List<Row> rows = new ArrayList<>();
+        long blank = 0;
+        while (sheetRows.hasNext()) {
+            List<String> values = cells(sheetRows.next(), evaluator);
+            if (values.stream().allMatch(String::isEmpty)) {
+                blank++;
+                continue;
+            }
+            rows.add(new Row(rows.size() + 1L, map(headers, values)));
+        }
+        if (blank > 0) {
+            LOGGER.info("skipped {} blank rows in sheet {}", blank, sheet.getSheetName());
+        }
+        return rows;
+    }
+
+    private List<String> cells(org.apache.poi.ss.usermodel.Row row, FormulaEvaluator evaluator) {
+        List<String> values = new ArrayList<>();
+        for (int column = 0; column < row.getLastCellNum(); column++) {
+            values.add(value(row.getCell(column), evaluator));
+        }
+        return values;
+    }
+
+    /**
+     * DataFormatter renders a date cell with the spreadsheet's own display style, which would make a
+     * mapping's date format depend on how somebody styled the file. Date cells are therefore rendered
+     * ISO-8601 instead, dropping the time part when it is midnight.
+     */
+    private String value(Cell cell, FormulaEvaluator evaluator) {
+        if (cell == null) {
+            return "";
+        }
+        if (isDate(cell, evaluator)) {
+            LocalDateTime moment = cell.getLocalDateTimeCellValue();
+            return moment.toLocalTime().equals(LocalTime.MIDNIGHT)
+                    ? moment.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
+                    : moment.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        }
+        return formatter.formatCellValue(cell, evaluator);
+    }
+
+    private static boolean isDate(Cell cell, FormulaEvaluator evaluator) {
+        CellType type = cell.getCellType() == CellType.FORMULA
+                ? evaluator.evaluateFormulaCell(cell)
+                : cell.getCellType();
+        return type == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell);
+    }
+
+    private static Map<String, String> map(List<String> headers, List<String> values) {
+        Map<String, String> mapped = new HashMap<>();
+        for (int column = 0; column < headers.size(); column++) {
+            if (headers.get(column) != null) {
+                mapped.put(headers.get(column), column < values.size() ? values.get(column) : "");
+            }
+        }
+        return mapped;
+    }
+
+    private static void close(Workbook workbook) {
+        try {
+            workbook.close();
+        } catch (IOException e) {
+            throw new UncheckedIOException("closing the workbook failed", e);
+        }
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
@@ -2,8 +2,8 @@ package org.icij.datashare.tabular;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
-import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.FormulaError;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -44,12 +45,19 @@ public class WorkbookRowSource implements RowSource {
 
     @Override
     public Stream<Row> rows(InputStream source, RowSourceOptions options) throws IOException {
-        Workbook workbook = WorkbookFactory.create(source);
+        // POI closes the stream inside create() when it succeeds, but not when it throws, and an
+        // encrypted or truncated workbook throws before there is any stream for the caller to close.
+        Workbook workbook;
+        try {
+            workbook = WorkbookFactory.create(source);
+        } catch (IOException | RuntimeException failure) {
+            closeQuietly(source);
+            throw failure;
+        }
         try {
             Sheet sheet = selectSheet(workbook, options.sheet());
             FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
-            DataFormatter formatter = new DataFormatter();
-            return read(sheet, evaluator, formatter).stream().onClose(() -> close(workbook));
+            return read(sheet, evaluator).stream().onClose(() -> close(workbook));
         } catch (RuntimeException failure) {
             close(workbook);
             throw failure;
@@ -77,17 +85,17 @@ public class WorkbookRowSource implements RowSource {
 
     // Materialized rather than lazily streamed: the workbook is already fully in memory, so a lazy
     // spliterator over it would buy nothing and would keep the workbook open for the caller to leak.
-    private static List<Row> read(Sheet sheet, FormulaEvaluator evaluator, DataFormatter formatter) {
+    private static List<Row> read(Sheet sheet, FormulaEvaluator evaluator) {
         java.util.Iterator<org.apache.poi.ss.usermodel.Row> sheetRows = sheet.iterator();
         if (!sheetRows.hasNext()) {
             throw new IllegalArgumentException("no header row: the sheet is empty");
         }
-        List<String> headers = Row.headers(cells(sheetRows.next(), evaluator, formatter));
+        List<String> headers = Row.headers(cells(sheetRows.next(), evaluator));
 
         List<Row> rows = new ArrayList<>();
         long blank = 0;
         while (sheetRows.hasNext()) {
-            List<String> values = cells(sheetRows.next(), evaluator, formatter);
+            List<String> values = cells(sheetRows.next(), evaluator);
             if (values.stream().allMatch(String::isEmpty)) {
                 blank++;
                 continue;
@@ -101,37 +109,65 @@ public class WorkbookRowSource implements RowSource {
         return rows;
     }
 
-    private static List<String> cells(org.apache.poi.ss.usermodel.Row row, FormulaEvaluator evaluator, DataFormatter formatter) {
+    private static List<String> cells(org.apache.poi.ss.usermodel.Row row, FormulaEvaluator evaluator) {
         List<String> values = new ArrayList<>();
         for (int column = 0; column < row.getLastCellNum(); column++) {
-            values.add(value(row.getCell(column), evaluator, formatter));
+            values.add(value(row.getCell(column), evaluator));
         }
         return values;
     }
 
     /**
-     * DataFormatter renders a date cell with the spreadsheet's own display style, which would make a
-     * mapping's date format depend on how somebody styled the file. Date cells are therefore rendered
-     * ISO-8601 instead, dropping the time part when it is midnight.
+     * The cell's own value, never its display string: DataFormatter renders what the spreadsheet shows,
+     * so a mapping's date format would depend on how somebody styled the file and a General-formatted
+     * account number would arrive as 1.23457E+11. Date cells are rendered ISO-8601 for the same reason.
      */
-    private static String value(Cell cell, FormulaEvaluator evaluator, DataFormatter formatter) {
+    private static String value(Cell cell, FormulaEvaluator evaluator) {
         if (cell == null) {
             return "";
         }
-        if (isDate(cell, evaluator)) {
-            LocalDateTime moment = cell.getLocalDateTimeCellValue();
-            return moment.toLocalTime().equals(LocalTime.MIDNIGHT)
-                    ? moment.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
-                    : moment.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        }
-        return formatter.formatCellValue(cell, evaluator);
+        return switch (resultType(cell, evaluator)) {
+            case NUMERIC -> numeric(cell);
+            case STRING -> cell.getStringCellValue();
+            case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+            case ERROR -> FormulaError.forInt(cell.getErrorCellValue()).getString();
+            default -> "";
+        };
     }
 
-    private static boolean isDate(Cell cell, FormulaEvaluator evaluator) {
-        CellType type = cell.getCellType() == CellType.FORMULA
-                ? evaluator.evaluateFormulaCell(cell)
-                : cell.getCellType();
-        return type == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell);
+    /**
+     * Evaluation first, because a generator that stores no cached result leaves a formula cell with no
+     * value until it is evaluated. The cached result is the fallback rather than the other way round,
+     * because POI throws NotImplementedException on the functions it does not implement (XLOOKUP,
+     * DATEDIF, the dynamic-array family) and one of those in a footer must not abort the whole sheet.
+     */
+    private static CellType resultType(Cell cell, FormulaEvaluator evaluator) {
+        if (cell.getCellType() != CellType.FORMULA) {
+            return cell.getCellType();
+        }
+        try {
+            return evaluator.evaluateFormulaCell(cell);
+        } catch (RuntimeException notEvaluable) {
+            LOGGER.info("falling back to the cached result of {}: {}",
+                    cell.getAddress(), notEvaluable.toString());
+            return cell.getCachedFormulaResultType();
+        }
+    }
+
+    private static String numeric(Cell cell) {
+        double serial = cell.getNumericCellValue();
+        if (!DateUtil.isCellDateFormatted(cell)) {
+            return BigDecimal.valueOf(serial).stripTrailingZeros().toPlainString();
+        }
+        LocalDateTime moment = cell.getLocalDateTimeCellValue();
+        // A serial below 1 has no date part at all: the format is time-only, and anchoring it on POI's
+        // day zero would invent a 1899-12-31 the document never contained.
+        if (serial < 1.0) {
+            return moment.toLocalTime().format(DateTimeFormatter.ISO_LOCAL_TIME);
+        }
+        return moment.toLocalTime().equals(LocalTime.MIDNIGHT)
+                ? moment.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE)
+                : moment.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 
     private static void close(Workbook workbook) {
@@ -139,6 +175,14 @@ public class WorkbookRowSource implements RowSource {
             workbook.close();
         } catch (IOException e) {
             throw new UncheckedIOException("closing the workbook failed", e);
+        }
+    }
+
+    private static void closeQuietly(InputStream source) {
+        try {
+            source.close();
+        } catch (IOException ignored) {
+            // the workbook already failed to open; the close failure adds nothing actionable
         }
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 public class DelimitedRowSourceTest {
     private final DelimitedRowSource source = new DelimitedRowSource();
@@ -91,5 +92,15 @@ public class DelimitedRowSourceTest {
     @Test
     public void test_header_with_no_data_rows_is_empty_not_an_error() throws Exception {
         assertThat(read("id,name\n", RowSourceOptions.defaults())).isEmpty();
+    }
+
+    @Test
+    public void test_malformed_record_names_the_row_number() throws Exception {
+        try {
+            read("id,name\n1,\"unterminated\n", RowSourceOptions.defaults());
+            fail("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("row 1");
+        }
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
@@ -146,4 +146,76 @@ public class DelimitedRowSourceTest {
             assertThat(e.getMessage()).contains("row 1");
         }
     }
+
+    @Test
+    public void test_a_byte_order_mark_is_not_part_of_the_first_column_name() throws Exception {
+        byte[] withBom = ("\uFEFFid,name\n1,ACME\n").getBytes(StandardCharsets.UTF_8);
+
+        List<Row> rows = read(withBom, RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().keySet()).containsOnly("id", "name");
+        assertThat(rows.get(0).values().get("id")).isEqualTo("1");
+    }
+
+    @Test
+    public void test_a_header_row_whose_every_name_is_blank_is_refused() throws Exception {
+        try {
+            read(",,\nid,name,country\n1,ACME,FR\n", RowSourceOptions.defaults());
+            fail("a title or spacer row above the data must not import every row as an empty map");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("every name is blank");
+        }
+    }
+
+    @Test
+    public void test_a_tab_separated_content_type_implies_the_tab_delimiter() throws Exception {
+        for (String contentType : List.of("text/tab-separated-values", "text/tsv")) {
+            List<Row> rows = read("id\tname\n1\tACME\n",
+                    RowSourceOptions.defaults().withContentType(contentType));
+
+            assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+        }
+    }
+
+    @Test
+    public void test_the_quote_character_is_configurable() throws Exception {
+        List<Row> rows = read("id,name\n1,'ACME, Inc'\n",
+                RowSourceOptions.defaults().withQuote('\''));
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME, Inc");
+    }
+
+    /**
+     * Tika settles on a single-byte charset for a large mostly-ascii export, and reading utf-8 as
+     * latin-1 never reports an error, so the detected charset cannot be taken at face value.
+     */
+    @Test
+    public void test_a_utf8_source_detected_as_latin1_is_still_read_as_utf8() throws Exception {
+        List<Row> rows = read("id,name\n1,R\u00e9publique\n",
+                RowSourceOptions.defaults().withCharset(Charset.forName("ISO-8859-1")));
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("R\u00e9publique");
+    }
+
+    @Test
+    public void test_a_genuinely_latin1_source_keeps_the_detected_charset() throws Exception {
+        byte[] latin1 = "id,name\n1,R\u00e9publique\n".getBytes(Charset.forName("ISO-8859-1"));
+
+        List<Row> rows = read(latin1, RowSourceOptions.defaults().withCharset(Charset.forName("ISO-8859-1")));
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("R\u00e9publique");
+    }
+
+    @Test
+    public void test_a_failure_after_the_header_still_releases_the_source() throws Exception {
+        TrackingInputStream stream = new TrackingInputStream("id,id\n1,2\n".getBytes(StandardCharsets.UTF_8));
+
+        try {
+            source.rows(stream, RowSourceOptions.defaults());
+            fail("a duplicate header name must be refused");
+        } catch (IllegalArgumentException expected) {
+            assertThat(stream.closed).isTrue();
+        }
+    }
+
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
@@ -1,0 +1,95 @@
+package org.icij.datashare.tabular;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class DelimitedRowSourceTest {
+    private final DelimitedRowSource source = new DelimitedRowSource();
+
+    private List<Row> read(String content, RowSourceOptions options) throws Exception {
+        return read(content.getBytes(StandardCharsets.UTF_8), options);
+    }
+
+    private List<Row> read(byte[] content, RowSourceOptions options) throws Exception {
+        try (InputStream stream = new ByteArrayInputStream(content);
+             Stream<Row> rows = source.rows(stream, options)) {
+            return rows.toList();
+        }
+    }
+
+    @Test
+    public void test_supports_delimited_content_types() {
+        assertThat(source.supports("text/csv")).isTrue();
+        assertThat(source.supports("text/tab-separated-values")).isTrue();
+        assertThat(source.supports("text/plain")).isTrue();
+        assertThat(source.supports("application/json")).isFalse();
+    }
+
+    @Test
+    public void test_reads_comma_separated_rows_with_header() throws Exception {
+        List<Row> rows = read("id,name\n1,ACME\n2,Globex\n", RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).number()).isEqualTo(1L);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+        assertThat(rows.get(1).number()).isEqualTo(2L);
+        assertThat(rows.get(1).values().get("id")).isEqualTo("2");
+    }
+
+    @Test
+    public void test_uses_the_delimiter_from_options() throws Exception {
+        List<Row> rows = read("id;name\n1;ACME\n",
+                RowSourceOptions.defaults().withDelimiter(';'));
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_quoted_field_keeps_delimiter_and_newline() throws Exception {
+        List<Row> rows = read("id,name\n1,\"ACME, Inc.\nsecond line\"\n", RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME, Inc.\nsecond line");
+    }
+
+    @Test
+    public void test_reads_with_the_given_charset() throws Exception {
+        byte[] latin1 = "id,name\n1,Café\n".getBytes(Charset.forName("windows-1252"));
+
+        List<Row> rows = read(latin1,
+                RowSourceOptions.defaults().withCharset(Charset.forName("windows-1252")));
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("Café");
+    }
+
+    @Test
+    public void test_drops_blank_named_columns() throws Exception {
+        List<Row> rows = read("id,,name\n1,ignored,ACME\n", RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values()).hasSize(2);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_duplicate_header_fails() throws Exception {
+        read("id,name,name\n1,a,b\n", RowSourceOptions.defaults());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_no_header_row_fails() throws Exception {
+        read("", RowSourceOptions.defaults());
+    }
+
+    @Test
+    public void test_header_with_no_data_rows_is_empty_not_an_error() throws Exception {
+        assertThat(read("id,name\n", RowSourceOptions.defaults())).isEmpty();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
@@ -114,6 +114,20 @@ public class DelimitedRowSourceTest {
         }
     }
 
+    /**
+     * A trailing delimiter is one of the commonest real CSV shapes. The surplus field it produces is
+     * empty, so it carries no data and cannot be the misalignment a long row is refused for.
+     */
+    @Test
+    public void test_a_trailing_delimiter_does_not_fail_the_row() throws Exception {
+        List<Row> rows = read("id,name\n1,ACME,\n", RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).values()).hasSize(2);
+        assertThat(rows.get(0).values().get("id")).isEqualTo("1");
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
     @Test
     public void test_skips_a_row_of_empty_fields_without_consuming_a_number() throws Exception {
         List<Row> rows = read("id,name\n,\n1,ACME\n", RowSourceOptions.defaults());

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/DelimitedRowSourceTest.java
@@ -95,6 +95,35 @@ public class DelimitedRowSourceTest {
     }
 
     @Test
+    public void test_a_short_row_pads_the_missing_columns() throws Exception {
+        List<Row> rows = read("id,name,country\n1,ACME\n", RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values()).hasSize(3);
+        assertThat(rows.get(0).values().get("country")).isEqualTo("");
+    }
+
+    @Test
+    public void test_a_row_with_more_fields_than_the_header_fails() throws Exception {
+        try {
+            read("id,name\n1,ACME,extra\n", RowSourceOptions.defaults());
+            fail("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("row 1");
+            assertThat(e.getMessage()).contains("3 fields");
+            assertThat(e.getMessage()).contains("declares 2");
+        }
+    }
+
+    @Test
+    public void test_skips_a_row_of_empty_fields_without_consuming_a_number() throws Exception {
+        List<Row> rows = read("id,name\n,\n1,ACME\n", RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).number()).isEqualTo(1L);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
     public void test_malformed_record_names_the_row_number() throws Exception {
         try {
             read("id,name\n1,\"unterminated\n", RowSourceOptions.defaults());

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
@@ -1,0 +1,86 @@
+package org.icij.datashare.tabular;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class JsonRowSourceTest {
+    private final JsonRowSource source = new JsonRowSource();
+
+    private List<Row> read(String content) throws Exception {
+        try (InputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+             Stream<Row> rows = source.rows(stream, RowSourceOptions.defaults())) {
+            return rows.toList();
+        }
+    }
+
+    @Test
+    public void test_supports_json_content_types() {
+        assertThat(source.supports("application/json")).isTrue();
+        assertThat(source.supports(JsonRowSource.NDJSON_CONTENT_TYPE)).isTrue();
+        assertThat(source.supports("text/csv")).isFalse();
+    }
+
+    @Test
+    public void test_reads_an_array_of_objects() throws Exception {
+        List<Row> rows = read("[{\"id\":1,\"name\":\"ACME\"},{\"id\":2,\"name\":\"Globex\"}]");
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).number()).isEqualTo(1L);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+        assertThat(rows.get(1).values().get("id")).isEqualTo("2");
+    }
+
+    @Test
+    public void test_reads_line_delimited_objects() throws Exception {
+        List<Row> rows = read("{\"id\":1,\"name\":\"ACME\"}\n{\"id\":2,\"name\":\"Globex\"}\n");
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(1).values().get("name")).isEqualTo("Globex");
+    }
+
+    @Test
+    public void test_flattens_nested_objects_to_dotted_columns() throws Exception {
+        List<Row> rows = read("[{\"id\":1,\"addr\":{\"city\":\"Paris\",\"zip\":\"75002\"}}]");
+
+        assertThat(rows.get(0).values().get("addr.city")).isEqualTo("Paris");
+        assertThat(rows.get(0).values().get("addr.zip")).isEqualTo("75002");
+        assertThat(rows.get(0).values().get("addr")).isNull();
+    }
+
+    @Test
+    public void test_joins_arrays_of_scalars() throws Exception {
+        List<Row> rows = read("[{\"id\":1,\"tags\":[\"a\",\"b\"]}]");
+
+        assertThat(rows.get(0).values().get("tags")).isEqualTo("a|b");
+    }
+
+    @Test
+    public void test_skips_arrays_of_objects() throws Exception {
+        List<Row> rows = read("[{\"id\":1,\"kids\":[{\"n\":1}]}]");
+
+        assertThat(rows.get(0).values().get("kids")).isNull();
+        assertThat(rows.get(0).values().get("id")).isEqualTo("1");
+    }
+
+    @Test
+    public void test_null_becomes_the_empty_string() throws Exception {
+        List<Row> rows = read("[{\"id\":1,\"name\":null}]");
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("");
+    }
+
+    @Test
+    public void test_records_may_carry_different_keys() throws Exception {
+        List<Row> rows = read("[{\"id\":1},{\"id\":2,\"name\":\"Globex\"}]");
+
+        assertThat(rows.get(0).values().get("name")).isNull();
+        assertThat(rows.get(1).values().get("name")).isEqualTo("Globex");
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -56,18 +57,20 @@ public class JsonRowSourceTest {
     }
 
     @Test
-    public void test_joins_arrays_of_scalars() throws Exception {
-        List<Row> rows = read("[{\"id\":1,\"tags\":[\"a\",\"b\"]}]");
-
-        assertThat(rows.get(0).values().get("tags")).isEqualTo("a|b");
-    }
-
-    @Test
-    public void test_skips_arrays_of_objects() throws Exception {
-        List<Row> rows = read("[{\"id\":1,\"kids\":[{\"n\":1}]}]");
-
-        assertThat(rows.get(0).values().get("kids")).isNull();
-        assertThat(rows.get(0).values().get("id")).isEqualTo("1");
+    public void test_an_array_value_is_refused_naming_its_row_and_column() throws Exception {
+        Map<String, String> columnByContent = Map.of(
+                "[{\"id\":1,\"tags\":[\"a\",\"b\"]}]", "tags",
+                "[{\"id\":1,\"kids\":[{\"n\":1}]}]", "kids",
+                "[{\"id\":1,\"addr\":{\"lines\":[]}}]", "addr.lines");
+        for (Map.Entry<String, String> arrayValue : columnByContent.entrySet()) {
+            try {
+                read(arrayValue.getKey());
+                fail("an array has no tabular representation: joining or skipping it loses data");
+            } catch (IllegalArgumentException failure) {
+                assertThat(failure.getMessage()).contains("row 1");
+                assertThat(failure.getMessage()).contains(arrayValue.getValue());
+            }
+        }
     }
 
     @Test
@@ -130,12 +133,6 @@ public class JsonRowSourceTest {
                 assertThat(failure.getMessage()).contains("the source is empty");
             }
         }
-    }
-
-    @Test
-    public void test_a_leading_empty_array_element_keeps_its_separator() throws Exception {
-        assertThat(read("{\"tags\":[\"\",\"b\"]}").get(0).values().get("tags")).isEqualTo("|b");
-        assertThat(read("{\"tags\":[null,null,\"c\"]}").get(0).values().get("tags")).isEqualTo("||c");
     }
 
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
@@ -88,4 +88,24 @@ public class JsonRowSourceTest {
     public void test_empty_array_is_empty_not_an_error() throws Exception {
         assertThat(read("[]")).isEmpty();
     }
+
+    @Test
+    public void test_a_record_that_is_not_an_object_fails() throws Exception {
+        try {
+            read("[1,2,3]");
+            throw new AssertionError("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("row 1");
+        }
+    }
+
+    @Test
+    public void test_a_top_level_scalar_fails() throws Exception {
+        try {
+            read("42");
+            throw new AssertionError("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("row 1");
+        }
+    }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
@@ -83,4 +83,9 @@ public class JsonRowSourceTest {
         assertThat(rows.get(0).values().get("name")).isNull();
         assertThat(rows.get(1).values().get("name")).isEqualTo("Globex");
     }
+
+    @Test
+    public void test_empty_array_is_empty_not_an_error() throws Exception {
+        assertThat(read("[]")).isEmpty();
+    }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tabular;
 
+import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -108,4 +109,33 @@ public class JsonRowSourceTest {
             assertThat(failure.getMessage()).contains("row 1");
         }
     }
+
+    @Test
+    public void test_content_after_the_root_array_is_refused() throws Exception {
+        try {
+            read("[{\"a\":1}] {\"b\":2}");
+            fail("two dumps concatenated must not import the first one and report success");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("content after the end of the json array");
+        }
+    }
+
+    @Test
+    public void test_an_empty_source_is_refused() throws Exception {
+        for (String empty : List.of("", "   ")) {
+            try {
+                read(empty);
+                fail("an export truncated to nothing must not import as a clean success");
+            } catch (IllegalArgumentException failure) {
+                assertThat(failure.getMessage()).contains("the source is empty");
+            }
+        }
+    }
+
+    @Test
+    public void test_a_leading_empty_array_element_keeps_its_separator() throws Exception {
+        assertThat(read("{\"tags\":[\"\",\"b\"]}").get(0).values().get("tags")).isEqualTo("|b");
+        assertThat(read("{\"tags\":[null,null,\"c\"]}").get(0).values().get("tags")).isEqualTo("||c");
+    }
+
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/RowSourceEquivalenceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/RowSourceEquivalenceTest.java
@@ -6,9 +6,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -27,12 +25,19 @@ public class RowSourceEquivalenceTest {
             Map.of("id", "1", "name", "ACME", "country", "FR"),
             Map.of("id", "2", "name", "Globex", "country", "US"));
 
+    /**
+     * The source stream is deliberately not in the try-with-resources list: closing the returned row
+     * stream is what has to release it, per the RowSource contract.
+     */
     private static List<Row> read(RowSource source, byte[] content, RowSourceOptions options)
             throws Exception {
-        try (InputStream stream = new ByteArrayInputStream(content);
-             Stream<Row> rows = source.rows(stream, options)) {
-            return rows.toList();
+        TrackingInputStream stream = new TrackingInputStream(content);
+        List<Row> read;
+        try (Stream<Row> rows = source.rows(stream, options)) {
+            read = rows.toList();
         }
+        assertThat(stream.closed).isTrue();
+        return read;
     }
 
     private static void assertEquivalent(List<Row> rows) {
@@ -111,6 +116,53 @@ public class RowSourceEquivalenceTest {
         assertEquivalent(read(new TikaTableRowSource(), ods(),
                 RowSourceOptions.defaults()
                         .withContentType("application/vnd.oasis.opendocument.spreadsheet")));
+    }
+
+    /**
+     * A row missing its last column, in each header-based reader. Every column the header declares is
+     * present in the map, so the mapping executor never branches on which format a row came from.
+     */
+    @Test
+    public void test_a_short_row_pads_the_missing_column_in_every_reader() throws Exception {
+        List<Map<String, String>> expected = List.of(
+                Map.of("id", "1", "name", "ACME", "country", "FR"),
+                Map.of("id", "2", "name", "Globex", "country", ""));
+
+        List<List<Row>> reads = List.of(
+                read(new DelimitedRowSource(),
+                        "id,name,country\n1,ACME,FR\n2,Globex\n".getBytes(StandardCharsets.UTF_8),
+                        RowSourceOptions.defaults()),
+                read(new WorkbookRowSource(), raggedWorkbook(), RowSourceOptions.defaults()),
+                read(new TikaTableRowSource(),
+                        ("<html><body><table>"
+                                + "<tr><th>id</th><th>name</th><th>country</th></tr>"
+                                + "<tr><td>1</td><td>ACME</td><td>FR</td></tr>"
+                                + "<tr><td>2</td><td>Globex</td></tr>"
+                                + "</table></body></html>").getBytes(StandardCharsets.UTF_8),
+                        RowSourceOptions.defaults().withContentType("text/html")));
+
+        for (List<Row> rows : reads) {
+            assertThat(rows).hasSize(2);
+            assertThat(rows.get(0).values()).isEqualTo(expected.get(0));
+            assertThat(rows.get(1).values()).isEqualTo(expected.get(1));
+        }
+    }
+
+    private static byte[] raggedWorkbook() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("companies");
+        String[][] table = {{"id", "name", "country"}, {"1", "ACME", "FR"}, {"2", "Globex"}};
+        for (int rowIndex = 0; rowIndex < table.length; rowIndex++) {
+            org.apache.poi.ss.usermodel.Row row = sheet.createRow(rowIndex);
+            for (int column = 0; column < table[rowIndex].length; column++) {
+                row.createCell(column).setCellValue(table[rowIndex][column]);
+            }
+        }
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            workbook.write(out);
+            workbook.close();
+            return out.toByteArray();
+        }
     }
 
     private static byte[] workbook(Workbook workbook) throws Exception {

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/RowSourceEquivalenceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/RowSourceEquivalenceTest.java
@@ -1,0 +1,169 @@
+package org.icij.datashare.tabular;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * The same logical table in every format a reader claims, asserted to produce identical rows. This is
+ * what keeps a new reader honest: adding one means adding its fixture here.
+ */
+public class RowSourceEquivalenceTest {
+    private static final List<Map<String, String>> EXPECTED = List.of(
+            Map.of("id", "1", "name", "ACME", "country", "FR"),
+            Map.of("id", "2", "name", "Globex", "country", "US"));
+
+    private static List<Row> read(RowSource source, byte[] content, RowSourceOptions options)
+            throws Exception {
+        try (InputStream stream = new ByteArrayInputStream(content);
+             Stream<Row> rows = source.rows(stream, options)) {
+            return rows.toList();
+        }
+    }
+
+    private static void assertEquivalent(List<Row> rows) {
+        assertThat(rows).hasSize(2);
+        for (int index = 0; index < EXPECTED.size(); index++) {
+            assertThat(rows.get(index).number()).isEqualTo(index + 1L);
+            assertThat(rows.get(index).values()).isEqualTo(EXPECTED.get(index));
+        }
+    }
+
+    @Test
+    public void test_comma_separated() throws Exception {
+        assertEquivalent(read(new DelimitedRowSource(),
+                "id,name,country\n1,ACME,FR\n2,Globex,US\n".getBytes(StandardCharsets.UTF_8),
+                RowSourceOptions.defaults()));
+    }
+
+    @Test
+    public void test_semicolon_separated() throws Exception {
+        assertEquivalent(read(new DelimitedRowSource(),
+                "id;name;country\n1;ACME;FR\n2;Globex;US\n".getBytes(StandardCharsets.UTF_8),
+                RowSourceOptions.defaults().withDelimiter(';')));
+    }
+
+    @Test
+    public void test_tab_separated() throws Exception {
+        assertEquivalent(read(new DelimitedRowSource(),
+                "id\tname\tcountry\n1\tACME\tFR\n2\tGlobex\tUS\n".getBytes(StandardCharsets.UTF_8),
+                RowSourceOptions.defaults().withDelimiter('\t')));
+    }
+
+    @Test
+    public void test_xlsx() throws Exception {
+        assertEquivalent(read(new WorkbookRowSource(), workbook(new XSSFWorkbook()),
+                RowSourceOptions.defaults()));
+    }
+
+    @Test
+    public void test_legacy_xls() throws Exception {
+        assertEquivalent(read(new WorkbookRowSource(), workbook(new HSSFWorkbook()),
+                RowSourceOptions.defaults()));
+    }
+
+    @Test
+    public void test_json_array() throws Exception {
+        assertEquivalent(read(new JsonRowSource(),
+                ("[{\"id\":1,\"name\":\"ACME\",\"country\":\"FR\"},"
+                        + "{\"id\":2,\"name\":\"Globex\",\"country\":\"US\"}]")
+                        .getBytes(StandardCharsets.UTF_8),
+                RowSourceOptions.defaults()));
+    }
+
+    @Test
+    public void test_line_delimited_json() throws Exception {
+        assertEquivalent(read(new JsonRowSource(),
+                ("{\"id\":1,\"name\":\"ACME\",\"country\":\"FR\"}\n"
+                        + "{\"id\":2,\"name\":\"Globex\",\"country\":\"US\"}\n")
+                        .getBytes(StandardCharsets.UTF_8),
+                RowSourceOptions.defaults()));
+    }
+
+    @Test
+    public void test_html_table_through_the_fallback() throws Exception {
+        String html = "<html><body><table>"
+                + "<tr><th>id</th><th>name</th><th>country</th></tr>"
+                + "<tr><td>1</td><td>ACME</td><td>FR</td></tr>"
+                + "<tr><td>2</td><td>Globex</td><td>US</td></tr>"
+                + "</table></body></html>";
+
+        assertEquivalent(read(new TikaTableRowSource(), html.getBytes(StandardCharsets.UTF_8),
+                RowSourceOptions.defaults().withContentType("text/html")));
+    }
+
+    @Test
+    public void test_open_document_spreadsheet_through_the_fallback() throws Exception {
+        assertEquivalent(read(new TikaTableRowSource(), ods(),
+                RowSourceOptions.defaults()
+                        .withContentType("application/vnd.oasis.opendocument.spreadsheet")));
+    }
+
+    private static byte[] workbook(Workbook workbook) throws Exception {
+        Sheet sheet = workbook.createSheet("companies");
+        String[][] table = {{"id", "name", "country"}, {"1", "ACME", "FR"}, {"2", "Globex", "US"}};
+        for (int rowIndex = 0; rowIndex < table.length; rowIndex++) {
+            org.apache.poi.ss.usermodel.Row row = sheet.createRow(rowIndex);
+            for (int column = 0; column < table[rowIndex].length; column++) {
+                row.createCell(column).setCellValue(table[rowIndex][column]);
+            }
+        }
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            workbook.write(out);
+            workbook.close();
+            return out.toByteArray();
+        }
+    }
+
+    /**
+     * A minimal OpenDocument spreadsheet, built by hand because POI cannot write ODS. Only the
+     * mimetype entry and content.xml are needed for Tika's OpenDocument parser to emit a table.
+     */
+    private static byte[] ods() throws Exception {
+        String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<office:document-content"
+                + " xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\""
+                + " xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\""
+                + " xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\">"
+                + "<office:body><office:spreadsheet>"
+                + "<table:table table:name=\"companies\">"
+                + row("id", "name", "country")
+                + row("1", "ACME", "FR")
+                + row("2", "Globex", "US")
+                + "</table:table>"
+                + "</office:spreadsheet></office:body></office:document-content>";
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            zip.putNextEntry(new ZipEntry("mimetype"));
+            zip.write("application/vnd.oasis.opendocument.spreadsheet".getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+            zip.putNextEntry(new ZipEntry("content.xml"));
+            zip.write(content.getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        return out.toByteArray();
+    }
+
+    private static String row(String... cells) {
+        StringBuilder row = new StringBuilder("<table:table-row>");
+        for (String cell : cells) {
+            row.append("<table:table-cell><text:p>").append(cell).append("</text:p></table:table-cell>");
+        }
+        return row.append("</table:table-row>").toString();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
@@ -10,7 +10,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
@@ -151,6 +151,17 @@ public class TabularRowReaderTest {
                 .isEqualTo("text/plain");
     }
 
+    /**
+     * The extension table refines both generic types, and application/octet-stream is the one where
+     * the txt entry carries its weight: no reader claims octet-stream, so without it a .txt whose
+     * bytes Tika declined to type would fail instead of reaching the delimited reader.
+     */
+    @Test
+    public void test_effective_content_type_refines_an_octet_stream_txt() {
+        assertThat(TabularRowReader.effectiveContentType(null, "application/octet-stream", "notes.txt"))
+                .isEqualTo("text/plain");
+    }
+
     @Test
     public void test_delimiter_from_metadata_maps_tika_names() {
         assertThat(TabularRowReader.delimiterFrom(Map.of("tika_metadata_csv_delimiter", "semicolon")))

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
@@ -118,6 +118,24 @@ public class TabularRowReaderTest {
     }
 
     @Test
+    public void test_a_reader_failure_closes_the_source() throws Exception {
+        String html = "<html><body><p>no table here</p></body></html>";
+        Document document = indexed("page.html", "text/html", html, Map.of());
+        SourceExtractor sourceExtractor = mock(SourceExtractor.class);
+        TrackingInputStream source = new TrackingInputStream(html);
+        when(sourceExtractor.getSource(project, document)).thenReturn(source);
+
+        try (Stream<Row> ignored = new TabularRowReader(indexer, sourceExtractor)
+                .rows(project, "docId", null, RowSourceOptions.defaults())) {
+            throw new AssertionError("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("no table");
+        }
+
+        assertThat(source.closed).isTrue();
+    }
+
+    @Test
     public void test_effective_content_type_prefers_the_override() {
         assertThat(TabularRowReader.effectiveContentType("application/json", "text/csv", "a.csv"))
                 .isEqualTo("application/json");

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 public class TabularRowReaderTest {
     @Rule public TemporaryFolder folder = new TemporaryFolder();
 
+    private static final List<String> CONTENT_FIELDS = List.of("content", "content_translated");
+
     private final Indexer indexer = mock(Indexer.class);
     private TabularRowReader reader;
     private Project project;
@@ -40,7 +42,7 @@ public class TabularRowReaderTest {
         Files.writeString(file, content, StandardCharsets.UTF_8);
         Document document = DocumentBuilder.createDoc("docId").with(file)
                 .ofContentType(contentType).with(StandardCharsets.UTF_8).with(metadata).build();
-        when(indexer.<Document>get("local-datashare", "docId", "docId")).thenReturn(document);
+        when(indexer.<Document>get("local-datashare", "docId", "docId", CONTENT_FIELDS)).thenReturn(document);
         return document;
     }
 
@@ -111,7 +113,7 @@ public class TabularRowReaderTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_a_missing_document_fails() throws Exception {
-        when(indexer.<Document>get("local-datashare", "missing", "missing")).thenReturn(null);
+        when(indexer.<Document>get("local-datashare", "missing", "missing", CONTENT_FIELDS)).thenReturn(null);
         try (Stream<Row> ignored = reader.rows(project, "missing", null, RowSourceOptions.defaults())) {
             // the failure is expected before any row is read
         }
@@ -176,4 +178,33 @@ public class TabularRowReaderTest {
         assertThat(TabularRowReader.delimiterFrom(Map.of("tika_metadata_csv_delimiter", "unknown")))
                 .isNull();
     }
+    /**
+     * An embedded document carries its container's path, so the path-derived name would hand a
+     * records.jsonl inside an archive the name of the archive and route the ndjson to the csv reader.
+     */
+    @Test
+    public void test_the_name_tika_recorded_beats_the_container_path() throws Exception {
+        indexed("archive.zip", "text/plain", "{\"id\":1,\"name\":\"ACME\"}\n",
+                Map.of("tika_metadata_resourcename", "records.jsonl"));
+
+        List<Row> rows = rows(RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_a_document_with_no_detected_content_type_is_refined_by_extension() throws Exception {
+        indexed("contacts.csv", null, "id,name\n1,ACME\n", Map.of());
+
+        assertThat(rows(RowSourceOptions.defaults()).get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_a_tsv_extension_supplies_the_delimiter_its_metadata_does_not() throws Exception {
+        indexed("companies.tsv", "text/plain", "id\tname\n1\tACME\n", Map.of());
+
+        assertThat(rows(RowSourceOptions.defaults()).get(0).values().get("name")).isEqualTo("ACME");
+    }
+
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TabularRowReaderTest.java
@@ -1,0 +1,151 @@
+package org.icij.datashare.tabular;
+
+import org.icij.datashare.text.Document;
+import org.icij.datashare.text.DocumentBuilder;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.Indexer;
+import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TabularRowReaderTest {
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    private final Indexer indexer = mock(Indexer.class);
+    private TabularRowReader reader;
+    private Project project;
+
+    @Before
+    public void setUp() {
+        project = new Project("local-datashare");
+        reader = new TabularRowReader(indexer, new SourceExtractor(new org.icij.datashare.PropertiesProvider()));
+    }
+
+    private Document indexed(String filename, String contentType, String content,
+                            Map<String, Object> metadata) throws Exception {
+        Path file = folder.getRoot().toPath().resolve(filename);
+        Files.writeString(file, content, StandardCharsets.UTF_8);
+        Document document = DocumentBuilder.createDoc("docId").with(file)
+                .ofContentType(contentType).with(StandardCharsets.UTF_8).with(metadata).build();
+        when(indexer.<Document>get("local-datashare", "docId", "docId")).thenReturn(document);
+        return document;
+    }
+
+    private List<Row> rows(RowSourceOptions options) throws Exception {
+        try (Stream<Row> rows = reader.rows(project, "docId", null, options)) {
+            return rows.toList();
+        }
+    }
+
+    @Test
+    public void test_reads_a_csv_document_through_the_delimited_reader() throws Exception {
+        indexed("companies.csv", "text/csv", "id,name\n1,ACME\n", Map.of());
+
+        assertThat(rows(RowSourceOptions.defaults()).get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_takes_the_delimiter_from_the_document_metadata() throws Exception {
+        indexed("companies.csv", "text/csv", "id;name\n1;ACME\n",
+                Map.of("tika_metadata_csv_delimiter", "semicolon"));
+
+        assertThat(rows(RowSourceOptions.defaults()).get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_the_mapping_delimiter_beats_the_metadata() throws Exception {
+        indexed("companies.csv", "text/csv", "id|name\n1|ACME\n",
+                Map.of("tika_metadata_csv_delimiter", "semicolon"));
+
+        assertThat(rows(RowSourceOptions.defaults().withDelimiter('|')).get(0).values().get("name"))
+                .isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_a_jsonl_file_typed_text_plain_reaches_the_json_reader() throws Exception {
+        indexed("dump.jsonl", "text/plain", "{\"id\":1,\"name\":\"ACME\"}\n", Map.of());
+
+        assertThat(rows(RowSourceOptions.defaults()).get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_a_csv_typed_text_plain_still_reaches_the_delimited_reader() throws Exception {
+        indexed("companies.txt", "text/plain", "id,name\n1,ACME\n", Map.of());
+
+        assertThat(rows(RowSourceOptions.defaults()).get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_the_mapping_content_type_beats_the_stored_one() throws Exception {
+        indexed("mislabelled.csv", "text/csv", "{\"id\":1,\"name\":\"ACME\"}\n", Map.of());
+
+        assertThat(rows(RowSourceOptions.defaults().withContentType("application/json"))
+                .get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_an_unsupported_content_type_fails() throws Exception {
+        indexed("scan.pdf", "application/pdf", "not really a pdf", Map.of());
+
+        try {
+            rows(RowSourceOptions.defaults());
+            throw new AssertionError("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("application/pdf");
+            assertThat(failure.getMessage()).contains("text/csv");
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_a_missing_document_fails() throws Exception {
+        when(indexer.<Document>get("local-datashare", "missing", "missing")).thenReturn(null);
+        try (Stream<Row> ignored = reader.rows(project, "missing", null, RowSourceOptions.defaults())) {
+            // the failure is expected before any row is read
+        }
+    }
+
+    @Test
+    public void test_effective_content_type_prefers_the_override() {
+        assertThat(TabularRowReader.effectiveContentType("application/json", "text/csv", "a.csv"))
+                .isEqualTo("application/json");
+    }
+
+    @Test
+    public void test_effective_content_type_falls_back_to_the_extension_only_when_generic() {
+        assertThat(TabularRowReader.effectiveContentType(null, "text/plain", "a.jsonl"))
+                .isEqualTo(JsonRowSource.NDJSON_CONTENT_TYPE);
+        assertThat(TabularRowReader.effectiveContentType(null, "text/csv", "a.jsonl"))
+                .isEqualTo("text/csv");
+        assertThat(TabularRowReader.effectiveContentType(null, "text/plain", "notes.md"))
+                .isEqualTo("text/plain");
+    }
+
+    @Test
+    public void test_delimiter_from_metadata_maps_tika_names() {
+        assertThat(TabularRowReader.delimiterFrom(Map.of("tika_metadata_csv_delimiter", "semicolon")))
+                .isEqualTo(';');
+        assertThat(TabularRowReader.delimiterFrom(Map.of("tika_metadata_csv_delimiter", "tab")))
+                .isEqualTo('\t');
+        assertThat(TabularRowReader.delimiterFrom(Map.of("tika_metadata_csv_delimiter", "pipe")))
+                .isEqualTo('|');
+        assertThat(TabularRowReader.delimiterFrom(Map.of("tika_metadata_csv_delimiter", "comma")))
+                .isEqualTo(',');
+        assertThat(TabularRowReader.delimiterFrom(Map.of())).isNull();
+        assertThat(TabularRowReader.delimiterFrom(Map.of("tika_metadata_csv_delimiter", "unknown")))
+                .isNull();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
@@ -179,4 +179,71 @@ public class TikaTableRowSourceTest {
             return out.toByteArray();
         }
     }
+
+    @Test
+    public void test_supports_the_modern_numbers_generations() {
+        assertThat(source.supports("application/vnd.apple.numbers.13")).isTrue();
+        assertThat(source.supports("application/vnd.apple.numbers.18")).isTrue();
+    }
+
+    @Test
+    public void test_a_nested_table_stays_out_of_the_outer_cell_value() throws Exception {
+        List<Row> rows = readHtml("<html><body><table>"
+                + "<tr><th>id</th><th>name</th></tr>"
+                + "<tr><td>1</td><td>ACME<table><tr><th>inner</th></tr><tr><td>nested</td></tr></table></td></tr>"
+                + "</table></body></html>", RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    /**
+     * Word, TinyMCE and CKEditor write colspan="1" on every cell they emit, and a span of one merges
+     * nothing.
+     */
+    @Test
+    public void test_a_span_of_one_is_not_a_merged_cell() throws Exception {
+        List<Row> rows = readHtml("<html><body><table>"
+                + "<tr><th colspan=\"1\">id</th><th rowspan=\"1\">name</th></tr>"
+                + "<tr><td>1</td><td>ACME</td></tr></table></body></html>", RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    /**
+     * Tika renders ODF's table:number-columns-repeated as a colspan, and LibreOffice writes it on the
+     * trailing empty cells of every sheet, so an empty span is padding and has to expand back into the
+     * columns it stands for rather than be read as a merge.
+     */
+    @Test
+    public void test_an_empty_repeated_cell_expands_instead_of_failing() throws Exception {
+        List<Row> rows = readHtml("<html><body><table>"
+                + "<tr><th>id</th><th></th><th></th><th>name</th></tr>"
+                + "<tr><td>1</td><td colspan=\"2\"></td><td>ACME</td></tr></table></body></html>",
+                RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_a_cell_with_content_across_two_columns_is_still_refused() throws Exception {
+        try {
+            readHtml("<html><body><table><tr><th>id</th><th>name</th></tr>"
+                    + "<tr><td colspan=\"2\">merged</td></tr></table></body></html>", RowSourceOptions.defaults());
+            throw new AssertionError("a value spanning two columns cannot be lined up with either header");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("merged cells");
+        }
+    }
+
+    @Test
+    public void test_a_tfoot_written_before_the_body_stays_after_it() throws Exception {
+        List<Row> rows = readHtml("<html><body><table>"
+                + "<thead><tr><th>id</th></tr></thead>"
+                + "<tfoot><tr><td>total</td></tr></tfoot>"
+                + "<tbody><tr><td>b1</td></tr></tbody></table></body></html>", RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("id")).isEqualTo("b1");
+        assertThat(rows.get(1).values().get("id")).isEqualTo("total");
+    }
+
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
@@ -116,6 +116,24 @@ public class TikaTableRowSourceTest {
     }
 
     @Test
+    public void test_a_nested_table_does_not_add_rows_to_the_outer_table() throws Exception {
+        List<Row> rows = readHtml(
+                "<html><body><table>"
+                        + "<tr><th>id</th><th>name</th></tr>"
+                        + "<tr><td>1</td><td>ACME"
+                        + "<table><tr><th>inner</th></tr><tr><td>nested</td></tr></table>"
+                        + "</td></tr>"
+                        + "<tr><td>2</td><td>Globex</td></tr>"
+                        + "</table></body></html>",
+                RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).values()).hasSize(2);
+        assertThat(rows.get(0).values().get("id")).isEqualTo("1");
+        assertThat(rows.get(1).values().get("name")).isEqualTo("Globex");
+    }
+
+    @Test
     public void test_closing_the_returned_stream_closes_the_source() throws Exception {
         TrackingInputStream stream = new TrackingInputStream(
                 "<html><body><table><tr><th>id</th></tr><tr><td>1</td></tr></table></body></html>");

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -94,6 +95,27 @@ public class TikaTableRowSourceTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void test_data_row_with_colspan_fails() throws Exception {
+        readHtml("<html><body><table>"
+                + "<tr><th>id</th><th>name</th></tr>"
+                + "<tr><td colspan=\"2\">both</td></tr>"
+                + "</table></body></html>", RowSourceOptions.defaults());
+    }
+
+    @Test
+    public void test_closing_the_returned_stream_closes_the_source() throws Exception {
+        TrackingInputStream stream = new TrackingInputStream(
+                ("<html><body><table><tr><th>id</th></tr><tr><td>1</td></tr></table></body></html>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        try (Stream<Row> rows = source.rows(stream, RowSourceOptions.defaults().withContentType("text/html"))) {
+            rows.toList();
+        }
+
+        assertThat(stream.closed).isTrue();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void test_no_table_at_all_fails() throws Exception {
         readHtml("<html><body><p>no table here</p></body></html>", RowSourceOptions.defaults());
     }
@@ -113,6 +135,20 @@ public class TikaTableRowSourceTest {
 
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    private static class TrackingInputStream extends ByteArrayInputStream {
+        private boolean closed = false;
+
+        private TrackingInputStream(byte[] content) {
+            super(content);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
     }
 
     private static byte[] docxWithTable() throws Exception {

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
@@ -1,0 +1,130 @@
+package org.icij.datashare.tabular;
+
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFTable;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class TikaTableRowSourceTest {
+    private final TikaTableRowSource source = new TikaTableRowSource();
+
+    private List<Row> read(byte[] content, RowSourceOptions options) throws Exception {
+        try (InputStream stream = new ByteArrayInputStream(content);
+             Stream<Row> rows = source.rows(stream, options)) {
+            return rows.toList();
+        }
+    }
+
+    private List<Row> readHtml(String html, RowSourceOptions options) throws Exception {
+        return read(html.getBytes(StandardCharsets.UTF_8), options.withContentType("text/html"));
+    }
+
+    @Test
+    public void test_supports_the_verified_tier_two_types_only() {
+        assertThat(source.supports("application/vnd.oasis.opendocument.spreadsheet")).isTrue();
+        assertThat(source.supports("application/vnd.ms-excel.sheet.binary.macroenabled.12")).isTrue();
+        assertThat(source.supports("application/vnd.openxmlformats-officedocument.wordprocessingml.document")).isTrue();
+        assertThat(source.supports("application/msword")).isTrue();
+        assertThat(source.supports("text/html")).isTrue();
+        assertThat(source.supports("application/vnd.apple.numbers")).isTrue();
+    }
+
+    @Test
+    public void test_does_not_claim_pdf_or_rtf_or_tier_one_types() {
+        assertThat(source.supports("application/pdf")).isFalse();
+        assertThat(source.supports("application/rtf")).isFalse();
+        assertThat(source.supports("text/csv")).isFalse();
+        assertThat(source.supports("application/vnd.ms-excel")).isFalse();
+    }
+
+    @Test
+    public void test_reads_an_html_table() throws Exception {
+        List<Row> rows = readHtml(
+                "<html><body><table>"
+                        + "<tr><th>id</th><th>name</th></tr>"
+                        + "<tr><td>1</td><td>ACME</td></tr>"
+                        + "<tr><td>2</td><td>Globex</td></tr>"
+                        + "</table></body></html>",
+                RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).number()).isEqualTo(1L);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+        assertThat(rows.get(1).values().get("id")).isEqualTo("2");
+    }
+
+    @Test
+    public void test_reads_the_first_table_by_default() throws Exception {
+        List<Row> rows = readHtml(
+                "<html><body>"
+                        + "<table><tr><th>id</th></tr><tr><td>first</td></tr></table>"
+                        + "<table><tr><th>id</th></tr><tr><td>second</td></tr></table>"
+                        + "</body></html>",
+                RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("id")).isEqualTo("first");
+    }
+
+    @Test
+    public void test_reads_the_table_at_the_index_in_the_options() throws Exception {
+        List<Row> rows = readHtml(
+                "<html><body>"
+                        + "<table><tr><th>id</th></tr><tr><td>first</td></tr></table>"
+                        + "<table><tr><th>id</th></tr><tr><td>second</td></tr></table>"
+                        + "</body></html>",
+                new RowSourceOptions(null, null, null, null, null, 2));
+
+        assertThat(rows.get(0).values().get("id")).isEqualTo("second");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_header_row_with_colspan_fails() throws Exception {
+        readHtml("<html><body><table>"
+                + "<tr><th colspan=\"2\">both</th></tr>"
+                + "<tr><td>1</td><td>ACME</td></tr>"
+                + "</table></body></html>", RowSourceOptions.defaults());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_no_table_at_all_fails() throws Exception {
+        readHtml("<html><body><p>no table here</p></body></html>", RowSourceOptions.defaults());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_table_index_out_of_range_fails() throws Exception {
+        readHtml("<html><body><table><tr><th>id</th></tr></table></body></html>",
+                new RowSourceOptions(null, null, null, null, null, 9));
+    }
+
+    @Test
+    public void test_reads_a_table_from_a_docx() throws Exception {
+        byte[] docx = docxWithTable();
+
+        List<Row> rows = read(docx, RowSourceOptions.defaults().withContentType(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    private static byte[] docxWithTable() throws Exception {
+        try (XWPFDocument document = new XWPFDocument();
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XWPFTable table = document.createTable(2, 2);
+            table.getRow(0).getCell(0).setText("id");
+            table.getRow(0).getCell(1).setText("name");
+            table.getRow(1).getCell(0).setText("1");
+            table.getRow(1).getCell(1).setText("ACME");
+            document.write(out);
+            return out.toByteArray();
+        }
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TikaTableRowSourceTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -103,10 +102,23 @@ public class TikaTableRowSourceTest {
     }
 
     @Test
+    public void test_a_row_with_more_cells_than_the_header_keeps_the_declared_columns() throws Exception {
+        List<Row> rows = readHtml(
+                "<html><body><table>"
+                        + "<tr><th>id</th><th>name</th></tr>"
+                        + "<tr><td>1</td><td>ACME</td><td>stray</td></tr>"
+                        + "</table></body></html>",
+                RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).values()).hasSize(2);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
     public void test_closing_the_returned_stream_closes_the_source() throws Exception {
         TrackingInputStream stream = new TrackingInputStream(
-                ("<html><body><table><tr><th>id</th></tr><tr><td>1</td></tr></table></body></html>")
-                        .getBytes(StandardCharsets.UTF_8));
+                "<html><body><table><tr><th>id</th></tr><tr><td>1</td></tr></table></body></html>");
 
         try (Stream<Row> rows = source.rows(stream, RowSourceOptions.defaults().withContentType("text/html"))) {
             rows.toList();
@@ -135,20 +147,6 @@ public class TikaTableRowSourceTest {
 
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
-    }
-
-    private static class TrackingInputStream extends ByteArrayInputStream {
-        private boolean closed = false;
-
-        private TrackingInputStream(byte[] content) {
-            super(content);
-        }
-
-        @Override
-        public void close() throws IOException {
-            closed = true;
-            super.close();
-        }
     }
 
     private static byte[] docxWithTable() throws Exception {

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/TrackingInputStream.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/TrackingInputStream.java
@@ -1,0 +1,24 @@
+package org.icij.datashare.tabular;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/** Records whether the reader closed the stream it was handed, which is the RowSource contract. */
+class TrackingInputStream extends ByteArrayInputStream {
+    boolean closed = false;
+
+    TrackingInputStream(byte[] content) {
+        super(content);
+    }
+
+    TrackingInputStream(String content) {
+        this(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        super.close();
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
@@ -101,6 +101,68 @@ public class WorkbookRowSourceTest {
     }
 
     @Test
+    public void test_reads_the_sheet_at_the_index_in_the_options() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        fill(workbook.createSheet("first"));
+        Sheet second = workbook.createSheet("second");
+        second.createRow(0).createCell(0).setCellValue("id");
+        second.createRow(1).createCell(0).setCellValue("999");
+
+        List<Row> rows = read(bytes(workbook),
+                new RowSourceOptions(null, null, null, null, "2", null));
+
+        assertThat(rows.get(0).values().get("id")).isEqualTo("999");
+    }
+
+    @Test
+    public void test_a_sheet_named_like_a_number_beats_that_position() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet named = workbook.createSheet("2");
+        named.createRow(0).createCell(0).setCellValue("id");
+        named.createRow(1).createCell(0).setCellValue("by name");
+        Sheet second = workbook.createSheet("other");
+        second.createRow(0).createCell(0).setCellValue("id");
+        second.createRow(1).createCell(0).setCellValue("by position");
+
+        List<Row> rows = read(bytes(workbook),
+                new RowSourceOptions(null, null, null, null, "2", null));
+
+        assertThat(rows.get(0).values().get("id")).isEqualTo("by name");
+    }
+
+    @Test
+    public void test_an_unknown_sheet_reference_fails() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        fill(workbook.createSheet("companies"));
+        byte[] content = bytes(workbook);
+
+        try {
+            read(content, new RowSourceOptions(null, null, null, null, "nope", null));
+            throw new AssertionError("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("no such sheet: nope");
+        }
+    }
+
+    @Test
+    public void test_a_row_with_more_cells_than_the_header_fails() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("companies");
+        fill(sheet);
+        sheet.getRow(1).createCell(2).setCellValue("surplus");
+        byte[] content = bytes(workbook);
+
+        try {
+            read(content, RowSourceOptions.defaults());
+            throw new AssertionError("expected an IllegalArgumentException");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("row 1");
+            assertThat(failure.getMessage()).contains("3 fields");
+            assertThat(failure.getMessage()).contains("declares 2");
+        }
+    }
+
+    @Test
     public void test_renders_a_date_cell_as_iso_date() throws Exception {
         XSSFWorkbook workbook = new XSSFWorkbook();
         Sheet sheet = workbook.createSheet("dates");

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
@@ -162,6 +162,25 @@ public class WorkbookRowSourceTest {
         }
     }
 
+    /**
+     * Excel keeps cells past the last filled column when they were styled or previously emptied, and
+     * the user cannot see them. A blank surplus cell carries no data, so refusing the file over it
+     * would reject a very common workbook for nothing.
+     */
+    @Test
+    public void test_a_blank_cell_past_the_header_width_does_not_fail_the_row() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("companies");
+        fill(sheet);
+        sheet.getRow(1).createCell(2);
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).values()).hasSize(2);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
     @Test
     public void test_renders_a_date_cell_as_iso_date() throws Exception {
         XSSFWorkbook workbook = new XSSFWorkbook();

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
@@ -1,0 +1,175 @@
+package org.icij.datashare.tabular;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class WorkbookRowSourceTest {
+    private final WorkbookRowSource source = new WorkbookRowSource();
+
+    private List<Row> read(byte[] workbook, RowSourceOptions options) throws Exception {
+        try (InputStream stream = new ByteArrayInputStream(workbook);
+             Stream<Row> rows = source.rows(stream, options)) {
+            return rows.toList();
+        }
+    }
+
+    private static byte[] bytes(Workbook workbook) throws Exception {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            workbook.write(out);
+            workbook.close();
+            return out.toByteArray();
+        }
+    }
+
+    private static void fill(Sheet sheet) {
+        sheet.createRow(0).createCell(0).setCellValue("id");
+        sheet.getRow(0).createCell(1).setCellValue("name");
+        sheet.createRow(1).createCell(0).setCellValue("1");
+        sheet.getRow(1).createCell(1).setCellValue("ACME");
+    }
+
+    @Test
+    public void test_supports_excel_content_types() {
+        assertThat(source.supports("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")).isTrue();
+        assertThat(source.supports("application/vnd.ms-excel")).isTrue();
+        assertThat(source.supports("application/vnd.ms-excel.sheet.macroenabled.12")).isTrue();
+        assertThat(source.supports("application/vnd.ms-excel.sheet.binary.macroenabled.12")).isFalse();
+        assertThat(source.supports("text/csv")).isFalse();
+    }
+
+    @Test
+    public void test_reads_xlsx_rows() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        fill(workbook.createSheet("companies"));
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).number()).isEqualTo(1L);
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_reads_legacy_xls_rows() throws Exception {
+        HSSFWorkbook workbook = new HSSFWorkbook();
+        fill(workbook.createSheet("companies"));
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("ACME");
+    }
+
+    @Test
+    public void test_reads_the_first_sheet_by_default() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        fill(workbook.createSheet("first"));
+        Sheet second = workbook.createSheet("second");
+        second.createRow(0).createCell(0).setCellValue("id");
+        second.createRow(1).createCell(0).setCellValue("999");
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("id")).isEqualTo("1");
+    }
+
+    @Test
+    public void test_reads_the_sheet_named_in_the_options() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        fill(workbook.createSheet("first"));
+        Sheet second = workbook.createSheet("second");
+        second.createRow(0).createCell(0).setCellValue("id");
+        second.createRow(1).createCell(0).setCellValue("999");
+
+        List<Row> rows = read(bytes(workbook),
+                new RowSourceOptions(null, null, null, null, "second", null));
+
+        assertThat(rows.get(0).values().get("id")).isEqualTo("999");
+    }
+
+    @Test
+    public void test_renders_a_date_cell_as_iso_date() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("dates");
+        sheet.createRow(0).createCell(0).setCellValue("born");
+        CellStyle dateStyle = workbook.createCellStyle();
+        dateStyle.setDataFormat(workbook.createDataFormat().getFormat("dd/mm/yyyy"));
+        Cell cell = sheet.createRow(1).createCell(0);
+        cell.setCellValue(LocalDateTime.of(1984, 3, 17, 0, 0));
+        cell.setCellStyle(dateStyle);
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("born")).isEqualTo("1984-03-17");
+    }
+
+    @Test
+    public void test_renders_a_datetime_cell_as_iso_datetime() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("dates");
+        sheet.createRow(0).createCell(0).setCellValue("seen");
+        CellStyle style = workbook.createCellStyle();
+        style.setDataFormat(workbook.createDataFormat().getFormat("dd/mm/yyyy hh:mm"));
+        Cell cell = sheet.createRow(1).createCell(0);
+        cell.setCellValue(LocalDateTime.of(1984, 3, 17, 14, 30));
+        cell.setCellStyle(style);
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("seen")).isEqualTo("1984-03-17T14:30:00");
+    }
+
+    @Test
+    public void test_renders_a_formula_cell_as_its_computed_value() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("sums");
+        sheet.createRow(0).createCell(0).setCellValue("total");
+        sheet.createRow(1).createCell(0).setCellFormula("2+3");
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("total")).isEqualTo("5");
+    }
+
+    @Test
+    public void test_skips_entirely_blank_rows() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("companies");
+        fill(sheet);
+        sheet.createRow(2).createCell(0).setCellValue("");
+        sheet.createRow(3).createCell(0).setCellValue("2");
+        sheet.getRow(3).createCell(1).setCellValue("Globex");
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(1).values().get("name")).isEqualTo("Globex");
+        assertThat(rows.get(1).number()).isEqualTo(2L);
+    }
+
+    @Test
+    public void test_blank_cell_is_the_empty_string() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("companies");
+        sheet.createRow(0).createCell(0).setCellValue("id");
+        sheet.getRow(0).createCell(1).setCellValue("name");
+        sheet.createRow(1).createCell(0).setCellValue("1");
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("name")).isEqualTo("");
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/WorkbookRowSourceTest.java
@@ -6,6 +6,7 @@ import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -253,4 +254,66 @@ public class WorkbookRowSourceTest {
 
         assertThat(rows.get(0).values().get("name")).isEqualTo("");
     }
+
+    @Test
+    public void test_a_long_numeric_id_keeps_every_digit() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("companies");
+        sheet.createRow(0).createCell(0).setCellValue("siren");
+        sheet.createRow(1).createCell(0).setCellValue(123456789012d);
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("siren")).isEqualTo("123456789012");
+    }
+
+    @Test
+    public void test_renders_a_time_only_cell_as_a_time() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("times");
+        sheet.createRow(0).createCell(0).setCellValue("at");
+        CellStyle style = workbook.createCellStyle();
+        style.setDataFormat(workbook.createDataFormat().getFormat("hh:mm"));
+        Cell cell = sheet.createRow(1).createCell(0);
+        cell.setCellValue(14.5 / 24.0);
+        cell.setCellStyle(style);
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows.get(0).values().get("at")).isEqualTo("14:30:00");
+    }
+
+    /**
+     * POI throws NotImplementedException on the functions it does not implement, and the file already
+     * holds the value the spreadsheet computed, so one such cell must cost its own value and no more.
+     */
+    @Test
+    public void test_an_unevaluatable_formula_does_not_abort_the_sheet() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("companies");
+        sheet.createRow(0).createCell(0).setCellValue("id");
+        sheet.getRow(0).createCell(1).setCellValue("age");
+        sheet.createRow(1).createCell(0).setCellValue("1");
+        sheet.getRow(1).createCell(1).setCellFormula("DATEDIF(DATE(2020,1,1),DATE(2021,1,1),\"y\")");
+        sheet.createRow(2).createCell(0).setCellValue("2");
+        sheet.getRow(2).createCell(1).setCellValue("ok");
+
+        List<Row> rows = read(bytes(workbook), RowSourceOptions.defaults());
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(1).values().get("age")).isEqualTo("ok");
+    }
+
+    @Test
+    public void test_a_workbook_that_cannot_be_opened_releases_the_source() throws Exception {
+        TrackingInputStream stream = new TrackingInputStream("not a workbook".getBytes(StandardCharsets.UTF_8));
+
+        try {
+            source.rows(stream, RowSourceOptions.defaults());
+            throw new AssertionError("bytes that are not a workbook must be refused");
+        } catch (Exception expected) {
+            assertThat(stream.closed).isTrue();
+        }
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,14 @@
                 <artifactId>poi-scratchpad</artifactId>
                 <version>${poi.version}</version>
             </dependency>
+            <!-- Reached only transitively, through Tika's OOXML parsers. Left to mediation, a future
+                 extract-lib bump could skew it against the POI pinned above, which fails at runtime
+                 with an OOXML schema error rather than at build time. -->
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml-full</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
             <!-- tika-parsers 3.3.0 manages commons-io 2.17.0, which wins Maven mediation, but the
                  commons-compress 1.28.0 it also pulls calls AbstractStreamBuilder.getInputStream(),
                  which only became public in commons-io 2.18.0. With 2.17.0 (protected), Tika's

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <aws-s3.version>2.35.10</aws-s3.version>
         <extract.version>9.16.0</extract.version>
         <opennlp.version>1.6.0</opennlp.version>
+        <poi.version>5.5.1</poi.version>
         <elasticsearch.version>8.19.8</elasticsearch.version>
         <jooq.version>3.19.10</jooq.version>
         <lucene.version>10.3.1</lucene.version>
@@ -417,6 +418,23 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
                 <version>1.14.0</version>
+            </dependency>
+            <!-- Pinned because datashare-app now declares POI directly rather than relying on
+                 extract-lib's transitive. -->
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-scratchpad</artifactId>
+                <version>${poi.version}</version>
             </dependency>
             <!-- tika-parsers 3.3.0 manages commons-io 2.17.0, which wins Maven mediation, but the
                  commons-compress 1.28.0 it also pulls calls AbstractStreamBuilder.getInputStream(),


### PR DESCRIPTION
Reads rows straight out of tabular files, keeping the columns intact instead of going through the text-extraction path that flattens tables. Part of #2194, closes #2198. No production caller yet: #2204 and #2206 are the consumers.

- feat: add the `RowSource` contract with `Row` and `RowSourceOptions` in `datashare-api`
- feat: read delimited files (comma, tab, semicolon, pipe) with configurable delimiter, quote and charset
- feat: read xlsx, xlsm and legacy xls with POI
- feat: read json arrays and line-delimited json, flattening nested values to dotted column names
- feat: add a Tika XHTML table fallback covering ods, xlsb, docx/doc, html and numbers
- feat: resolve a document id to its rows through the index, so a file embedded in an archive or an email works
- fix: read a workbook cell's own value rather than its rendering, so long ids keep their digits and currency and percentage cells arrive as their underlying value
- fix: stop reading spans, nested tables and footers as data
- fix: refuse a nameless header row, and a json source that is empty or runs past its array
- fix: release the source on every failed read
- chore: drop the duplicate poi-ooxml-lite copy of the ooxml schemas
- test: 99 tests, one of them asserting every reader returns the same rows for an equivalent file

## Architecture

```mermaid
flowchart LR
  ID["project + documentId + rootId"] --> R["TabularRowReader"]
  R -->|"indexer.get, content excluded"| DOC[("Document: type, name, charset, metadata")]
  R -->|"SourceExtractor"| SRC[("source bytes, root or embedded")]
  DOC --> RES["resolve: content type, charset, delimiter"]
  RES --> SEL{"select by content type"}
  SEL -->|tier 1| D["DelimitedRowSource"] & W["WorkbookRowSource"] & J["JsonRowSource"]
  SEL -->|tier 2 fallback| T["TikaTableRowSource"]
  D & W & J & T --> ROWS(["Stream&lt;Row&gt;"])
```

**Routing.** The four `SUPPORTED` sets are disjoint, so selection order is inert today.

| Reader | Claims |
|---|---|
| `DelimitedRowSource` | `text/csv`, `text/tab-separated-values`, `text/tsv`, `text/plain` |
| `WorkbookRowSource` | xlsx, `application/vnd.ms-excel`, xlsm |
| `JsonRowSource` | `application/json`, `application/x-ndjson` |
| `TikaTableRowSource` (tier 2) | ods, xlsb, docx, doc, html, numbers + `.13` + `.18` |

**The two ladders**, worth reading twice:

- Content type: mapping override → stored type → *if generic* (`text/plain`, `application/octet-stream`, `unknown`), refine by extension.
- Delimiter: explicit option → Tika's `csv:delimiter` → extension (`tsv`, `psv`) → implied by a TSV content type → comma.

**Ownership.** `RowSource.rows` owns the source and releases it when the returned stream closes, or immediately if it throws before returning one. `TabularRowReader` also wraps with `onClose`, so the double close is expected and harmless.

**Deliberately absent**, so nobody spends a round on it:

- No production caller: #2204 and #2206 are the consumers.
- Authorization and the size guard belong to #2206, which must route through `DocumentSourceAccess.gated`.
- Tier 1 and tier 2 differ on purpose: tier 1 refuses surplus non-blank cells and forces ISO-8601 dates, tier 2 tolerates and passes dates through.

Reading order: `RowSource` → `Row` → `TabularRowReader` → the four readers.
