### PR TITLE
feat: model-neutral core contracts and the FtM model in-JVM

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/model/EntityType.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/EntityType.java
@@ -1,0 +1,10 @@
+package org.icij.datashare.model;
+
+import java.util.Map;
+import java.util.Set;
+
+public record EntityType(String name, boolean isAbstract, Set<String> ancestors,
+                         Map<String, Property> properties, Set<String> required, Edge edge) {
+
+    public record Edge(String source, String target, boolean directed) { }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -14,6 +15,9 @@ import java.util.TreeSet;
 public record ModelEntity(String id, Set<String> types, Map<String, List<String>> properties) {
 
     public ModelEntity {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(types, "types");
+        Objects.requireNonNull(properties, "properties");
         types = Set.copyOf(types);
         Map<String, List<String>> copy = new LinkedHashMap<>();
         properties.forEach((property, values) -> copy.put(property, List.copyOf(values)));
@@ -25,15 +29,20 @@ public record ModelEntity(String id, Set<String> types, Map<String, List<String>
             throw new IllegalArgumentException("cannot rebuild an entity from no statement");
         }
         SortedSet<String> ids = new TreeSet<>();
+        SortedSet<String> models = new TreeSet<>();
         Set<String> types = new LinkedHashSet<>();
         Map<String, Set<String>> values = new LinkedHashMap<>();
         for (Statement statement : statements) {
             ids.add(statement.entityId());
+            models.add(statement.model());
             types.add(statement.entityType());
             values.computeIfAbsent(statement.property(), property -> new LinkedHashSet<>()).add(statement.value());
         }
         if (ids.size() > 1) {
             throw new IllegalArgumentException("statements belong to " + ids.size() + " entities: " + ids);
+        }
+        if (models.size() > 1) {
+            throw new IllegalArgumentException("statements belong to " + models.size() + " models: " + models);
         }
         Map<String, List<String>> properties = new LinkedHashMap<>();
         values.forEach((property, distinct) -> properties.put(property, new ArrayList<>(distinct)));

--- a/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
@@ -2,6 +2,7 @@ package org.icij.datashare.model;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -11,6 +12,13 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 public record ModelEntity(String id, Set<String> types, Map<String, List<String>> properties) {
+
+    public ModelEntity {
+        types = Set.copyOf(types);
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+        properties.forEach((property, values) -> copy.put(property, List.copyOf(values)));
+        properties = Collections.unmodifiableMap(copy);
+    }
 
     public static ModelEntity from(Collection<Statement> statements) {
         if (statements.isEmpty()) {

--- a/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
@@ -1,0 +1,34 @@
+package org.icij.datashare.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public record ModelEntity(String id, Set<String> types, Map<String, List<String>> properties) {
+
+    public static ModelEntity from(Collection<Statement> statements) {
+        if (statements.isEmpty()) {
+            throw new IllegalArgumentException("cannot rebuild an entity from no statement");
+        }
+        SortedSet<String> ids = new TreeSet<>();
+        Set<String> types = new LinkedHashSet<>();
+        Map<String, Set<String>> values = new LinkedHashMap<>();
+        for (Statement statement : statements) {
+            ids.add(statement.entityId());
+            types.add(statement.entityType());
+            values.computeIfAbsent(statement.property(), property -> new LinkedHashSet<>()).add(statement.value());
+        }
+        if (ids.size() > 1) {
+            throw new IllegalArgumentException("statements belong to " + ids.size() + " entities: " + ids);
+        }
+        Map<String, List<String>> properties = new LinkedHashMap<>();
+        values.forEach((property, distinct) -> properties.put(property, new ArrayList<>(distinct)));
+        return new ModelEntity(ids.first(), types, properties);
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/Property.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/Property.java
@@ -1,0 +1,3 @@
+package org.icij.datashare.model;
+
+public record Property(String name, String qname, String type, String range, boolean stub) { }

--- a/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
@@ -9,18 +9,19 @@ public record Statement(String id, String model, String entityId, String entityT
 
     public Statement {
         Objects.requireNonNull(id, "id");
-        Objects.requireNonNull(model, "model");
-        Objects.requireNonNull(entityId, "entityId");
-        Objects.requireNonNull(entityType, "entityType");
-        Objects.requireNonNull(property, "property");
-        Objects.requireNonNull(value, "value");
+        model = component(model, "model");
+        entityId = component(entityId, "entityId");
+        entityType = component(entityType, "entityType");
+        property = component(property, "property");
+        value = component(value, "value");
         Objects.requireNonNull(provenance, "provenance");
     }
 
     public record Provenance(String documentId, String sheet, long rowNumber, String column) {
         public Provenance {
-            Objects.requireNonNull(documentId, "documentId");
-            Objects.requireNonNull(column, "column");
+            documentId = component(documentId, "documentId");
+            sheet = sheet == null ? "" : component(sheet, "sheet");
+            column = component(column, "column");
         }
     }
 
@@ -34,13 +35,22 @@ public record Statement(String id, String model, String entityId, String entityT
         return model + ":" + property;
     }
 
+    private static String component(String value, String field) {
+        Objects.requireNonNull(value, field);
+        if (value.indexOf('\u0000') >= 0) {
+            throw new IllegalArgumentException("'" + field + "' contains a NUL character");
+        }
+        return value;
+    }
+
     // NUL-separated rather than a printable delimiter: a cell value can hold any printable
-    // character, so only a value containing a literal NUL could forge a collision.
+    // character, and every joined component is rejected at construction if it holds a NUL, so no
+    // input can forge a collision.
     private static String id(String model, String entityId, String entityType,
                              String property, String value, Provenance provenance) {
         return Hasher.SHA_384.hash(String.join("\u0000", model, entityId, entityType, property, value,
                 provenance.documentId(),
-                provenance.sheet() == null ? "" : provenance.sheet(),
+                provenance.sheet(),
                 String.valueOf(provenance.rowNumber()),
                 provenance.column()));
     }

--- a/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
@@ -2,10 +2,27 @@ package org.icij.datashare.model;
 
 import org.icij.datashare.text.Hasher;
 
+import java.util.Objects;
+
 public record Statement(String id, String model, String entityId, String entityType,
                         String property, String value, Provenance provenance) {
 
-    public record Provenance(String documentId, String sheet, long rowNumber, String column) { }
+    public Statement {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(model, "model");
+        Objects.requireNonNull(entityId, "entityId");
+        Objects.requireNonNull(entityType, "entityType");
+        Objects.requireNonNull(property, "property");
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(provenance, "provenance");
+    }
+
+    public record Provenance(String documentId, String sheet, long rowNumber, String column) {
+        public Provenance {
+            Objects.requireNonNull(documentId, "documentId");
+            Objects.requireNonNull(column, "column");
+        }
+    }
 
     public static Statement of(String model, String entityId, String entityType,
                                String property, String value, Provenance provenance) {

--- a/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
@@ -1,0 +1,30 @@
+package org.icij.datashare.model;
+
+import org.icij.datashare.text.Hasher;
+
+public record Statement(String id, String model, String entityId, String entityType,
+                        String property, String value, Provenance provenance) {
+
+    public record Provenance(String documentId, String sheet, long rowNumber, String column) { }
+
+    public static Statement of(String model, String entityId, String entityType,
+                               String property, String value, Provenance provenance) {
+        return new Statement(id(model, entityId, entityType, property, value, provenance),
+                model, entityId, entityType, property, value, provenance);
+    }
+
+    public String qualifiedProperty() {
+        return model + ":" + property;
+    }
+
+    // NUL-separated rather than a printable delimiter: a cell value can hold any printable
+    // character, so only a value containing a literal NUL could forge a collision.
+    private static String id(String model, String entityId, String entityType,
+                             String property, String value, Provenance provenance) {
+        return Hasher.SHA_384.hash(String.join("\u0000", model, entityId, entityType, property, value,
+                provenance.documentId(),
+                provenance.sheet() == null ? "" : provenance.sheet(),
+                String.valueOf(provenance.rowNumber()),
+                provenance.column()));
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
@@ -14,8 +14,17 @@ public interface TargetModel {
 
     Optional<EntityType> type(String name);
 
+    /**
+     * Writes the entity in this model's native JSON form, without validating it: an entity that
+     * {@link #validate} would reject (e.g. an abstract type) can still be serialized.
+     */
     String serialize(ModelEntity entity);
 
+    /**
+     * Reads an entity back from this model's native JSON form. The projection is lossy: a
+     * multi-type entity collapses to its most specific single type, so statements, not this JSON,
+     * remain the system of record.
+     */
     ModelEntity parse(String json);
 
     record Violation(String message) { }
@@ -24,6 +33,10 @@ public interface TargetModel {
         return type(type).map(found -> found.properties().get(name));
     }
 
+    /**
+     * Checks the entity's types and properties against this model's structure. Returns every
+     * violation found, or an empty list if the entity is structurally valid.
+     */
     default List<Violation> validate(ModelEntity entity) {
         List<Violation> violations = new ArrayList<>();
         if (entity.types().isEmpty()) {

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
@@ -1,9 +1,11 @@
 package org.icij.datashare.model;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Stream;
@@ -71,9 +73,12 @@ public interface TargetModel {
                 }
             }
         }
+        Set<String> reported = new HashSet<>();
         for (EntityType type : types) {
-            type.required().stream().filter(required -> isBlank(entity, required)).forEach(required ->
-                    violations.add(new Violation("type '" + type.name() + "' requires '" + required + "'")));
+            type.required().stream()
+                    .filter(required -> isBlank(entity, required) && reported.add(required))
+                    .forEach(required ->
+                            violations.add(new Violation("type '" + type.name() + "' requires '" + required + "'")));
             if (type.edge() != null) {
                 Stream.of(type.edge().source(), type.edge().target())
                         .filter(end -> !type.required().contains(end))

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
@@ -1,10 +1,11 @@
 package org.icij.datashare.model;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 
 public interface TargetModel {
@@ -39,33 +40,36 @@ public interface TargetModel {
      */
     default List<Violation> validate(ModelEntity entity) {
         List<Violation> violations = new ArrayList<>();
-        if (entity.types().isEmpty()) {
+        SortedSet<String> names = new TreeSet<>(entity.types());
+        if (names.isEmpty()) {
             violations.add(new Violation("entity '" + entity.id() + "' has no type"));
         }
         List<EntityType> types = new ArrayList<>();
-        for (String name : entity.types()) {
+        for (String name : names) {
             Optional<EntityType> found = type(name);
             if (found.isEmpty()) {
                 violations.add(new Violation("unknown type '" + name + "' in model '" + name() + "'"));
             } else {
-                if (found.get().isAbstract()) {
-                    violations.add(new Violation("type '" + name + "' is abstract and cannot be instantiated"));
-                }
                 types.add(found.get());
             }
         }
+        if (!types.isEmpty() && types.stream().allMatch(EntityType::isAbstract)) {
+            violations.add(new Violation("every type in " + types.stream().map(EntityType::name).toList()
+                    + " is abstract and cannot be instantiated"));
+        }
         if (!types.isEmpty()) {
-            Map<String, Property> declared = new LinkedHashMap<>();
-            types.forEach(type -> type.properties().forEach(declared::putIfAbsent));
-            entity.properties().keySet().forEach(property -> {
-                Property declaration = declared.get(property);
-                if (declaration == null) {
-                    violations.add(new Violation("no property '" + property + "' on " + entity.types()));
-                } else if (declaration.stub()) {
+            for (String property : entity.properties().keySet()) {
+                List<Property> declarations = types.stream()
+                        .map(type -> type.properties().get(property))
+                        .filter(Objects::nonNull)
+                        .toList();
+                if (declarations.isEmpty()) {
+                    violations.add(new Violation("no property '" + property + "' on " + names));
+                } else if (declarations.stream().allMatch(Property::stub)) {
                     violations.add(new Violation("property '" + property + "' is a stub: it is inferred from the '"
-                            + declaration.range() + "' relation rather than written"));
+                            + declarations.get(0).range() + "' relation rather than written"));
                 }
-            });
+            }
         }
         for (EntityType type : types) {
             type.required().stream().filter(required -> isBlank(entity, required)).forEach(required ->

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
@@ -1,0 +1,74 @@
+package org.icij.datashare.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public interface TargetModel {
+    String name();
+
+    String version();
+
+    Optional<EntityType> type(String name);
+
+    String serialize(ModelEntity entity);
+
+    ModelEntity parse(String json);
+
+    record Violation(String message) { }
+
+    default Optional<Property> property(String type, String name) {
+        return type(type).map(found -> found.properties().get(name));
+    }
+
+    default List<Violation> validate(ModelEntity entity) {
+        List<Violation> violations = new ArrayList<>();
+        if (entity.types().isEmpty()) {
+            violations.add(new Violation("entity '" + entity.id() + "' has no type"));
+        }
+        List<EntityType> types = new ArrayList<>();
+        for (String name : entity.types()) {
+            Optional<EntityType> found = type(name);
+            if (found.isEmpty()) {
+                violations.add(new Violation("unknown type '" + name + "' in model '" + name() + "'"));
+            } else {
+                if (found.get().isAbstract()) {
+                    violations.add(new Violation("type '" + name + "' is abstract and cannot be instantiated"));
+                }
+                types.add(found.get());
+            }
+        }
+        if (!types.isEmpty()) {
+            Map<String, Property> declared = new LinkedHashMap<>();
+            types.forEach(type -> type.properties().forEach(declared::putIfAbsent));
+            entity.properties().keySet().forEach(property -> {
+                Property declaration = declared.get(property);
+                if (declaration == null) {
+                    violations.add(new Violation("no property '" + property + "' on " + entity.types()));
+                } else if (declaration.stub()) {
+                    violations.add(new Violation("property '" + property + "' is a stub: it is inferred from the '"
+                            + declaration.range() + "' relation rather than written"));
+                }
+            });
+        }
+        for (EntityType type : types) {
+            type.required().stream().filter(required -> isBlank(entity, required)).forEach(required ->
+                    violations.add(new Violation("type '" + type.name() + "' requires '" + required + "'")));
+            if (type.edge() != null) {
+                Stream.of(type.edge().source(), type.edge().target())
+                        .filter(end -> !type.required().contains(end))
+                        .filter(end -> isBlank(entity, end))
+                        .forEach(end -> violations.add(
+                                new Violation("edge type '" + type.name() + "' needs '" + end + "'")));
+            }
+        }
+        return violations;
+    }
+
+    private static boolean isBlank(ModelEntity entity, String property) {
+        return entity.properties().getOrDefault(property, List.of()).stream().allMatch(String::isBlank);
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
@@ -3,12 +3,14 @@ package org.icij.datashare.model;
 import org.icij.datashare.model.ftm.FtmTargetModel;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeSet;
 
 public class TargetModelRegistry {
     private static final Map<String, TargetModel> MODELS = Map.of("ftm", new FtmTargetModel());
 
     public static TargetModel get(String name) {
+        Objects.requireNonNull(name, "name");
         TargetModel model = MODELS.get(name);
         if (model == null) {
             throw new IllegalArgumentException("unknown data model '" + name

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
@@ -1,0 +1,19 @@
+package org.icij.datashare.model;
+
+import org.icij.datashare.model.ftm.FtmTargetModel;
+
+import java.util.Map;
+import java.util.TreeSet;
+
+public class TargetModelRegistry {
+    private static final Map<String, TargetModel> MODELS = Map.of("ftm", new FtmTargetModel());
+
+    public static TargetModel get(String name) {
+        TargetModel model = MODELS.get(name);
+        if (model == null) {
+            throw new IllegalArgumentException("unknown data model '" + name
+                    + "', known models: " + new TreeSet<>(MODELS.keySet()));
+        }
+        return model;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
@@ -4,7 +4,6 @@ import org.icij.datashare.model.ftm.FtmTargetModel;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeSet;
 
 public class TargetModelRegistry {
     private static final Map<String, TargetModel> MODELS = Map.of("ftm", new FtmTargetModel());
@@ -13,8 +12,7 @@ public class TargetModelRegistry {
         Objects.requireNonNull(name, "name");
         TargetModel model = MODELS.get(name);
         if (model == null) {
-            throw new IllegalArgumentException("unknown data model '" + name
-                    + "', known models: " + new TreeSet<>(MODELS.keySet()));
+            throw new UnknownTargetModel(name, MODELS.keySet());
         }
         return model;
     }

--- a/datashare-api/src/main/java/org/icij/datashare/model/UnknownTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/UnknownTargetModel.java
@@ -1,0 +1,13 @@
+package org.icij.datashare.model;
+
+import java.util.Collection;
+import java.util.TreeSet;
+
+public class UnknownTargetModel extends IllegalArgumentException {
+    public final String name;
+
+    public UnknownTargetModel(String name, Collection<String> known) {
+        super("unknown data model '%s', known models: %s".formatted(name, new TreeSet<>(known)));
+        this.name = name;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/UnreadableModelResource.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/UnreadableModelResource.java
@@ -1,0 +1,15 @@
+package org.icij.datashare.model;
+
+public class UnreadableModelResource extends RuntimeException {
+    public final String resource;
+
+    public UnreadableModelResource(String resource) {
+        super("no data model bundled at '%s'".formatted(resource));
+        this.resource = resource;
+    }
+
+    public UnreadableModelResource(String resource, Throwable root) {
+        super("cannot read the data model at '%s'".formatted(resource), root);
+        this.resource = resource;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -72,12 +72,20 @@ public class FtmTargetModel implements TargetModel {
 
     @Override
     public ModelEntity parse(String json) {
+        FtmEntity read;
         try {
-            FtmEntity read = JsonObjectMapper.getMapper().readValue(json, FtmEntity.class);
-            return new ModelEntity(read.id(), Set.of(read.schema()), read.properties());
+            read = JsonObjectMapper.getMapper().readValue(json, FtmEntity.class);
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("cannot read FtM JSON", e);
         }
+        if (read.id() == null) {
+            throw new IllegalArgumentException("missing 'id' in FtM JSON");
+        }
+        if (read.schema() == null) {
+            throw new IllegalArgumentException("missing 'schema' in FtM JSON");
+        }
+        return new ModelEntity(read.id(), Set.of(read.schema()),
+                read.properties() == null ? Map.of() : read.properties());
     }
 
     @Override

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -1,0 +1,113 @@
+package org.icij.datashare.model.ftm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.model.EntityType;
+import org.icij.datashare.model.ModelEntity;
+import org.icij.datashare.model.Property;
+import org.icij.datashare.model.TargetModel;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The FollowTheMoney model, read from a bundled copy of its prebuilt ontology. The
+ * {@code org.icij:ftm.java} artifact on the classpath is a build-time code generator and carries no
+ * model data, so the file is vendored: version 4.10.2, retrieved 2026-08-21 from
+ * https://raw.githubusercontent.com/opensanctions/followthemoney/main/js/src/defaultModel.json
+ */
+public class FtmTargetModel implements TargetModel {
+    private static final String RESOURCE = "ftm/defaultModel-4.10.2.json";
+
+    private final String version;
+    private final Map<String, EntityType> types;
+
+    public FtmTargetModel() {
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(RESOURCE)) {
+            if (stream == null) {
+                throw new IllegalStateException("no FtM model bundled at " + RESOURCE);
+            }
+            JsonNode root = JsonObjectMapper.getMapper().readTree(stream);
+            this.version = root.get("version").asText();
+            this.types = types(root.get("schemata"));
+        } catch (IOException e) {
+            throw new IllegalStateException("cannot read the FtM model at " + RESOURCE, e);
+        }
+    }
+
+    @Override
+    public String name() {
+        return "ftm";
+    }
+
+    @Override
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public Optional<EntityType> type(String name) {
+        return Optional.ofNullable(types.get(name));
+    }
+
+    @Override
+    public String serialize(ModelEntity entity) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ModelEntity parse(String json) {
+        throw new UnsupportedOperationException();
+    }
+
+    private static Map<String, EntityType> types(JsonNode schemata) {
+        Map<String, Map<String, Property>> declared = new HashMap<>();
+        schemata.fields().forEachRemaining(schema ->
+                declared.put(schema.getKey(), properties(schema.getValue().get("properties"))));
+        Map<String, EntityType> types = new HashMap<>();
+        schemata.fields().forEachRemaining(schema ->
+                types.put(schema.getKey(), type(schema.getKey(), schema.getValue(), declared)));
+        return Map.copyOf(types);
+    }
+
+    private static EntityType type(String name, JsonNode schema, Map<String, Map<String, Property>> declared) {
+        Set<String> ancestors = strings(schema.get("schemata"));
+        Map<String, Property> properties = new HashMap<>();
+        ancestors.forEach(ancestor -> properties.putAll(declared.getOrDefault(ancestor, Map.of())));
+        return new EntityType(name, schema.path("abstract").asBoolean(false), ancestors,
+                Map.copyOf(properties), strings(schema.path("required")), edge(schema.path("edge")));
+    }
+
+    private static Map<String, Property> properties(JsonNode properties) {
+        Map<String, Property> declared = new HashMap<>();
+        properties.fields().forEachRemaining(property ->
+                declared.put(property.getKey(), property(property.getValue())));
+        return declared;
+    }
+
+    private static Property property(JsonNode property) {
+        return new Property(property.get("name").asText(), property.get("qname").asText(),
+                property.get("type").asText(), text(property, "range"),
+                property.path("stub").asBoolean(false));
+    }
+
+    private static EntityType.Edge edge(JsonNode edge) {
+        return edge.isMissingNode() ? null : new EntityType.Edge(edge.get("source").asText(),
+                edge.get("target").asText(), edge.get("directed").asBoolean(false));
+    }
+
+    private static Set<String> strings(JsonNode array) {
+        Set<String> values = new HashSet<>();
+        array.forEach(value -> values.add(value.asText()));
+        return Set.copyOf(values);
+    }
+
+    private static String text(JsonNode node, String field) {
+        return node.has(field) ? node.get(field).asText() : null;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -7,22 +7,28 @@ import org.icij.datashare.model.EntityType;
 import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.Property;
 import org.icij.datashare.model.TargetModel;
+import org.icij.datashare.model.UnreadableModelResource;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * The FollowTheMoney model, read from a bundled copy of its prebuilt ontology. The
  * {@code org.icij:ftm.java} artifact on the classpath is a build-time code generator and carries no
  * model data, so the file is vendored: version 4.10.2, retrieved 2026-08-21 from
- * https://raw.githubusercontent.com/opensanctions/followthemoney/main/js/src/defaultModel.json
+ * https://raw.githubusercontent.com/opensanctions/followthemoney/b9418ecd32bd60dd09c261134464860a0082ffb7/js/src/defaultModel.json
+ * with sha256 d1733d7963b4a662e8162529dfc8a1eb0dd86d035425853fbc67c26b63d99992. That path carries
+ * no {@code 4.10.2} tag, so the commit sha is the only stable pin. FollowTheMoney is MIT-licensed
+ * and its notice ships beside the ontology, as the {@code ftm/LICENSE} resource.
  */
 public class FtmTargetModel implements TargetModel {
     private static final String RESOURCE = "ftm/defaultModel-4.10.2.json";
@@ -31,15 +37,19 @@ public class FtmTargetModel implements TargetModel {
     private final Map<String, EntityType> types;
 
     public FtmTargetModel() {
-        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(RESOURCE)) {
+        this(RESOURCE);
+    }
+
+    FtmTargetModel(String resource) {
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(resource)) {
             if (stream == null) {
-                throw new IllegalStateException("no FtM model bundled at " + RESOURCE);
+                throw new UnreadableModelResource(resource);
             }
             JsonNode root = JsonObjectMapper.getMapper().readTree(stream);
             this.version = root.get("version").asText();
             this.types = types(root.get("schemata"));
         } catch (IOException e) {
-            throw new IllegalStateException("cannot read the FtM model at " + RESOURCE, e);
+            throw new UnreadableModelResource(resource, e);
         }
     }
 
@@ -61,7 +71,7 @@ public class FtmTargetModel implements TargetModel {
     @Override
     public String serialize(ModelEntity entity) {
         String schema = mostSpecific(entity.types()).orElseThrow(() -> new IllegalArgumentException(
-                "types " + entity.types() + " have no common schema in the FtM model"));
+                "types " + new TreeSet<>(entity.types()) + " have no common schema in the FtM model"));
         try {
             return JsonObjectMapper.getMapper()
                     .writeValueAsString(new FtmEntity(entity.id(), schema, entity.properties()));
@@ -78,21 +88,32 @@ public class FtmTargetModel implements TargetModel {
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("cannot read FtM JSON", e);
         }
+        if (read == null) {
+            throw new IllegalArgumentException("no entity in FtM JSON");
+        }
         if (read.id() == null) {
             throw new IllegalArgumentException("missing 'id' in FtM JSON");
         }
         if (read.schema() == null) {
             throw new IllegalArgumentException("missing 'schema' in FtM JSON");
         }
-        return new ModelEntity(read.id(), Set.of(read.schema()),
-                read.properties() == null ? Map.of() : read.properties());
+        Map<String, List<String>> properties = read.properties() == null ? Map.of() : read.properties();
+        properties.forEach((property, values) -> {
+            if (values == null) {
+                throw new IllegalArgumentException("property '" + property + "' has no values in FtM JSON");
+            }
+            if (values.contains(null)) {
+                throw new IllegalArgumentException("property '" + property + "' has a null value in FtM JSON");
+            }
+        });
+        return new ModelEntity(read.id(), Set.of(read.schema()), properties);
     }
 
     @Override
     public List<Violation> validate(ModelEntity entity) {
         List<Violation> violations = new ArrayList<>(TargetModel.super.validate(entity));
         if (entity.types().size() > 1 && mostSpecific(entity.types()).isEmpty()) {
-            violations.add(new Violation("types " + entity.types()
+            violations.add(new Violation("types " + new TreeSet<>(entity.types())
                     + " have no common schema, so the entity cannot be written as FtM JSON"));
         }
         return violations;
@@ -119,7 +140,8 @@ public class FtmTargetModel implements TargetModel {
     private static EntityType type(String name, JsonNode schema, Map<String, Map<String, Property>> declared) {
         Set<String> ancestors = strings(schema.get("schemata"));
         Map<String, Property> properties = new HashMap<>();
-        ancestors.forEach(ancestor -> properties.putAll(declared.getOrDefault(ancestor, Map.of())));
+        // Two ancestors can declare the same property with different qnames: last one by name wins.
+        new TreeSet<>(ancestors).forEach(ancestor -> properties.putAll(declared.getOrDefault(ancestor, Map.of())));
         return new EntityType(name, schema.path("abstract").asBoolean(false), ancestors,
                 Map.copyOf(properties), strings(schema.path("required")), edge(schema.path("edge")));
     }
@@ -143,9 +165,9 @@ public class FtmTargetModel implements TargetModel {
     }
 
     private static Set<String> strings(JsonNode array) {
-        Set<String> values = new HashSet<>();
+        Set<String> values = new LinkedHashSet<>();
         array.forEach(value -> values.add(value.asText()));
-        return Set.copyOf(values);
+        return Collections.unmodifiableSet(values);
     }
 
     private static String text(JsonNode node, String field) {

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -69,8 +69,7 @@ public class FtmTargetModel implements TargetModel {
         String schema = mostSpecific(entity.types()).orElseThrow(() -> new IllegalArgumentException(
                 "types " + new TreeSet<>(entity.types()) + " have no common schema in the FtM model"));
         try {
-            return JsonObjectMapper.getMapper()
-                    .writeValueAsString(new FtmEntity(entity.id(), schema, entity.properties()));
+            return JsonObjectMapper.writeValueAsString(new FtmEntity(entity.id(), schema, entity.properties()));
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("cannot write entity '" + entity.id() + "' as FtM JSON", e);
         }
@@ -80,8 +79,8 @@ public class FtmTargetModel implements TargetModel {
     public ModelEntity parse(String json) {
         FtmEntity read;
         try {
-            read = JsonObjectMapper.getMapper().readValue(json, FtmEntity.class);
-        } catch (JsonProcessingException e) {
+            read = JsonObjectMapper.readValue(json, FtmEntity.class);
+        } catch (IOException e) {
             throw new IllegalArgumentException("cannot read FtM JSON", e);
         }
         if (read == null) {

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -37,19 +37,15 @@ public class FtmTargetModel implements TargetModel {
     private final Map<String, EntityType> types;
 
     public FtmTargetModel() {
-        this(RESOURCE);
-    }
-
-    FtmTargetModel(String resource) {
-        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(resource)) {
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(RESOURCE)) {
             if (stream == null) {
-                throw new UnreadableModelResource(resource);
+                throw new UnreadableModelResource(RESOURCE);
             }
             JsonNode root = JsonObjectMapper.getMapper().readTree(stream);
             this.version = root.get("version").asText();
             this.types = types(root.get("schemata"));
         } catch (IOException e) {
-            throw new UnreadableModelResource(resource, e);
+            throw new UnreadableModelResource(RESOURCE, e);
         }
     }
 

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.model.ftm;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.model.EntityType;
@@ -9,8 +10,10 @@ import org.icij.datashare.model.TargetModel;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -57,12 +60,42 @@ public class FtmTargetModel implements TargetModel {
 
     @Override
     public String serialize(ModelEntity entity) {
-        throw new UnsupportedOperationException();
+        String schema = mostSpecific(entity.types()).orElseThrow(() -> new IllegalArgumentException(
+                "types " + entity.types() + " have no common schema in the FtM model"));
+        try {
+            return JsonObjectMapper.getMapper()
+                    .writeValueAsString(new FtmEntity(entity.id(), schema, entity.properties()));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("cannot write entity '" + entity.id() + "' as FtM JSON", e);
+        }
     }
 
     @Override
     public ModelEntity parse(String json) {
-        throw new UnsupportedOperationException();
+        try {
+            FtmEntity read = JsonObjectMapper.getMapper().readValue(json, FtmEntity.class);
+            return new ModelEntity(read.id(), Set.of(read.schema()), read.properties());
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("cannot read FtM JSON", e);
+        }
+    }
+
+    @Override
+    public List<Violation> validate(ModelEntity entity) {
+        List<Violation> violations = new ArrayList<>(TargetModel.super.validate(entity));
+        if (entity.types().size() > 1 && mostSpecific(entity.types()).isEmpty()) {
+            violations.add(new Violation("types " + entity.types()
+                    + " have no common schema, so the entity cannot be written as FtM JSON"));
+        }
+        return violations;
+    }
+
+    private Optional<String> mostSpecific(Set<String> types) {
+        return types.stream()
+                .filter(candidate -> type(candidate)
+                        .map(found -> found.ancestors().containsAll(types))
+                        .orElse(false))
+                .findFirst();
     }
 
     private static Map<String, EntityType> types(JsonNode schemata) {
@@ -110,4 +143,6 @@ public class FtmTargetModel implements TargetModel {
     private static String text(JsonNode node, String field) {
         return node.has(field) ? node.get(field).asText() : null;
     }
+
+    record FtmEntity(String id, String schema, Map<String, List<String>> properties) { }
 }

--- a/datashare-api/src/main/resources/ftm/LICENSE
+++ b/datashare-api/src/main/resources/ftm/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2017-2024 Journalism Development Network, Inc.
+Copyright (c) 2025 OpenSanctions Datenbanken GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/datashare-api/src/main/resources/ftm/defaultModel-4.10.2.json
+++ b/datashare-api/src/main/resources/ftm/defaultModel-4.10.2.json
@@ -1,0 +1,8398 @@
+{
+  "schemata": {
+    "Address": {
+      "caption": [
+        "full",
+        "summary",
+        "city",
+        "remarks"
+      ],
+      "description": "A location associated with an entity.\n",
+      "extends": [
+        "Thing"
+      ],
+      "featured": [
+        "full",
+        "city",
+        "street",
+        "country"
+      ],
+      "label": "Address",
+      "matchable": true,
+      "plural": "Addresses",
+      "properties": {
+        "city": {
+          "description": "City, town, village or other locality",
+          "label": "City",
+          "maxLength": 1024,
+          "name": "city",
+          "qname": "Address:city",
+          "type": "string"
+        },
+        "full": {
+          "label": "Full address",
+          "matchable": true,
+          "maxLength": 250,
+          "name": "full",
+          "qname": "Address:full",
+          "type": "address"
+        },
+        "googlePlaceId": {
+          "label": "Google Places ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "googlePlaceId",
+          "qname": "Address:googlePlaceId",
+          "type": "identifier"
+        },
+        "latitude": {
+          "label": "Latitude",
+          "maxLength": 250,
+          "name": "latitude",
+          "qname": "Address:latitude",
+          "type": "number"
+        },
+        "longitude": {
+          "label": "Longitude",
+          "maxLength": 250,
+          "name": "longitude",
+          "qname": "Address:longitude",
+          "type": "number"
+        },
+        "osmId": {
+          "label": "OpenStreetmap Place ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "osmId",
+          "qname": "Address:osmId",
+          "type": "identifier"
+        },
+        "postOfficeBox": {
+          "description": "A mailbox identifier at the post office",
+          "label": "PO Box",
+          "maxLength": 1024,
+          "name": "postOfficeBox",
+          "qname": "Address:postOfficeBox",
+          "type": "string"
+        },
+        "postalCode": {
+          "description": "Zip code or postcode",
+          "label": "Postal code",
+          "maxLength": 16,
+          "name": "postalCode",
+          "qname": "Address:postalCode",
+          "type": "string"
+        },
+        "region": {
+          "description": "Also province or area",
+          "label": "Region",
+          "maxLength": 1024,
+          "name": "region",
+          "qname": "Address:region",
+          "type": "string"
+        },
+        "remarks": {
+          "description": "Handling instructions, like 'care of'",
+          "label": "Remarks",
+          "maxLength": 1024,
+          "name": "remarks",
+          "qname": "Address:remarks",
+          "type": "string"
+        },
+        "state": {
+          "description": "State or federal unit",
+          "label": "State",
+          "maxLength": 1024,
+          "name": "state",
+          "qname": "Address:state",
+          "type": "string"
+        },
+        "street": {
+          "label": "Street address",
+          "maxLength": 1024,
+          "name": "street",
+          "qname": "Address:street",
+          "type": "string"
+        },
+        "street2": {
+          "label": "Street address (ctd.)",
+          "maxLength": 1024,
+          "name": "street2",
+          "qname": "Address:street2",
+          "type": "string"
+        },
+        "things": {
+          "label": "Located there",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "things",
+          "qname": "Address:things",
+          "range": "Thing",
+          "reverse": "addressEntity",
+          "stub": true,
+          "type": "entity"
+        },
+        "tripsDeparting": {
+          "label": "Trips departing",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "tripsDeparting",
+          "qname": "Address:tripsDeparting",
+          "range": "Trip",
+          "reverse": "startLocation",
+          "stub": true,
+          "type": "entity"
+        },
+        "tripsIncoming": {
+          "label": "Trips incoming",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "tripsIncoming",
+          "qname": "Address:tripsIncoming",
+          "range": "Trip",
+          "reverse": "endLocation",
+          "stub": true,
+          "type": "entity"
+        }
+      },
+      "schemata": [
+        "Address",
+        "Thing"
+      ]
+    },
+    "Airplane": {
+      "caption": [
+        "name",
+        "registrationNumber"
+      ],
+      "description": "An airplane, helicopter or other flying vehicle.\n",
+      "extends": [
+        "Vehicle"
+      ],
+      "featured": [
+        "type",
+        "registrationNumber",
+        "country",
+        "operator",
+        "owner"
+      ],
+      "label": "Airplane",
+      "matchable": true,
+      "plural": "Airplanes",
+      "properties": {
+        "icaoCode": {
+          "label": "ICAO aircraft type designator",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "icaoCode",
+          "qname": "Airplane:icaoCode",
+          "type": "identifier"
+        },
+        "manufacturer": {
+          "label": "Manufacturer",
+          "maxLength": 1024,
+          "name": "manufacturer",
+          "qname": "Airplane:manufacturer",
+          "type": "string"
+        },
+        "serialNumber": {
+          "label": "Serial Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "serialNumber",
+          "qname": "Airplane:serialNumber",
+          "type": "identifier"
+        }
+      },
+      "schemata": [
+        "Airplane",
+        "Asset",
+        "Thing",
+        "Value",
+        "Vehicle"
+      ],
+      "temporalExtent": {
+        "end": [
+          "deregistrationDate"
+        ],
+        "start": [
+          "buildDate",
+          "registrationDate"
+        ]
+      }
+    },
+    "Analyzable": {
+      "abstract": true,
+      "description": "An entity suitable for being processed via named-entity recognition.\n",
+      "extends": [],
+      "generated": true,
+      "label": "Analyzable",
+      "plural": "Analyzables",
+      "properties": {
+        "companiesMentioned": {
+          "hidden": true,
+          "label": "Detected companies",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "companiesMentioned",
+          "qname": "Analyzable:companiesMentioned",
+          "type": "name"
+        },
+        "detectedCountry": {
+          "hidden": true,
+          "label": "Detected country",
+          "maxLength": 16,
+          "name": "detectedCountry",
+          "qname": "Analyzable:detectedCountry",
+          "type": "country"
+        },
+        "detectedLanguage": {
+          "hidden": true,
+          "label": "Detected language",
+          "maxLength": 16,
+          "name": "detectedLanguage",
+          "qname": "Analyzable:detectedLanguage",
+          "type": "language"
+        },
+        "emailMentioned": {
+          "hidden": true,
+          "label": "Detected e-mail addresses",
+          "matchable": true,
+          "maxLength": 250,
+          "name": "emailMentioned",
+          "qname": "Analyzable:emailMentioned",
+          "type": "email"
+        },
+        "ibanMentioned": {
+          "format": "iban",
+          "hidden": true,
+          "label": "Detected IBANs",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "ibanMentioned",
+          "qname": "Analyzable:ibanMentioned",
+          "type": "identifier"
+        },
+        "ipMentioned": {
+          "hidden": true,
+          "label": "Detected IP addresses",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "ipMentioned",
+          "qname": "Analyzable:ipMentioned",
+          "type": "ip"
+        },
+        "locationMentioned": {
+          "hidden": true,
+          "label": "Detected locations",
+          "maxLength": 250,
+          "name": "locationMentioned",
+          "qname": "Analyzable:locationMentioned",
+          "type": "address"
+        },
+        "namesMentioned": {
+          "hidden": true,
+          "label": "Detected names",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "namesMentioned",
+          "qname": "Analyzable:namesMentioned",
+          "type": "name"
+        },
+        "peopleMentioned": {
+          "hidden": true,
+          "label": "Detected people",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "peopleMentioned",
+          "qname": "Analyzable:peopleMentioned",
+          "type": "name"
+        },
+        "phoneMentioned": {
+          "hidden": true,
+          "label": "Detected phones",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "phoneMentioned",
+          "qname": "Analyzable:phoneMentioned",
+          "type": "phone"
+        }
+      },
+      "schemata": [
+        "Analyzable"
+      ]
+    },
+    "Article": {
+      "caption": [
+        "title",
+        "fileName"
+      ],
+      "description": "A piece of media reporting about a subject.\n",
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "author",
+        "publishedAt"
+      ],
+      "generated": true,
+      "label": "Article",
+      "plural": "Articles",
+      "properties": {},
+      "schemata": [
+        "Analyzable",
+        "Article",
+        "Document",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Asset": {
+      "caption": [
+        "name"
+      ],
+      "description": "A piece of property which can be owned and assigned a monetary value.\n",
+      "extends": [
+        "Thing",
+        "Value"
+      ],
+      "featured": [
+        "name",
+        "amount"
+      ],
+      "label": "Asset",
+      "plural": "Assets",
+      "properties": {
+        "ownershipAsset": {
+          "label": "Ownership and Control",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "ownershipAsset",
+          "qname": "Asset:ownershipAsset",
+          "range": "Ownership",
+          "reverse": "asset",
+          "stub": true,
+          "type": "entity"
+        }
+      },
+      "schemata": [
+        "Asset",
+        "Thing",
+        "Value"
+      ]
+    },
+    "Associate": {
+      "description": "Non-family association between two people.",
+      "edge": {
+        "caption": [
+          "relationship"
+        ],
+        "directed": false,
+        "label": "associated with",
+        "source": "person",
+        "target": "associate"
+      },
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "person",
+        "associate",
+        "relationship"
+      ],
+      "label": "Associate",
+      "plural": "Associates",
+      "properties": {
+        "associate": {
+          "description": "An associate of the subject person",
+          "label": "Associate",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "associate",
+          "qname": "Associate:associate",
+          "range": "Person",
+          "reverse": "associations",
+          "type": "entity"
+        },
+        "person": {
+          "description": "The subject of the association",
+          "label": "Person",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "person",
+          "qname": "Associate:person",
+          "range": "Person",
+          "reverse": "associates",
+          "type": "entity"
+        },
+        "relationship": {
+          "description": "Nature of the association",
+          "label": "Relationship",
+          "maxLength": 1024,
+          "name": "relationship",
+          "qname": "Associate:relationship",
+          "type": "string"
+        }
+      },
+      "required": [
+        "person",
+        "associate"
+      ],
+      "schemata": [
+        "Associate",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Audio": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Audio",
+      "plural": "Audio files",
+      "properties": {
+        "duration": {
+          "description": "Duration of the audio in ms",
+          "label": "Duration",
+          "maxLength": 250,
+          "name": "duration",
+          "qname": "Audio:duration",
+          "type": "number"
+        },
+        "samplingRate": {
+          "description": "Sampling rate of the audio in Hz",
+          "label": "Sampling Rate",
+          "maxLength": 250,
+          "name": "samplingRate",
+          "qname": "Audio:samplingRate",
+          "type": "number"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Audio",
+        "Document",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "BankAccount": {
+      "caption": [
+        "name",
+        "iban",
+        "accountNumber"
+      ],
+      "description": "An account held at a bank and controlled by an owner. This may also be used to describe more complex arrangements like correspondent bank settlement accounts.\n",
+      "extends": [
+        "Asset"
+      ],
+      "featured": [
+        "accountNumber",
+        "bankName"
+      ],
+      "label": "Bank account",
+      "matchable": true,
+      "plural": "Bank accounts",
+      "properties": {
+        "accountNumber": {
+          "label": "Account number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "accountNumber",
+          "qname": "BankAccount:accountNumber",
+          "type": "identifier"
+        },
+        "accountType": {
+          "label": "Account type",
+          "maxLength": 1024,
+          "name": "accountType",
+          "qname": "BankAccount:accountType",
+          "type": "string"
+        },
+        "balance": {
+          "label": "Balance",
+          "maxLength": 250,
+          "name": "balance",
+          "qname": "BankAccount:balance",
+          "type": "number"
+        },
+        "balanceDate": {
+          "label": "Balance date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "balanceDate",
+          "qname": "BankAccount:balanceDate",
+          "type": "date"
+        },
+        "bank": {
+          "label": "Bank",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "bank",
+          "qname": "BankAccount:bank",
+          "range": "Organization",
+          "reverse": "bankAccounts",
+          "type": "entity"
+        },
+        "bankAddress": {
+          "label": "Bank address",
+          "maxLength": 1024,
+          "name": "bankAddress",
+          "qname": "BankAccount:bankAddress",
+          "type": "string"
+        },
+        "bankName": {
+          "label": "Bank name",
+          "maxLength": 1024,
+          "name": "bankName",
+          "qname": "BankAccount:bankName",
+          "type": "string"
+        },
+        "bic": {
+          "format": "bic",
+          "label": "Bank Identifier Code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "bic",
+          "qname": "BankAccount:bic",
+          "type": "identifier"
+        },
+        "closingDate": {
+          "label": "Closing date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "closingDate",
+          "qname": "BankAccount:closingDate",
+          "type": "date"
+        },
+        "contractBankAccount": {
+          "label": "Customs declarations",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contractBankAccount",
+          "qname": "BankAccount:contractBankAccount",
+          "range": "EconomicActivity",
+          "reverse": "bankAccount",
+          "stub": true,
+          "type": "entity"
+        },
+        "foreignBankAccount": {
+          "label": "Customs declarations (as foreign bank)",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "foreignBankAccount",
+          "qname": "BankAccount:foreignBankAccount",
+          "range": "EconomicActivity",
+          "reverse": "bankForeign",
+          "stub": true,
+          "type": "entity"
+        },
+        "iban": {
+          "format": "iban",
+          "label": "IBAN",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "iban",
+          "qname": "BankAccount:iban",
+          "type": "identifier"
+        },
+        "maxBalance": {
+          "label": "Maximum balance",
+          "maxLength": 250,
+          "name": "maxBalance",
+          "qname": "BankAccount:maxBalance",
+          "type": "number"
+        },
+        "maxBalanceDate": {
+          "label": "Maximum balance date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "maxBalanceDate",
+          "qname": "BankAccount:maxBalanceDate",
+          "type": "date"
+        },
+        "openingDate": {
+          "label": "Opening date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "openingDate",
+          "qname": "BankAccount:openingDate",
+          "type": "date"
+        },
+        "paymentBeneficiaryAccount": {
+          "label": "Payments received",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "paymentBeneficiaryAccount",
+          "qname": "BankAccount:paymentBeneficiaryAccount",
+          "range": "Payment",
+          "reverse": "beneficiaryAccount",
+          "stub": true,
+          "type": "entity"
+        },
+        "paymentPayerAccount": {
+          "label": "Payments made",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "paymentPayerAccount",
+          "qname": "BankAccount:paymentPayerAccount",
+          "range": "Payment",
+          "reverse": "payerAccount",
+          "stub": true,
+          "type": "entity"
+        },
+        "rubBankAccount": {
+          "label": "Customs declarations (as rouble bank)",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "rubBankAccount",
+          "qname": "BankAccount:rubBankAccount",
+          "range": "EconomicActivity",
+          "reverse": "bankRub",
+          "stub": true,
+          "type": "entity"
+        }
+      },
+      "schemata": [
+        "Asset",
+        "BankAccount",
+        "Thing",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [
+          "closingDate"
+        ],
+        "start": [
+          "openingDate"
+        ]
+      }
+    },
+    "Call": {
+      "caption": [
+        "callerNumber",
+        "receiverNumber"
+      ],
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "callerNumber",
+        "caller",
+        "receiverNumber",
+        "receiver",
+        "date"
+      ],
+      "generated": true,
+      "label": "Call",
+      "plural": "Calls",
+      "properties": {
+        "caller": {
+          "label": "Caller",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "caller",
+          "qname": "Call:caller",
+          "range": "LegalEntity",
+          "reverse": "callsMade",
+          "type": "entity"
+        },
+        "callerNumber": {
+          "label": "Caller's Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "callerNumber",
+          "qname": "Call:callerNumber",
+          "type": "phone"
+        },
+        "duration": {
+          "label": "Duration",
+          "maxLength": 250,
+          "name": "duration",
+          "qname": "Call:duration",
+          "type": "number"
+        },
+        "receiver": {
+          "label": "Receiver",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "receiver",
+          "qname": "Call:receiver",
+          "range": "LegalEntity",
+          "reverse": "callsReceived",
+          "type": "entity"
+        },
+        "receiverNumber": {
+          "label": "Receiver's Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "receiverNumber",
+          "qname": "Call:receiverNumber",
+          "type": "phone"
+        }
+      },
+      "schemata": [
+        "Call",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "CallForTenders": {
+      "caption": [
+        "title"
+      ],
+      "description": "A public appeal issued by an authority, possibly on behalf of another, for buying a specific work, supply or service.\n",
+      "extends": [
+        "Interval",
+        "Thing"
+      ],
+      "featured": [
+        "title",
+        "authority"
+      ],
+      "label": "Call for tenders",
+      "plural": "Calls for tenders",
+      "properties": {
+        "authority": {
+          "label": "Name of contracting authority",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "authority",
+          "qname": "CallForTenders:authority",
+          "range": "LegalEntity",
+          "reverse": "callForTenders",
+          "type": "entity"
+        },
+        "authorityReferenceId": {
+          "label": "Contracting authority reference ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "authorityReferenceId",
+          "qname": "CallForTenders:authorityReferenceId",
+          "type": "identifier"
+        },
+        "awardNoticeDate": {
+          "label": "Award Notice Date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "awardNoticeDate",
+          "qname": "CallForTenders:awardNoticeDate",
+          "type": "date"
+        },
+        "awardedInLots": {
+          "label": "Contract awarded in Lots",
+          "maxLength": 1024,
+          "name": "awardedInLots",
+          "qname": "CallForTenders:awardedInLots",
+          "type": "string"
+        },
+        "awardingDate": {
+          "label": "Date of awarding",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "awardingDate",
+          "qname": "CallForTenders:awardingDate",
+          "type": "date"
+        },
+        "callId": {
+          "label": "CfT unique id",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "callId",
+          "qname": "CallForTenders:callId",
+          "type": "identifier"
+        },
+        "certificationCheck": {
+          "label": "Certification check",
+          "maxLength": 1024,
+          "name": "certificationCheck",
+          "qname": "CallForTenders:certificationCheck",
+          "type": "string"
+        },
+        "clarificationDeadline": {
+          "label": "End of clarification period",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "clarificationDeadline",
+          "qname": "CallForTenders:clarificationDeadline",
+          "type": "date"
+        },
+        "contractAwards": {
+          "label": "Contract Awards",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contractAwards",
+          "qname": "CallForTenders:contractAwards",
+          "range": "ContractAward",
+          "reverse": "callForTenders",
+          "stub": true,
+          "type": "entity"
+        },
+        "contractNoticeDate": {
+          "label": "Contract notice date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "contractNoticeDate",
+          "qname": "CallForTenders:contractNoticeDate",
+          "type": "date"
+        },
+        "cpvCode": {
+          "description": "Common Procurement Vocabulary (CPV)",
+          "label": "CPV code",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "cpvCode",
+          "qname": "CallForTenders:cpvCode",
+          "type": "identifier"
+        },
+        "directive": {
+          "label": "Directive",
+          "maxLength": 1024,
+          "name": "directive",
+          "qname": "CallForTenders:directive",
+          "type": "string"
+        },
+        "euFunding": {
+          "label": "EU funding",
+          "maxLength": 1024,
+          "name": "euFunding",
+          "qname": "CallForTenders:euFunding",
+          "type": "string"
+        },
+        "evaluationMechanism": {
+          "label": "Evaluation mechanism",
+          "maxLength": 1024,
+          "name": "evaluationMechanism",
+          "qname": "CallForTenders:evaluationMechanism",
+          "type": "string"
+        },
+        "fallsUnderGPPScope": {
+          "description": "European Green Public Procurement (GPP) or green purchasing",
+          "label": "Does this call fall under the scope of GPP?",
+          "maxLength": 1024,
+          "name": "fallsUnderGPPScope",
+          "qname": "CallForTenders:fallsUnderGPPScope",
+          "type": "string"
+        },
+        "involvesOutcome": {
+          "description": "The nature of the contractual agreement that will result from this CfT",
+          "label": "Call for tenders result",
+          "maxLength": 1024,
+          "name": "involvesOutcome",
+          "qname": "CallForTenders:involvesOutcome",
+          "type": "string"
+        },
+        "lotsNames": {
+          "label": "Lots names",
+          "maxLength": 1024,
+          "name": "lotsNames",
+          "qname": "CallForTenders:lotsNames",
+          "type": "string"
+        },
+        "maximumNumberOfLots": {
+          "label": "Maximum number of lots",
+          "maxLength": 250,
+          "name": "maximumNumberOfLots",
+          "qname": "CallForTenders:maximumNumberOfLots",
+          "type": "number"
+        },
+        "multipleTenders": {
+          "label": "Multiple tenders will be accepted",
+          "maxLength": 1024,
+          "name": "multipleTenders",
+          "qname": "CallForTenders:multipleTenders",
+          "type": "string"
+        },
+        "numberOfLots": {
+          "label": "Number of lots",
+          "maxLength": 250,
+          "name": "numberOfLots",
+          "qname": "CallForTenders:numberOfLots",
+          "type": "number"
+        },
+        "nutsCode": {
+          "description": "Nomenclature of Territorial Units for Statistics (NUTS)",
+          "label": "NUTS code",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "nutsCode",
+          "qname": "CallForTenders:nutsCode",
+          "type": "identifier"
+        },
+        "onBehalfOf": {
+          "label": "Published on behalf of",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "onBehalfOf",
+          "qname": "CallForTenders:onBehalfOf",
+          "range": "LegalEntity",
+          "reverse": "delegatedCallForTenders",
+          "type": "entity"
+        },
+        "paymentOptions": {
+          "label": "Payment options",
+          "maxLength": 1024,
+          "name": "paymentOptions",
+          "qname": "CallForTenders:paymentOptions",
+          "type": "string"
+        },
+        "procedure": {
+          "label": "Procedure",
+          "maxLength": 1024,
+          "name": "procedure",
+          "qname": "CallForTenders:procedure",
+          "type": "string"
+        },
+        "procurementType": {
+          "label": "Procurement type",
+          "maxLength": 1024,
+          "name": "procurementType",
+          "qname": "CallForTenders:procurementType",
+          "type": "string"
+        },
+        "publicationDate": {
+          "label": "Date of publication/invitation",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "publicationDate",
+          "qname": "CallForTenders:publicationDate",
+          "type": "date"
+        },
+        "relationToThreshold": {
+          "label": "Above or below threshold",
+          "maxLength": 1024,
+          "name": "relationToThreshold",
+          "qname": "CallForTenders:relationToThreshold",
+          "type": "string"
+        },
+        "reverseAuctionsIncluded": {
+          "label": "Inclusion of e-Auctions",
+          "maxLength": 1024,
+          "name": "reverseAuctionsIncluded",
+          "qname": "CallForTenders:reverseAuctionsIncluded",
+          "type": "string"
+        },
+        "submissionDeadline": {
+          "label": "Submission deadline",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "submissionDeadline",
+          "qname": "CallForTenders:submissionDeadline",
+          "type": "date"
+        },
+        "tedUrl": {
+          "label": "TED link for published notices",
+          "matchable": true,
+          "maxLength": 4096,
+          "name": "tedUrl",
+          "qname": "CallForTenders:tedUrl",
+          "type": "url"
+        },
+        "tenderers": {
+          "label": "Tenderers",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "tenderers",
+          "qname": "CallForTenders:tenderers",
+          "range": "LegalEntity",
+          "reverse": "callForTenders",
+          "type": "entity"
+        },
+        "tendersForLots": {
+          "label": "Tenders for lots",
+          "maxLength": 1024,
+          "name": "tendersForLots",
+          "qname": "CallForTenders:tendersForLots",
+          "type": "string"
+        },
+        "title": {
+          "label": "Title",
+          "maxLength": 1024,
+          "name": "title",
+          "qname": "CallForTenders:title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "authority"
+      ],
+      "schemata": [
+        "CallForTenders",
+        "Interval",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Company": {
+      "caption": [
+        "name",
+        "alias",
+        "abbreviation",
+        "weakAlias",
+        "previousName",
+        "registrationNumber"
+      ],
+      "description": "A corporation, usually for profit. Does not distinguish between private and public companies, and can also be used to model more specific constructs like trusts and funds. Companies are assets, so they can be owned by other legal entities.\n",
+      "extends": [
+        "Asset",
+        "Organization"
+      ],
+      "featured": [
+        "name",
+        "jurisdiction",
+        "registrationNumber",
+        "incorporationDate"
+      ],
+      "label": "Company",
+      "matchable": true,
+      "plural": "Companies",
+      "properties": {
+        "bikCode": {
+          "description": "Russian bank account code",
+          "label": "BIK",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "bikCode",
+          "qname": "Company:bikCode",
+          "type": "identifier"
+        },
+        "caemCode": {
+          "description": "Romanian classifier used to identify the types of economic activities that a business can provide in Romania",
+          "label": "COD CAEM",
+          "maxLength": 1024,
+          "name": "caemCode",
+          "qname": "Company:caemCode",
+          "type": "string"
+        },
+        "capital": {
+          "label": "Capital",
+          "maxLength": 250,
+          "name": "capital",
+          "qname": "Company:capital",
+          "type": "number"
+        },
+        "cikCode": {
+          "description": "US SEC Central Index Key for listed companies",
+          "label": "SEC Central Index Key",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "cikCode",
+          "qname": "Company:cikCode",
+          "type": "identifier"
+        },
+        "coatoCode": {
+          "description": "Soviet classifier for territories, regions, districts, villages. Aka. SOATO and same as OKATO.",
+          "label": "COATO / SOATO / OKATO",
+          "maxLength": 64,
+          "name": "coatoCode",
+          "qname": "Company:coatoCode",
+          "type": "identifier"
+        },
+        "fnsCode": {
+          "description": "(RU, ФНС) Federal Tax Service related info",
+          "label": "Federal tax service code",
+          "maxLength": 64,
+          "name": "fnsCode",
+          "qname": "Company:fnsCode",
+          "type": "identifier"
+        },
+        "fssCode": {
+          "description": "(RU, ФСС) Social Security",
+          "label": "FSS",
+          "maxLength": 1024,
+          "name": "fssCode",
+          "qname": "Company:fssCode",
+          "type": "string"
+        },
+        "ipoCode": {
+          "label": "IPO",
+          "maxLength": 64,
+          "name": "ipoCode",
+          "qname": "Company:ipoCode",
+          "type": "identifier"
+        },
+        "irsCode": {
+          "description": "US tax ID",
+          "label": "IRS Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "irsCode",
+          "qname": "Company:irsCode",
+          "type": "identifier"
+        },
+        "isinCode": {
+          "deprecated": true,
+          "description": "International Securities Identification Number",
+          "label": "ISIN",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "isinCode",
+          "qname": "Company:isinCode",
+          "type": "identifier"
+        },
+        "jibCode": {
+          "description": "Yugoslavia company ID",
+          "label": "JIB",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "jibCode",
+          "qname": "Company:jibCode",
+          "type": "identifier"
+        },
+        "kppCode": {
+          "description": "(RU, КПП) Russian code issued by the tax authority, identifies the reason for registration at the Federal Tax Service. A company may have multiple KPP codes (e.g. for different branches), and the codes are not unique across companies.",
+          "label": "KPP",
+          "maxLength": 64,
+          "name": "kppCode",
+          "qname": "Company:kppCode",
+          "type": "identifier"
+        },
+        "mbsCode": {
+          "label": "MBS",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "mbsCode",
+          "qname": "Company:mbsCode",
+          "type": "identifier"
+        },
+        "okopfCode": {
+          "description": "(RU, ОКОПФ) Russian classifier that categorizes different types of legal entities in Russia based on their organizational and legal structure",
+          "label": "OKOPF",
+          "maxLength": 1024,
+          "name": "okopfCode",
+          "qname": "Company:okopfCode",
+          "type": "string"
+        },
+        "oksmCode": {
+          "description": "(RU, ОКСМ) Russian countries classifier",
+          "label": "OKSM",
+          "maxLength": 1024,
+          "name": "oksmCode",
+          "qname": "Company:oksmCode",
+          "type": "string"
+        },
+        "pfrNumber": {
+          "description": "(RU, ПФР) Pension Fund Registration number. AAA-BBB-CCCCCC, where AAA is organisation region, BBB is district, and CCCCCC is the number at a specific branch.",
+          "label": "PFR Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "pfrNumber",
+          "qname": "Company:pfrNumber",
+          "type": "identifier"
+        },
+        "ricCode": {
+          "label": "Reuters Instrument Code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "ricCode",
+          "qname": "Company:ricCode",
+          "type": "identifier"
+        },
+        "ticker": {
+          "label": "Stock ticker symbol",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "ticker",
+          "qname": "Company:ticker",
+          "type": "identifier"
+        },
+        "voenCode": {
+          "description": "Azerbaijan taxpayer ID",
+          "label": "VOEN",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "voenCode",
+          "qname": "Company:voenCode",
+          "type": "identifier"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "Asset",
+        "Company",
+        "LegalEntity",
+        "Organization",
+        "Thing",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [
+          "dissolutionDate"
+        ],
+        "start": [
+          "incorporationDate"
+        ]
+      }
+    },
+    "Contract": {
+      "caption": [
+        "title",
+        "name",
+        "procedureNumber"
+      ],
+      "description": "A contract or contract lot issued by an authority. Multiple lots may be awarded to different suppliers (see `ContractAward`).\n",
+      "extends": [
+        "Asset"
+      ],
+      "featured": [
+        "title",
+        "amount",
+        "authority",
+        "contractDate"
+      ],
+      "label": "Contract",
+      "plural": "Contracts",
+      "properties": {
+        "authority": {
+          "label": "Contract authority",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "authority",
+          "qname": "Contract:authority",
+          "range": "LegalEntity",
+          "reverse": "contractAuthority",
+          "type": "entity"
+        },
+        "awards": {
+          "label": "Lots awarded",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "awards",
+          "qname": "Contract:awards",
+          "range": "ContractAward",
+          "reverse": "contract",
+          "stub": true,
+          "type": "entity"
+        },
+        "cancelled": {
+          "label": "Cancelled?",
+          "maxLength": 1024,
+          "name": "cancelled",
+          "qname": "Contract:cancelled",
+          "type": "string"
+        },
+        "classification": {
+          "label": "Classification",
+          "maxLength": 1024,
+          "name": "classification",
+          "qname": "Contract:classification",
+          "type": "string"
+        },
+        "contractDate": {
+          "label": "Contract date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "contractDate",
+          "qname": "Contract:contractDate",
+          "type": "date"
+        },
+        "criteria": {
+          "label": "Contract award criteria",
+          "maxLength": 1024,
+          "name": "criteria",
+          "qname": "Contract:criteria",
+          "type": "string"
+        },
+        "economicActivityContract": {
+          "label": "Used in customs",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "economicActivityContract",
+          "qname": "Contract:economicActivityContract",
+          "range": "EconomicActivity",
+          "reverse": "contract",
+          "stub": true,
+          "type": "entity"
+        },
+        "language": {
+          "label": "Language",
+          "maxLength": 16,
+          "name": "language",
+          "qname": "Contract:language",
+          "type": "language"
+        },
+        "method": {
+          "label": "Procurement method",
+          "maxLength": 1024,
+          "name": "method",
+          "qname": "Contract:method",
+          "type": "string"
+        },
+        "noticeId": {
+          "label": "Contract Award Notice ID",
+          "maxLength": 1024,
+          "name": "noticeId",
+          "qname": "Contract:noticeId",
+          "type": "string"
+        },
+        "numberAwards": {
+          "label": "Number of awards",
+          "maxLength": 1024,
+          "name": "numberAwards",
+          "qname": "Contract:numberAwards",
+          "type": "string"
+        },
+        "paymentContract": {
+          "label": "Contractual payments",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "paymentContract",
+          "qname": "Contract:paymentContract",
+          "range": "Payment",
+          "reverse": "contract",
+          "stub": true,
+          "type": "entity"
+        },
+        "procedure": {
+          "label": "Contract procedure",
+          "maxLength": 1024,
+          "name": "procedure",
+          "qname": "Contract:procedure",
+          "type": "string"
+        },
+        "procedureNumber": {
+          "label": "Procedure number",
+          "maxLength": 1024,
+          "name": "procedureNumber",
+          "qname": "Contract:procedureNumber",
+          "type": "string"
+        },
+        "project": {
+          "label": "Project",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "project",
+          "qname": "Contract:project",
+          "range": "Project",
+          "reverse": "contracts",
+          "type": "entity"
+        },
+        "status": {
+          "examples": [
+            "In force",
+            "Annulled"
+          ],
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "Contract:status",
+          "type": "string"
+        },
+        "title": {
+          "label": "Title",
+          "maxLength": 1024,
+          "name": "title",
+          "qname": "Contract:title",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of contract",
+          "examples": [
+            "W (Works)",
+            "U (Supplies)",
+            "S (Services)"
+          ],
+          "label": "Type",
+          "maxLength": 1024,
+          "name": "type",
+          "qname": "Contract:type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "schemata": [
+        "Asset",
+        "Contract",
+        "Thing",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "contractDate"
+        ]
+      }
+    },
+    "ContractAward": {
+      "description": "A contract or contract lot as awarded to a supplier.",
+      "edge": {
+        "caption": [
+          "lotNumber"
+        ],
+        "directed": true,
+        "label": "awarded to",
+        "source": "contract",
+        "target": "supplier"
+      },
+      "extends": [
+        "Interest",
+        "Value"
+      ],
+      "featured": [
+        "supplier",
+        "contract",
+        "amount",
+        "lotNumber",
+        "decisionReason"
+      ],
+      "label": "Contract award",
+      "plural": "Contract awards",
+      "properties": {
+        "amended": {
+          "description": "Was this award amended, modified or updated by a subsequent document?",
+          "label": "Amended",
+          "maxLength": 1024,
+          "name": "amended",
+          "qname": "ContractAward:amended",
+          "type": "string"
+        },
+        "callForTenders": {
+          "label": "Call For Tenders",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "callForTenders",
+          "qname": "ContractAward:callForTenders",
+          "range": "CallForTenders",
+          "reverse": "contractAwards",
+          "type": "entity"
+        },
+        "contract": {
+          "label": "Contract",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contract",
+          "qname": "ContractAward:contract",
+          "range": "Contract",
+          "reverse": "awards",
+          "type": "entity"
+        },
+        "cpvCode": {
+          "description": "Contract Procurement Vocabulary (what type of goods/services, EU)",
+          "label": "CPV code",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "cpvCode",
+          "qname": "ContractAward:cpvCode",
+          "type": "identifier"
+        },
+        "decisionReason": {
+          "label": "Decision reason",
+          "maxLength": 65000,
+          "name": "decisionReason",
+          "qname": "ContractAward:decisionReason",
+          "type": "text"
+        },
+        "documentNumber": {
+          "label": "Document number",
+          "maxLength": 1024,
+          "name": "documentNumber",
+          "qname": "ContractAward:documentNumber",
+          "type": "string"
+        },
+        "documentType": {
+          "label": "Document type",
+          "maxLength": 1024,
+          "name": "documentType",
+          "qname": "ContractAward:documentType",
+          "type": "string"
+        },
+        "lotNumber": {
+          "label": "Lot number",
+          "maxLength": 1024,
+          "name": "lotNumber",
+          "qname": "ContractAward:lotNumber",
+          "type": "string"
+        },
+        "nutsCode": {
+          "description": "Nomencalture of Territorial Units for Statistics (NUTS)",
+          "label": "NUTS code",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "nutsCode",
+          "qname": "ContractAward:nutsCode",
+          "type": "identifier"
+        },
+        "supplier": {
+          "description": "The entity the contract was awarded to",
+          "label": "Supplier",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "supplier",
+          "qname": "ContractAward:supplier",
+          "range": "LegalEntity",
+          "reverse": "contractAwardSupplier",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "supplier",
+        "contract"
+      ],
+      "schemata": [
+        "ContractAward",
+        "Interest",
+        "Interval",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "CourtCase": {
+      "caption": [
+        "name",
+        "caseNumber"
+      ],
+      "extends": [
+        "Thing"
+      ],
+      "featured": [
+        "name",
+        "fileDate",
+        "caseNumber"
+      ],
+      "label": "Court case",
+      "plural": "Court cases",
+      "properties": {
+        "caseNumber": {
+          "label": "Case number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "caseNumber",
+          "qname": "CourtCase:caseNumber",
+          "type": "identifier"
+        },
+        "category": {
+          "label": "Category",
+          "maxLength": 1024,
+          "name": "category",
+          "qname": "CourtCase:category",
+          "type": "string"
+        },
+        "closeDate": {
+          "label": "Close date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "closeDate",
+          "qname": "CourtCase:closeDate",
+          "type": "date"
+        },
+        "court": {
+          "label": "Court",
+          "maxLength": 1024,
+          "name": "court",
+          "qname": "CourtCase:court",
+          "type": "string"
+        },
+        "fileDate": {
+          "label": "File date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "fileDate",
+          "qname": "CourtCase:fileDate",
+          "type": "date"
+        },
+        "parties": {
+          "label": "Parties",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "parties",
+          "qname": "CourtCase:parties",
+          "range": "CourtCaseParty",
+          "reverse": "case",
+          "stub": true,
+          "type": "entity"
+        },
+        "status": {
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "CourtCase:status",
+          "type": "string"
+        },
+        "type": {
+          "label": "Type",
+          "maxLength": 1024,
+          "name": "type",
+          "qname": "CourtCase:type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "CourtCase",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "closeDate"
+        ],
+        "start": [
+          "fileDate"
+        ]
+      }
+    },
+    "CourtCaseParty": {
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": true,
+        "label": "involved in",
+        "source": "party",
+        "target": "case"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "party",
+        "case",
+        "role"
+      ],
+      "label": "Case party",
+      "plural": "Case parties",
+      "properties": {
+        "case": {
+          "label": "Case",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "case",
+          "qname": "CourtCaseParty:case",
+          "range": "CourtCase",
+          "reverse": "parties",
+          "type": "entity"
+        },
+        "party": {
+          "label": "Party",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "party",
+          "qname": "CourtCaseParty:party",
+          "range": "Thing",
+          "reverse": "courtCase",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "case",
+        "party"
+      ],
+      "schemata": [
+        "CourtCaseParty",
+        "Interest",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "CryptoWallet": {
+      "caption": [
+        "publicKey",
+        "name",
+        "summary"
+      ],
+      "description": "A cryptocurrency wallet is a view on the transactions conducted by one participant on a blockchain / distributed ledger system.\n",
+      "extends": [
+        "Thing",
+        "Value"
+      ],
+      "featured": [
+        "currency",
+        "publicKey"
+      ],
+      "label": "Cryptocurrency wallet",
+      "matchable": true,
+      "plural": "Cryptocurrency wallets",
+      "properties": {
+        "accountId": {
+          "description": "Platform-specific user/account identifier",
+          "label": "Account ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "accountId",
+          "qname": "CryptoWallet:accountId",
+          "type": "identifier"
+        },
+        "balance": {
+          "label": "Balance",
+          "maxLength": 250,
+          "name": "balance",
+          "qname": "CryptoWallet:balance",
+          "type": "number"
+        },
+        "balanceDate": {
+          "label": "Balance date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "balanceDate",
+          "qname": "CryptoWallet:balanceDate",
+          "type": "date"
+        },
+        "blockchain": {
+          "description": "The blockchain or distributed ledger system on which the wallet operates",
+          "label": "Blockchain",
+          "maxLength": 1024,
+          "name": "blockchain",
+          "qname": "CryptoWallet:blockchain",
+          "type": "string"
+        },
+        "creationDate": {
+          "label": "Creation date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "creationDate",
+          "qname": "CryptoWallet:creationDate",
+          "type": "date"
+        },
+        "cryptoAddress": {
+          "description": "The crypto address of the wallet",
+          "label": "Crypto address",
+          "matchable": true,
+          "maxLength": 512,
+          "name": "cryptoAddress",
+          "qname": "CryptoWallet:cryptoAddress",
+          "type": "identifier"
+        },
+        "currencySymbol": {
+          "label": "Currency short code",
+          "maxLength": 1024,
+          "name": "currencySymbol",
+          "qname": "CryptoWallet:currencySymbol",
+          "type": "string"
+        },
+        "custodyType": {
+          "description": "Type of custody arrangement for the wallet (e.g., self-custody, custodial service)",
+          "label": "Custody type",
+          "maxLength": 1024,
+          "name": "custodyType",
+          "qname": "CryptoWallet:custodyType",
+          "type": "string"
+        },
+        "holder": {
+          "label": "Wallet holder",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "holder",
+          "qname": "CryptoWallet:holder",
+          "range": "LegalEntity",
+          "reverse": "cryptoWallets",
+          "type": "entity"
+        },
+        "managingExchange": {
+          "label": "Managing exchange",
+          "maxLength": 1024,
+          "name": "managingExchange",
+          "qname": "CryptoWallet:managingExchange",
+          "type": "string"
+        },
+        "privateKey": {
+          "label": "Private key",
+          "maxLength": 1024,
+          "name": "privateKey",
+          "qname": "CryptoWallet:privateKey",
+          "type": "string"
+        },
+        "publicKey": {
+          "description": "Public key used to identify the wallet",
+          "label": "Address",
+          "matchable": true,
+          "maxLength": 512,
+          "name": "publicKey",
+          "qname": "CryptoWallet:publicKey",
+          "type": "identifier"
+        }
+      },
+      "schemata": [
+        "CryptoWallet",
+        "Thing",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "creationDate"
+        ]
+      }
+    },
+    "Debt": {
+      "description": "A monetary debt between two parties.",
+      "edge": {
+        "caption": [
+          "amount"
+        ],
+        "directed": true,
+        "label": "owes",
+        "source": "debtor",
+        "target": "creditor"
+      },
+      "extends": [
+        "Interval",
+        "Value"
+      ],
+      "featured": [
+        "debtor",
+        "creditor",
+        "date",
+        "amount"
+      ],
+      "label": "Debt",
+      "plural": "Debts",
+      "properties": {
+        "creditor": {
+          "label": "Creditor",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "creditor",
+          "qname": "Debt:creditor",
+          "range": "LegalEntity",
+          "reverse": "debtCreditor",
+          "type": "entity"
+        },
+        "debtor": {
+          "label": "Debtor",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "debtor",
+          "qname": "Debt:debtor",
+          "range": "LegalEntity",
+          "reverse": "debtDebtor",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "debtor"
+      ],
+      "schemata": [
+        "Debt",
+        "Interval",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Directorship": {
+      "caption": [
+        "role"
+      ],
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": true,
+        "label": "directs",
+        "source": "director",
+        "target": "organization"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "director",
+        "organization",
+        "role",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Directorship",
+      "plural": "Directorships",
+      "properties": {
+        "director": {
+          "description": "The entity exercising control over another",
+          "label": "Director",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "director",
+          "qname": "Directorship:director",
+          "range": "LegalEntity",
+          "reverse": "directorshipDirector",
+          "type": "entity"
+        },
+        "organization": {
+          "label": "Organization",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "organization",
+          "qname": "Directorship:organization",
+          "range": "Organization",
+          "reverse": "directorshipOrganization",
+          "type": "entity"
+        },
+        "secretary": {
+          "label": "Secretary",
+          "maxLength": 1024,
+          "name": "secretary",
+          "qname": "Directorship:secretary",
+          "type": "string"
+        }
+      },
+      "required": [
+        "director",
+        "organization"
+      ],
+      "schemata": [
+        "Directorship",
+        "Interest",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Document": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "extends": [
+        "Analyzable",
+        "Thing"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "File",
+      "plural": "Files",
+      "properties": {
+        "ancestors": {
+          "hidden": true,
+          "label": "Ancestors",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "ancestors",
+          "qname": "Document:ancestors",
+          "range": "Folder",
+          "reverse": "descendants",
+          "type": "entity"
+        },
+        "author": {
+          "description": "The original author, not the uploader",
+          "label": "Author",
+          "maxLength": 1024,
+          "name": "author",
+          "qname": "Document:author",
+          "type": "string"
+        },
+        "authoredAt": {
+          "label": "Authored on",
+          "maxLength": 32,
+          "name": "authoredAt",
+          "qname": "Document:authoredAt",
+          "type": "date"
+        },
+        "bodyText": {
+          "hidden": true,
+          "label": "Text",
+          "maxLength": 65000,
+          "name": "bodyText",
+          "qname": "Document:bodyText",
+          "type": "text"
+        },
+        "contentHash": {
+          "description": "SHA1 hash of the data",
+          "label": "Checksum",
+          "matchable": true,
+          "maxLength": 40,
+          "name": "contentHash",
+          "qname": "Document:contentHash",
+          "type": "checksum"
+        },
+        "crawler": {
+          "description": "The crawler used to acquire this file",
+          "label": "Crawler",
+          "maxLength": 1024,
+          "name": "crawler",
+          "qname": "Document:crawler",
+          "type": "string"
+        },
+        "date": {
+          "description": "If not otherwise specified",
+          "label": "Date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "date",
+          "qname": "Document:date",
+          "type": "date"
+        },
+        "encoding": {
+          "label": "File encoding",
+          "maxLength": 1024,
+          "name": "encoding",
+          "qname": "Document:encoding",
+          "type": "string"
+        },
+        "extension": {
+          "label": "File extension",
+          "maxLength": 1024,
+          "name": "extension",
+          "qname": "Document:extension",
+          "type": "string"
+        },
+        "fileName": {
+          "label": "File name",
+          "maxLength": 1024,
+          "name": "fileName",
+          "qname": "Document:fileName",
+          "type": "string"
+        },
+        "fileSize": {
+          "label": "File size",
+          "maxLength": 250,
+          "name": "fileSize",
+          "qname": "Document:fileSize",
+          "type": "number"
+        },
+        "generator": {
+          "description": "The program used to generate this file",
+          "label": "Generator",
+          "maxLength": 1024,
+          "name": "generator",
+          "qname": "Document:generator",
+          "type": "string"
+        },
+        "language": {
+          "label": "Language",
+          "maxLength": 16,
+          "name": "language",
+          "qname": "Document:language",
+          "type": "language"
+        },
+        "mentionedEntities": {
+          "hidden": true,
+          "label": "Extracted names",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "mentionedEntities",
+          "qname": "Document:mentionedEntities",
+          "range": "Mention",
+          "reverse": "document",
+          "stub": true,
+          "type": "entity"
+        },
+        "messageId": {
+          "description": "Message ID of a document; unique in most cases",
+          "label": "Message ID",
+          "maxLength": 1024,
+          "name": "messageId",
+          "qname": "Document:messageId",
+          "type": "string"
+        },
+        "mimeType": {
+          "label": "MIME type",
+          "maxLength": 250,
+          "name": "mimeType",
+          "qname": "Document:mimeType",
+          "type": "mimetype"
+        },
+        "parent": {
+          "label": "Folder",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "parent",
+          "qname": "Document:parent",
+          "range": "Folder",
+          "reverse": "children",
+          "type": "entity"
+        },
+        "processedAt": {
+          "description": "Date and time of the most recent ingestion of the Document",
+          "hidden": true,
+          "label": "Processed at",
+          "maxLength": 32,
+          "name": "processedAt",
+          "qname": "Document:processedAt",
+          "type": "date"
+        },
+        "processingAgent": {
+          "description": "Name and version of the processing agent used to process the Document",
+          "label": "Processing agent",
+          "maxLength": 1024,
+          "name": "processingAgent",
+          "qname": "Document:processingAgent",
+          "type": "string"
+        },
+        "processingError": {
+          "hidden": true,
+          "label": "Processing error",
+          "maxLength": 1024,
+          "name": "processingError",
+          "qname": "Document:processingError",
+          "type": "string"
+        },
+        "processingStatus": {
+          "hidden": true,
+          "label": "Processing status",
+          "maxLength": 1024,
+          "name": "processingStatus",
+          "qname": "Document:processingStatus",
+          "type": "string"
+        },
+        "proven": {
+          "label": "Derived entities",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "proven",
+          "qname": "Document:proven",
+          "range": "Thing",
+          "reverse": "proof",
+          "stub": true,
+          "type": "entity"
+        },
+        "provenIntervals": {
+          "label": "Derived relationships",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "provenIntervals",
+          "qname": "Document:provenIntervals",
+          "range": "Interval",
+          "reverse": "proof",
+          "stub": true,
+          "type": "entity"
+        },
+        "publishedAt": {
+          "label": "Published on",
+          "maxLength": 32,
+          "name": "publishedAt",
+          "qname": "Document:publishedAt",
+          "type": "date"
+        },
+        "relatedEntities": {
+          "label": "Related entities",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "relatedEntities",
+          "qname": "Document:relatedEntities",
+          "range": "Documentation",
+          "reverse": "document",
+          "stub": true,
+          "type": "entity"
+        },
+        "title": {
+          "label": "Title",
+          "maxLength": 1024,
+          "name": "title",
+          "qname": "Document:title",
+          "type": "string"
+        },
+        "translatedLanguage": {
+          "hidden": true,
+          "label": "The language of the translated text",
+          "maxLength": 16,
+          "name": "translatedLanguage",
+          "qname": "Document:translatedLanguage",
+          "type": "language"
+        },
+        "translatedText": {
+          "hidden": true,
+          "label": "Translated version of the body text",
+          "maxLength": 65000,
+          "name": "translatedText",
+          "qname": "Document:translatedText",
+          "type": "text"
+        }
+      },
+      "required": [
+        "fileName"
+      ],
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Documentation": {
+      "description": "Links some entity to a document, which might provide further detail or evidence regarding the entity.\n",
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": false,
+        "label": "documents",
+        "source": "document",
+        "target": "entity"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "document",
+        "entity",
+        "role"
+      ],
+      "label": "Documentation",
+      "plural": "Documentations",
+      "properties": {
+        "document": {
+          "label": "Document",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "document",
+          "qname": "Documentation:document",
+          "range": "Document",
+          "reverse": "relatedEntities",
+          "type": "entity"
+        },
+        "entity": {
+          "label": "Entity",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "entity",
+          "qname": "Documentation:entity",
+          "range": "Thing",
+          "reverse": "documentedBy",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "document",
+        "entity"
+      ],
+      "schemata": [
+        "Documentation",
+        "Interest",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "EconomicActivity": {
+      "caption": [
+        "summary",
+        "goodsDescription",
+        "ccdNumber"
+      ],
+      "description": "A foreign economic activity.",
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "sender",
+        "receiver",
+        "contract",
+        "goodsDescription",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Customs declaration",
+      "plural": "Customs declarations",
+      "properties": {
+        "bankAccount": {
+          "description": "Bank account of the contract",
+          "label": "Bank Account",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "bankAccount",
+          "qname": "EconomicActivity:bankAccount",
+          "range": "BankAccount",
+          "reverse": "contractBankAccount",
+          "type": "entity"
+        },
+        "bankForeign": {
+          "description": "Bank account for payments in foreign currency",
+          "label": "Foreign currency bank",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "bankForeign",
+          "qname": "EconomicActivity:bankForeign",
+          "range": "BankAccount",
+          "reverse": "foreignBankAccount",
+          "type": "entity"
+        },
+        "bankRub": {
+          "description": "Bank account for payments in roubles",
+          "label": "Rouble bank",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "bankRub",
+          "qname": "EconomicActivity:bankRub",
+          "range": "BankAccount",
+          "reverse": "rubBankAccount",
+          "type": "entity"
+        },
+        "ccdNumber": {
+          "label": "Customs Cargo Declaration Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "ccdNumber",
+          "qname": "EconomicActivity:ccdNumber",
+          "type": "identifier"
+        },
+        "ccdValue": {
+          "description": "Declaration Value",
+          "label": "CCD Value",
+          "maxLength": 1024,
+          "name": "ccdValue",
+          "qname": "EconomicActivity:ccdValue",
+          "type": "string"
+        },
+        "contract": {
+          "label": "Contract",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contract",
+          "qname": "EconomicActivity:contract",
+          "range": "Contract",
+          "reverse": "economicActivityContract",
+          "type": "entity"
+        },
+        "contractHolder": {
+          "description": "Customs formalities caretaker",
+          "label": "Contract holder",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contractHolder",
+          "qname": "EconomicActivity:contractHolder",
+          "range": "LegalEntity",
+          "reverse": "economicActivityHolder",
+          "type": "entity"
+        },
+        "customsAmount": {
+          "description": "Customs Value of goods",
+          "label": "Customs Value Amount",
+          "maxLength": 1024,
+          "name": "customsAmount",
+          "qname": "EconomicActivity:customsAmount",
+          "type": "string"
+        },
+        "customsProcedure": {
+          "description": "Customs Procedure — type of customs clearance",
+          "label": "Customs Procedure",
+          "maxLength": 1024,
+          "name": "customsProcedure",
+          "qname": "EconomicActivity:customsProcedure",
+          "type": "string"
+        },
+        "declarant": {
+          "description": "Customs declarant",
+          "label": "Declarant",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "declarant",
+          "qname": "EconomicActivity:declarant",
+          "range": "LegalEntity",
+          "reverse": "economicActivityDeclarant",
+          "type": "entity"
+        },
+        "departureCountry": {
+          "description": "Country out of which the goods are transported",
+          "label": "Country of departure",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "departureCountry",
+          "qname": "EconomicActivity:departureCountry",
+          "type": "country"
+        },
+        "destinationCountry": {
+          "description": "Final destination for the goods",
+          "label": "Country of destination",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "destinationCountry",
+          "qname": "EconomicActivity:destinationCountry",
+          "type": "country"
+        },
+        "directionOfTransportation": {
+          "description": "Direction of transportation (import/export)",
+          "label": "Direction of transportation",
+          "maxLength": 1024,
+          "name": "directionOfTransportation",
+          "qname": "EconomicActivity:directionOfTransportation",
+          "type": "string"
+        },
+        "dollarExchRate": {
+          "description": "USD Exchange Rate for the activity",
+          "label": "USD Exchange Rate",
+          "maxLength": 1024,
+          "name": "dollarExchRate",
+          "qname": "EconomicActivity:dollarExchRate",
+          "type": "string"
+        },
+        "goodsDescription": {
+          "label": "Description of goods",
+          "maxLength": 65000,
+          "name": "goodsDescription",
+          "qname": "EconomicActivity:goodsDescription",
+          "type": "text"
+        },
+        "invoiceAmount": {
+          "description": "Invoice Value of goods",
+          "label": "Invoice Value Amount",
+          "maxLength": 1024,
+          "name": "invoiceAmount",
+          "qname": "EconomicActivity:invoiceAmount",
+          "type": "string"
+        },
+        "originCountry": {
+          "description": "Country of origin of goods",
+          "label": "Country of origin",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "originCountry",
+          "qname": "EconomicActivity:originCountry",
+          "type": "country"
+        },
+        "receiver": {
+          "description": "Destination of the goods",
+          "label": "Receiver",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "receiver",
+          "qname": "EconomicActivity:receiver",
+          "range": "LegalEntity",
+          "reverse": "economicActivityReceiver",
+          "type": "entity"
+        },
+        "sender": {
+          "description": "Origin of the goods",
+          "label": "Sender",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "sender",
+          "qname": "EconomicActivity:sender",
+          "range": "LegalEntity",
+          "reverse": "economicActivitySender",
+          "type": "entity"
+        },
+        "tradingCountry": {
+          "description": "Trading Country of the company which transports the goods via Russian border",
+          "label": "Trading Country",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "tradingCountry",
+          "qname": "EconomicActivity:tradingCountry",
+          "type": "country"
+        },
+        "transport": {
+          "description": "Means of transportation",
+          "label": "Transport",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "transport",
+          "qname": "EconomicActivity:transport",
+          "range": "Vehicle",
+          "reverse": "declaredCustoms",
+          "type": "entity"
+        },
+        "vedCode": {
+          "description": "(Код ТН ВЭД) Foreign Economic Activity Commodity Code",
+          "label": "FEAC Code",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "vedCode",
+          "qname": "EconomicActivity:vedCode",
+          "type": "identifier"
+        },
+        "vedCodeDescription": {
+          "description": "(Описание кода ТН ВЭД) Foreign Economic Activity Commodity Code description",
+          "label": "FEAC Code description",
+          "maxLength": 1024,
+          "name": "vedCodeDescription",
+          "qname": "EconomicActivity:vedCodeDescription",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "EconomicActivity",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Email": {
+      "caption": [
+        "subject",
+        "threadTopic",
+        "title",
+        "name",
+        "fileName"
+      ],
+      "description": "An internet mail message. The body can be formatted as plain text and/or HTML, and the message may have any number of attachments.",
+      "extends": [
+        "Folder",
+        "HyperText",
+        "PlainText"
+      ],
+      "featured": [
+        "subject",
+        "date",
+        "from"
+      ],
+      "generated": true,
+      "label": "E-Mail",
+      "plural": "E-Mails",
+      "properties": {
+        "bcc": {
+          "description": "Blind carbon copy",
+          "label": "BCC",
+          "maxLength": 1024,
+          "name": "bcc",
+          "qname": "Email:bcc",
+          "type": "string"
+        },
+        "cc": {
+          "description": "Carbon copy",
+          "label": "CC",
+          "maxLength": 1024,
+          "name": "cc",
+          "qname": "Email:cc",
+          "type": "string"
+        },
+        "emitters": {
+          "label": "Emitter",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "emitters",
+          "qname": "Email:emitters",
+          "range": "LegalEntity",
+          "reverse": "emailsSent",
+          "type": "entity"
+        },
+        "from": {
+          "label": "From",
+          "maxLength": 1024,
+          "name": "from",
+          "qname": "Email:from",
+          "type": "string"
+        },
+        "headers": {
+          "hidden": true,
+          "label": "Raw headers",
+          "maxLength": 250,
+          "name": "headers",
+          "qname": "Email:headers",
+          "type": "json"
+        },
+        "inReplyTo": {
+          "description": "Message ID of the preceding email in the thread",
+          "hidden": true,
+          "label": "In Reply To",
+          "maxLength": 1024,
+          "name": "inReplyTo",
+          "qname": "Email:inReplyTo",
+          "type": "string"
+        },
+        "inReplyToEmail": {
+          "label": "Responding to",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "inReplyToEmail",
+          "qname": "Email:inReplyToEmail",
+          "range": "Email",
+          "reverse": "responses",
+          "type": "entity"
+        },
+        "recipients": {
+          "label": "Recipients",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "recipients",
+          "qname": "Email:recipients",
+          "range": "LegalEntity",
+          "reverse": "emailsReceived",
+          "type": "entity"
+        },
+        "responses": {
+          "label": "Responses",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "responses",
+          "qname": "Email:responses",
+          "range": "Email",
+          "reverse": "inReplyToEmail",
+          "stub": true,
+          "type": "entity"
+        },
+        "sender": {
+          "label": "Sender",
+          "maxLength": 1024,
+          "name": "sender",
+          "qname": "Email:sender",
+          "type": "string"
+        },
+        "subject": {
+          "label": "Subject",
+          "maxLength": 1024,
+          "name": "subject",
+          "qname": "Email:subject",
+          "type": "string"
+        },
+        "threadTopic": {
+          "label": "Thread topic",
+          "maxLength": 1024,
+          "name": "threadTopic",
+          "qname": "Email:threadTopic",
+          "type": "string"
+        },
+        "to": {
+          "label": "To",
+          "maxLength": 1024,
+          "name": "to",
+          "qname": "Email:to",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Email",
+        "Folder",
+        "HyperText",
+        "PlainText",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Employment": {
+      "caption": [
+        "role"
+      ],
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": true,
+        "label": "works for",
+        "source": "employee",
+        "target": "employer"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "employer",
+        "employee",
+        "role",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Employment",
+      "plural": "Employments",
+      "properties": {
+        "employee": {
+          "label": "Employee",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "employee",
+          "qname": "Employment:employee",
+          "range": "Person",
+          "reverse": "employers",
+          "type": "entity"
+        },
+        "employer": {
+          "label": "Employer",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "employer",
+          "qname": "Employment:employer",
+          "range": "Organization",
+          "reverse": "employees",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "employer",
+        "employee"
+      ],
+      "schemata": [
+        "Employment",
+        "Interest",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Event": {
+      "caption": [
+        "name",
+        "summary",
+        "date"
+      ],
+      "extends": [
+        "Analyzable",
+        "Interval",
+        "Thing"
+      ],
+      "featured": [
+        "name",
+        "summary",
+        "date",
+        "location"
+      ],
+      "label": "Event",
+      "plural": "Events",
+      "properties": {
+        "important": {
+          "label": "Important",
+          "maxLength": 1024,
+          "name": "important",
+          "qname": "Event:important",
+          "type": "string"
+        },
+        "involved": {
+          "label": "Involved",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "involved",
+          "qname": "Event:involved",
+          "range": "LegalEntity",
+          "reverse": "eventsInvolved",
+          "type": "entity"
+        },
+        "location": {
+          "label": "Location",
+          "matchable": true,
+          "maxLength": 250,
+          "name": "location",
+          "qname": "Event:location",
+          "type": "address"
+        },
+        "organizer": {
+          "label": "Organizer",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "organizer",
+          "qname": "Event:organizer",
+          "range": "LegalEntity",
+          "reverse": "eventsOrganized",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "Analyzable",
+        "Event",
+        "Interval",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Family": {
+      "description": "Family relationship between two people.",
+      "edge": {
+        "caption": [
+          "relationship"
+        ],
+        "directed": false,
+        "label": "related to",
+        "source": "person",
+        "target": "relative"
+      },
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "person",
+        "relative",
+        "relationship"
+      ],
+      "label": "Family",
+      "plural": "Family members",
+      "properties": {
+        "person": {
+          "description": "The subject of the familial relation",
+          "label": "Person",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "person",
+          "qname": "Family:person",
+          "range": "Person",
+          "reverse": "familyPerson",
+          "type": "entity"
+        },
+        "relationship": {
+          "description": "Nature of the relationship from the `person`'s perspective, e.g. 'mother', where `relative` is the mother of `person`",
+          "examples": [
+            "mother",
+            "sibling"
+          ],
+          "label": "Relationship",
+          "maxLength": 1024,
+          "name": "relationship",
+          "qname": "Family:relationship",
+          "type": "string"
+        },
+        "relative": {
+          "description": "The relative of the subject person",
+          "label": "Relative",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "relative",
+          "qname": "Family:relative",
+          "range": "Person",
+          "reverse": "familyRelative",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "person",
+        "relative"
+      ],
+      "schemata": [
+        "Family",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Folder": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Folder",
+      "plural": "Folders",
+      "properties": {
+        "children": {
+          "hidden": true,
+          "label": "Child documents",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "children",
+          "qname": "Folder:children",
+          "range": "Document",
+          "reverse": "parent",
+          "stub": true,
+          "type": "entity"
+        },
+        "descendants": {
+          "hidden": true,
+          "label": "Descendants",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "descendants",
+          "qname": "Folder:descendants",
+          "range": "Document",
+          "reverse": "ancestors",
+          "stub": true,
+          "type": "entity"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Folder",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "HyperText": {
+      "caption": [
+        "title",
+        "fileName"
+      ],
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Web page",
+      "plural": "Web pages",
+      "properties": {
+        "bodyHtml": {
+          "hidden": true,
+          "label": "HTML",
+          "maxLength": 65000,
+          "name": "bodyHtml",
+          "qname": "HyperText:bodyHtml",
+          "type": "html"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "HyperText",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Identification": {
+      "caption": [
+        "number"
+      ],
+      "description": "A form of identification associated with its holder and some issuing country. This can be used for national ID cards, voter enrollments, and similar instruments.\n",
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "number",
+        "country",
+        "type",
+        "holder",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Identification",
+      "plural": "Identifications",
+      "properties": {
+        "authority": {
+          "description": "Government body issuing the identification document",
+          "label": "Authority",
+          "maxLength": 1024,
+          "name": "authority",
+          "qname": "Identification:authority",
+          "type": "string"
+        },
+        "country": {
+          "label": "Country",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "country",
+          "qname": "Identification:country",
+          "type": "country"
+        },
+        "holder": {
+          "label": "Identification holder",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "holder",
+          "qname": "Identification:holder",
+          "range": "LegalEntity",
+          "reverse": "identification",
+          "type": "entity"
+        },
+        "number": {
+          "label": "Document number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "number",
+          "qname": "Identification:number",
+          "type": "identifier"
+        },
+        "type": {
+          "examples": [
+            "Passport",
+            "Driving license"
+          ],
+          "label": "Type",
+          "maxLength": 1024,
+          "name": "type",
+          "qname": "Identification:type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "holder",
+        "number"
+      ],
+      "schemata": [
+        "Identification",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Image": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "description": "An image file.\n",
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Image",
+      "plural": "Images",
+      "properties": {
+        "credit": {
+          "description": "The credit or attribution for the image",
+          "label": "Credit",
+          "maxLength": 1024,
+          "name": "credit",
+          "qname": "Image:credit",
+          "type": "string"
+        },
+        "pictured": {
+          "label": "Pictured",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "pictured",
+          "qname": "Image:pictured",
+          "range": "Person",
+          "reverse": "images",
+          "type": "entity"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Image",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Interest": {
+      "abstract": true,
+      "extends": [
+        "Interval"
+      ],
+      "label": "Interest",
+      "plural": "Interest",
+      "properties": {
+        "role": {
+          "label": "Role",
+          "maxLength": 1024,
+          "name": "role",
+          "qname": "Interest:role",
+          "type": "string"
+        },
+        "status": {
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "Interest:status",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Interest",
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Interval": {
+      "abstract": true,
+      "description": "An object which is bounded in time.\n",
+      "extends": [],
+      "label": "Interval",
+      "plural": "Interval",
+      "properties": {
+        "alephUrl": {
+          "hidden": true,
+          "label": "Aleph URL",
+          "maxLength": 4096,
+          "name": "alephUrl",
+          "qname": "Interval:alephUrl",
+          "type": "url"
+        },
+        "date": {
+          "description": "Date associated with an Interval that isn't explicitly its `startDate` or `endDate` (prefer those when available)",
+          "label": "Date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "date",
+          "qname": "Interval:date",
+          "type": "date"
+        },
+        "description": {
+          "label": "Description",
+          "maxLength": 65000,
+          "name": "description",
+          "qname": "Interval:description",
+          "type": "text"
+        },
+        "endDate": {
+          "description": "The date of expiry of a document, or on which a relationship, sanctioned status, occupation, etc. ended",
+          "label": "End date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "endDate",
+          "qname": "Interval:endDate",
+          "type": "date"
+        },
+        "indexText": {
+          "hidden": true,
+          "label": "Index text",
+          "maxLength": 65000,
+          "name": "indexText",
+          "qname": "Interval:indexText",
+          "type": "text"
+        },
+        "modifiedAt": {
+          "description": "The date on which the entity (like the ID document) was modified, not to be confused with an internal 'last updated'-style metadata field",
+          "label": "Modified on",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "modifiedAt",
+          "qname": "Interval:modifiedAt",
+          "type": "date"
+        },
+        "namesMentioned": {
+          "hidden": true,
+          "label": "Detected names",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "namesMentioned",
+          "qname": "Interval:namesMentioned",
+          "type": "name"
+        },
+        "proof": {
+          "label": "Source document",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "proof",
+          "qname": "Interval:proof",
+          "range": "Document",
+          "reverse": "provenIntervals",
+          "type": "entity"
+        },
+        "publisher": {
+          "label": "Publishing source",
+          "maxLength": 1024,
+          "name": "publisher",
+          "qname": "Interval:publisher",
+          "type": "string"
+        },
+        "publisherUrl": {
+          "label": "Publishing source URL",
+          "maxLength": 4096,
+          "name": "publisherUrl",
+          "qname": "Interval:publisherUrl",
+          "type": "url"
+        },
+        "recordId": {
+          "description": "Identifier of a record upon which this link is based",
+          "label": "Record ID",
+          "maxLength": 1024,
+          "name": "recordId",
+          "qname": "Interval:recordId",
+          "type": "string"
+        },
+        "retrievedAt": {
+          "description": "Retrieval date generated by a data gathering system, not to be confused with an internal 'first found'-style metadata field",
+          "label": "Retrieved on",
+          "maxLength": 32,
+          "name": "retrievedAt",
+          "qname": "Interval:retrievedAt",
+          "type": "date"
+        },
+        "sourceUrl": {
+          "description": "A deep link to a source website for the profile",
+          "label": "Source link",
+          "maxLength": 4096,
+          "name": "sourceUrl",
+          "qname": "Interval:sourceUrl",
+          "type": "url"
+        },
+        "startDate": {
+          "description": "The date of issue of a document, or on which a relationship, sanctioned status, occupation, etc. started",
+          "label": "Start date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "startDate",
+          "qname": "Interval:startDate",
+          "type": "date"
+        },
+        "summary": {
+          "label": "Summary",
+          "maxLength": 65000,
+          "name": "summary",
+          "qname": "Interval:summary",
+          "type": "text"
+        }
+      },
+      "schemata": [
+        "Interval"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "LegalEntity": {
+      "caption": [
+        "name",
+        "alias",
+        "abbreviation",
+        "weakAlias",
+        "previousName",
+        "email",
+        "phone",
+        "registrationNumber"
+      ],
+      "description": "Any party to legal proceedings, such as asset ownership, corporate governance or social interactions. Often used when raw data does not specify if something is a person, organization or company.\n",
+      "extends": [
+        "Thing"
+      ],
+      "featured": [
+        "name",
+        "country",
+        "legalForm",
+        "status"
+      ],
+      "label": "Legal entity",
+      "matchable": true,
+      "plural": "Legal entities",
+      "properties": {
+        "abbreviation": {
+          "description": "Abbreviated name or acronym",
+          "label": "Abbreviation",
+          "maxLength": 384,
+          "name": "abbreviation",
+          "qname": "LegalEntity:abbreviation",
+          "type": "name"
+        },
+        "agencyClient": {
+          "label": "Clients",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "agencyClient",
+          "qname": "LegalEntity:agencyClient",
+          "range": "Representation",
+          "reverse": "agent",
+          "stub": true,
+          "type": "entity"
+        },
+        "agentRepresentation": {
+          "label": "Agents",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "agentRepresentation",
+          "qname": "LegalEntity:agentRepresentation",
+          "range": "Representation",
+          "reverse": "client",
+          "stub": true,
+          "type": "entity"
+        },
+        "brightQueryId": {
+          "label": "BrightQuery ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "brightQueryId",
+          "qname": "LegalEntity:brightQueryId",
+          "type": "identifier"
+        },
+        "brightQueryOrgId": {
+          "hidden": true,
+          "label": "BrightQuery Organization ID",
+          "maxLength": 64,
+          "name": "brightQueryOrgId",
+          "qname": "LegalEntity:brightQueryOrgId",
+          "type": "identifier"
+        },
+        "bvdId": {
+          "label": "Bureau van Dijk ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "bvdId",
+          "qname": "LegalEntity:bvdId",
+          "type": "identifier"
+        },
+        "callForTenders": {
+          "label": "Call For Tenders",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "callForTenders",
+          "qname": "LegalEntity:callForTenders",
+          "range": "CallForTenders",
+          "reverse": "authority",
+          "stub": true,
+          "type": "entity"
+        },
+        "callsMade": {
+          "label": "Calls made",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "callsMade",
+          "qname": "LegalEntity:callsMade",
+          "range": "Call",
+          "reverse": "caller",
+          "stub": true,
+          "type": "entity"
+        },
+        "callsReceived": {
+          "label": "Calls received",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "callsReceived",
+          "qname": "LegalEntity:callsReceived",
+          "range": "Call",
+          "reverse": "receiver",
+          "stub": true,
+          "type": "entity"
+        },
+        "classification": {
+          "description": "Classification as provided by the data source or inferred based on other provided data; prefer `sector` if relevant",
+          "examples": [
+            "Local government (current)",
+            "Banking operations license",
+            "4. Priority Sector Apparel",
+            "Entities Directly Serving the Defense and Security Sectors"
+          ],
+          "label": "Classification",
+          "maxLength": 1024,
+          "name": "classification",
+          "qname": "LegalEntity:classification",
+          "type": "string"
+        },
+        "contractAuthority": {
+          "label": "Contracts issued",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contractAuthority",
+          "qname": "LegalEntity:contractAuthority",
+          "range": "Contract",
+          "reverse": "authority",
+          "stub": true,
+          "type": "entity"
+        },
+        "contractAwardSupplier": {
+          "label": "Contracts awarded",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contractAwardSupplier",
+          "qname": "LegalEntity:contractAwardSupplier",
+          "range": "ContractAward",
+          "reverse": "supplier",
+          "stub": true,
+          "type": "entity"
+        },
+        "cryptoWallets": {
+          "label": "Cryptocurrency wallets",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "cryptoWallets",
+          "qname": "LegalEntity:cryptoWallets",
+          "range": "CryptoWallet",
+          "reverse": "holder",
+          "stub": true,
+          "type": "entity"
+        },
+        "debtCreditor": {
+          "label": "Credits",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "debtCreditor",
+          "qname": "LegalEntity:debtCreditor",
+          "range": "Debt",
+          "reverse": "creditor",
+          "stub": true,
+          "type": "entity"
+        },
+        "debtDebtor": {
+          "label": "Debts",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "debtDebtor",
+          "qname": "LegalEntity:debtDebtor",
+          "range": "Debt",
+          "reverse": "debtor",
+          "stub": true,
+          "type": "entity"
+        },
+        "delegatedCallForTenders": {
+          "label": "Delegated call for tenders",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "delegatedCallForTenders",
+          "qname": "LegalEntity:delegatedCallForTenders",
+          "range": "CallForTenders",
+          "reverse": "onBehalfOf",
+          "stub": true,
+          "type": "entity"
+        },
+        "directorshipDirector": {
+          "label": "Directorships",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "directorshipDirector",
+          "qname": "LegalEntity:directorshipDirector",
+          "range": "Directorship",
+          "reverse": "director",
+          "stub": true,
+          "type": "entity"
+        },
+        "dissolutionDate": {
+          "description": "The date the legal entity was dissolved, if applicable",
+          "label": "Dissolution date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "dissolutionDate",
+          "qname": "LegalEntity:dissolutionDate",
+          "type": "date"
+        },
+        "dunsCode": {
+          "description": "Data Universal Numbering System - Dun & Bradstreet identifier",
+          "label": "DUNS",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "dunsCode",
+          "qname": "LegalEntity:dunsCode",
+          "type": "identifier"
+        },
+        "economicActivityDeclarant": {
+          "label": "Customs declarations",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "economicActivityDeclarant",
+          "qname": "LegalEntity:economicActivityDeclarant",
+          "range": "EconomicActivity",
+          "reverse": "declarant",
+          "stub": true,
+          "type": "entity"
+        },
+        "economicActivityHolder": {
+          "label": "Customs declarations facilitated",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "economicActivityHolder",
+          "qname": "LegalEntity:economicActivityHolder",
+          "range": "EconomicActivity",
+          "reverse": "contractHolder",
+          "stub": true,
+          "type": "entity"
+        },
+        "economicActivityReceiver": {
+          "label": "Goods received",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "economicActivityReceiver",
+          "qname": "LegalEntity:economicActivityReceiver",
+          "range": "EconomicActivity",
+          "reverse": "receiver",
+          "stub": true,
+          "type": "entity"
+        },
+        "economicActivitySender": {
+          "label": "Goods originated",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "economicActivitySender",
+          "qname": "LegalEntity:economicActivitySender",
+          "range": "EconomicActivity",
+          "reverse": "sender",
+          "stub": true,
+          "type": "entity"
+        },
+        "email": {
+          "description": "Email address",
+          "label": "Email",
+          "matchable": true,
+          "maxLength": 250,
+          "name": "email",
+          "qname": "LegalEntity:email",
+          "type": "email"
+        },
+        "emailsReceived": {
+          "label": "E-Mails received",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "emailsReceived",
+          "qname": "LegalEntity:emailsReceived",
+          "range": "Email",
+          "reverse": "recipients",
+          "stub": true,
+          "type": "entity"
+        },
+        "emailsSent": {
+          "label": "E-Mails sent",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "emailsSent",
+          "qname": "LegalEntity:emailsSent",
+          "range": "Email",
+          "reverse": "emitters",
+          "stub": true,
+          "type": "entity"
+        },
+        "eventsInvolved": {
+          "label": "Events",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "eventsInvolved",
+          "qname": "LegalEntity:eventsInvolved",
+          "range": "Event",
+          "reverse": "involved",
+          "stub": true,
+          "type": "entity"
+        },
+        "eventsOrganized": {
+          "label": "Organized events",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "eventsOrganized",
+          "qname": "LegalEntity:eventsOrganized",
+          "range": "Event",
+          "reverse": "organizer",
+          "stub": true,
+          "type": "entity"
+        },
+        "icijId": {
+          "description": "ID according to International Consortium for Investigative Journalists",
+          "label": "ICIJ ID",
+          "maxLength": 1024,
+          "name": "icijId",
+          "qname": "LegalEntity:icijId",
+          "type": "string"
+        },
+        "idNumber": {
+          "description": "ID of any applicable personal identification document. Used mainly for people and their national ID cards.",
+          "label": "ID Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "idNumber",
+          "qname": "LegalEntity:idNumber",
+          "type": "identifier"
+        },
+        "identification": {
+          "label": "Identifications",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "identification",
+          "qname": "LegalEntity:identification",
+          "range": "Identification",
+          "reverse": "holder",
+          "stub": true,
+          "type": "entity"
+        },
+        "incorporationDate": {
+          "description": "The date the legal entity was incorporated",
+          "label": "Incorporation date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "incorporationDate",
+          "qname": "LegalEntity:incorporationDate",
+          "type": "date"
+        },
+        "innCode": {
+          "description": "(RU, ИНН) Russian tax identification number. Issued to businesses and individuals in Russia.",
+          "format": "inn",
+          "label": "INN",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "innCode",
+          "qname": "LegalEntity:innCode",
+          "type": "identifier"
+        },
+        "jurisdiction": {
+          "description": "Country or region in which this entity operates; prefer over broader `country` when relevant",
+          "label": "Jurisdiction",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "jurisdiction",
+          "qname": "LegalEntity:jurisdiction",
+          "type": "country"
+        },
+        "legalForm": {
+          "description": "Company or organization type",
+          "examples": [
+            "Joint Stock Company"
+          ],
+          "label": "Legal form",
+          "maxLength": 1024,
+          "name": "legalForm",
+          "qname": "LegalEntity:legalForm",
+          "type": "string"
+        },
+        "leiCode": {
+          "description": "Legal Entity Identifier",
+          "format": "lei",
+          "label": "LEI",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "leiCode",
+          "qname": "LegalEntity:leiCode",
+          "type": "identifier"
+        },
+        "licenseNumber": {
+          "description": "For licenses granted to an entity",
+          "label": "License Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "licenseNumber",
+          "qname": "LegalEntity:licenseNumber",
+          "type": "identifier"
+        },
+        "mainCountry": {
+          "description": "Primary country of this entity; prefer over broader `country` when relevant",
+          "label": "Country of origin",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "mainCountry",
+          "qname": "LegalEntity:mainCountry",
+          "type": "country"
+        },
+        "membershipMember": {
+          "label": "Memberships",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "membershipMember",
+          "qname": "LegalEntity:membershipMember",
+          "range": "Membership",
+          "reverse": "member",
+          "stub": true,
+          "type": "entity"
+        },
+        "mentionedBy": {
+          "label": "Document mentions",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "mentionedBy",
+          "qname": "LegalEntity:mentionedBy",
+          "range": "Mention",
+          "reverse": "resolved",
+          "stub": true,
+          "type": "entity"
+        },
+        "messagesReceived": {
+          "label": "Messages received",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "messagesReceived",
+          "qname": "LegalEntity:messagesReceived",
+          "range": "Message",
+          "reverse": "recipients",
+          "stub": true,
+          "type": "entity"
+        },
+        "messagesSent": {
+          "label": "Messages sent",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "messagesSent",
+          "qname": "LegalEntity:messagesSent",
+          "range": "Message",
+          "reverse": "sender",
+          "stub": true,
+          "type": "entity"
+        },
+        "npiCode": {
+          "description": "National Provider Identifier, issued to health care providers in the United States",
+          "format": "npi",
+          "label": "NPI",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "npiCode",
+          "qname": "LegalEntity:npiCode",
+          "type": "identifier"
+        },
+        "ogrnCode": {
+          "description": "(RU, ОГРН) Registration number used in Russia's Unified State Register of Legal Entities (EGRUL)",
+          "format": "ogrn",
+          "label": "OGRN",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "ogrnCode",
+          "qname": "LegalEntity:ogrnCode",
+          "type": "identifier"
+        },
+        "okpoCode": {
+          "description": "Russian industry classifier",
+          "label": "OKPO",
+          "maxLength": 64,
+          "name": "okpoCode",
+          "qname": "LegalEntity:okpoCode",
+          "type": "identifier"
+        },
+        "okvedCode": {
+          "description": "Russian industry classifier code for economic activities",
+          "label": "OKVED",
+          "maxLength": 64,
+          "name": "okvedCode",
+          "qname": "LegalEntity:okvedCode",
+          "type": "identifier"
+        },
+        "opencorporatesUrl": {
+          "label": "OpenCorporates URL",
+          "matchable": true,
+          "maxLength": 4096,
+          "name": "opencorporatesUrl",
+          "qname": "LegalEntity:opencorporatesUrl",
+          "type": "url"
+        },
+        "operatedVehicles": {
+          "label": "Vehicles operated",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "operatedVehicles",
+          "qname": "LegalEntity:operatedVehicles",
+          "range": "Vehicle",
+          "reverse": "operator",
+          "stub": true,
+          "type": "entity"
+        },
+        "ownedVehicles": {
+          "label": "Vehicles owned",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "ownedVehicles",
+          "qname": "LegalEntity:ownedVehicles",
+          "range": "Vehicle",
+          "reverse": "owner",
+          "stub": true,
+          "type": "entity"
+        },
+        "ownershipOwner": {
+          "label": "Assets and shares",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "ownershipOwner",
+          "qname": "LegalEntity:ownershipOwner",
+          "range": "Ownership",
+          "reverse": "owner",
+          "stub": true,
+          "type": "entity"
+        },
+        "parent": {
+          "deprecated": true,
+          "description": "Deprecated, use `Ownership` link instead",
+          "label": "Parent company",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "parent",
+          "qname": "LegalEntity:parent",
+          "range": "LegalEntity",
+          "reverse": "subsidiaries",
+          "type": "entity"
+        },
+        "paymentBeneficiary": {
+          "label": "Payments received",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "paymentBeneficiary",
+          "qname": "LegalEntity:paymentBeneficiary",
+          "range": "Payment",
+          "reverse": "beneficiary",
+          "stub": true,
+          "type": "entity"
+        },
+        "paymentPayer": {
+          "label": "Payments made",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "paymentPayer",
+          "qname": "LegalEntity:paymentPayer",
+          "range": "Payment",
+          "reverse": "payer",
+          "stub": true,
+          "type": "entity"
+        },
+        "phone": {
+          "description": "Phone number",
+          "label": "Phone",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "phone",
+          "qname": "LegalEntity:phone",
+          "type": "phone"
+        },
+        "predecessors": {
+          "label": "Predecessors",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "predecessors",
+          "qname": "LegalEntity:predecessors",
+          "range": "Succession",
+          "reverse": "successor",
+          "stub": true,
+          "type": "entity"
+        },
+        "projectParticipation": {
+          "label": "Projects",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "projectParticipation",
+          "qname": "LegalEntity:projectParticipation",
+          "range": "ProjectParticipant",
+          "reverse": "participant",
+          "stub": true,
+          "type": "entity"
+        },
+        "registrationNumber": {
+          "description": "Company registration number",
+          "label": "Registration number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "registrationNumber",
+          "qname": "LegalEntity:registrationNumber",
+          "type": "identifier"
+        },
+        "sayariId": {
+          "label": "Sayari Entity ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "sayariId",
+          "qname": "LegalEntity:sayariId",
+          "type": "identifier"
+        },
+        "sector": {
+          "description": "Industrial or trade sector as provided by the data source",
+          "examples": [
+            "Registered Nurse",
+            "Retail and wholesale",
+            "Sea and coastal freight water transport"
+          ],
+          "label": "Sector",
+          "maxLength": 1024,
+          "name": "sector",
+          "qname": "LegalEntity:sector",
+          "type": "string"
+        },
+        "securities": {
+          "label": "Issued securities",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "securities",
+          "qname": "LegalEntity:securities",
+          "range": "Security",
+          "reverse": "issuer",
+          "stub": true,
+          "type": "entity"
+        },
+        "status": {
+          "description": "A short string describing how 'active' (broadly defined) an entity is",
+          "examples": [
+            "Current / Former / Sitting / Retired",
+            "Active / Inactive",
+            "Dissolved (last known activity October 2024)",
+            "Liquidated on 12 November 2022"
+          ],
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "LegalEntity:status",
+          "type": "string"
+        },
+        "subsidiaries": {
+          "label": "Subsidiaries",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "subsidiaries",
+          "qname": "LegalEntity:subsidiaries",
+          "range": "LegalEntity",
+          "reverse": "parent",
+          "stub": true,
+          "type": "entity"
+        },
+        "successors": {
+          "label": "Successors",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "successors",
+          "qname": "LegalEntity:successors",
+          "range": "Succession",
+          "reverse": "predecessor",
+          "stub": true,
+          "type": "entity"
+        },
+        "swiftBic": {
+          "description": "SWIFT Bank identifier code from ISO9362",
+          "format": "bic",
+          "label": "SWIFT/BIC",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "swiftBic",
+          "qname": "LegalEntity:swiftBic",
+          "type": "identifier"
+        },
+        "taxNumber": {
+          "description": "Tax identification number",
+          "label": "Tax Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "taxNumber",
+          "qname": "LegalEntity:taxNumber",
+          "type": "identifier"
+        },
+        "taxRolls": {
+          "label": "Tax rolls",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "taxRolls",
+          "qname": "LegalEntity:taxRolls",
+          "range": "TaxRoll",
+          "reverse": "taxee",
+          "stub": true,
+          "type": "entity"
+        },
+        "taxStatus": {
+          "examples": [
+            "Non-Habitual Resident",
+            "Compliant as at March 2022"
+          ],
+          "label": "Tax status",
+          "maxLength": 1024,
+          "name": "taxStatus",
+          "qname": "LegalEntity:taxStatus",
+          "type": "string"
+        },
+        "uniqueEntityId": {
+          "description": "UEI from SAM.gov",
+          "format": "uei",
+          "label": "Unique Entity ID",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "uniqueEntityId",
+          "qname": "LegalEntity:uniqueEntityId",
+          "type": "identifier"
+        },
+        "uscCode": {
+          "description": "Chinese Unified Social Credit Identifier",
+          "format": "uscc",
+          "label": "USCC",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "uscCode",
+          "qname": "LegalEntity:uscCode",
+          "type": "identifier"
+        },
+        "userAccounts": {
+          "label": "User accounts",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "userAccounts",
+          "qname": "LegalEntity:userAccounts",
+          "range": "UserAccount",
+          "reverse": "owner",
+          "stub": true,
+          "type": "entity"
+        },
+        "vatCode": {
+          "description": "(EU) VAT number",
+          "label": "V.A.T. Identifier",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "vatCode",
+          "qname": "LegalEntity:vatCode",
+          "type": "identifier"
+        },
+        "website": {
+          "description": "Website address",
+          "label": "Website",
+          "matchable": true,
+          "maxLength": 4096,
+          "name": "website",
+          "qname": "LegalEntity:website",
+          "type": "url"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "LegalEntity",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "dissolutionDate"
+        ],
+        "start": [
+          "incorporationDate"
+        ]
+      }
+    },
+    "License": {
+      "caption": [
+        "name"
+      ],
+      "description": "A grant of land, rights or property. A type of `Contract`.",
+      "extends": [
+        "Contract"
+      ],
+      "featured": [
+        "name",
+        "amount",
+        "authority",
+        "contractDate",
+        "commodities"
+      ],
+      "label": "License",
+      "plural": "Licenses",
+      "properties": {
+        "area": {
+          "description": "Spatial area of the license or concession",
+          "label": "Area",
+          "maxLength": 250,
+          "name": "area",
+          "qname": "License:area",
+          "type": "number"
+        },
+        "commodities": {
+          "label": "Commodities",
+          "maxLength": 1024,
+          "name": "commodities",
+          "qname": "License:commodities",
+          "type": "string"
+        },
+        "reviewDate": {
+          "label": "License review date",
+          "maxLength": 1024,
+          "name": "reviewDate",
+          "qname": "License:reviewDate",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "authority"
+      ],
+      "schemata": [
+        "Asset",
+        "Contract",
+        "License",
+        "Thing",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "contractDate"
+        ]
+      }
+    },
+    "Membership": {
+      "caption": [
+        "role"
+      ],
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": true,
+        "label": "belongs to",
+        "source": "member",
+        "target": "organization"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "member",
+        "organization",
+        "role",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Membership",
+      "plural": "Memberships",
+      "properties": {
+        "member": {
+          "label": "Member",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "member",
+          "qname": "Membership:member",
+          "range": "LegalEntity",
+          "reverse": "membershipMember",
+          "type": "entity"
+        },
+        "organization": {
+          "label": "Organization",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "organization",
+          "qname": "Membership:organization",
+          "range": "Organization",
+          "reverse": "membershipOrganization",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "member",
+        "organization"
+      ],
+      "schemata": [
+        "Interest",
+        "Interval",
+        "Membership"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Mention": {
+      "caption": [
+        "name"
+      ],
+      "extends": [],
+      "featured": [
+        "document",
+        "name",
+        "resolved"
+      ],
+      "generated": true,
+      "hidden": true,
+      "label": "Mention",
+      "plural": "Mentions",
+      "properties": {
+        "contextCountry": {
+          "hidden": true,
+          "label": "Co-occurring countries",
+          "maxLength": 16,
+          "name": "contextCountry",
+          "qname": "Mention:contextCountry",
+          "type": "country"
+        },
+        "contextEmail": {
+          "hidden": true,
+          "label": "Co-occurring e-mail addresses",
+          "maxLength": 250,
+          "name": "contextEmail",
+          "qname": "Mention:contextEmail",
+          "type": "email"
+        },
+        "contextPhone": {
+          "hidden": true,
+          "label": "Co-occurring phone numbers",
+          "maxLength": 64,
+          "name": "contextPhone",
+          "qname": "Mention:contextPhone",
+          "type": "phone"
+        },
+        "detectedSchema": {
+          "hidden": true,
+          "label": "Detected entity type",
+          "maxLength": 1024,
+          "name": "detectedSchema",
+          "qname": "Mention:detectedSchema",
+          "type": "string"
+        },
+        "document": {
+          "label": "Document",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "document",
+          "qname": "Mention:document",
+          "range": "Document",
+          "reverse": "mentionedEntities",
+          "type": "entity"
+        },
+        "name": {
+          "label": "Name",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "name",
+          "qname": "Mention:name",
+          "type": "name"
+        },
+        "resolved": {
+          "label": "Entity",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "resolved",
+          "qname": "Mention:resolved",
+          "range": "LegalEntity",
+          "reverse": "mentionedBy",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "document",
+        "name"
+      ],
+      "schemata": [
+        "Mention"
+      ]
+    },
+    "Message": {
+      "caption": [
+        "subject",
+        "title",
+        "threadTopic",
+        "fileName"
+      ],
+      "extends": [
+        "Folder",
+        "HyperText",
+        "Interval",
+        "PlainText"
+      ],
+      "featured": [
+        "subject",
+        "date",
+        "sender",
+        "recipients"
+      ],
+      "generated": true,
+      "label": "Message",
+      "plural": "Messages",
+      "properties": {
+        "inReplyTo": {
+          "description": "Message ID of the preceding message in the thread",
+          "hidden": true,
+          "label": "In Reply To",
+          "maxLength": 1024,
+          "name": "inReplyTo",
+          "qname": "Message:inReplyTo",
+          "type": "string"
+        },
+        "inReplyToMessage": {
+          "label": "Responding to",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "inReplyToMessage",
+          "qname": "Message:inReplyToMessage",
+          "range": "Message",
+          "reverse": "responses",
+          "type": "entity"
+        },
+        "metadata": {
+          "hidden": true,
+          "label": "Metadata",
+          "maxLength": 250,
+          "name": "metadata",
+          "qname": "Message:metadata",
+          "type": "json"
+        },
+        "recipientAccount": {
+          "label": "Recipient Account",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "recipientAccount",
+          "qname": "Message:recipientAccount",
+          "range": "UserAccount",
+          "reverse": "messagesReceived",
+          "type": "entity"
+        },
+        "recipients": {
+          "label": "Recipients",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "recipients",
+          "qname": "Message:recipients",
+          "range": "LegalEntity",
+          "reverse": "messagesReceived",
+          "type": "entity"
+        },
+        "responses": {
+          "label": "Responses",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "responses",
+          "qname": "Message:responses",
+          "range": "Message",
+          "reverse": "inReplyToMessage",
+          "stub": true,
+          "type": "entity"
+        },
+        "sender": {
+          "label": "Sender",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "sender",
+          "qname": "Message:sender",
+          "range": "LegalEntity",
+          "reverse": "messagesSent",
+          "type": "entity"
+        },
+        "senderAccount": {
+          "label": "Sender Account",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "senderAccount",
+          "qname": "Message:senderAccount",
+          "range": "UserAccount",
+          "reverse": "messagesSent",
+          "type": "entity"
+        },
+        "subject": {
+          "label": "Subject",
+          "maxLength": 1024,
+          "name": "subject",
+          "qname": "Message:subject",
+          "type": "string"
+        },
+        "threadTopic": {
+          "label": "Thread topic",
+          "maxLength": 1024,
+          "name": "threadTopic",
+          "qname": "Message:threadTopic",
+          "type": "string"
+        }
+      },
+      "required": [
+        "bodyText",
+        "sender"
+      ],
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Folder",
+        "HyperText",
+        "Interval",
+        "Message",
+        "PlainText",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Note": {
+      "caption": [
+        "description"
+      ],
+      "description": "An annotation that applies to a document or entity.\n",
+      "extends": [
+        "Analyzable",
+        "Thing"
+      ],
+      "featured": [
+        "description",
+        "entity"
+      ],
+      "label": "Note",
+      "plural": "Notes",
+      "properties": {
+        "entity": {
+          "label": "Entity",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "entity",
+          "qname": "Note:entity",
+          "range": "Thing",
+          "reverse": "noteEntities",
+          "type": "entity"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Note",
+        "Thing"
+      ]
+    },
+    "Occupancy": {
+      "description": "The occupation of a position by a person for a specific period of time.\n",
+      "edge": {
+        "caption": [
+          "startDate",
+          "endDate"
+        ],
+        "directed": true,
+        "label": "holds",
+        "source": "holder",
+        "target": "post"
+      },
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "holder",
+        "post"
+      ],
+      "label": "Occupancy",
+      "plural": "Occupancies",
+      "properties": {
+        "constituency": {
+          "description": "The geographic area/district represented by the holder",
+          "label": "Constituency",
+          "maxLength": 1024,
+          "name": "constituency",
+          "qname": "Occupancy:constituency",
+          "type": "string"
+        },
+        "declarationDate": {
+          "description": "If established by an asset declaration",
+          "label": "Declaration date",
+          "maxLength": 32,
+          "name": "declarationDate",
+          "qname": "Occupancy:declarationDate",
+          "type": "date"
+        },
+        "electionDate": {
+          "description": "Election date for the position, if applicable",
+          "label": "Election date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "electionDate",
+          "qname": "Occupancy:electionDate",
+          "type": "date"
+        },
+        "holder": {
+          "label": "Holder",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "holder",
+          "qname": "Occupancy:holder",
+          "range": "Person",
+          "reverse": "positionOccupancies",
+          "type": "entity"
+        },
+        "periodEnd": {
+          "description": "End date of the fixed office term. Unlike `endDate`, which tracks when an individual's mandate ends, `periodEnd` refers to the term itself and is the same for everyone holding the position during that period.",
+          "label": "Period end",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "periodEnd",
+          "qname": "Occupancy:periodEnd",
+          "type": "date"
+        },
+        "periodStart": {
+          "description": "Start date of the fixed office term (e.g. a parliamentary session). Unlike `startDate`, which tracks when an individual's mandate begins, `periodStart` refers to the term itself and is the same for everyone holding the position during that period.",
+          "label": "Period start",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "periodStart",
+          "qname": "Occupancy:periodStart",
+          "type": "date"
+        },
+        "politicalGroup": {
+          "description": "Caucus, faction or parliamentary group of the holder",
+          "label": "Political group",
+          "maxLength": 1024,
+          "name": "politicalGroup",
+          "qname": "Occupancy:politicalGroup",
+          "type": "string"
+        },
+        "post": {
+          "label": "Position occupied",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "post",
+          "qname": "Occupancy:post",
+          "range": "Position",
+          "reverse": "occupancies",
+          "type": "entity"
+        },
+        "status": {
+          "examples": [
+            "current",
+            "ended"
+          ],
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "Occupancy:status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "holder",
+        "post"
+      ],
+      "schemata": [
+        "Interval",
+        "Occupancy"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate",
+          "periodEnd"
+        ],
+        "start": [
+          "startDate",
+          "periodStart",
+          "electionDate",
+          "declarationDate",
+          "date"
+        ]
+      }
+    },
+    "Organization": {
+      "caption": [
+        "name",
+        "alias",
+        "abbreviation",
+        "weakAlias",
+        "previousName",
+        "registrationNumber"
+      ],
+      "description": "Any type of incorporated entity that cannot be owned by another (see `Company`). This might include charities, foundations or state-owned enterprises, depending on their jurisdiction.\n",
+      "extends": [
+        "LegalEntity"
+      ],
+      "featured": [
+        "name",
+        "country",
+        "legalForm",
+        "status"
+      ],
+      "label": "Organization",
+      "matchable": true,
+      "plural": "Organizations",
+      "properties": {
+        "bankAccounts": {
+          "label": "Bank accounts",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "bankAccounts",
+          "qname": "Organization:bankAccounts",
+          "range": "BankAccount",
+          "reverse": "bank",
+          "stub": true,
+          "type": "entity"
+        },
+        "cageCode": {
+          "description": "Commercial and Government Entity Code (CAGE)",
+          "label": "CAGE",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "cageCode",
+          "qname": "Organization:cageCode",
+          "type": "identifier"
+        },
+        "directorshipOrganization": {
+          "label": "Directors",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "directorshipOrganization",
+          "qname": "Organization:directorshipOrganization",
+          "range": "Directorship",
+          "reverse": "organization",
+          "stub": true,
+          "type": "entity"
+        },
+        "employees": {
+          "label": "Employees",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "employees",
+          "qname": "Organization:employees",
+          "range": "Employment",
+          "reverse": "employer",
+          "stub": true,
+          "type": "entity"
+        },
+        "giiNumber": {
+          "description": "Global Intermediary Identification Number",
+          "label": "GIIN",
+          "matchable": true,
+          "maxLength": 20,
+          "name": "giiNumber",
+          "qname": "Organization:giiNumber",
+          "type": "identifier"
+        },
+        "imoNumber": {
+          "format": "imo",
+          "label": "IMO Number",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "imoNumber",
+          "qname": "Organization:imoNumber",
+          "type": "identifier"
+        },
+        "membershipOrganization": {
+          "label": "Members",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "membershipOrganization",
+          "qname": "Organization:membershipOrganization",
+          "range": "Membership",
+          "reverse": "organization",
+          "stub": true,
+          "type": "entity"
+        },
+        "permId": {
+          "description": "LSEG/Refinitiv code for a company",
+          "label": "PermID",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "permId",
+          "qname": "Organization:permId",
+          "type": "identifier"
+        },
+        "positions": {
+          "label": "Positions",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "positions",
+          "qname": "Organization:positions",
+          "range": "Position",
+          "reverse": "organization",
+          "stub": true,
+          "type": "entity"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "LegalEntity",
+        "Organization",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "dissolutionDate"
+        ],
+        "start": [
+          "incorporationDate"
+        ]
+      }
+    },
+    "Ownership": {
+      "edge": {
+        "caption": [
+          "percentage"
+        ],
+        "directed": true,
+        "label": "owns",
+        "source": "owner",
+        "target": "asset"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "owner",
+        "asset",
+        "role",
+        "percentage",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Ownership",
+      "plural": "Ownerships",
+      "properties": {
+        "asset": {
+          "label": "Asset",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "asset",
+          "qname": "Ownership:asset",
+          "range": "Asset",
+          "reverse": "ownershipAsset",
+          "type": "entity"
+        },
+        "legalBasis": {
+          "label": "Legal basis",
+          "maxLength": 1024,
+          "name": "legalBasis",
+          "qname": "Ownership:legalBasis",
+          "type": "string"
+        },
+        "owner": {
+          "label": "Owner",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "owner",
+          "qname": "Ownership:owner",
+          "range": "LegalEntity",
+          "reverse": "ownershipOwner",
+          "type": "entity"
+        },
+        "ownershipType": {
+          "examples": [
+            "beneficial",
+            "direct",
+            "indirect",
+            "ultimate"
+          ],
+          "label": "Type of ownership",
+          "maxLength": 1024,
+          "name": "ownershipType",
+          "qname": "Ownership:ownershipType",
+          "type": "string"
+        },
+        "percentage": {
+          "label": "Percentage held",
+          "maxLength": 1024,
+          "name": "percentage",
+          "qname": "Ownership:percentage",
+          "type": "string"
+        },
+        "sharesCount": {
+          "label": "Number of shares",
+          "maxLength": 1024,
+          "name": "sharesCount",
+          "qname": "Ownership:sharesCount",
+          "type": "string"
+        },
+        "sharesCurrency": {
+          "label": "Currency of shares",
+          "maxLength": 1024,
+          "name": "sharesCurrency",
+          "qname": "Ownership:sharesCurrency",
+          "type": "string"
+        },
+        "sharesType": {
+          "label": "Type of shares",
+          "maxLength": 1024,
+          "name": "sharesType",
+          "qname": "Ownership:sharesType",
+          "type": "string"
+        },
+        "sharesValue": {
+          "label": "Value of shares",
+          "maxLength": 1024,
+          "name": "sharesValue",
+          "qname": "Ownership:sharesValue",
+          "type": "string"
+        }
+      },
+      "required": [
+        "owner",
+        "asset"
+      ],
+      "schemata": [
+        "Interest",
+        "Interval",
+        "Ownership"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Package": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "description": "A bundle of files that have been packaged together into some form of archive.\n",
+      "extends": [
+        "Folder"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Package",
+      "plural": "Packages",
+      "properties": {},
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Folder",
+        "Package",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Page": {
+      "extends": [],
+      "generated": true,
+      "hidden": true,
+      "label": "Page",
+      "plural": "Pages",
+      "properties": {
+        "bodyText": {
+          "hidden": true,
+          "label": "Text",
+          "maxLength": 65000,
+          "name": "bodyText",
+          "qname": "Page:bodyText",
+          "type": "text"
+        },
+        "detectedLanguage": {
+          "hidden": true,
+          "label": "Detected language",
+          "maxLength": 16,
+          "name": "detectedLanguage",
+          "qname": "Page:detectedLanguage",
+          "type": "language"
+        },
+        "document": {
+          "label": "Document",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "document",
+          "qname": "Page:document",
+          "range": "Pages",
+          "reverse": "pages",
+          "type": "entity"
+        },
+        "index": {
+          "label": "Index",
+          "maxLength": 250,
+          "name": "index",
+          "qname": "Page:index",
+          "type": "number"
+        },
+        "indexText": {
+          "hidden": true,
+          "label": "Index text",
+          "maxLength": 65000,
+          "name": "indexText",
+          "qname": "Page:indexText",
+          "type": "text"
+        },
+        "translatedText": {
+          "hidden": true,
+          "label": "Translated version of the body text",
+          "maxLength": 65000,
+          "name": "translatedText",
+          "qname": "Page:translatedText",
+          "type": "text"
+        },
+        "translatedTextLanguage": {
+          "hidden": true,
+          "label": "The language of the translated text",
+          "maxLength": 1024,
+          "name": "translatedTextLanguage",
+          "qname": "Page:translatedTextLanguage",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Page"
+      ]
+    },
+    "Pages": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "description": "A multi-page document, such as a PDF or Word file or slide-show presentation.\n",
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Document",
+      "plural": "Documents",
+      "properties": {
+        "pages": {
+          "hidden": true,
+          "label": "Pages",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "pages",
+          "qname": "Pages:pages",
+          "range": "Page",
+          "reverse": "document",
+          "stub": true,
+          "type": "entity"
+        },
+        "pdfHash": {
+          "hidden": true,
+          "label": "PDF alternative version checksum",
+          "maxLength": 40,
+          "name": "pdfHash",
+          "qname": "Pages:pdfHash",
+          "type": "checksum"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Pages",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Passport": {
+      "caption": [
+        "passportNumber",
+        "number"
+      ],
+      "description": "A passport held by a person.\n",
+      "extends": [
+        "Identification"
+      ],
+      "featured": [
+        "number",
+        "country",
+        "type",
+        "holder",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Passport",
+      "plural": "Passports",
+      "properties": {
+        "birthDate": {
+          "label": "Birth date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "birthDate",
+          "qname": "Passport:birthDate",
+          "type": "date"
+        },
+        "birthPlace": {
+          "label": "Place of birth",
+          "maxLength": 1024,
+          "name": "birthPlace",
+          "qname": "Passport:birthPlace",
+          "type": "string"
+        },
+        "gender": {
+          "label": "Gender",
+          "maxLength": 16,
+          "name": "gender",
+          "qname": "Passport:gender",
+          "type": "gender"
+        },
+        "givenName": {
+          "deprecated": true,
+          "description": "Deprecated, use `Identification:holder` link's `firstName` / `middleName` instead",
+          "label": "Given name",
+          "maxLength": 1024,
+          "name": "givenName",
+          "qname": "Passport:givenName",
+          "type": "string"
+        },
+        "passportNumber": {
+          "deprecated": true,
+          "description": "Deprecated, use `Identification:number` instead",
+          "hidden": true,
+          "label": "Passport number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "passportNumber",
+          "qname": "Passport:passportNumber",
+          "type": "identifier"
+        },
+        "personalNumber": {
+          "label": "Personal number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "personalNumber",
+          "qname": "Passport:personalNumber",
+          "type": "identifier"
+        },
+        "surname": {
+          "deprecated": true,
+          "description": "Deprecated, use `Identification:holder` link's `lastName` instead",
+          "label": "Surname",
+          "maxLength": 1024,
+          "name": "surname",
+          "qname": "Passport:surname",
+          "type": "string"
+        }
+      },
+      "required": [
+        "holder",
+        "number"
+      ],
+      "schemata": [
+        "Identification",
+        "Interval",
+        "Passport"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Payment": {
+      "caption": [
+        "amount"
+      ],
+      "description": "A monetary payment between two parties.",
+      "edge": {
+        "caption": [
+          "amount",
+          "date",
+          "purpose"
+        ],
+        "directed": true,
+        "label": "paid",
+        "source": "payer",
+        "target": "beneficiary"
+      },
+      "extends": [
+        "Interval",
+        "Value"
+      ],
+      "featured": [
+        "payer",
+        "beneficiary",
+        "date",
+        "amount",
+        "purpose"
+      ],
+      "label": "Payment",
+      "plural": "Payments",
+      "properties": {
+        "beneficiary": {
+          "label": "Beneficiary",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "beneficiary",
+          "qname": "Payment:beneficiary",
+          "range": "LegalEntity",
+          "reverse": "paymentBeneficiary",
+          "type": "entity"
+        },
+        "beneficiaryAccount": {
+          "label": "Beneficiary bank account",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "beneficiaryAccount",
+          "qname": "Payment:beneficiaryAccount",
+          "range": "BankAccount",
+          "reverse": "paymentBeneficiaryAccount",
+          "type": "entity"
+        },
+        "contract": {
+          "label": "Contract",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contract",
+          "qname": "Payment:contract",
+          "range": "Contract",
+          "reverse": "paymentContract",
+          "type": "entity"
+        },
+        "payer": {
+          "label": "Payer",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "payer",
+          "qname": "Payment:payer",
+          "range": "LegalEntity",
+          "reverse": "paymentPayer",
+          "type": "entity"
+        },
+        "payerAccount": {
+          "label": "Payer bank account",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "payerAccount",
+          "qname": "Payment:payerAccount",
+          "range": "BankAccount",
+          "reverse": "paymentPayerAccount",
+          "type": "entity"
+        },
+        "programme": {
+          "description": "Programme name, funding code, category identifier, etc.",
+          "label": "Payment programme",
+          "maxLength": 1024,
+          "name": "programme",
+          "qname": "Payment:programme",
+          "type": "string"
+        },
+        "project": {
+          "label": "Project",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "project",
+          "qname": "Payment:project",
+          "range": "Project",
+          "reverse": "payments",
+          "type": "entity"
+        },
+        "purpose": {
+          "label": "Payment purpose",
+          "maxLength": 65000,
+          "name": "purpose",
+          "qname": "Payment:purpose",
+          "type": "text"
+        },
+        "sequenceNumber": {
+          "label": "Sequence number",
+          "maxLength": 1024,
+          "name": "sequenceNumber",
+          "qname": "Payment:sequenceNumber",
+          "type": "string"
+        },
+        "transactionNumber": {
+          "label": "Transaction number",
+          "maxLength": 1024,
+          "name": "transactionNumber",
+          "qname": "Payment:transactionNumber",
+          "type": "string"
+        }
+      },
+      "required": [
+        "payer",
+        "beneficiary"
+      ],
+      "schemata": [
+        "Interval",
+        "Payment",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Person": {
+      "caption": [
+        "name",
+        "alias",
+        "previousName",
+        "weakAlias",
+        "abbreviation",
+        "lastName",
+        "email",
+        "phone"
+      ],
+      "description": "A natural person, as opposed to a corporation of some type.\n",
+      "extends": [
+        "LegalEntity"
+      ],
+      "featured": [
+        "name",
+        "nationality",
+        "birthDate"
+      ],
+      "label": "Person",
+      "matchable": true,
+      "plural": "People",
+      "properties": {
+        "appearance": {
+          "label": "Physical appearance",
+          "maxLength": 1024,
+          "name": "appearance",
+          "qname": "Person:appearance",
+          "type": "string"
+        },
+        "associates": {
+          "label": "Associates",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "associates",
+          "qname": "Person:associates",
+          "range": "Associate",
+          "reverse": "person",
+          "stub": true,
+          "type": "entity"
+        },
+        "associations": {
+          "label": "Associations",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "associations",
+          "qname": "Person:associations",
+          "range": "Associate",
+          "reverse": "associate",
+          "stub": true,
+          "type": "entity"
+        },
+        "biography": {
+          "description": "A biographical narrative of the person.",
+          "label": "Biography",
+          "maxLength": 65000,
+          "name": "biography",
+          "qname": "Person:biography",
+          "type": "text"
+        },
+        "birthCountry": {
+          "label": "Country of birth",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "birthCountry",
+          "qname": "Person:birthCountry",
+          "type": "country"
+        },
+        "birthDate": {
+          "label": "Birth date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "birthDate",
+          "qname": "Person:birthDate",
+          "type": "date"
+        },
+        "birthPlace": {
+          "label": "Place of birth",
+          "maxLength": 1024,
+          "name": "birthPlace",
+          "qname": "Person:birthPlace",
+          "type": "string"
+        },
+        "citizenship": {
+          "label": "Citizenship",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "citizenship",
+          "qname": "Person:citizenship",
+          "type": "country"
+        },
+        "deathDate": {
+          "description": "Joined the choir invisible.",
+          "label": "Death date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "deathDate",
+          "qname": "Person:deathDate",
+          "type": "date"
+        },
+        "education": {
+          "label": "Education",
+          "maxLength": 1024,
+          "name": "education",
+          "qname": "Person:education",
+          "type": "string"
+        },
+        "employers": {
+          "label": "Employers",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "employers",
+          "qname": "Person:employers",
+          "range": "Employment",
+          "reverse": "employee",
+          "stub": true,
+          "type": "entity"
+        },
+        "ethnicity": {
+          "label": "Ethnicity",
+          "maxLength": 1024,
+          "name": "ethnicity",
+          "qname": "Person:ethnicity",
+          "type": "string"
+        },
+        "eyeColor": {
+          "label": "Eye color",
+          "maxLength": 1024,
+          "name": "eyeColor",
+          "qname": "Person:eyeColor",
+          "type": "string"
+        },
+        "familyPerson": {
+          "label": "Family members",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "familyPerson",
+          "qname": "Person:familyPerson",
+          "range": "Family",
+          "reverse": "person",
+          "stub": true,
+          "type": "entity"
+        },
+        "familyRelative": {
+          "label": "Relatives",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "familyRelative",
+          "qname": "Person:familyRelative",
+          "range": "Family",
+          "reverse": "relative",
+          "stub": true,
+          "type": "entity"
+        },
+        "fatherName": {
+          "description": "The part of a name based on the given name of one's father",
+          "label": "Patronymic",
+          "maxLength": 1024,
+          "name": "fatherName",
+          "qname": "Person:fatherName",
+          "type": "string"
+        },
+        "firstName": {
+          "description": "The part of a name that indicates the person, also often called given name or forename",
+          "label": "First name",
+          "maxLength": 1024,
+          "name": "firstName",
+          "qname": "Person:firstName",
+          "type": "string"
+        },
+        "gender": {
+          "label": "Gender",
+          "maxLength": 16,
+          "name": "gender",
+          "qname": "Person:gender",
+          "type": "gender"
+        },
+        "hairColor": {
+          "label": "Hair color",
+          "maxLength": 1024,
+          "name": "hairColor",
+          "qname": "Person:hairColor",
+          "type": "string"
+        },
+        "height": {
+          "label": "Height",
+          "maxLength": 250,
+          "name": "height",
+          "qname": "Person:height",
+          "type": "number"
+        },
+        "images": {
+          "label": "Images",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "images",
+          "qname": "Person:images",
+          "range": "Image",
+          "reverse": "pictured",
+          "stub": true,
+          "type": "entity"
+        },
+        "lastName": {
+          "description": "The part of a name that indicates one's family, also often called surname or family name",
+          "label": "Last name",
+          "maxLength": 1024,
+          "name": "lastName",
+          "qname": "Person:lastName",
+          "type": "string"
+        },
+        "middleName": {
+          "description": "The part of name written between a person's given name and family name. Often abbreviated as a middle initial.",
+          "label": "Middle name",
+          "maxLength": 1024,
+          "name": "middleName",
+          "qname": "Person:middleName",
+          "type": "string"
+        },
+        "motherName": {
+          "description": "The part of a name based on the given name of one's mother",
+          "label": "Matronymic",
+          "maxLength": 1024,
+          "name": "motherName",
+          "qname": "Person:motherName",
+          "type": "string"
+        },
+        "nameSuffix": {
+          "examples": [
+            "OBE"
+          ],
+          "label": "Name suffix",
+          "maxLength": 1024,
+          "name": "nameSuffix",
+          "qname": "Person:nameSuffix",
+          "type": "string"
+        },
+        "nationality": {
+          "label": "Nationality",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "nationality",
+          "qname": "Person:nationality",
+          "type": "country"
+        },
+        "passportNumber": {
+          "label": "Passport number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "passportNumber",
+          "qname": "Person:passportNumber",
+          "type": "identifier"
+        },
+        "political": {
+          "label": "Political association",
+          "maxLength": 1024,
+          "name": "political",
+          "qname": "Person:political",
+          "type": "string"
+        },
+        "position": {
+          "label": "Position",
+          "maxLength": 1024,
+          "name": "position",
+          "qname": "Person:position",
+          "type": "string"
+        },
+        "positionOccupancies": {
+          "label": "Positions held",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "positionOccupancies",
+          "qname": "Person:positionOccupancies",
+          "range": "Occupancy",
+          "reverse": "holder",
+          "stub": true,
+          "type": "entity"
+        },
+        "profession": {
+          "label": "Profession",
+          "maxLength": 1024,
+          "name": "profession",
+          "qname": "Person:profession",
+          "type": "string"
+        },
+        "religion": {
+          "label": "Religion",
+          "maxLength": 1024,
+          "name": "religion",
+          "qname": "Person:religion",
+          "type": "string"
+        },
+        "secondName": {
+          "deprecated": true,
+          "description": "Deprecated, use one of the other more specific name properties instead",
+          "label": "Second name",
+          "maxLength": 1024,
+          "name": "secondName",
+          "qname": "Person:secondName",
+          "type": "string"
+        },
+        "socialSecurityNumber": {
+          "format": "ssn",
+          "label": "Social security number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "socialSecurityNumber",
+          "qname": "Person:socialSecurityNumber",
+          "type": "identifier"
+        },
+        "spokenLanguage": {
+          "label": "Spoken language",
+          "maxLength": 16,
+          "name": "spokenLanguage",
+          "qname": "Person:spokenLanguage",
+          "type": "language"
+        },
+        "title": {
+          "label": "Title",
+          "maxLength": 1024,
+          "name": "title",
+          "qname": "Person:title",
+          "type": "string"
+        },
+        "weight": {
+          "label": "Weight",
+          "maxLength": 250,
+          "name": "weight",
+          "qname": "Person:weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "LegalEntity",
+        "Person",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "deathDate"
+        ],
+        "start": [
+          "birthDate"
+        ]
+      }
+    },
+    "PlainText": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "description": "Text files, like .txt or source code.\n",
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Text file",
+      "plural": "Text files",
+      "properties": {},
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "PlainText",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Position": {
+      "caption": [
+        "name"
+      ],
+      "description": "A post, role or position within an organization or body. This describes a position one or more people may occupy and not the occupation of the post by a specific individual at a specific point in time (see `Occupancy`).\n",
+      "extends": [
+        "Thing"
+      ],
+      "featured": [
+        "name",
+        "country",
+        "subnationalArea"
+      ],
+      "label": "Position",
+      "matchable": true,
+      "plural": "Positions",
+      "properties": {
+        "dissolutionDate": {
+          "label": "Dissolution date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "dissolutionDate",
+          "qname": "Position:dissolutionDate",
+          "type": "date"
+        },
+        "inceptionDate": {
+          "label": "Inception date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "inceptionDate",
+          "qname": "Position:inceptionDate",
+          "type": "date"
+        },
+        "numberOfSeats": {
+          "label": "Total number of seats",
+          "maxLength": 250,
+          "name": "numberOfSeats",
+          "qname": "Position:numberOfSeats",
+          "type": "number"
+        },
+        "occupancies": {
+          "label": "Position holders",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "occupancies",
+          "qname": "Position:occupancies",
+          "range": "Occupancy",
+          "reverse": "post",
+          "stub": true,
+          "type": "entity"
+        },
+        "organization": {
+          "label": "Organization",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "organization",
+          "qname": "Position:organization",
+          "range": "Organization",
+          "reverse": "positions",
+          "type": "entity"
+        },
+        "subnationalArea": {
+          "description": "The name or code of a subnational jurisdiction, only when the position is geographically limited. Prefer `Occupancy:constituency` where relevant.",
+          "label": "Subnational area",
+          "maxLength": 1024,
+          "name": "subnationalArea",
+          "qname": "Position:subnationalArea",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "Position",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "dissolutionDate"
+        ],
+        "start": [
+          "inceptionDate"
+        ]
+      }
+    },
+    "Project": {
+      "caption": [
+        "name",
+        "projectId"
+      ],
+      "description": "An activity carried out by a group of `participants`.\n",
+      "extends": [
+        "Interval",
+        "Thing",
+        "Value"
+      ],
+      "featured": [
+        "name",
+        "projectId",
+        "startDate"
+      ],
+      "label": "Project",
+      "plural": "Projects",
+      "properties": {
+        "contracts": {
+          "label": "Contracts",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "contracts",
+          "qname": "Project:contracts",
+          "range": "Contract",
+          "reverse": "project",
+          "stub": true,
+          "type": "entity"
+        },
+        "goal": {
+          "label": "Project goal",
+          "maxLength": 1024,
+          "name": "goal",
+          "qname": "Project:goal",
+          "type": "string"
+        },
+        "participants": {
+          "label": "Participants",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "participants",
+          "qname": "Project:participants",
+          "range": "ProjectParticipant",
+          "reverse": "project",
+          "stub": true,
+          "type": "entity"
+        },
+        "payments": {
+          "label": "Payments",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "payments",
+          "qname": "Project:payments",
+          "range": "Payment",
+          "reverse": "project",
+          "stub": true,
+          "type": "entity"
+        },
+        "phase": {
+          "label": "Phase",
+          "maxLength": 1024,
+          "name": "phase",
+          "qname": "Project:phase",
+          "type": "string"
+        },
+        "projectId": {
+          "label": "Project ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "projectId",
+          "qname": "Project:projectId",
+          "type": "identifier"
+        },
+        "status": {
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "Project:status",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Interval",
+        "Project",
+        "Thing",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "ProjectParticipant": {
+      "caption": [
+        "role"
+      ],
+      "description": "A participant in a `Project`.\n",
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": true,
+        "label": "participates in",
+        "source": "participant",
+        "target": "project"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "project",
+        "participant",
+        "role"
+      ],
+      "label": "Project participant",
+      "plural": "Project participants",
+      "properties": {
+        "participant": {
+          "label": "Participant",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "participant",
+          "qname": "ProjectParticipant:participant",
+          "range": "LegalEntity",
+          "reverse": "projectParticipation",
+          "type": "entity"
+        },
+        "project": {
+          "label": "Project",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "project",
+          "qname": "ProjectParticipant:project",
+          "range": "Project",
+          "reverse": "participants",
+          "type": "entity"
+        }
+      },
+      "schemata": [
+        "Interest",
+        "Interval",
+        "ProjectParticipant"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "PublicBody": {
+      "caption": [
+        "name",
+        "alias",
+        "abbreviation",
+        "weakAlias",
+        "previousName"
+      ],
+      "description": "A public body, such as a ministry, department or state company.\n",
+      "extends": [
+        "Organization"
+      ],
+      "featured": [
+        "name",
+        "country",
+        "legalForm",
+        "status"
+      ],
+      "label": "Public body",
+      "matchable": true,
+      "plural": "Public bodies",
+      "properties": {},
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "LegalEntity",
+        "Organization",
+        "PublicBody",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [
+          "dissolutionDate"
+        ],
+        "start": [
+          "incorporationDate"
+        ]
+      }
+    },
+    "RealEstate": {
+      "caption": [
+        "name",
+        "address",
+        "registrationNumber"
+      ],
+      "description": "A piece of land or property.",
+      "extends": [
+        "Asset"
+      ],
+      "featured": [
+        "registrationNumber",
+        "address",
+        "country"
+      ],
+      "label": "Real estate",
+      "plural": "Real estates",
+      "properties": {
+        "area": {
+          "label": "Area",
+          "maxLength": 250,
+          "name": "area",
+          "qname": "RealEstate:area",
+          "type": "number"
+        },
+        "cadastralCode": {
+          "label": "Cadastral code",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "cadastralCode",
+          "qname": "RealEstate:cadastralCode",
+          "type": "identifier"
+        },
+        "censusBlock": {
+          "label": "Census block",
+          "maxLength": 1024,
+          "name": "censusBlock",
+          "qname": "RealEstate:censusBlock",
+          "type": "string"
+        },
+        "createDate": {
+          "label": "Record date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "createDate",
+          "qname": "RealEstate:createDate",
+          "type": "date"
+        },
+        "encumbrance": {
+          "description": "An encumbrance is a right to, interest in, or legal liability on real property that does not prohibit passing title to the property but that diminishes its value.\n",
+          "label": "Encumbrance",
+          "maxLength": 1024,
+          "name": "encumbrance",
+          "qname": "RealEstate:encumbrance",
+          "type": "string"
+        },
+        "landType": {
+          "label": "Land type",
+          "maxLength": 1024,
+          "name": "landType",
+          "qname": "RealEstate:landType",
+          "type": "string"
+        },
+        "latitude": {
+          "label": "Latitude",
+          "maxLength": 250,
+          "name": "latitude",
+          "qname": "RealEstate:latitude",
+          "type": "number"
+        },
+        "longitude": {
+          "label": "Longitude",
+          "maxLength": 250,
+          "name": "longitude",
+          "qname": "RealEstate:longitude",
+          "type": "number"
+        },
+        "parent": {
+          "description": "If this entity is a subunit, another entity (real estate) is its parent",
+          "label": "Parent unit",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "parent",
+          "qname": "RealEstate:parent",
+          "range": "RealEstate",
+          "reverse": "subunits",
+          "type": "entity"
+        },
+        "propertyType": {
+          "label": "Property type",
+          "maxLength": 1024,
+          "name": "propertyType",
+          "qname": "RealEstate:propertyType",
+          "type": "string"
+        },
+        "registrationNumber": {
+          "label": "Registration number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "registrationNumber",
+          "qname": "RealEstate:registrationNumber",
+          "type": "identifier"
+        },
+        "subunits": {
+          "label": "Subunits",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "subunits",
+          "qname": "RealEstate:subunits",
+          "range": "RealEstate",
+          "reverse": "parent",
+          "stub": true,
+          "type": "entity"
+        },
+        "tenure": {
+          "label": "Tenure",
+          "maxLength": 1024,
+          "name": "tenure",
+          "qname": "RealEstate:tenure",
+          "type": "string"
+        },
+        "titleNumber": {
+          "label": "Title number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "titleNumber",
+          "qname": "RealEstate:titleNumber",
+          "type": "identifier"
+        }
+      },
+      "schemata": [
+        "Asset",
+        "RealEstate",
+        "Thing",
+        "Value"
+      ]
+    },
+    "Representation": {
+      "description": "A mediatory, intermediary, middleman, or broker acting on behalf of a legal entity.",
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": true,
+        "label": "represents",
+        "source": "agent",
+        "target": "client"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "agent",
+        "client",
+        "role"
+      ],
+      "label": "Representation",
+      "plural": "Representations",
+      "properties": {
+        "agent": {
+          "label": "Agent",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "agent",
+          "qname": "Representation:agent",
+          "range": "LegalEntity",
+          "reverse": "agencyClient",
+          "type": "entity"
+        },
+        "client": {
+          "label": "Client",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "client",
+          "qname": "Representation:client",
+          "range": "LegalEntity",
+          "reverse": "agentRepresentation",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "agent",
+        "client"
+      ],
+      "schemata": [
+        "Interest",
+        "Interval",
+        "Representation"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Risk": {
+      "caption": [
+        "reason",
+        "status"
+      ],
+      "description": "A risk associated with an entity.",
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "entity",
+        "country",
+        "reason",
+        "status",
+        "startDate"
+      ],
+      "label": "Risk",
+      "plural": "Risks",
+      "properties": {
+        "country": {
+          "label": "Country",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "country",
+          "qname": "Risk:country",
+          "type": "country"
+        },
+        "duration": {
+          "label": "Duration",
+          "maxLength": 250,
+          "name": "duration",
+          "qname": "Risk:duration",
+          "type": "number"
+        },
+        "entity": {
+          "label": "Entity",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "entity",
+          "qname": "Risk:entity",
+          "range": "Thing",
+          "reverse": "risks",
+          "type": "entity"
+        },
+        "listingDate": {
+          "label": "Listing date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "listingDate",
+          "qname": "Risk:listingDate",
+          "type": "date"
+        },
+        "reason": {
+          "label": "Reason",
+          "maxLength": 65000,
+          "name": "reason",
+          "qname": "Risk:reason",
+          "type": "text"
+        },
+        "status": {
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "Risk:status",
+          "type": "string"
+        },
+        "topics": {
+          "label": "Topics",
+          "maxLength": 64,
+          "name": "topics",
+          "qname": "Risk:topics",
+          "type": "topic"
+        }
+      },
+      "required": [
+        "entity"
+      ],
+      "schemata": [
+        "Interval",
+        "Risk"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Sanction": {
+      "caption": [
+        "program"
+      ],
+      "description": "A sanction designation.",
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "entity",
+        "country",
+        "authority",
+        "program",
+        "startDate"
+      ],
+      "label": "Sanction",
+      "plural": "Sanctions",
+      "properties": {
+        "authority": {
+          "label": "Authority",
+          "maxLength": 1024,
+          "name": "authority",
+          "qname": "Sanction:authority",
+          "type": "string"
+        },
+        "authorityId": {
+          "label": "Authority-issued identifier",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "authorityId",
+          "qname": "Sanction:authorityId",
+          "type": "identifier"
+        },
+        "country": {
+          "label": "Country",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "country",
+          "qname": "Sanction:country",
+          "type": "country"
+        },
+        "duration": {
+          "label": "Duration",
+          "maxLength": 250,
+          "name": "duration",
+          "qname": "Sanction:duration",
+          "type": "number"
+        },
+        "entity": {
+          "label": "Entity",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "entity",
+          "qname": "Sanction:entity",
+          "range": "Thing",
+          "reverse": "sanctions",
+          "type": "entity"
+        },
+        "listingDate": {
+          "description": "The date on which the designation is listed; distinct from the `startDate`, which is the date on which the designation goes into effect",
+          "label": "Listing date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "listingDate",
+          "qname": "Sanction:listingDate",
+          "type": "date"
+        },
+        "program": {
+          "label": "Program",
+          "maxLength": 1024,
+          "name": "program",
+          "qname": "Sanction:program",
+          "type": "string"
+        },
+        "programId": {
+          "label": "Program ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "programId",
+          "qname": "Sanction:programId",
+          "type": "identifier"
+        },
+        "programUrl": {
+          "label": "Program URL",
+          "matchable": true,
+          "maxLength": 4096,
+          "name": "programUrl",
+          "qname": "Sanction:programUrl",
+          "type": "url"
+        },
+        "provisions": {
+          "label": "Scope of sanctions",
+          "maxLength": 1024,
+          "name": "provisions",
+          "qname": "Sanction:provisions",
+          "type": "string"
+        },
+        "reason": {
+          "description": "An explanation of the designation's justification.",
+          "label": "Reason",
+          "maxLength": 65000,
+          "name": "reason",
+          "qname": "Sanction:reason",
+          "type": "text"
+        },
+        "status": {
+          "examples": [
+            "Active",
+            "Inactive",
+            "Expired",
+            "Suspended"
+          ],
+          "label": "Status",
+          "maxLength": 1024,
+          "name": "status",
+          "qname": "Sanction:status",
+          "type": "string"
+        },
+        "unscId": {
+          "description": "Identifier issued by the UN Security Council for sanctions designations",
+          "label": "UN SC identifier",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "unscId",
+          "qname": "Sanction:unscId",
+          "type": "identifier"
+        }
+      },
+      "required": [
+        "entity"
+      ],
+      "schemata": [
+        "Interval",
+        "Sanction"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Security": {
+      "caption": [
+        "name",
+        "isin",
+        "registrationNumber"
+      ],
+      "description": "A tradeable financial asset.",
+      "extends": [
+        "Asset"
+      ],
+      "featured": [
+        "isin",
+        "name",
+        "issuer",
+        "country"
+      ],
+      "label": "Security",
+      "matchable": true,
+      "plural": "Securities",
+      "properties": {
+        "classification": {
+          "label": "Classification",
+          "maxLength": 1024,
+          "name": "classification",
+          "qname": "Security:classification",
+          "type": "string"
+        },
+        "collateral": {
+          "label": "Collateral",
+          "maxLength": 1024,
+          "name": "collateral",
+          "qname": "Security:collateral",
+          "type": "string"
+        },
+        "figiCode": {
+          "format": "figi",
+          "label": "Financial Instrument Global Identifier",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "figiCode",
+          "qname": "Security:figiCode",
+          "type": "identifier"
+        },
+        "isin": {
+          "description": "International Securities Identification Number",
+          "format": "isin",
+          "label": "ISIN",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "isin",
+          "qname": "Security:isin",
+          "type": "identifier"
+        },
+        "issueDate": {
+          "label": "Date issued",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "issueDate",
+          "qname": "Security:issueDate",
+          "type": "date"
+        },
+        "issuer": {
+          "label": "Issuer",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "issuer",
+          "qname": "Security:issuer",
+          "range": "LegalEntity",
+          "reverse": "securities",
+          "type": "entity"
+        },
+        "maturityDate": {
+          "label": "Maturity date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "maturityDate",
+          "qname": "Security:maturityDate",
+          "type": "date"
+        },
+        "registrationNumber": {
+          "label": "Registration number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "registrationNumber",
+          "qname": "Security:registrationNumber",
+          "type": "identifier"
+        },
+        "ticker": {
+          "label": "Stock ticker symbol",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "ticker",
+          "qname": "Security:ticker",
+          "type": "identifier"
+        },
+        "type": {
+          "label": "Type",
+          "maxLength": 1024,
+          "name": "type",
+          "qname": "Security:type",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Asset",
+        "Security",
+        "Thing",
+        "Value"
+      ],
+      "temporalExtent": {
+        "end": [
+          "maturityDate"
+        ],
+        "start": [
+          "issueDate"
+        ]
+      }
+    },
+    "Similar": {
+      "caption": [
+        "confidenceScore",
+        "criteria"
+      ],
+      "description": "A link between two entities that are presumed to be the same, e.g. as the outcome of a probabilistic record linkage process.\n",
+      "extends": [],
+      "featured": [
+        "candidate",
+        "match",
+        "confidenceScore"
+      ],
+      "generated": true,
+      "label": "Similar",
+      "plural": "Similar entities",
+      "properties": {
+        "candidate": {
+          "label": "Candidate",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "candidate",
+          "qname": "Similar:candidate",
+          "range": "Thing",
+          "reverse": "candidateSimilars",
+          "type": "entity"
+        },
+        "confidenceScore": {
+          "label": "Confidence score",
+          "maxLength": 250,
+          "name": "confidenceScore",
+          "qname": "Similar:confidenceScore",
+          "type": "number"
+        },
+        "criteria": {
+          "label": "Matching criteria",
+          "maxLength": 1024,
+          "name": "criteria",
+          "qname": "Similar:criteria",
+          "type": "string"
+        },
+        "match": {
+          "label": "Match",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "match",
+          "qname": "Similar:match",
+          "range": "Thing",
+          "reverse": "matchSimilars",
+          "type": "entity"
+        },
+        "matcher": {
+          "label": "Matcher",
+          "maxLength": 1024,
+          "name": "matcher",
+          "qname": "Similar:matcher",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Similar"
+      ]
+    },
+    "Succession": {
+      "description": "Two entities that legally succeed each other.",
+      "edge": {
+        "caption": [
+          "date"
+        ],
+        "directed": true,
+        "label": "preceeds",
+        "source": "predecessor",
+        "target": "successor"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "predecessor",
+        "successor",
+        "date"
+      ],
+      "label": "Succession",
+      "plural": "Successions",
+      "properties": {
+        "predecessor": {
+          "label": "Predecessor",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "predecessor",
+          "qname": "Succession:predecessor",
+          "range": "LegalEntity",
+          "reverse": "successors",
+          "type": "entity"
+        },
+        "successor": {
+          "label": "Successor",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "successor",
+          "qname": "Succession:successor",
+          "range": "LegalEntity",
+          "reverse": "predecessors",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "predecessor",
+        "successor"
+      ],
+      "schemata": [
+        "Interest",
+        "Interval",
+        "Succession"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Table": {
+      "caption": [
+        "title",
+        "name",
+        "fileName"
+      ],
+      "description": "A document structured into rows and cells. This includes simple CSV files, spreadsheet sheets or database relations.\n",
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Table",
+      "plural": "Tables",
+      "properties": {
+        "columns": {
+          "hidden": true,
+          "label": "Column headings",
+          "maxLength": 250,
+          "name": "columns",
+          "qname": "Table:columns",
+          "type": "json"
+        },
+        "csvHash": {
+          "hidden": true,
+          "label": "CSV alternative version checksum",
+          "maxLength": 40,
+          "name": "csvHash",
+          "qname": "Table:csvHash",
+          "type": "checksum"
+        },
+        "rowCount": {
+          "label": "Number of rows",
+          "maxLength": 250,
+          "name": "rowCount",
+          "qname": "Table:rowCount",
+          "type": "number"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Table",
+        "Thing"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "TaxRoll": {
+      "description": "A tax declaration of an individual.",
+      "extends": [
+        "Interval"
+      ],
+      "featured": [
+        "taxee",
+        "date",
+        "income",
+        "wealth",
+        "taxPaid"
+      ],
+      "label": "Tax roll",
+      "plural": "Tax rolls",
+      "properties": {
+        "birthDate": {
+          "label": "Birth date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "birthDate",
+          "qname": "TaxRoll:birthDate",
+          "type": "date"
+        },
+        "country": {
+          "label": "Country",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "country",
+          "qname": "TaxRoll:country",
+          "type": "country"
+        },
+        "givenName": {
+          "label": "Given name",
+          "maxLength": 1024,
+          "name": "givenName",
+          "qname": "TaxRoll:givenName",
+          "type": "string"
+        },
+        "income": {
+          "label": "Registered income",
+          "maxLength": 1024,
+          "name": "income",
+          "qname": "TaxRoll:income",
+          "type": "string"
+        },
+        "surname": {
+          "label": "Surname",
+          "maxLength": 1024,
+          "name": "surname",
+          "qname": "TaxRoll:surname",
+          "type": "string"
+        },
+        "taxPaid": {
+          "label": "Amount of tax paid",
+          "maxLength": 1024,
+          "name": "taxPaid",
+          "qname": "TaxRoll:taxPaid",
+          "type": "string"
+        },
+        "taxee": {
+          "label": "Taxee",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "taxee",
+          "qname": "TaxRoll:taxee",
+          "range": "LegalEntity",
+          "reverse": "taxRolls",
+          "type": "entity"
+        },
+        "wealth": {
+          "label": "Registered wealth",
+          "maxLength": 1024,
+          "name": "wealth",
+          "qname": "TaxRoll:wealth",
+          "type": "string"
+        }
+      },
+      "required": [
+        "taxee"
+      ],
+      "schemata": [
+        "Interval",
+        "TaxRoll"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "Thing": {
+      "abstract": true,
+      "caption": [
+        "name"
+      ],
+      "extends": [],
+      "featured": [
+        "name",
+        "country"
+      ],
+      "label": "Thing",
+      "plural": "Thing",
+      "properties": {
+        "address": {
+          "description": "A textual description of an address linked to the entity",
+          "label": "Address",
+          "matchable": true,
+          "maxLength": 250,
+          "name": "address",
+          "qname": "Thing:address",
+          "type": "address"
+        },
+        "addressEntity": {
+          "description": "A reference to an `Address` entity with structured place information",
+          "label": "Address",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "addressEntity",
+          "qname": "Thing:addressEntity",
+          "range": "Address",
+          "reverse": "things",
+          "type": "entity"
+        },
+        "alephUrl": {
+          "hidden": true,
+          "label": "Aleph URL",
+          "maxLength": 4096,
+          "name": "alephUrl",
+          "qname": "Thing:alephUrl",
+          "type": "url"
+        },
+        "alias": {
+          "description": "An alternative or secondary name",
+          "label": "Alias",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "alias",
+          "qname": "Thing:alias",
+          "type": "name"
+        },
+        "candidateSimilars": {
+          "label": "Similar to this",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "candidateSimilars",
+          "qname": "Thing:candidateSimilars",
+          "range": "Similar",
+          "reverse": "candidate",
+          "stub": true,
+          "type": "entity"
+        },
+        "country": {
+          "description": "An association between the entity and a country that is not covered by a more specific property (e.g. `jurisdiction`, `birthCountry`, `mainCountry`)",
+          "label": "Country",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "country",
+          "qname": "Thing:country",
+          "type": "country"
+        },
+        "courtCase": {
+          "label": "Court cases",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "courtCase",
+          "qname": "Thing:courtCase",
+          "range": "CourtCaseParty",
+          "reverse": "party",
+          "stub": true,
+          "type": "entity"
+        },
+        "createdAt": {
+          "description": "The date on which the entity was created, not to be confused with an internal 'first saved'-style metadata field",
+          "label": "Created at",
+          "maxLength": 32,
+          "name": "createdAt",
+          "qname": "Thing:createdAt",
+          "type": "date"
+        },
+        "description": {
+          "description": "A longer description; see also `notes`, `summary`",
+          "label": "Description",
+          "maxLength": 65000,
+          "name": "description",
+          "qname": "Thing:description",
+          "type": "text"
+        },
+        "documentedBy": {
+          "label": "Documents",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "documentedBy",
+          "qname": "Thing:documentedBy",
+          "range": "Documentation",
+          "reverse": "entity",
+          "stub": true,
+          "type": "entity"
+        },
+        "indexText": {
+          "hidden": true,
+          "label": "Index text",
+          "maxLength": 65000,
+          "name": "indexText",
+          "qname": "Thing:indexText",
+          "type": "text"
+        },
+        "keywords": {
+          "description": "Plain text keywords provided for the entity; prefer more specific `type`, `status`, etc. as appropriate",
+          "label": "Keywords",
+          "maxLength": 1024,
+          "name": "keywords",
+          "qname": "Thing:keywords",
+          "type": "string"
+        },
+        "matchSimilars": {
+          "label": "Similar as this",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "matchSimilars",
+          "qname": "Thing:matchSimilars",
+          "range": "Similar",
+          "reverse": "match",
+          "stub": true,
+          "type": "entity"
+        },
+        "modifiedAt": {
+          "description": "The date on which the entity was modified, not to be confused with an internal 'last updated'-style metadata field",
+          "label": "Modified on",
+          "maxLength": 32,
+          "name": "modifiedAt",
+          "qname": "Thing:modifiedAt",
+          "type": "date"
+        },
+        "name": {
+          "description": "The primary name of the entity",
+          "label": "Name",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "name",
+          "qname": "Thing:name",
+          "type": "name"
+        },
+        "noteEntities": {
+          "label": "Notes",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "noteEntities",
+          "qname": "Thing:noteEntities",
+          "range": "Note",
+          "reverse": "entity",
+          "stub": true,
+          "type": "entity"
+        },
+        "notes": {
+          "description": "Narrative description of the entity; see also `description`, `summary`",
+          "label": "Notes",
+          "maxLength": 65000,
+          "name": "notes",
+          "qname": "Thing:notes",
+          "type": "text"
+        },
+        "previousName": {
+          "description": "A former name of the entity",
+          "label": "Previous name",
+          "matchable": true,
+          "maxLength": 384,
+          "name": "previousName",
+          "qname": "Thing:previousName",
+          "type": "name"
+        },
+        "program": {
+          "description": "Regulatory program or sanctions list on which an entity is listed",
+          "label": "Program",
+          "maxLength": 1024,
+          "name": "program",
+          "qname": "Thing:program",
+          "type": "string"
+        },
+        "programId": {
+          "hidden": true,
+          "label": "Program ID",
+          "maxLength": 64,
+          "name": "programId",
+          "qname": "Thing:programId",
+          "type": "identifier"
+        },
+        "proof": {
+          "label": "Source document",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "proof",
+          "qname": "Thing:proof",
+          "range": "Document",
+          "reverse": "proven",
+          "type": "entity"
+        },
+        "publisher": {
+          "label": "Publishing source",
+          "maxLength": 1024,
+          "name": "publisher",
+          "qname": "Thing:publisher",
+          "type": "string"
+        },
+        "publisherUrl": {
+          "label": "Publishing source URL",
+          "maxLength": 4096,
+          "name": "publisherUrl",
+          "qname": "Thing:publisherUrl",
+          "type": "url"
+        },
+        "retrievedAt": {
+          "description": "Retrieval date generated by a data gathering system, not to be confused with an internal 'first found'-style metadata field",
+          "label": "Retrieved on",
+          "maxLength": 32,
+          "name": "retrievedAt",
+          "qname": "Thing:retrievedAt",
+          "type": "date"
+        },
+        "riskSource": {
+          "description": "The directly-designated entity from which this entity's risk classification ultimately derives, e.g. the sanctioned owner at the origin of an ownership chain. See also the `topics` property.",
+          "label": "Risk source",
+          "maxLength": 200,
+          "name": "riskSource",
+          "qname": "Thing:riskSource",
+          "range": "Thing",
+          "type": "entity"
+        },
+        "risks": {
+          "label": "Risks",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "risks",
+          "qname": "Thing:risks",
+          "range": "Risk",
+          "reverse": "entity",
+          "stub": true,
+          "type": "entity"
+        },
+        "sanctions": {
+          "label": "Sanctions",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "sanctions",
+          "qname": "Thing:sanctions",
+          "range": "Sanction",
+          "reverse": "entity",
+          "stub": true,
+          "type": "entity"
+        },
+        "sourceUrl": {
+          "description": "A deep link to a source website for the profile",
+          "label": "Source link",
+          "maxLength": 4096,
+          "name": "sourceUrl",
+          "qname": "Thing:sourceUrl",
+          "type": "url"
+        },
+        "summary": {
+          "description": "A short one-liner description; see also `description`, `notes`",
+          "label": "Summary",
+          "maxLength": 65000,
+          "name": "summary",
+          "qname": "Thing:summary",
+          "type": "text"
+        },
+        "topics": {
+          "description": "Controlled tags used to qualify the entity and associate it with a risk category",
+          "examples": [
+            "sanction",
+            "debarment",
+            "role.pep"
+          ],
+          "label": "Topics",
+          "maxLength": 64,
+          "name": "topics",
+          "qname": "Thing:topics",
+          "type": "topic"
+        },
+        "unknownLinkFrom": {
+          "label": "Linked from",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "unknownLinkFrom",
+          "qname": "Thing:unknownLinkFrom",
+          "range": "UnknownLink",
+          "reverse": "object",
+          "stub": true,
+          "type": "entity"
+        },
+        "unknownLinkTo": {
+          "label": "Linked to",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "unknownLinkTo",
+          "qname": "Thing:unknownLinkTo",
+          "range": "UnknownLink",
+          "reverse": "subject",
+          "stub": true,
+          "type": "entity"
+        },
+        "weakAlias": {
+          "description": "A relatively broad or generic alias that should not be used for matching in screening systems. It may still may be useful for identification purposes, particularly in confirming a possible match triggered by other identifier information.",
+          "label": "Weak alias",
+          "maxLength": 384,
+          "name": "weakAlias",
+          "qname": "Thing:weakAlias",
+          "type": "name"
+        },
+        "wikidataId": {
+          "examples": [
+            "Q7747"
+          ],
+          "format": "wikidata",
+          "label": "Wikidata ID",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "wikidataId",
+          "qname": "Thing:wikidataId",
+          "type": "identifier"
+        },
+        "wikipediaUrl": {
+          "label": "Wikipedia Article",
+          "maxLength": 4096,
+          "name": "wikipediaUrl",
+          "qname": "Thing:wikipediaUrl",
+          "type": "url"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "Thing"
+      ]
+    },
+    "Trip": {
+      "caption": [
+        "name",
+        "startDate",
+        "endDate"
+      ],
+      "extends": [
+        "Event"
+      ],
+      "featured": [
+        "endLocation",
+        "startLocation",
+        "vehicle",
+        "startDate",
+        "endDate"
+      ],
+      "label": "Trip",
+      "plural": "Trips",
+      "properties": {
+        "endLocation": {
+          "label": "End location",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "endLocation",
+          "qname": "Trip:endLocation",
+          "range": "Address",
+          "reverse": "tripsIncoming",
+          "type": "entity"
+        },
+        "startLocation": {
+          "label": "Start location",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "startLocation",
+          "qname": "Trip:startLocation",
+          "range": "Address",
+          "reverse": "tripsDeparting",
+          "type": "entity"
+        },
+        "vehicle": {
+          "label": "Vehicle",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "vehicle",
+          "qname": "Trip:vehicle",
+          "range": "Vehicle",
+          "reverse": "tripsInvolved",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "name",
+        "endLocation",
+        "startLocation"
+      ],
+      "schemata": [
+        "Analyzable",
+        "Event",
+        "Interval",
+        "Thing",
+        "Trip"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "UnknownLink": {
+      "edge": {
+        "caption": [
+          "role"
+        ],
+        "directed": false,
+        "label": "linked to",
+        "source": "subject",
+        "target": "object"
+      },
+      "extends": [
+        "Interest"
+      ],
+      "featured": [
+        "subject",
+        "object",
+        "role"
+      ],
+      "label": "Other link",
+      "plural": "Other links",
+      "properties": {
+        "object": {
+          "label": "Object",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "object",
+          "qname": "UnknownLink:object",
+          "range": "Thing",
+          "reverse": "unknownLinkFrom",
+          "type": "entity"
+        },
+        "subject": {
+          "label": "Subject",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "subject",
+          "qname": "UnknownLink:subject",
+          "range": "Thing",
+          "reverse": "unknownLinkTo",
+          "type": "entity"
+        }
+      },
+      "required": [
+        "subject",
+        "object"
+      ],
+      "schemata": [
+        "Interest",
+        "Interval",
+        "UnknownLink"
+      ],
+      "temporalExtent": {
+        "end": [
+          "endDate"
+        ],
+        "start": [
+          "startDate",
+          "date"
+        ]
+      }
+    },
+    "UserAccount": {
+      "caption": [
+        "username",
+        "email",
+        "service"
+      ],
+      "extends": [
+        "Thing"
+      ],
+      "featured": [
+        "username",
+        "service",
+        "email",
+        "owner"
+      ],
+      "generated": true,
+      "label": "User account",
+      "matchable": true,
+      "plural": "User accounts",
+      "properties": {
+        "email": {
+          "description": "Email address",
+          "label": "Email",
+          "matchable": true,
+          "maxLength": 250,
+          "name": "email",
+          "qname": "UserAccount:email",
+          "type": "email"
+        },
+        "ipAddress": {
+          "label": "IP address",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "ipAddress",
+          "qname": "UserAccount:ipAddress",
+          "type": "ip"
+        },
+        "messagesReceived": {
+          "label": "Messages received",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "messagesReceived",
+          "qname": "UserAccount:messagesReceived",
+          "range": "Message",
+          "reverse": "recipientAccount",
+          "stub": true,
+          "type": "entity"
+        },
+        "messagesSent": {
+          "label": "Messages sent",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "messagesSent",
+          "qname": "UserAccount:messagesSent",
+          "range": "Message",
+          "reverse": "senderAccount",
+          "stub": true,
+          "type": "entity"
+        },
+        "owner": {
+          "label": "Owner",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "owner",
+          "qname": "UserAccount:owner",
+          "range": "LegalEntity",
+          "reverse": "userAccounts",
+          "type": "entity"
+        },
+        "password": {
+          "label": "Password",
+          "maxLength": 1024,
+          "name": "password",
+          "qname": "UserAccount:password",
+          "type": "string"
+        },
+        "phone": {
+          "description": "Phone number",
+          "label": "Phone",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "phone",
+          "qname": "UserAccount:phone",
+          "type": "phone"
+        },
+        "service": {
+          "label": "Service",
+          "maxLength": 1024,
+          "name": "service",
+          "qname": "UserAccount:service",
+          "type": "string"
+        },
+        "username": {
+          "label": "Username",
+          "maxLength": 1024,
+          "name": "username",
+          "qname": "UserAccount:username",
+          "type": "string"
+        }
+      },
+      "required": [
+        "username"
+      ],
+      "schemata": [
+        "Thing",
+        "UserAccount"
+      ]
+    },
+    "Value": {
+      "abstract": true,
+      "extends": [],
+      "label": "Value",
+      "plural": "Values",
+      "properties": {
+        "amount": {
+          "label": "Amount",
+          "maxLength": 250,
+          "name": "amount",
+          "qname": "Value:amount",
+          "type": "number"
+        },
+        "amountEur": {
+          "label": "Amount in EUR",
+          "maxLength": 250,
+          "name": "amountEur",
+          "qname": "Value:amountEur",
+          "type": "number"
+        },
+        "amountUsd": {
+          "label": "Amount in USD",
+          "maxLength": 250,
+          "name": "amountUsd",
+          "qname": "Value:amountUsd",
+          "type": "number"
+        },
+        "currency": {
+          "label": "Currency",
+          "maxLength": 1024,
+          "name": "currency",
+          "qname": "Value:currency",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Value"
+      ]
+    },
+    "Vehicle": {
+      "caption": [
+        "name",
+        "registrationNumber"
+      ],
+      "extends": [
+        "Asset"
+      ],
+      "featured": [
+        "type",
+        "name",
+        "registrationNumber",
+        "country",
+        "owner"
+      ],
+      "label": "Vehicle",
+      "matchable": true,
+      "plural": "Vehicles",
+      "properties": {
+        "buildDate": {
+          "label": "Build Date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "buildDate",
+          "qname": "Vehicle:buildDate",
+          "type": "date"
+        },
+        "declaredCustoms": {
+          "label": "Customs declarations",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "declaredCustoms",
+          "qname": "Vehicle:declaredCustoms",
+          "range": "EconomicActivity",
+          "reverse": "transport",
+          "stub": true,
+          "type": "entity"
+        },
+        "deregistrationDate": {
+          "label": "De-registration Date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "deregistrationDate",
+          "qname": "Vehicle:deregistrationDate",
+          "type": "date"
+        },
+        "model": {
+          "label": "Model",
+          "maxLength": 1024,
+          "name": "model",
+          "qname": "Vehicle:model",
+          "type": "string"
+        },
+        "operator": {
+          "label": "Operator",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "operator",
+          "qname": "Vehicle:operator",
+          "range": "LegalEntity",
+          "reverse": "operatedVehicles",
+          "type": "entity"
+        },
+        "owner": {
+          "deprecated": true,
+          "description": "Deprecated, use `Ownership` link instead",
+          "label": "Owner",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "owner",
+          "qname": "Vehicle:owner",
+          "range": "LegalEntity",
+          "reverse": "ownedVehicles",
+          "type": "entity"
+        },
+        "registrationDate": {
+          "label": "Registration Date",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "registrationDate",
+          "qname": "Vehicle:registrationDate",
+          "type": "date"
+        },
+        "registrationNumber": {
+          "label": "Registration number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "registrationNumber",
+          "qname": "Vehicle:registrationNumber",
+          "type": "identifier"
+        },
+        "tripsInvolved": {
+          "label": "Trips",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "tripsInvolved",
+          "qname": "Vehicle:tripsInvolved",
+          "range": "Trip",
+          "reverse": "vehicle",
+          "stub": true,
+          "type": "entity"
+        },
+        "type": {
+          "examples": [
+            "Bulk carrier"
+          ],
+          "label": "Type",
+          "maxLength": 1024,
+          "name": "type",
+          "qname": "Vehicle:type",
+          "type": "string"
+        }
+      },
+      "schemata": [
+        "Asset",
+        "Thing",
+        "Value",
+        "Vehicle"
+      ],
+      "temporalExtent": {
+        "end": [
+          "deregistrationDate"
+        ],
+        "start": [
+          "buildDate",
+          "registrationDate"
+        ]
+      }
+    },
+    "Vessel": {
+      "caption": [
+        "name",
+        "imoNumber"
+      ],
+      "description": "A boat or ship. Typically flying some sort of national flag.\n",
+      "extends": [
+        "Vehicle"
+      ],
+      "featured": [
+        "name",
+        "imoNumber",
+        "type",
+        "flag"
+      ],
+      "label": "Vessel",
+      "matchable": true,
+      "plural": "Vessels",
+      "properties": {
+        "callSign": {
+          "label": "Call Sign",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "callSign",
+          "qname": "Vessel:callSign",
+          "type": "identifier"
+        },
+        "crsNumber": {
+          "label": "CRS Number",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "crsNumber",
+          "qname": "Vessel:crsNumber",
+          "type": "identifier"
+        },
+        "deadweightTonnage": {
+          "description": "Weight of the vessel when not carrying freight",
+          "label": "Deadweight Tonnage",
+          "maxLength": 250,
+          "name": "deadweightTonnage",
+          "qname": "Vessel:deadweightTonnage",
+          "type": "number"
+        },
+        "flag": {
+          "label": "Flag",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "flag",
+          "qname": "Vessel:flag",
+          "type": "country"
+        },
+        "grossRegisteredTonnage": {
+          "label": "Gross Registered Tonnage",
+          "maxLength": 250,
+          "name": "grossRegisteredTonnage",
+          "qname": "Vessel:grossRegisteredTonnage",
+          "type": "number"
+        },
+        "imoNumber": {
+          "format": "imo",
+          "label": "IMO Number",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "imoNumber",
+          "qname": "Vessel:imoNumber",
+          "type": "identifier"
+        },
+        "mmsi": {
+          "label": "MMSI",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "mmsi",
+          "qname": "Vessel:mmsi",
+          "type": "identifier"
+        },
+        "nameChangeDate": {
+          "label": "Date of Name Change",
+          "matchable": true,
+          "maxLength": 32,
+          "name": "nameChangeDate",
+          "qname": "Vessel:nameChangeDate",
+          "type": "date"
+        },
+        "navigationArea": {
+          "label": "Navigation Area",
+          "maxLength": 1024,
+          "name": "navigationArea",
+          "qname": "Vessel:navigationArea",
+          "type": "string"
+        },
+        "pastFlags": {
+          "label": "Past Flags",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "pastFlags",
+          "qname": "Vessel:pastFlags",
+          "type": "country"
+        },
+        "pastTypes": {
+          "label": "Past Types",
+          "maxLength": 1024,
+          "name": "pastTypes",
+          "qname": "Vessel:pastTypes",
+          "type": "string"
+        },
+        "registrationPort": {
+          "label": "Port of Registration",
+          "maxLength": 1024,
+          "name": "registrationPort",
+          "qname": "Vessel:registrationPort",
+          "type": "string"
+        },
+        "tonnage": {
+          "label": "Tonnage",
+          "maxLength": 250,
+          "name": "tonnage",
+          "qname": "Vessel:tonnage",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "Asset",
+        "Thing",
+        "Value",
+        "Vehicle",
+        "Vessel"
+      ],
+      "temporalExtent": {
+        "end": [
+          "deregistrationDate"
+        ],
+        "start": [
+          "buildDate",
+          "registrationDate"
+        ]
+      }
+    },
+    "Video": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "extends": [
+        "Document"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "mimeType",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Video",
+      "plural": "Videos",
+      "properties": {
+        "duration": {
+          "description": "Duration of the video in ms",
+          "label": "Duration",
+          "maxLength": 250,
+          "name": "duration",
+          "qname": "Video:duration",
+          "type": "number"
+        }
+      },
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Thing",
+        "Video"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    },
+    "Workbook": {
+      "caption": [
+        "fileName",
+        "title"
+      ],
+      "description": "A spreadsheet document, for example from Excel. Each spreadsheet contains a set of sheets that hold actual data.\n",
+      "extends": [
+        "Folder"
+      ],
+      "featured": [
+        "title",
+        "fileName",
+        "parent"
+      ],
+      "generated": true,
+      "label": "Workbook",
+      "plural": "Workbooks",
+      "properties": {},
+      "schemata": [
+        "Analyzable",
+        "Document",
+        "Folder",
+        "Thing",
+        "Workbook"
+      ],
+      "temporalExtent": {
+        "end": [],
+        "start": [
+          "date",
+          "authoredAt",
+          "publishedAt"
+        ]
+      }
+    }
+  },
+  "types": {
+    "address": {
+      "description": "A geographic address used to describe a location of a residence or post\nbox. There is no specified order for the sub-parts of an address (e.g. street,\ncity, postal code), and we should consider introducing an Address schema type\nto retain fidelity in cases where address parts are specified.",
+      "group": "addresses",
+      "label": "Address",
+      "matchable": true,
+      "maxLength": 250,
+      "pivot": true,
+      "plural": "Addresses"
+    },
+    "checksum": {
+      "description": "Content hashes calculated using SHA1. Checksum references are used by\ndocument-typed entities in Aleph to refer to raw data in the archive\n(e.g. the document from which the entity is extracted).\n\nUnfortunately, this has some security implications: in order to avoid people\ngetting access to documents for which they know the checksum, properties\nof this type are scrubbed when submitted via the normal API. Checksums can only\nbe defined by uploading a document to be ingested.",
+      "group": "checksums",
+      "label": "Checksum",
+      "matchable": true,
+      "maxLength": 40,
+      "pivot": true,
+      "plural": "Checksums"
+    },
+    "country": {
+      "description": "Properties to define countries and territories. This is completely\ndescriptive and needs to deal with data from many origins, so we support\na number of unusual and controversial designations (e.g. the Soviet Union,\nTransnistria, Somaliland, Kosovo).",
+      "group": "countries",
+      "label": "Country",
+      "matchable": true,
+      "maxLength": 16,
+      "plural": "Countries",
+      "values": {
+        "ac": "Ascension Island",
+        "ad": "Andorra",
+        "ae": "United Arab Emirates",
+        "af": "Afghanistan",
+        "ag": "Antigua and Barbuda",
+        "ai": "Anguilla",
+        "al": "Albania",
+        "am": "Armenia",
+        "ao": "Angola",
+        "aq": "Antarctica",
+        "ar": "Argentina",
+        "as": "American Samoa",
+        "at": "Austria",
+        "au": "Australia",
+        "aw": "Aruba",
+        "ax": "Åland Islands",
+        "az": "Azerbaijan",
+        "az-nk": "Artsakh",
+        "ba": "Bosnia and Herzegovina",
+        "bb": "Barbados",
+        "bd": "Bangladesh",
+        "be": "Belgium",
+        "bf": "Burkina Faso",
+        "bg": "Bulgaria",
+        "bh": "Bahrain",
+        "bi": "Burundi",
+        "bj": "Benin",
+        "bl": "Saint Barthélemy",
+        "bm": "Bermuda",
+        "bn": "Brunei",
+        "bo": "Bolivia",
+        "bq": "Bonaire, Sint Eustatius and Saba",
+        "br": "Brazil",
+        "bs": "Bahamas",
+        "bt": "Bhutan",
+        "bv": "Bouvet Island",
+        "bw": "Botswana",
+        "by": "Belarus",
+        "bz": "Belize",
+        "ca": "Canada",
+        "cc": "Cocos (Keeling) Islands",
+        "cd": "DR Congo",
+        "cf": "Central African Republic",
+        "cg": "Congo-Brazzaville",
+        "ch": "Switzerland",
+        "ci": "Côte d'Ivoire",
+        "ck": "Cook Islands",
+        "cl": "Chile",
+        "cm": "Cameroon",
+        "cn": "China",
+        "cn-xz": "Tibet",
+        "co": "Colombia",
+        "cp": "Clipperton Island",
+        "cq": "Sark",
+        "cr": "Costa Rica",
+        "cshh": "Czechoslovakia",
+        "csxx": "Serbia and Montenegro",
+        "cu": "Cuba",
+        "cv": "Cape Verde",
+        "cw": "Curaçao",
+        "cx": "Christmas Island",
+        "cy": "Cyprus",
+        "cy-trnc": "Northern Cyprus",
+        "cz": "Czechia",
+        "dd": "East Germany",
+        "de": "Germany",
+        "dg": "Diego Garcia",
+        "dj": "Djibouti",
+        "dk": "Denmark",
+        "dm": "Dominica",
+        "do": "Dominican Republic",
+        "dz": "Algeria",
+        "ec": "Ecuador",
+        "ee": "Estonia",
+        "eg": "Egypt",
+        "eh": "Western Sahara",
+        "er": "Eritrea",
+        "es": "Spain",
+        "et": "Ethiopia",
+        "eu": "European Union",
+        "fi": "Finland",
+        "fj": "Fiji",
+        "fk": "Falkland Islands",
+        "fm": "Micronesia",
+        "fo": "Faroe Islands",
+        "fr": "France",
+        "ga": "Gabon",
+        "gb": "United Kingdom",
+        "gb-nir": "Northern Ireland",
+        "gb-sct": "Scotland",
+        "gb-wls": "Wales",
+        "gd": "Grenada",
+        "ge": "Georgia",
+        "ge-ab": "Abkhazia (Occupied Georgia)",
+        "gf": "French Guiana",
+        "gg": "Guernsey",
+        "gh": "Ghana",
+        "gi": "Gibraltar",
+        "gl": "Greenland",
+        "gm": "Gambia",
+        "gn": "Guinea",
+        "gp": "Guadeloupe",
+        "gq": "Equatorial Guinea",
+        "gr": "Greece",
+        "gs": "South Georgia and the South Sandwich Islands",
+        "gt": "Guatemala",
+        "gu": "Guam",
+        "gw": "Guinea-Bissau",
+        "gy": "Guyana",
+        "hk": "Hong Kong SAR",
+        "hm": "Heard and McDonald Islands",
+        "hn": "Honduras",
+        "hr": "Croatia",
+        "ht": "Haiti",
+        "hu": "Hungary",
+        "ic": "Canary Islands",
+        "id": "Indonesia",
+        "ie": "Ireland",
+        "il": "Israel",
+        "im": "Isle of Man",
+        "in": "India",
+        "io": "British Indian Ocean Territory",
+        "ip": "Cyberspace",
+        "iq": "Iraq",
+        "iq-kr": "Kurdistan",
+        "ir": "Iran",
+        "is": "Iceland",
+        "it": "Italy",
+        "je": "Jersey",
+        "jm": "Jamaica",
+        "jo": "Jordan",
+        "jp": "Japan",
+        "ke": "Kenya",
+        "kg": "Kyrgyzstan",
+        "kh": "Cambodia",
+        "ki": "Kiribati",
+        "km": "Comoros",
+        "kn": "Saint Kitts and Nevis",
+        "kp": "North Korea",
+        "kr": "South Korea",
+        "kw": "Kuwait",
+        "ky": "Cayman Islands",
+        "kz": "Kazakhstan",
+        "la": "Laos",
+        "lb": "Lebanon",
+        "lc": "Saint Lucia",
+        "li": "Liechtenstein",
+        "lk": "Sri Lanka",
+        "lr": "Liberia",
+        "ls": "Lesotho",
+        "lt": "Lithuania",
+        "lu": "Luxembourg",
+        "lv": "Latvia",
+        "ly": "Libya",
+        "ma": "Morocco",
+        "mc": "Monaco",
+        "md": "Moldova",
+        "md-pmr": "Transnistria",
+        "me": "Montenegro",
+        "mf": "Saint Martin",
+        "mg": "Madagascar",
+        "mh": "Marshall Islands",
+        "mk": "North Macedonia",
+        "ml": "Mali",
+        "mm": "Myanmar",
+        "mn": "Mongolia",
+        "mo": "Macao SAR",
+        "mp": "Northern Mariana Islands",
+        "mq": "Martinique",
+        "mr": "Mauritania",
+        "ms": "Montserrat",
+        "mt": "Malta",
+        "mu": "Mauritius",
+        "mv": "Maldives",
+        "mw": "Malawi",
+        "mx": "Mexico",
+        "my": "Malaysia",
+        "mz": "Mozambique",
+        "na": "Namibia",
+        "nc": "New Caledonia",
+        "ne": "Niger",
+        "nf": "Norfolk Island",
+        "ng": "Nigeria",
+        "ni": "Nicaragua",
+        "nl": "Netherlands",
+        "no": "Norway",
+        "np": "Nepal",
+        "nr": "Naoero",
+        "nu": "Niue",
+        "nz": "New Zealand",
+        "om": "Oman",
+        "pa": "Panama",
+        "pe": "Peru",
+        "pf": "French Polynesia",
+        "pg": "Papua New Guinea",
+        "ph": "Philippines",
+        "pk": "Pakistan",
+        "pk-km": "Kashmir",
+        "pl": "Poland",
+        "pm": "Saint Pierre and Miquelon",
+        "pn": "Pitcairn",
+        "pr": "Puerto Rico",
+        "ps": "Palestine",
+        "pt": "Portugal",
+        "pw": "Palau",
+        "py": "Paraguay",
+        "qa": "Qatar",
+        "re": "Réunion",
+        "ro": "Romania",
+        "rs": "Serbia",
+        "ru": "Russia",
+        "rw": "Rwanda",
+        "sa": "Saudi Arabia",
+        "sb": "Solomon Islands",
+        "sc": "Seychelles",
+        "sd": "Sudan",
+        "se": "Sweden",
+        "sg": "Singapore",
+        "sh": "Saint Helena, Ascension and Tristan da Cunha",
+        "si": "Slovenia",
+        "sj": "Svalbard and Jan Mayen",
+        "sk": "Slovakia",
+        "sl": "Sierra Leone",
+        "sm": "San Marino",
+        "sn": "Senegal",
+        "so": "Somalia",
+        "so-som": "Somaliland",
+        "sr": "Suriname",
+        "ss": "South Sudan",
+        "st": "São Tomé and Príncipe",
+        "suhh": "Soviet Union",
+        "sv": "El Salvador",
+        "sx": "Sint Maarten",
+        "sy": "Syria",
+        "sz": "Eswatini",
+        "ta": "Tristan da Cunha",
+        "tc": "Turks and Caicos Islands",
+        "td": "Chad",
+        "tf": "French Southern Territories",
+        "tg": "Togo",
+        "th": "Thailand",
+        "tj": "Tajikistan",
+        "tk": "Tokelau",
+        "tl": "Timor-Leste",
+        "tm": "Turkmenistan",
+        "tn": "Tunisia",
+        "to": "Tonga",
+        "tr": "Türkiye",
+        "tt": "Trinidad and Tobago",
+        "tv": "Tuvalu",
+        "tw": "Taiwan",
+        "tz": "Tanzania",
+        "ua": "Ukraine",
+        "ua-cri": "Crimea (Occupied Ukraine)",
+        "ua-dpr": "Donetsk (Occupied Ukraine)",
+        "ua-lpr": "Luhansk (Occupied Ukraine)",
+        "ug": "Uganda",
+        "um": "U.S. Outlying Islands",
+        "un": "United Nations",
+        "us": "United States",
+        "uy": "Uruguay",
+        "uz": "Uzbekistan",
+        "va": "Holy See",
+        "vc": "Saint Vincent and the Grenadines",
+        "ve": "Venezuela",
+        "vg": "British Virgin Islands",
+        "vi": "U.S. Virgin Islands",
+        "vn": "Vietnam",
+        "vu": "Vanuatu",
+        "wf": "Wallis and Futuna",
+        "ws": "Samoa",
+        "x-so": "South Ossetia (Occupied Georgia)",
+        "xk": "Kosovo",
+        "ye": "Yemen",
+        "yt": "Mayotte",
+        "yucs": "Yugoslavia",
+        "za": "South Africa",
+        "zm": "Zambia",
+        "zr": "Zaire",
+        "zw": "Zimbabwe",
+        "zz": "Global"
+      }
+    },
+    "date": {
+      "description": "A date or time stamp. This is based on ISO 8601, but meant to allow for different\ndegrees of precision by specifying a prefix. This means that `2021`, `2021-02`,\n`2021-02-16`, `2021-02-16T21`, `2021-02-16T21:48` and `2021-02-16T21:48:52`\nare all valid values, with an implied precision.\n\nThe timezone is always expected to be UTC and cannot be specified otherwise. There is\nno support for calendar weeks (`2021-W7`) and date ranges (`2021-2024`).",
+      "group": "dates",
+      "label": "Date",
+      "matchable": true,
+      "maxLength": 32,
+      "plural": "Dates"
+    },
+    "email": {
+      "description": "Internet mail address (e.g. user@example.com). These are notoriously hard\nto validate, but we use an irresponsibly simple rule and hope for the best.",
+      "group": "emails",
+      "label": "E-Mail Address",
+      "matchable": true,
+      "maxLength": 250,
+      "pivot": true,
+      "plural": "E-Mail Addresses"
+    },
+    "entity": {
+      "description": "A reference to another entity via its ID. This is how entities in FtM\nbecome a graph: by pointing at each other using references.\n\nEntity IDs can either be `namespaced` or `plain`, depending on the context.\nWhen setting properties of this type, you can pass in an entity proxy or\ndict of the entity, the ID will then be extracted and stored.",
+      "group": "entities",
+      "label": "Entity",
+      "matchable": true,
+      "maxLength": 200,
+      "pivot": true,
+      "plural": "Entities"
+    },
+    "gender": {
+      "description": "A human gender. This is not meant to be a comprehensive model of\nthe social realities of gender but a way to capture data from (mostly)\ngovernment databases and represent it in a way that can be used by\nstructured tools. I'm not sure this justifies the simplification.",
+      "group": "genders",
+      "label": "Gender",
+      "maxLength": 16,
+      "plural": "Genders",
+      "values": {
+        "female": "female",
+        "male": "male",
+        "other": "other"
+      }
+    },
+    "html": {
+      "description": "Properties that contain raw hypertext markup (HTML).\n\nUser interfaces rendering properties of this type need to take extreme\ncare not to allow attacks such as cross-site scripting. It is recommended\nto perform server-side sanitisation, or to not render this property at all.",
+      "label": "HTML",
+      "maxLength": 65000,
+      "plural": "HTMLs"
+    },
+    "identifier": {
+      "description": "Used for registration numbers and other codes assigned by an authority\nto identify an entity. This might include tax identifiers and statistical\ncodes.\n\nSince identifiers are high-value criteria when comparing two entities, numbers\nshould only be modelled as identifiers if they are long enough to be meaningful.\nFour- or five-digit industry classifiers create more noise than value.",
+      "group": "identifiers",
+      "label": "Identifier",
+      "matchable": true,
+      "maxLength": 64,
+      "pivot": true,
+      "plural": "Identifiers"
+    },
+    "ip": {
+      "description": "Internet protocol addresses. This supports both addresses used\nby the protocol versions 4 (e.g. `192.168.1.143`) and 6\n(e.g. `0:0:0:0:0:ffff:c0a8:18f`).",
+      "group": "ips",
+      "label": "IP Address",
+      "matchable": true,
+      "maxLength": 64,
+      "pivot": true,
+      "plural": "IP Addresses"
+    },
+    "json": {
+      "description": "An encoded JSON object. This is used to store raw HTTP headers for documents\nand some other edge cases. It's a really bad idea and we should try to get rid\nof JSON properties.",
+      "label": "Nested data",
+      "maxLength": 250,
+      "plural": "Nested data"
+    },
+    "language": {
+      "description": "A human written language. This list is arbitrarily limited for some\nweird upstream technical reasons, but we'll happily accept pull requests\nfor additional languages once there is a specific need for them to be\nsupported.",
+      "group": "languages",
+      "label": "Language",
+      "maxLength": 16,
+      "plural": "Languages",
+      "values": {
+        "afr": "Afrikaans",
+        "amh": "Amharic",
+        "ara": "Arabic",
+        "aze": "Azerbaijani",
+        "bel": "Belarusian",
+        "ben": "Bangla",
+        "bos": "Bosnian",
+        "bul": "Bulgarian",
+        "cat": "Catalan",
+        "ces": "Czech",
+        "cnr": "Montenegrin",
+        "dan": "Danish",
+        "deu": "German",
+        "ell": "Greek",
+        "eng": "English",
+        "est": "Estonian",
+        "fas": "Persian",
+        "fil": "Filipino",
+        "fin": "Finnish",
+        "fra": "French",
+        "gle": "Irish",
+        "heb": "Hebrew",
+        "hin": "Hindi",
+        "hrv": "Croatian",
+        "hun": "Hungarian",
+        "hye": "Armenian",
+        "ind": "Indonesian",
+        "isl": "Icelandic",
+        "ita": "Italian",
+        "jpn": "Japanese",
+        "kan": "Kannada",
+        "kat": "Georgian",
+        "kaz": "Kazakh",
+        "khm": "Khmer",
+        "kir": "Kyrgyz",
+        "kor": "Korean",
+        "lao": "Lao",
+        "lav": "Latvian",
+        "lit": "Lithuanian",
+        "ltz": "Luxembourgish",
+        "mkd": "Macedonian",
+        "mlt": "Maltese",
+        "mon": "Mongolian",
+        "msa": "Malay",
+        "mya": "Burmese",
+        "nep": "Nepali",
+        "nld": "Dutch",
+        "nor": "Norwegian",
+        "pol": "Polish",
+        "por": "Portuguese",
+        "pus": "Pashto",
+        "ron": "Romanian",
+        "rus": "Russian",
+        "sin": "Sinhala",
+        "slk": "Slovak",
+        "slv": "Slovenian",
+        "spa": "Spanish",
+        "sqi": "Albanian",
+        "srp": "Serbian",
+        "swa": "Swahili",
+        "swe": "Swedish",
+        "tam": "Tamil",
+        "tel": "Telugu",
+        "tgk": "Tajik",
+        "tgl": "Tagalog",
+        "tha": "Thai",
+        "tuk": "Turkmen",
+        "tur": "Turkish",
+        "ukr": "Ukrainian",
+        "urd": "Urdu",
+        "uzb": "Uzbek",
+        "vie": "Vietnamese",
+        "zho": "Chinese"
+      }
+    },
+    "mimetype": {
+      "description": "A MIME media type are a specification of a content type on a network.\nEach MIME type is assigned by IANA and consists of two parts: the type\nand sub-type. Common examples are: `text/plain`, `application/json` and\n`application/pdf`.\n\nMIME type properties do not contain parameters as used in HTTP headers,\nlike `charset=UTF-8`.",
+      "group": "mimetypes",
+      "label": "MIME-Type",
+      "maxLength": 250,
+      "plural": "MIME-Types"
+    },
+    "name": {
+      "description": "A name used for a person or company. This is assumed to be as complete\na name as available - when a first name, family name or patronymic are given\nseparately, these are stored to string-type properties instead.\n\nNo validation rules apply, and things having multiple names must be considered\na perfectly ordinary case.",
+      "group": "names",
+      "label": "Name",
+      "matchable": true,
+      "maxLength": 384,
+      "pivot": true,
+      "plural": "Names"
+    },
+    "number": {
+      "description": "A numeric value, like the size of a piece of land, or the value of a\ncontract. Since all property values in FtM are strings, this is also a\nstring and there is no specified format (e.g. `1,000.00` vs. `1.000,00`).\n\nIn the future we might want to enable annotations for format, units, or\neven to introduce a separate property type for monetary values.",
+      "label": "Number",
+      "maxLength": 250,
+      "plural": "Numbers"
+    },
+    "phone": {
+      "description": "A phone number in E.164 format, i.e. one that always carries an\ninternational dialing prefix (e.g. `+38760183628`).\n\nSource data often gives numbers in national format, without that prefix. Pass\nthe country the number is dialed in as the `format` hint to have the prefix\napplied, e.g. `entity.add(\"phone\", \"017623423980\", format=\"de\")`. A number\nthat is neither in international format nor accompanied by a hint is rejected.",
+      "group": "phones",
+      "label": "Phone number",
+      "matchable": true,
+      "maxLength": 64,
+      "pivot": true,
+      "plural": "Phone numbers"
+    },
+    "string": {
+      "description": "A simple string property with no additional semantics.",
+      "label": "Label",
+      "maxLength": 1024,
+      "plural": "Labels"
+    },
+    "text": {
+      "description": "Longer text fragments, such as descriptions or document text. Unlike\nstring properties, it might make sense to treat properties of this type as\nfull-text search material.",
+      "label": "Text",
+      "maxLength": 65000,
+      "plural": "Texts"
+    },
+    "topic": {
+      "description": "Topics define a controlled vocabulary of terms applicable to some\nentities, such as companies and people. They describe categories of\njournalistic interest which may apply to the given entity, for example\nif a given person is a criminal or a politician.\n\nBesides the informative value, topics are ultimately supposed to bear\nfruits in the context of graph-based data analysis, where they would\nenable queries such as _find all paths between a government procurement\naward and a politician_.",
+      "group": "topics",
+      "label": "Topic",
+      "maxLength": 64,
+      "plural": "Topics",
+      "values": {
+        "asset.frozen": "Frozen asset",
+        "corp.disqual": "Disqualified",
+        "corp.offshore": "Offshore",
+        "corp.public": "Public listed company",
+        "corp.shell": "Shell company",
+        "crime": "Crime",
+        "crime.boss": "Criminal leadership",
+        "crime.cyber": "Cybercrime",
+        "crime.env": "Environmental violations",
+        "crime.fin": "Financial crime",
+        "crime.fraud": "Fraud",
+        "crime.terror": "Terrorism",
+        "crime.theft": "Theft",
+        "crime.traffick": "Trafficking",
+        "crime.traffick.drug": "Drug trafficking",
+        "crime.traffick.human": "Human trafficking",
+        "crime.war": "War crimes",
+        "debarment": "Debarred",
+        "export.control": "Export controlled",
+        "export.control.linked": "Export control-linked",
+        "export.risk": "Trade risk",
+        "fin": "Financial services",
+        "fin.adivsor": "Financial advisor",
+        "fin.bank": "Bank",
+        "fin.fund": "Fund",
+        "forced.labor": "Forced labor",
+        "gov": "Government",
+        "gov.admin": "Civil service",
+        "gov.executive": "Executive branch of government",
+        "gov.financial": "Central banking and financial integrity",
+        "gov.head": "Head of government or state",
+        "gov.igo": "Intergovernmental organization",
+        "gov.judicial": "Judicial branch of government",
+        "gov.legislative": "Legislative branch of government",
+        "gov.muni": "Municipal government",
+        "gov.national": "National government",
+        "gov.religion": "Religious leadership",
+        "gov.security": "Security services",
+        "gov.soe": "State-owned enterprise",
+        "gov.state": "State government",
+        "invest.ban": "Investment ban",
+        "invest.risk": "Investment risk",
+        "mare.detained": "Maritime detention",
+        "mare.shadow": "Shadow fleet",
+        "mare.sts": "Ship-to-ship transfer",
+        "mil": "Military",
+        "poi": "Person of interest",
+        "pol.party": "Political party",
+        "pol.union": "Union",
+        "reg.action": "Regulator action",
+        "reg.warn": "Regulator warning",
+        "rel": "Religion",
+        "role.acct": "Accountant",
+        "role.act": "Activist",
+        "role.civil": "Civil servant",
+        "role.diplo": "Diplomat",
+        "role.journo": "Journalist",
+        "role.judge": "Judge",
+        "role.lawyer": "Lawyer",
+        "role.lobby": "Lobbyist",
+        "role.oligarch": "Oligarch",
+        "role.pep": "PEP",
+        "role.pep.frmr": "Former PEP",
+        "role.pep.intl": "International PEP",
+        "role.pep.natl": "National PEP",
+        "role.pol": "Politician",
+        "role.rca": "Close Associate",
+        "role.spy": "Spy",
+        "sanction": "Sanctioned",
+        "sanction.control": "Sanction ownership or control",
+        "sanction.counter": "Counter-sanctioned",
+        "sanction.linked": "Sanction-linked",
+        "wanted": "Wanted"
+      }
+    },
+    "url": {
+      "description": "A uniform resource locator (URL). This will perform some normalisation\non the URL so that it's sure to be using valid encoding/quoting, and to\nmake sure the URL has a schema (e.g. `http`, `https`, ...).",
+      "group": "urls",
+      "label": "URL",
+      "matchable": true,
+      "maxLength": 4096,
+      "pivot": true,
+      "plural": "URLs"
+    }
+  },
+  "version": "4.10.2"
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 public class ModelEntityTest {
     @Test(expected = UnsupportedOperationException.class)
@@ -79,6 +80,49 @@ public class ModelEntityTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_refuses_an_empty_collection() {
         ModelEntity.from(List.of());
+    }
+
+    @Test
+    public void test_a_null_id_is_rejected() {
+        try {
+            new ModelEntity(null, Set.of("Person"), Map.of("name", List.of("Jane Doe")));
+            fail("should have rejected a null id");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("id");
+        }
+    }
+
+    @Test
+    public void test_null_types_are_rejected() {
+        try {
+            new ModelEntity("p-1", null, Map.of("name", List.of("Jane Doe")));
+            fail("should have rejected null types");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("types");
+        }
+    }
+
+    @Test
+    public void test_null_properties_are_rejected() {
+        try {
+            new ModelEntity("p-1", Set.of("Person"), null);
+            fail("should have rejected null properties");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("properties");
+        }
+    }
+
+    @Test
+    public void test_refuses_statements_belonging_to_two_models() {
+        try {
+            ModelEntity.from(List.of(statement("name", "Jane Doe", "full_name"),
+                    Statement.of("wikidata", "person-1", "Q5", "name", "Jane Q",
+                            new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))));
+            fail("should have refused statements from two models");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("ftm");
+            assertThat(e.getMessage()).contains("wikidata");
+        }
     }
 
     private Statement statement(String property, String value, String column) {

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -2,11 +2,40 @@ package org.icij.datashare.model;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 public class ModelEntityTest {
+    @Test(expected = UnsupportedOperationException.class)
+    public void test_the_types_are_immutable() {
+        ModelEntity entity = new ModelEntity("p-1", new HashSet<>(Set.of("Person")),
+                new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
+
+        entity.types().add("Company");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void test_the_properties_map_is_immutable() {
+        ModelEntity entity = new ModelEntity("p-1", new HashSet<>(Set.of("Person")),
+                new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
+
+        entity.properties().put("birthDate", List.of("1980-04-02"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void test_a_properties_value_list_is_immutable() {
+        ModelEntity entity = new ModelEntity("p-1", new HashSet<>(Set.of("Person")),
+                new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
+
+        entity.properties().get("name").add("J. Doe");
+    }
+
     @Test
     public void test_groups_the_values_of_a_property_in_order() {
         ModelEntity entity = ModelEntity.from(List.of(

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -11,7 +11,6 @@ import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 public class ModelEntityTest {
     @Test
@@ -71,36 +70,24 @@ public class ModelEntityTest {
     }
 
     @Test
-    public void test_a_null_id_is_rejected() {
-        try {
-            new ModelEntity(null, Set.of("Person"), Map.of("name", List.of("Jane Doe")));
-            fail("should have rejected a null id");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("id");
-        }
+    public void test_the_null_arguments_are_rejected() {
+        assertRejectsNull("id", () -> new ModelEntity(null, Set.of("Person"), Map.of("name", List.of("Jane Doe"))));
+        assertRejectsNull("types", () -> new ModelEntity("p-1", null, Map.of("name", List.of("Jane Doe"))));
     }
 
-    @Test
-    public void test_null_types_are_rejected() {
-        try {
-            new ModelEntity("p-1", null, Map.of("name", List.of("Jane Doe")));
-            fail("should have rejected null types");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("types");
-        }
+    private static void assertRejectsNull(String field, Runnable construction) {
+        assertThat(assertThrows(NullPointerException.class, construction::run).getMessage()).contains(field);
     }
 
     @Test
     public void test_refuses_statements_belonging_to_two_models() {
-        try {
-            ModelEntity.from(List.of(statement("name", "Jane Doe", "full_name"),
-                    Statement.of("wikidata", "person-1", "Q5", "name", "Jane Q",
-                            new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))));
-            fail("should have refused statements from two models");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("ftm");
-            assertThat(e.getMessage()).contains("wikidata");
-        }
+        String message = assertThrows(IllegalArgumentException.class, () ->
+                ModelEntity.from(List.of(statement("name", "Jane Doe", "full_name"),
+                        Statement.of("wikidata", "person-1", "Q5", "name", "Jane Q",
+                                new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))))).getMessage();
+
+        assertThat(message).contains("ftm");
+        assertThat(message).contains("wikidata");
     }
 
     private Statement statement(String property, String value, String column) {

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -10,31 +10,19 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class ModelEntityTest {
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_the_types_are_immutable() {
+    @Test
+    public void test_the_entity_copies_the_collections_it_was_handed() {
         ModelEntity entity = new ModelEntity("p-1", new HashSet<>(Set.of("Person")),
                 new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
 
-        entity.types().add("Company");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_the_properties_map_is_immutable() {
-        ModelEntity entity = new ModelEntity("p-1", new HashSet<>(Set.of("Person")),
-                new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
-
-        entity.properties().put("birthDate", List.of("1980-04-02"));
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_a_properties_value_list_is_immutable() {
-        ModelEntity entity = new ModelEntity("p-1", new HashSet<>(Set.of("Person")),
-                new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
-
-        entity.properties().get("name").add("J. Doe");
+        assertThrows(UnsupportedOperationException.class, () -> entity.types().add("Company"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> entity.properties().put("birthDate", List.of("1980-04-02")));
+        assertThrows(UnsupportedOperationException.class, () -> entity.properties().get("name").add("J. Doe"));
     }
 
     @Test

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -1,0 +1,59 @@
+package org.icij.datashare.model;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ModelEntityTest {
+    @Test
+    public void test_groups_the_values_of_a_property_in_order() {
+        ModelEntity entity = ModelEntity.from(List.of(
+                statement("name", "Jane Doe", "full_name"),
+                statement("birthDate", "1980-04-02", "dob"),
+                statement("name", "J. Doe", "known_as")));
+
+        assertThat(entity.id()).isEqualTo("person-1");
+        assertThat(entity.types()).containsOnly("Person");
+        assertThat(entity.properties().get("name")).containsExactly("Jane Doe", "J. Doe");
+        assertThat(entity.properties().get("birthDate")).containsExactly("1980-04-02");
+    }
+
+    @Test
+    public void test_unions_the_types_of_the_statements() {
+        ModelEntity entity = ModelEntity.from(List.of(
+                statement("name", "Jane Doe", "full_name"),
+                Statement.of("ftm", "person-1", "LegalEntity", "name", "Jane Doe",
+                        new Statement.Provenance("doc-2", null, 3, "counterparty"))));
+
+        assertThat(entity.types()).containsOnly("Person", "LegalEntity");
+    }
+
+    @Test
+    public void test_the_same_value_from_two_cells_is_two_statements_but_one_value() {
+        ModelEntity entity = ModelEntity.from(List.of(
+                statement("name", "Jane Doe", "full_name"),
+                statement("name", "Jane Doe", "legal_name")));
+
+        assertThat(entity.properties().get("name")).containsExactly("Jane Doe");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_refuses_statements_belonging_to_two_entities() {
+        ModelEntity.from(List.of(
+                statement("name", "Jane Doe", "full_name"),
+                Statement.of("ftm", "person-2", "Person", "name", "John Doe",
+                        new Statement.Provenance("doc-1", "Sheet1", 13, "full_name"))));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_refuses_an_empty_collection() {
+        ModelEntity.from(List.of());
+    }
+
+    private Statement statement(String property, String value, String column) {
+        return Statement.of("ftm", "person-1", "Person", property, value,
+                new Statement.Provenance("doc-1", "Sheet1", 12, column));
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -103,16 +103,6 @@ public class ModelEntityTest {
     }
 
     @Test
-    public void test_null_properties_are_rejected() {
-        try {
-            new ModelEntity("p-1", Set.of("Person"), null);
-            fail("should have rejected null properties");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("properties");
-        }
-    }
-
-    @Test
     public void test_refuses_statements_belonging_to_two_models() {
         try {
             ModelEntity.from(List.of(statement("name", "Jane Doe", "full_name"),

--- a/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.model;
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class StatementTest {
@@ -77,93 +78,22 @@ public class StatementTest {
     }
 
     @Test
-    public void test_a_null_id_is_rejected() {
-        try {
-            new Statement(null, "ftm", "person-1", "Person", "name", "Jane Doe", provenance);
-            fail("should have rejected a null id");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("id");
-        }
+    public void test_a_null_component_is_rejected_and_names_the_field() {
+        assertRejectsNull("id", () -> new Statement(null, "ftm", "person-1", "Person", "name", "Jane Doe", provenance));
+        assertRejectsNull("model", () -> new Statement("id", null, "person-1", "Person", "name", "Jane Doe", provenance));
+        assertRejectsNull("entityId", () -> new Statement("id", "ftm", null, "Person", "name", "Jane Doe", provenance));
+        assertRejectsNull("entityType", () -> new Statement("id", "ftm", "person-1", null, "name", "Jane Doe", provenance));
+        assertRejectsNull("property", () -> new Statement("id", "ftm", "person-1", "Person", null, "Jane Doe", provenance));
+        assertRejectsNull("value", () -> new Statement("id", "ftm", "person-1", "Person", "name", null, provenance));
+        assertRejectsNull("provenance", () -> new Statement("id", "ftm", "person-1", "Person", "name", "Jane Doe", null));
+        assertRejectsNull("documentId", () -> new Statement.Provenance(null, "Sheet1", 12, "full_name"));
+        assertRejectsNull("column", () -> new Statement.Provenance("doc-1", "Sheet1", 12, null));
     }
 
-    @Test
-    public void test_a_null_model_is_rejected() {
-        try {
-            new Statement("id", null, "person-1", "Person", "name", "Jane Doe", provenance);
-            fail("should have rejected a null model");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("model");
-        }
-    }
-
-    @Test
-    public void test_a_null_entity_id_is_rejected() {
-        try {
-            new Statement("id", "ftm", null, "Person", "name", "Jane Doe", provenance);
-            fail("should have rejected a null entityId");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("entityId");
-        }
-    }
-
-    @Test
-    public void test_a_null_entity_type_is_rejected() {
-        try {
-            new Statement("id", "ftm", "person-1", null, "name", "Jane Doe", provenance);
-            fail("should have rejected a null entityType");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("entityType");
-        }
-    }
-
-    @Test
-    public void test_a_null_property_is_rejected() {
-        try {
-            new Statement("id", "ftm", "person-1", "Person", null, "Jane Doe", provenance);
-            fail("should have rejected a null property");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("property");
-        }
-    }
-
-    @Test
-    public void test_a_null_value_is_rejected() {
-        try {
-            new Statement("id", "ftm", "person-1", "Person", "name", null, provenance);
-            fail("should have rejected a null value");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("value");
-        }
-    }
-
-    @Test
-    public void test_a_null_provenance_is_rejected() {
-        try {
-            new Statement("id", "ftm", "person-1", "Person", "name", "Jane Doe", null);
-            fail("should have rejected a null provenance");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("provenance");
-        }
-    }
-
-    @Test
-    public void test_a_null_document_id_is_rejected() {
-        try {
-            new Statement.Provenance(null, "Sheet1", 12, "full_name");
-            fail("should have rejected a null documentId");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("documentId");
-        }
-    }
-
-    @Test
-    public void test_a_null_column_is_rejected() {
-        try {
-            new Statement.Provenance("doc-1", "Sheet1", 12, null);
-            fail("should have rejected a null column");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("column");
-        }
+    // Every component is guarded the same way, so the field the message names is the only thing worth
+    // pinning: a copy-pasted guard naming its neighbour is what this catches.
+    private static void assertRejectsNull(String field, Runnable construction) {
+        assertThat(assertThrows(NullPointerException.class, construction::run).getMessage()).contains(field);
     }
 
     @Test

--- a/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.model;
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 public class StatementTest {
     private final Statement.Provenance provenance = new Statement.Provenance("doc-1", "Sheet1", 12, "full_name");
@@ -31,17 +32,112 @@ public class StatementTest {
                 new Statement.Provenance("doc-1", "Sheet1", 12, "legal_name"));
         Statement three = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
                 new Statement.Provenance("doc-1", "Sheet2", 12, "full_name"));
+        Statement four = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                new Statement.Provenance("doc-1", "Sheet1", 13, "full_name"));
 
         assertThat(one.id()).isNotEqualTo(two.id());
         assertThat(one.id()).isNotEqualTo(three.id());
+        assertThat(one.id()).isNotEqualTo(four.id());
     }
 
     @Test
     public void test_a_single_table_source_has_no_sheet() {
-        Statement statement = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+        Statement withNullSheet = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
                 new Statement.Provenance("doc-1", null, 1, "full_name"));
+        Statement withEmptySheet = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                new Statement.Provenance("doc-1", "", 1, "full_name"));
 
-        assertThat(statement.id().length()).isEqualTo(96);
+        assertThat(withNullSheet.id()).isEqualTo(withEmptySheet.id());
+    }
+
+    @Test
+    public void test_a_null_id_is_rejected() {
+        try {
+            new Statement(null, "ftm", "person-1", "Person", "name", "Jane Doe", provenance);
+            fail("should have rejected a null id");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("id");
+        }
+    }
+
+    @Test
+    public void test_a_null_model_is_rejected() {
+        try {
+            new Statement("id", null, "person-1", "Person", "name", "Jane Doe", provenance);
+            fail("should have rejected a null model");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("model");
+        }
+    }
+
+    @Test
+    public void test_a_null_entity_id_is_rejected() {
+        try {
+            new Statement("id", "ftm", null, "Person", "name", "Jane Doe", provenance);
+            fail("should have rejected a null entityId");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("entityId");
+        }
+    }
+
+    @Test
+    public void test_a_null_entity_type_is_rejected() {
+        try {
+            new Statement("id", "ftm", "person-1", null, "name", "Jane Doe", provenance);
+            fail("should have rejected a null entityType");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("entityType");
+        }
+    }
+
+    @Test
+    public void test_a_null_property_is_rejected() {
+        try {
+            new Statement("id", "ftm", "person-1", "Person", null, "Jane Doe", provenance);
+            fail("should have rejected a null property");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("property");
+        }
+    }
+
+    @Test
+    public void test_a_null_value_is_rejected() {
+        try {
+            new Statement("id", "ftm", "person-1", "Person", "name", null, provenance);
+            fail("should have rejected a null value");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("value");
+        }
+    }
+
+    @Test
+    public void test_a_null_provenance_is_rejected() {
+        try {
+            new Statement("id", "ftm", "person-1", "Person", "name", "Jane Doe", null);
+            fail("should have rejected a null provenance");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("provenance");
+        }
+    }
+
+    @Test
+    public void test_a_null_document_id_is_rejected() {
+        try {
+            new Statement.Provenance(null, "Sheet1", 12, "full_name");
+            fail("should have rejected a null documentId");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("documentId");
+        }
+    }
+
+    @Test
+    public void test_a_null_column_is_rejected() {
+        try {
+            new Statement.Provenance("doc-1", "Sheet1", 12, null);
+            fail("should have rejected a null column");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("column");
+        }
     }
 
     @Test

--- a/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
@@ -1,0 +1,53 @@
+package org.icij.datashare.model;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class StatementTest {
+    private final Statement.Provenance provenance = new Statement.Provenance("doc-1", "Sheet1", 12, "full_name");
+
+    @Test
+    public void test_the_same_fact_gets_the_same_id() {
+        Statement one = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe", provenance);
+        Statement two = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe", provenance);
+
+        assertThat(one.id()).isEqualTo(two.id());
+        assertThat(one.id().length()).isEqualTo(96);
+    }
+
+    @Test
+    public void test_the_id_changes_with_the_value() {
+        Statement one = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe", provenance);
+        Statement two = Statement.of("ftm", "person-1", "Person", "name", "Jane Doa", provenance);
+
+        assertThat(one.id()).isNotEqualTo(two.id());
+    }
+
+    @Test
+    public void test_the_id_changes_with_the_cell_it_came_from() {
+        Statement one = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe", provenance);
+        Statement two = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                new Statement.Provenance("doc-1", "Sheet1", 12, "legal_name"));
+        Statement three = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                new Statement.Provenance("doc-1", "Sheet2", 12, "full_name"));
+
+        assertThat(one.id()).isNotEqualTo(two.id());
+        assertThat(one.id()).isNotEqualTo(three.id());
+    }
+
+    @Test
+    public void test_a_single_table_source_has_no_sheet() {
+        Statement statement = Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                new Statement.Provenance("doc-1", null, 1, "full_name"));
+
+        assertThat(statement.id().length()).isEqualTo(96);
+    }
+
+    @Test
+    public void test_the_qualified_property_prefixes_the_model() {
+        Statement statement = Statement.of("ftm", "person-1", "Person", "birthDate", "1980-04-02", provenance);
+
+        assertThat(statement.qualifiedProperty()).isEqualTo("ftm:birthDate");
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
@@ -51,6 +51,32 @@ public class StatementTest {
     }
 
     @Test
+    public void test_a_null_sheet_and_an_empty_sheet_are_the_same_provenance() {
+        assertThat(new Statement.Provenance("doc-1", null, 1, "full_name"))
+                .isEqualTo(new Statement.Provenance("doc-1", "", 1, "full_name"));
+    }
+
+    @Test
+    public void test_a_nul_in_a_value_is_rejected() {
+        try {
+            Statement.of("ftm", "person-1", "Person", "name", "Jane\u0000doc-1", provenance);
+            fail("should have rejected the NUL in the value");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("value");
+        }
+    }
+
+    @Test
+    public void test_a_nul_in_the_provenance_is_rejected() {
+        try {
+            new Statement.Provenance("doc-1\u0000", "Sheet1", 12, "full_name");
+            fail("should have rejected the NUL in the documentId");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("documentId");
+        }
+    }
+
+    @Test
     public void test_a_null_id_is_rejected() {
         try {
             new Statement(null, "ftm", "person-1", "Person", "name", "Jane Doe", provenance);

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
@@ -3,7 +3,7 @@ package org.icij.datashare.model;
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class TargetModelRegistryTest {
     @Test
@@ -17,33 +17,17 @@ public class TargetModelRegistryTest {
     }
 
     @Test
-    public void test_an_unknown_model_names_the_known_ones() {
-        try {
-            TargetModelRegistry.get("wikidata");
-            fail("should have refused an unregistered model");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("wikidata");
-            assertThat(e.getMessage()).contains("ftm");
-        }
-    }
+    public void test_an_unknown_model_names_the_known_ones_and_keeps_the_requested_name() {
+        UnknownTargetModel e = assertThrows(UnknownTargetModel.class, () -> TargetModelRegistry.get("wikidata"));
 
-    @Test
-    public void test_an_unknown_model_keeps_the_requested_name() {
-        try {
-            TargetModelRegistry.get("wikidata");
-            fail("should have refused an unregistered model");
-        } catch (UnknownTargetModel e) {
-            assertThat(e.name).isEqualTo("wikidata");
-        }
+        assertThat(e.getMessage()).contains("wikidata");
+        assertThat(e.getMessage()).contains("ftm");
+        assertThat(e.name).isEqualTo("wikidata");
     }
 
     @Test
     public void test_a_null_name_is_rejected() {
-        try {
-            TargetModelRegistry.get(null);
-            fail("should have rejected a null name");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).contains("name");
-        }
+        assertThat(assertThrows(NullPointerException.class, () -> TargetModelRegistry.get(null)).getMessage())
+                .contains("name");
     }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
@@ -1,0 +1,29 @@
+package org.icij.datashare.model;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class TargetModelRegistryTest {
+    @Test
+    public void test_resolves_the_ftm_model() {
+        assertThat(TargetModelRegistry.get("ftm").name()).isEqualTo("ftm");
+    }
+
+    @Test
+    public void test_parses_the_model_once() {
+        assertThat(TargetModelRegistry.get("ftm")).isSameAs(TargetModelRegistry.get("ftm"));
+    }
+
+    @Test
+    public void test_an_unknown_model_names_the_known_ones() {
+        try {
+            TargetModelRegistry.get("wikidata");
+            fail("should have refused an unregistered model");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("wikidata");
+            assertThat(e.getMessage()).contains("ftm");
+        }
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
@@ -26,4 +26,14 @@ public class TargetModelRegistryTest {
             assertThat(e.getMessage()).contains("ftm");
         }
     }
+
+    @Test
+    public void test_a_null_name_is_rejected() {
+        try {
+            TargetModelRegistry.get(null);
+            fail("should have rejected a null name");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("name");
+        }
+    }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelRegistryTest.java
@@ -28,6 +28,16 @@ public class TargetModelRegistryTest {
     }
 
     @Test
+    public void test_an_unknown_model_keeps_the_requested_name() {
+        try {
+            TargetModelRegistry.get("wikidata");
+            fail("should have refused an unregistered model");
+        } catch (UnknownTargetModel e) {
+            assertThat(e.name).isEqualTo("wikidata");
+        }
+    }
+
+    @Test
     public void test_a_null_name_is_rejected() {
         try {
             TargetModelRegistry.get(null);

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
@@ -99,6 +99,21 @@ public class TargetModelValidationTest {
                 Map.of("name", List.of("Jane Doe"), "vatNumber", List.of("FR123"))))).isEmpty();
     }
 
+    @Test
+    public void test_a_concrete_type_makes_its_abstract_ancestor_instantiable() {
+        assertThat(model.validate(new ModelEntity("p-1", Set.of("Person", "Thing"),
+                Map.of("name", List.of("Jane Doe"))))).isEmpty();
+    }
+
+    @Test
+    public void test_an_undeclared_property_names_the_types_in_a_stable_order() {
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person", "Company"),
+                Map.of("name", List.of("Jane Doe"), "shoeSize", List.of("42"))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("[Company, Person]");
+    }
+
     private static class FakeModel implements TargetModel {
         private static final Map<String, EntityType> TYPES = Map.of(
                 "Thing", new EntityType("Thing", true, Set.of("Thing"),

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
@@ -1,0 +1,149 @@
+package org.icij.datashare.model;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class TargetModelValidationTest {
+    private final TargetModel model = new FakeModel();
+
+    @Test
+    public void test_a_valid_entity_has_no_violation() {
+        assertThat(model.validate(new ModelEntity("p-1", Set.of("Person"),
+                Map.of("name", List.of("Jane Doe"))))).isEmpty();
+    }
+
+    @Test
+    public void test_a_property_declared_by_an_ancestor_resolves() {
+        assertThat(model.property("Person", "name").isPresent()).isTrue();
+        assertThat(model.property("Person", "nope").isPresent()).isFalse();
+        assertThat(model.property("Nope", "name").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_an_unknown_type_is_a_violation() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("p-1", Set.of("Robot"), Map.of("name", List.of("Jane Doe"))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("Robot");
+        assertThat(violations.get(0).message()).contains("fake");
+    }
+
+    @Test
+    public void test_an_abstract_type_cannot_be_instantiated() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("t-1", Set.of("Thing"), Map.of("name", List.of("Jane Doe"))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("Thing");
+        assertThat(violations.get(0).message()).contains("abstract");
+    }
+
+    @Test
+    public void test_an_undeclared_property_is_a_violation() {
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person"),
+                Map.of("name", List.of("Jane Doe"), "shoeSize", List.of("42"))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("shoeSize");
+    }
+
+    @Test
+    public void test_a_stub_property_cannot_be_written() {
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person"),
+                Map.of("name", List.of("Jane Doe"), "employers", List.of("e-1"))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("employers");
+        assertThat(violations.get(0).message()).contains("stub");
+    }
+
+    @Test
+    public void test_a_missing_required_property_is_a_violation() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("p-1", Set.of("Person"), Map.of()));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("Person");
+        assertThat(violations.get(0).message()).contains("name");
+    }
+
+    @Test
+    public void test_a_blank_required_property_is_a_violation() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("p-1", Set.of("Person"), Map.of("name", List.of(" "))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("name");
+    }
+
+    @Test
+    public void test_an_edge_needs_both_of_its_ends() {
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("e-1", Set.of("Employment"),
+                Map.of("employee", List.of("p-1"))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("Employment");
+        assertThat(violations.get(0).message()).contains("employer");
+    }
+
+    @Test
+    public void test_a_multi_type_entity_may_use_a_property_of_either_type() {
+        assertThat(model.validate(new ModelEntity("p-1", Set.of("Person", "Company"),
+                Map.of("name", List.of("Jane Doe"), "vatNumber", List.of("FR123"))))).isEmpty();
+    }
+
+    private static class FakeModel implements TargetModel {
+        private static final Map<String, EntityType> TYPES = Map.of(
+                "Thing", new EntityType("Thing", true, Set.of("Thing"),
+                        Map.of("name", property("name")), Set.of("name"), null),
+                "Person", new EntityType("Person", false, Set.of("Person", "Thing"),
+                        Map.of("name", property("name"), "employers", stub("employers")),
+                        Set.of("name"), null),
+                "Company", new EntityType("Company", false, Set.of("Company", "Thing"),
+                        Map.of("name", property("name"), "vatNumber", property("vatNumber")),
+                        Set.of("name"), null),
+                "Employment", new EntityType("Employment", false, Set.of("Employment"),
+                        Map.of("employee", property("employee"), "employer", property("employer")),
+                        Set.of("employee"), new EntityType.Edge("employee", "employer", true)));
+
+        @Override
+        public String name() {
+            return "fake";
+        }
+
+        @Override
+        public String version() {
+            return "1";
+        }
+
+        @Override
+        public Optional<EntityType> type(String name) {
+            return Optional.ofNullable(TYPES.get(name));
+        }
+
+        @Override
+        public String serialize(ModelEntity entity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ModelEntity parse(String json) {
+            throw new UnsupportedOperationException();
+        }
+
+        private static Property property(String name) {
+            return new Property(name, "Fake:" + name, "string", null, false);
+        }
+
+        private static Property stub(String name) {
+            return new Property(name, "Fake:" + name, "entity", "Employment", true);
+        }
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
@@ -96,6 +96,44 @@ public class FtmTargetModelSerializationTest {
     }
 
     @Test
+    public void test_a_json_null_fails_with_a_clear_error() {
+        try {
+            model.parse("null");
+            fail("should have refused the null document");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("FtM");
+        }
+    }
+
+    @Test
+    public void test_a_property_with_null_values_fails_with_a_clear_error() {
+        try {
+            model.parse("{\"id\":\"person-1\",\"schema\":\"Person\",\"properties\":{\"name\":null}}");
+            fail("should have refused the null value list");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("name");
+            assertThat(e.getMessage()).contains("FtM");
+        }
+    }
+
+    @Test
+    public void test_a_property_holding_a_null_value_fails_with_a_clear_error() {
+        try {
+            model.parse("{\"id\":\"person-1\",\"schema\":\"Person\",\"properties\":{\"name\":[null]}}");
+            fail("should have refused the null value");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("name");
+            assertThat(e.getMessage()).contains("FtM");
+        }
+    }
+
+    @Test
+    public void test_the_multi_type_entity_it_collapses_is_valid() {
+        assertThat(model.validate(new ModelEntity("person-1", Set.of("Person", "LegalEntity", "Thing"),
+                Map.of("name", List.of("Jane Doe"))))).isEmpty();
+    }
+
+    @Test
     public void test_an_absent_properties_reads_as_empty() {
         ModelEntity entity = model.parse("{\"id\":\"person-1\",\"schema\":\"Person\"}");
 

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class FtmTargetModelSerializationTest {
     private final TargetModel model = new FtmTargetModel();
@@ -53,78 +53,42 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_serializing_types_with_no_common_schema_fails() {
-        try {
-            model.serialize(new ModelEntity("x-1", Set.of("Person", "Company"),
-                    Map.of("name", List.of("Jane Doe"))));
-            fail("should have refused to pick a schema");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("Person");
-            assertThat(e.getMessage()).contains("Company");
-        }
+        assertThrowsContaining(() -> model.serialize(new ModelEntity("x-1", Set.of("Person", "Company"),
+                Map.of("name", List.of("Jane Doe")))), "Person", "Company");
     }
 
     @Test
     public void test_unreadable_json_fails_with_a_clear_error() {
-        try {
-            model.parse("{\"id\": ");
-            fail("should have refused the truncated json");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("FtM");
-        }
+        assertThrowsContaining(() -> model.parse("{\"id\": "), "FtM");
     }
 
     @Test
     public void test_a_missing_id_fails_with_a_clear_error() {
-        try {
-            model.parse("{\"schema\":\"Person\"}");
-            fail("should have refused the missing id");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("id");
-            assertThat(e.getMessage()).contains("FtM");
-        }
+        assertThrowsContaining(() -> model.parse("{\"schema\":\"Person\"}"), "id", "FtM");
     }
 
     @Test
     public void test_a_missing_schema_fails_with_a_clear_error() {
-        try {
-            model.parse("{\"id\":\"person-1\"}");
-            fail("should have refused the missing schema");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("schema");
-            assertThat(e.getMessage()).contains("FtM");
-        }
+        assertThrowsContaining(() -> model.parse("{\"id\":\"person-1\"}"), "schema", "FtM");
     }
 
     @Test
     public void test_a_json_null_fails_with_a_clear_error() {
-        try {
-            model.parse("null");
-            fail("should have refused the null document");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("FtM");
-        }
+        assertThrowsContaining(() -> model.parse("null"), "FtM");
     }
 
     @Test
     public void test_a_property_with_null_values_fails_with_a_clear_error() {
-        try {
-            model.parse("{\"id\":\"person-1\",\"schema\":\"Person\",\"properties\":{\"name\":null}}");
-            fail("should have refused the null value list");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("name");
-            assertThat(e.getMessage()).contains("FtM");
-        }
+        assertThrowsContaining(
+                () -> model.parse("{\"id\":\"person-1\",\"schema\":\"Person\",\"properties\":{\"name\":null}}"),
+                "name", "FtM");
     }
 
     @Test
     public void test_a_property_holding_a_null_value_fails_with_a_clear_error() {
-        try {
-            model.parse("{\"id\":\"person-1\",\"schema\":\"Person\",\"properties\":{\"name\":[null]}}");
-            fail("should have refused the null value");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).contains("name");
-            assertThat(e.getMessage()).contains("FtM");
-        }
+        assertThrowsContaining(
+                () -> model.parse("{\"id\":\"person-1\",\"schema\":\"Person\",\"properties\":{\"name\":[null]}}"),
+                "name", "FtM");
     }
 
     @Test
@@ -138,5 +102,12 @@ public class FtmTargetModelSerializationTest {
         ModelEntity entity = model.parse("{\"id\":\"person-1\",\"schema\":\"Person\"}");
 
         assertThat(entity.properties()).isEqualTo(Map.of());
+    }
+
+    private static void assertThrowsContaining(Runnable action, String... messageParts) {
+        String message = assertThrows(IllegalArgumentException.class, action::run).getMessage();
+        for (String part : messageParts) {
+            assertThat(message).contains(part);
+        }
     }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
@@ -1,0 +1,75 @@
+package org.icij.datashare.model.ftm;
+
+import org.icij.datashare.model.ModelEntity;
+import org.icij.datashare.model.TargetModel;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class FtmTargetModelSerializationTest {
+    private final TargetModel model = new FtmTargetModel();
+
+    @Test
+    public void test_round_trips_a_person() {
+        ModelEntity person = new ModelEntity("person-1", Set.of("Person"),
+                Map.of("name", List.of("Jane Doe", "J. Doe"), "birthDate", List.of("1980-04-02")));
+
+        assertThat(model.parse(model.serialize(person))).isEqualTo(person);
+    }
+
+    @Test
+    public void test_serializes_the_ftm_entity_shape() {
+        String json = model.serialize(new ModelEntity("person-1", Set.of("Person"),
+                Map.of("name", List.of("Jane Doe"))));
+
+        assertThat(json).contains("\"id\":\"person-1\"");
+        assertThat(json).contains("\"schema\":\"Person\"");
+        assertThat(json).contains("\"name\":[\"Jane Doe\"]");
+    }
+
+    @Test
+    public void test_collapses_a_multi_type_entity_to_its_most_specific_type() {
+        String json = model.serialize(new ModelEntity("person-1", Set.of("Person", "LegalEntity", "Thing"),
+                Map.of("name", List.of("Jane Doe"))));
+
+        assertThat(json).contains("\"schema\":\"Person\"");
+    }
+
+    @Test
+    public void test_types_with_no_common_schema_are_a_violation() {
+        ModelEntity confused = new ModelEntity("x-1", Set.of("Person", "Company"),
+                Map.of("name", List.of("Jane Doe")));
+
+        List<TargetModel.Violation> violations = model.validate(confused);
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("no common schema");
+    }
+
+    @Test
+    public void test_serializing_types_with_no_common_schema_fails() {
+        try {
+            model.serialize(new ModelEntity("x-1", Set.of("Person", "Company"),
+                    Map.of("name", List.of("Jane Doe"))));
+            fail("should have refused to pick a schema");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("Person");
+            assertThat(e.getMessage()).contains("Company");
+        }
+    }
+
+    @Test
+    public void test_unreadable_json_fails_with_a_clear_error() {
+        try {
+            model.parse("{\"id\": ");
+            fail("should have refused the truncated json");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("FtM");
+        }
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
@@ -72,4 +72,33 @@ public class FtmTargetModelSerializationTest {
             assertThat(e.getMessage()).contains("FtM");
         }
     }
+
+    @Test
+    public void test_a_missing_id_fails_with_a_clear_error() {
+        try {
+            model.parse("{\"schema\":\"Person\"}");
+            fail("should have refused the missing id");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("id");
+            assertThat(e.getMessage()).contains("FtM");
+        }
+    }
+
+    @Test
+    public void test_a_missing_schema_fails_with_a_clear_error() {
+        try {
+            model.parse("{\"id\":\"person-1\"}");
+            fail("should have refused the missing schema");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("schema");
+            assertThat(e.getMessage()).contains("FtM");
+        }
+    }
+
+    @Test
+    public void test_an_absent_properties_reads_as_empty() {
+        ModelEntity entity = model.parse("{\"id\":\"person-1\",\"schema\":\"Person\"}");
+
+        assertThat(entity.properties()).isEqualTo(Map.of());
+    }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -1,9 +1,14 @@
 package org.icij.datashare.model.ftm;
 
 import org.icij.datashare.model.EntityType;
+import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.Property;
 import org.icij.datashare.model.TargetModel;
 import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -72,5 +77,35 @@ public class FtmTargetModelTest {
     public void test_an_unknown_property_or_type_is_empty() {
         assertThat(model.property("Person", "shoeSize").isPresent()).isFalse();
         assertThat(model.property("Persona", "name").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_validating_a_company_with_no_properties_reports_the_missing_inherited_name() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("c-1", Set.of("Company"), Map.of()));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("Company");
+        assertThat(violations.get(0).message()).contains("name");
+    }
+
+    @Test
+    public void test_validating_an_interest_reports_that_the_type_is_abstract() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("i-1", Set.of("Interest"), Map.of()));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("Interest");
+        assertThat(violations.get(0).message()).contains("abstract");
+    }
+
+    @Test
+    public void test_validating_a_person_writing_the_stub_property_employers_reports_the_stub() {
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person"),
+                Map.of("name", List.of("Jane Doe"), "employers", List.of("e-1"))));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("employers");
+        assertThat(violations.get(0).message()).contains("stub");
     }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -4,6 +4,7 @@ import org.icij.datashare.model.EntityType;
 import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.Property;
 import org.icij.datashare.model.TargetModel;
+import org.icij.datashare.model.UnreadableModelResource;
 import org.junit.Test;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 public class FtmTargetModelTest {
     private final TargetModel model = new FtmTargetModel();
@@ -77,6 +79,40 @@ public class FtmTargetModelTest {
     public void test_an_unknown_property_or_type_is_empty() {
         assertThat(model.property("Person", "shoeSize").isPresent()).isFalse();
         assertThat(model.property("Persona", "name").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_a_property_two_ancestors_declare_resolves_to_the_last_ancestor_by_name() {
+        assertThat(model.property("Message", "date").get().qname()).isEqualTo("Interval:date");
+        assertThat(model.property("Message", "description").get().qname()).isEqualTo("Thing:description");
+        assertThat(model.property("Event", "namesMentioned").get().qname()).isEqualTo("Interval:namesMentioned");
+    }
+
+    @Test
+    public void test_a_stub_property_another_of_the_types_declares_as_written_is_no_violation() {
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("x-1",
+                Set.of("LegalEntity", "ContractAward"),
+                Map.of("name", List.of("Total"), "callForTenders", List.of("c-1"))));
+
+        assertThat(violations.stream().anyMatch(violation -> violation.message().contains("stub"))).isFalse();
+    }
+
+    @Test
+    public void test_the_missing_required_properties_are_reported_in_the_model_s_order() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("e-1", Set.of("Employment"), Map.of()));
+
+        assertThat(violations.get(0).message()).isEqualTo("type 'Employment' requires 'employer'");
+    }
+
+    @Test
+    public void test_a_missing_bundled_model_names_the_resource() {
+        try {
+            new FtmTargetModel("ftm/nope.json");
+            fail("should have refused the missing resource");
+        } catch (UnreadableModelResource e) {
+            assertThat(e.resource).isEqualTo("ftm/nope.json");
+        }
     }
 
     @Test

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -106,6 +106,15 @@ public class FtmTargetModelTest {
     }
 
     @Test
+    public void test_a_property_required_by_several_types_is_reported_once() {
+        List<TargetModel.Violation> violations = model.validate(
+                new ModelEntity("p-1", Set.of("Person", "LegalEntity"), Map.of()));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0).message()).contains("name");
+    }
+
+    @Test
     public void test_validating_a_company_with_no_properties_reports_the_missing_inherited_name() {
         List<TargetModel.Violation> violations = model.validate(
                 new ModelEntity("c-1", Set.of("Company"), Map.of()));

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -1,0 +1,76 @@
+package org.icij.datashare.model.ftm;
+
+import org.icij.datashare.model.EntityType;
+import org.icij.datashare.model.Property;
+import org.icij.datashare.model.TargetModel;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class FtmTargetModelTest {
+    private final TargetModel model = new FtmTargetModel();
+
+    @Test
+    public void test_loads_the_bundled_model() {
+        assertThat(model.name()).isEqualTo("ftm");
+        assertThat(model.version()).isEqualTo("4.10.2");
+    }
+
+    @Test
+    public void test_looks_a_type_up_by_name() {
+        assertThat(model.type("Person").isPresent()).isTrue();
+        assertThat(model.type("Persona").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_an_inherited_property_resolves_from_the_type_that_declares_it() {
+        Property name = model.property("Person", "name").get();
+
+        assertThat(name.qname()).isEqualTo("Thing:name");
+        assertThat(name.type()).isEqualTo("name");
+    }
+
+    @Test
+    public void test_knows_which_types_are_abstract() {
+        assertThat(model.type("Thing").get().isAbstract()).isTrue();
+        assertThat(model.type("Interest").get().isAbstract()).isTrue();
+        assertThat(model.type("LegalEntity").get().isAbstract()).isFalse();
+    }
+
+    @Test
+    public void test_an_edge_type_carries_its_ends() {
+        EntityType.Edge edge = model.type("Employment").get().edge();
+
+        assertThat(edge.source()).isEqualTo("employee");
+        assertThat(edge.target()).isEqualTo("employer");
+        assertThat(edge.directed()).isTrue();
+        assertThat(model.type("Person").get().edge()).isNull();
+    }
+
+    @Test
+    public void test_required_is_taken_verbatim_rather_than_inherited() {
+        assertThat(model.type("Person").get().required()).containsOnly("name");
+        assertThat(model.type("Address").get().required()).isEmpty();
+        assertThat(model.type("Employment").get().required()).containsOnly("employee", "employer");
+    }
+
+    @Test
+    public void test_ancestors_include_the_type_itself() {
+        assertThat(model.type("Person").get().ancestors()).containsOnly("Person", "LegalEntity", "Thing");
+    }
+
+    @Test
+    public void test_a_reverse_relation_is_flagged_as_a_stub() {
+        Property employers = model.property("Person", "employers").get();
+
+        assertThat(employers.stub()).isTrue();
+        assertThat(employers.range()).isEqualTo("Employment");
+        assertThat(model.property("Person", "birthDate").get().stub()).isFalse();
+    }
+
+    @Test
+    public void test_an_unknown_property_or_type_is_empty() {
+        assertThat(model.property("Person", "shoeSize").isPresent()).isFalse();
+        assertThat(model.property("Persona", "name").isPresent()).isFalse();
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -106,16 +106,6 @@ public class FtmTargetModelTest {
     }
 
     @Test
-    public void test_a_missing_bundled_model_names_the_resource() {
-        try {
-            new FtmTargetModel("ftm/nope.json");
-            fail("should have refused the missing resource");
-        } catch (UnreadableModelResource e) {
-            assertThat(e.resource).isEqualTo("ftm/nope.json");
-        }
-    }
-
-    @Test
     public void test_validating_a_company_with_no_properties_reports_the_missing_inherited_name() {
         List<TargetModel.Violation> violations = model.validate(
                 new ModelEntity("c-1", Set.of("Company"), Map.of()));


### PR DESCRIPTION
Ships the small set of interfaces the rest of #2194 targets ("a data model" rather than FollowTheMoney directly), the agreed shape of a stored fact, and FtM as the first and only implementation. New package `org.icij.datashare.model` in datashare-api, so #2201 and #2202 can see it from datashare-db. No new Maven dependency, nothing outside the new package touched, no production callers yet.

Closes #2197
Closes #2200

- feat: add `Statement`, one fact from one cell, with a deterministic SHA-384 id and cell-level provenance
- feat: add `ModelEntity.from(Collection<Statement>)`, rebuilding a multi-valued entity from its statements
- feat: add the `TargetModel` contract with structural validation shared as a default method, plus `EntityType` and `Property`
- feat: bundle FollowTheMoney 4.10.2 and load it into the contract's records
- feat: serialize and parse FtM's canonical single-entity JSON, collapsing a multi-type entity to its most specific schema
- feat: select a data model by name through `TargetModelRegistry`
- fix: resolve a property across every type of an entity, so validation no longer depends on JVM-randomised set iteration order
- fix: break the ancestor tie by name when two ancestors declare the same property, so the loaded ontology is reproducible
- fix: report an abstract type only when none of the entity's types is concrete, so `validate` agrees with `serialize`
- fix: reject a null document, a null value list and a null value in `parse`
- fix: normalise a null sheet to `""` and reject a NUL in any statement id component
- chore: bundle the upstream MIT licence and pin the vendored ontology to its source commit and sha256

**Why not [ftm.java](https://github.com/ICIJ/ftm.java)?** It is a build-time generator: the `0.3.1` jar ships no ontology (classes, `logback.xml` and its own pom only), its YAML loader is package-private, `Person.getName()` returns `String` where FtM properties are always arrays, and it is declared on `datashare-app` alone while `datashare-db` (#2201, #2202) sees only `datashare-api`. It stays the generator behind `FtmDocument` and `/api/ftm`, untouched here.
