### PR TITLE
feat(db): add the statement store and persist the extraction mapping

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
@@ -1,20 +1,19 @@
 package org.icij.datashare.model;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
-public record ModelEntity(String id, Set<String> types, Map<String, List<String>> properties) {
+public record ModelEntity(String model, String id, Set<String> types, Map<String, List<String>> properties) {
 
     public ModelEntity {
+        Objects.requireNonNull(model, "model");
         Objects.requireNonNull(id, "id");
         Objects.requireNonNull(types, "types");
         Objects.requireNonNull(properties, "properties");
@@ -24,19 +23,23 @@ public record ModelEntity(String id, Set<String> types, Map<String, List<String>
         properties = Collections.unmodifiableMap(copy);
     }
 
-    public static ModelEntity from(Collection<Statement> statements) {
-        if (statements.isEmpty()) {
-            throw new IllegalArgumentException("cannot rebuild an entity from no statement");
-        }
+    /** Folds statements into the entity they describe, one at a time: only its distinct values are
+     *  held, so a group larger than memory is not built to be collapsed. Properties and values come
+     *  out in natural order, not in the order the statements arrived, so a database collation never
+     *  decides what an entity looks like. */
+    public static ModelEntity from(Iterable<Statement> statements) {
         SortedSet<String> ids = new TreeSet<>();
         SortedSet<String> models = new TreeSet<>();
-        Set<String> types = new LinkedHashSet<>();
-        Map<String, Set<String>> values = new LinkedHashMap<>();
+        Set<String> types = new TreeSet<>();
+        Map<String, SortedSet<String>> values = new TreeMap<>();
         for (Statement statement : statements) {
             ids.add(statement.entityId());
             models.add(statement.model());
             types.add(statement.entityType());
-            values.computeIfAbsent(statement.property(), property -> new LinkedHashSet<>()).add(statement.value());
+            values.computeIfAbsent(statement.property(), property -> new TreeSet<>()).add(statement.value());
+        }
+        if (ids.isEmpty()) {
+            throw new IllegalArgumentException("cannot rebuild an entity from no statement");
         }
         if (ids.size() > 1) {
             throw new IllegalArgumentException("statements belong to " + ids.size() + " entities: " + ids);
@@ -45,7 +48,7 @@ public record ModelEntity(String id, Set<String> types, Map<String, List<String>
             throw new IllegalArgumentException("statements belong to " + models.size() + " models: " + models);
         }
         Map<String, List<String>> properties = new LinkedHashMap<>();
-        values.forEach((property, distinct) -> properties.put(property, new ArrayList<>(distinct)));
-        return new ModelEntity(ids.first(), types, properties);
+        values.forEach((property, distinct) -> properties.put(property, List.copyOf(distinct)));
+        return new ModelEntity(models.first(), ids.first(), types, properties);
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/model/Property.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/Property.java
@@ -1,3 +1,3 @@
 package org.icij.datashare.model;
 
-public record Property(String name, String qname, String type, String range, boolean stub) { }
+public record Property(String qname, String range, boolean stub) { }

--- a/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
@@ -34,10 +34,12 @@ public record Statement(String id, String model, String entityId, String entityT
     }
 
     /** Builds a statement for the write path, rejecting a model no {@link TargetModelRegistry} knows
-     *  before any of it reaches the store. The canonical constructor stays lenient, so a row written
-     *  under a model since retired still reads back. */
+     *  before any of it reaches the store. Leniency is a read-only promise: the canonical constructor
+     *  takes any model name, so a row written under a model since retired still reads back, but
+     *  writing that row again fails, since the store stamps every row with the model's version. */
     public static Statement of(String model, String entityId, String entityType,
                                String property, String value, Provenance provenance) {
+        Objects.requireNonNull(model, "model");
         TargetModelRegistry.get(model);
         return new Statement(id(model, entityId, entityType, property, value, provenance),
                 model, entityId, entityType, property, value, provenance);

--- a/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/Statement.java
@@ -6,11 +6,19 @@ import java.util.Objects;
 
 public record Statement(String id, String model, String entityId, String entityType,
                         String property, String value, Provenance provenance) {
+    /** An entity id ends up in the (prj_id, entity_id) index, whose entries Postgres caps at 2704
+     *  bytes and SQLite does not cap at all. Bounding it here is what keeps the two dialects from
+     *  disagreeing on which mapping key a project accepts. */
+    public static final int MAX_ENTITY_ID_LENGTH = 512;
 
     public Statement {
         Objects.requireNonNull(id, "id");
         model = component(model, "model");
         entityId = component(entityId, "entityId");
+        if (entityId.length() > MAX_ENTITY_ID_LENGTH) {
+            throw new IllegalArgumentException("'entityId' is longer than " + MAX_ENTITY_ID_LENGTH
+                    + " characters: " + entityId.length());
+        }
         entityType = component(entityType, "entityType");
         property = component(property, "property");
         value = component(value, "value");
@@ -25,8 +33,12 @@ public record Statement(String id, String model, String entityId, String entityT
         }
     }
 
+    /** Builds a statement for the write path, rejecting a model no {@link TargetModelRegistry} knows
+     *  before any of it reaches the store. The canonical constructor stays lenient, so a row written
+     *  under a model since retired still reads back. */
     public static Statement of(String model, String entityId, String entityType,
                                String property, String value, Provenance provenance) {
+        TargetModelRegistry.get(model);
         return new Statement(id(model, entityId, entityType, property, value, provenance),
                 model, entityId, entityType, property, value, provenance);
     }

--- a/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
@@ -7,7 +7,7 @@ import java.util.stream.Stream;
 /** Persists statements. Implementations own atomicity, as {@code ManifestRepository} does. */
 public interface StatementRepository {
     /** Upserts by statement id. An existing row keeps its first_seen and takes the new last_seen.
-     *  Returns the number of rows written. */
+     *  Returns the number of statements written. */
     int save(String projectId, String runId, Collection<Statement> statements);
 
     /** Every entity of a project, rebuilt by grouping its statements. Lazily read: the caller closes it. */

--- a/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
@@ -2,16 +2,27 @@ package org.icij.datashare.model;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
-/** Persists statements. Implementations own atomicity, as {@code ManifestRepository} does. */
+/** Persists statements. A save is chunked into independent transactions: a partial failure leaves a
+ *  partial, re-runnable result rather than an all-or-nothing outcome, which the upsert's idempotence
+ *  makes safe. */
 public interface StatementRepository {
-    /** Upserts by statement id. An existing row keeps its first_seen and takes the new last_seen.
-     *  Returns the number of statements written. */
+    /** Upserts by statement id. An existing row is left untouched: the write is a no-op on a re-save.
+     *  Returns the number of statements actually inserted. */
     int save(String projectId, String runId, Collection<Statement> statements);
 
-    /** Every entity of a project, rebuilt by grouping its statements. Lazily read: the caller closes it. */
+    /** Every entity of a project, rebuilt by grouping its statements. Lazily read, and backed by a
+     *  pooled connection that is released only when the returned stream is closed. The caller MUST
+     *  close it, including on every early exit (e.g. {@code findFirst}, {@code limit},
+     *  {@code anyMatch}) or exception: abandoning it without closing leaks a pooled connection.
+     *  Prefer {@link #entities(String, Function)}, which closes it for you. */
     Stream<ModelEntity> entities(String projectId);
+
+    /** Same as {@link #entities(String)}, but closes the stream for the caller once {@code consumer}
+     *  returns or throws. */
+    <R> R entities(String projectId, Function<Stream<ModelEntity>, R> consumer);
 
     Optional<ModelEntity> entity(String projectId, String entityId);
 }

--- a/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
@@ -1,0 +1,17 @@
+package org.icij.datashare.model;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/** Persists statements. Implementations own atomicity, as {@code ManifestRepository} does. */
+public interface StatementRepository {
+    /** Upserts by statement id. An existing row keeps its first_seen and takes the new last_seen.
+     *  Returns the number of rows written. */
+    int save(String projectId, String runId, Collection<Statement> statements);
+
+    /** Every entity of a project, rebuilt by grouping its statements. Lazily read: the caller closes it. */
+    Stream<ModelEntity> entities(String projectId);
+
+    Optional<ModelEntity> entity(String projectId, String entityId);
+}

--- a/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.model;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -9,17 +8,20 @@ import java.util.stream.Stream;
  *  partial, re-runnable result rather than an all-or-nothing outcome, which the upsert's idempotence
  *  makes safe. */
 public interface StatementRepository {
-    /** Upserts by statement id. An existing row is left untouched: the write is a no-op on a re-save.
-     *  Returns the number of statements inserted, or fewer when the JDBC driver rewrites the batch
-     *  and reports no per-row count. */
-    int save(String projectId, String runId, Collection<Statement> statements);
+    /** Upserts by statement id, refreshing the run and the model version of a statement this run has
+     *  seen again, so a row's age tells a re-observed statement from a stale one. The statements are
+     *  consumed lazily, one chunk at a time, so a whole extraction never has to fit in memory; the
+     *  stream is closed on return. Returns the number of statements written, or fewer when the JDBC
+     *  driver rewrites the batch and reports no per-row count. */
+    int save(String projectId, String runId, Stream<Statement> statements);
 
     /** Every entity of a project, rebuilt by grouping its statements. The stream is read lazily from
      *  a pooled connection and closed once {@code consumer} returns or throws, so {@code consumer}
      *  has to consume it: returning the stream itself hands back a closed one. */
     <R> R entities(String projectId, Function<Stream<ModelEntity>, R> consumer);
 
-    /** The entity a project holds under this id. An id shared by two models yields the first by model
-     *  order, since an entity belongs to one model. */
+    /** The entity a project holds under this id. An id shared by two models yields the first model in
+     *  natural order, since an entity belongs to one model, and the entity names the model it came
+     *  from. */
     Optional<ModelEntity> entity(String projectId, String entityId);
 }

--- a/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/StatementRepository.java
@@ -10,19 +10,16 @@ import java.util.stream.Stream;
  *  makes safe. */
 public interface StatementRepository {
     /** Upserts by statement id. An existing row is left untouched: the write is a no-op on a re-save.
-     *  Returns the number of statements actually inserted. */
+     *  Returns the number of statements inserted, or fewer when the JDBC driver rewrites the batch
+     *  and reports no per-row count. */
     int save(String projectId, String runId, Collection<Statement> statements);
 
-    /** Every entity of a project, rebuilt by grouping its statements. Lazily read, and backed by a
-     *  pooled connection that is released only when the returned stream is closed. The caller MUST
-     *  close it, including on every early exit (e.g. {@code findFirst}, {@code limit},
-     *  {@code anyMatch}) or exception: abandoning it without closing leaks a pooled connection.
-     *  Prefer {@link #entities(String, Function)}, which closes it for you. */
-    Stream<ModelEntity> entities(String projectId);
-
-    /** Same as {@link #entities(String)}, but closes the stream for the caller once {@code consumer}
-     *  returns or throws. */
+    /** Every entity of a project, rebuilt by grouping its statements. The stream is read lazily from
+     *  a pooled connection and closed once {@code consumer} returns or throws, so {@code consumer}
+     *  has to consume it: returning the stream itself hands back a closed one. */
     <R> R entities(String projectId, Function<Stream<ModelEntity>, R> consumer);
 
+    /** The entity a project holds under this id. An id shared by two models yields the first by model
+     *  order, since an entity belongs to one model. */
     Optional<ModelEntity> entity(String projectId, String entityId);
 }

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModel.java
@@ -60,7 +60,7 @@ public interface TargetModel {
                     + " is abstract and cannot be instantiated"));
         }
         if (!types.isEmpty()) {
-            for (String property : entity.properties().keySet()) {
+            for (String property : new TreeSet<>(entity.properties().keySet())) {
                 List<Property> declarations = types.stream()
                         .map(type -> type.properties().get(property))
                         .filter(Objects::nonNull)

--- a/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/TargetModelRegistry.java
@@ -4,16 +4,25 @@ import org.icij.datashare.model.ftm.FtmTargetModel;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 public class TargetModelRegistry {
-    private static final Map<String, TargetModel> MODELS = Map.of("ftm", new FtmTargetModel());
+    private static final Map<String, Supplier<TargetModel>> FACTORIES = Map.of("ftm", FtmTargetModel::new);
+    private static final Map<String, TargetModel> PARSED = new ConcurrentHashMap<>();
 
+    private TargetModelRegistry() {
+    }
+
+    /** Reads a model's ontology on first use rather than in a static initializer, so a bundle that
+     *  cannot be read reaches the caller as {@link UnreadableModelResource} on every call, instead of
+     *  an ExceptionInInitializerError once and a causeless NoClassDefFoundError from then on. */
     public static TargetModel get(String name) {
         Objects.requireNonNull(name, "name");
-        TargetModel model = MODELS.get(name);
-        if (model == null) {
-            throw new UnknownTargetModel(name, MODELS.keySet());
+        Supplier<TargetModel> factory = FACTORIES.get(name);
+        if (factory == null) {
+            throw new UnknownTargetModel(name, FACTORIES.keySet());
         }
-        return model;
+        return PARSED.computeIfAbsent(name, ignored -> factory.get());
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/model/UnreadableModelResource.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/UnreadableModelResource.java
@@ -8,6 +8,11 @@ public class UnreadableModelResource extends RuntimeException {
         this.resource = resource;
     }
 
+    public UnreadableModelResource(String resource, String detail) {
+        super("cannot read the data model at '%s': %s".formatted(resource, detail));
+        this.resource = resource;
+    }
+
     public UnreadableModelResource(String resource, Throwable root) {
         super("cannot read the data model at '%s'".formatted(resource), root);
         this.resource = resource;

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -42,8 +42,8 @@ public class FtmTargetModel implements TargetModel {
                 throw new UnreadableModelResource(RESOURCE);
             }
             JsonNode root = JsonObjectMapper.getMapper().readTree(stream);
-            this.version = root.get("version").asText();
-            this.types = types(root.get("schemata"));
+            this.version = present(root, "version").asText();
+            this.types = types(present(root, "schemata"));
         } catch (IOException e) {
             throw new UnreadableModelResource(RESOURCE, e);
         }
@@ -101,7 +101,7 @@ public class FtmTargetModel implements TargetModel {
                 throw new IllegalArgumentException("property '" + property + "' has a null value in FtM JSON");
             }
         });
-        return new ModelEntity(read.id(), Set.of(read.schema()), properties);
+        return new ModelEntity(name(), read.id(), Set.of(read.schema()), properties);
     }
 
     @Override
@@ -123,39 +123,51 @@ public class FtmTargetModel implements TargetModel {
     }
 
     private static Map<String, EntityType> types(JsonNode schemata) {
-        Map<String, Map<String, Property>> declared = new HashMap<>();
-        schemata.fields().forEachRemaining(schema ->
-                declared.put(schema.getKey(), properties(schema.getValue().get("properties"))));
+        Map<String, Map<String, Property>> properties = new HashMap<>();
+        Map<String, Set<String>> required = new HashMap<>();
+        schemata.properties().forEach(schema -> {
+            properties.put(schema.getKey(), properties(schema.getValue().path("properties")));
+            required.put(schema.getKey(), strings(schema.getValue().path("required")));
+        });
         Map<String, EntityType> types = new HashMap<>();
-        schemata.fields().forEachRemaining(schema ->
-                types.put(schema.getKey(), type(schema.getKey(), schema.getValue(), declared)));
+        schemata.properties().forEach(schema ->
+                types.put(schema.getKey(), type(schema.getKey(), schema.getValue(), properties, required)));
         return Map.copyOf(types);
     }
 
-    private static EntityType type(String name, JsonNode schema, Map<String, Map<String, Property>> declared) {
-        Set<String> ancestors = strings(schema.get("schemata"));
+    // The prebuilt ontology resolves neither properties nor required transitively, so both are merged
+    // over the ancestor closure here: 28 of the 69 concrete schemata require a property they inherit
+    // without redeclaring it. The type's own requirements come first so a violation list still reads
+    // in the order the schema states them.
+    private static EntityType type(String name, JsonNode schema, Map<String, Map<String, Property>> declared,
+                                   Map<String, Set<String>> declaredRequired) {
+        Set<String> ancestors = strings(present(schema, "schemata"));
         Map<String, Property> properties = new HashMap<>();
+        Set<String> required = new LinkedHashSet<>(declaredRequired.getOrDefault(name, Set.of()));
         // Two ancestors can declare the same property with different qnames: last one by name wins.
-        new TreeSet<>(ancestors).forEach(ancestor -> properties.putAll(declared.getOrDefault(ancestor, Map.of())));
+        new TreeSet<>(ancestors).forEach(ancestor -> {
+            properties.putAll(declared.getOrDefault(ancestor, Map.of()));
+            required.addAll(declaredRequired.getOrDefault(ancestor, Set.of()));
+        });
         return new EntityType(name, schema.path("abstract").asBoolean(false), ancestors,
-                Map.copyOf(properties), strings(schema.path("required")), edge(schema.path("edge")));
+                Map.copyOf(properties), Collections.unmodifiableSet(required), edge(schema.path("edge")));
     }
 
-    private static Map<String, Property> properties(JsonNode properties) {
+    private static Map<String, Property> properties(JsonNode node) {
         Map<String, Property> declared = new HashMap<>();
-        properties.fields().forEachRemaining(property ->
-                declared.put(property.getKey(), property(property.getValue())));
+        node.properties().forEach(property -> declared.put(property.getKey(), property(property.getValue())));
         return declared;
     }
 
     private static Property property(JsonNode property) {
-        return new Property(property.get("qname").asText(), text(property, "range"),
+        return new Property(present(property, "qname").asText(), property.path("range").asText(null),
                 property.path("stub").asBoolean(false));
     }
 
     private static EntityType.Edge edge(JsonNode edge) {
-        return edge.isMissingNode() ? null : new EntityType.Edge(edge.get("source").asText(),
-                edge.get("target").asText(), edge.get("directed").asBoolean(false));
+        return edge.isMissingNode() || edge.isNull() ? null
+                : new EntityType.Edge(present(edge, "source").asText(), present(edge, "target").asText(),
+                        edge.path("directed").asBoolean(false));
     }
 
     private static Set<String> strings(JsonNode array) {
@@ -164,8 +176,14 @@ public class FtmTargetModel implements TargetModel {
         return Collections.unmodifiableSet(values);
     }
 
-    private static String text(JsonNode node, String field) {
-        return node.has(field) ? node.get(field).asText() : null;
+    // Every field this parser needs is read through here rather than with get(), so a bundle whose
+    // shape moved fails as UnreadableModelResource naming the field instead of as a bare NPE.
+    private static JsonNode present(JsonNode node, String field) {
+        JsonNode value = node.path(field);
+        if (value.isMissingNode() || value.isNull()) {
+            throw new UnreadableModelResource(RESOURCE, "missing '" + field + "'");
+        }
+        return value;
     }
 
     record FtmEntity(String id, String schema, Map<String, List<String>> properties) { }

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -149,8 +149,7 @@ public class FtmTargetModel implements TargetModel {
     }
 
     private static Property property(JsonNode property) {
-        return new Property(property.get("name").asText(), property.get("qname").asText(),
-                property.get("type").asText(), text(property, "range"),
+        return new Property(property.get("qname").asText(), text(property, "range"),
                 property.path("stub").asBoolean(false));
     }
 

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/EmptyExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/EmptyExtractionMapping.java
@@ -1,10 +1,7 @@
 package org.icij.datashare.tabular;
 
 public class EmptyExtractionMapping extends IllegalArgumentException {
-    public final String id;
-
     public EmptyExtractionMapping(String id) {
         super("mapping '%s' builds no entity".formatted(id));
-        this.id = id;
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/EmptyExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/EmptyExtractionMapping.java
@@ -1,0 +1,10 @@
+package org.icij.datashare.tabular;
+
+public class EmptyExtractionMapping extends IllegalArgumentException {
+    public final String id;
+
+    public EmptyExtractionMapping(String id) {
+        super("mapping '%s' builds no entity".formatted(id));
+        this.id = id;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
@@ -1,0 +1,75 @@
+package org.icij.datashare.tabular;
+
+import org.icij.datashare.model.TargetModel;
+import org.icij.datashare.model.TargetModelRegistry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record ExtractionMapping(String id, String projectId, String userId, String name, String model,
+                                String documentId, RowSourceOptions options,
+                                Map<String, EntityMapping> entities) {
+
+    public ExtractionMapping {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(projectId, "projectId");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(documentId, "documentId");
+        options = options == null ? RowSourceOptions.defaults() : options;
+        Objects.requireNonNull(entities, "entities");
+        if (entities.isEmpty()) {
+            throw new IllegalArgumentException("a mapping builds no entity");
+        }
+        entities = Map.copyOf(entities);
+        TargetModelRegistry.get(Objects.requireNonNull(model, "model"));
+    }
+
+    public record EntityMapping(String type, List<String> keys, Map<String, PropertyMapping> properties) {
+        public EntityMapping {
+            Objects.requireNonNull(type, "type");
+            keys = List.copyOf(Objects.requireNonNull(keys, "keys"));
+            if (keys.isEmpty()) {
+                throw new IllegalArgumentException("entity type '" + type + "' has no key column");
+            }
+            properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
+        }
+    }
+
+    public record PropertyMapping(List<String> columns, String join, String literal, String entity, String format) {
+        public PropertyMapping {
+            columns = List.copyOf(columns == null ? List.of() : columns);
+            long sources = (columns.isEmpty() ? 0 : 1) + (literal == null ? 0 : 1) + (entity == null ? 0 : 1);
+            if (sources != 1) {
+                throw new IllegalArgumentException(
+                        "a property is filled from exactly one of columns, literal or entity, got " + sources);
+            }
+            if (join != null && columns.size() < 2) {
+                throw new IllegalArgumentException("'join' needs more than one column");
+            }
+            if (format != null && columns.isEmpty()) {
+                throw new IllegalArgumentException("'format' applies to columns only");
+            }
+        }
+    }
+
+    /** Checks every entity type and property against the target model. Called on save, not on read,
+     *  so a mapping stored before the ontology moved underneath it still loads. */
+    public List<TargetModel.Violation> validate() {
+        TargetModel target = TargetModelRegistry.get(model);
+        List<TargetModel.Violation> violations = new ArrayList<>();
+        entities.forEach((alias, entity) -> {
+            if (target.type(entity.type()).isEmpty()) {
+                violations.add(new TargetModel.Violation(
+                        "unknown type '" + entity.type() + "' for entity '" + alias + "' in model '" + model + "'"));
+                return;
+            }
+            entity.properties().keySet().stream()
+                    .filter(property -> target.property(entity.type(), property).isEmpty())
+                    .forEach(property -> violations.add(new TargetModel.Violation(
+                            "no property '" + property + "' on '" + entity.type() + "'")));
+        });
+        return violations;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.tabular;
 
+import org.icij.datashare.model.EntityType;
+import org.icij.datashare.model.Property;
 import org.icij.datashare.model.TargetModel;
 import org.icij.datashare.model.TargetModelRegistry;
 
@@ -7,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public record ExtractionMapping(String id, String projectId, String userId, String name, String model,
                                 String documentId, RowSourceOptions options,
@@ -60,15 +63,30 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
         TargetModel target = TargetModelRegistry.get(model);
         List<TargetModel.Violation> violations = new ArrayList<>();
         entities.forEach((alias, entity) -> {
-            if (target.type(entity.type()).isEmpty()) {
+            Optional<EntityType> type = target.type(entity.type());
+            if (type.isEmpty()) {
                 violations.add(new TargetModel.Violation(
                         "unknown type '" + entity.type() + "' for entity '" + alias + "' in model '" + model + "'"));
                 return;
             }
-            entity.properties().keySet().stream()
-                    .filter(property -> target.property(entity.type(), property).isEmpty())
-                    .forEach(property -> violations.add(new TargetModel.Violation(
-                            "no property '" + property + "' on '" + entity.type() + "'")));
+            if (type.get().isAbstract()) {
+                violations.add(new TargetModel.Violation(
+                        "type '" + entity.type() + "' for entity '" + alias + "' is abstract and cannot be instantiated"));
+            }
+            entity.properties().forEach((name, mapping) -> {
+                Optional<Property> property = target.property(entity.type(), name);
+                if (property.isEmpty()) {
+                    violations.add(new TargetModel.Violation("no property '" + name + "' on '" + entity.type() + "'"));
+                } else if (property.get().stub()) {
+                    violations.add(new TargetModel.Violation(
+                            "property '" + name + "' on '" + entity.type() + "' is a stub: it is inferred from the '"
+                                    + property.get().range() + "' relation rather than written"));
+                }
+                if (mapping.entity() != null && !entities.containsKey(mapping.entity())) {
+                    violations.add(new TargetModel.Violation(
+                            "property '" + name + "' on entity '" + alias + "' references unknown entity '" + mapping.entity() + "'"));
+                }
+            });
         });
         return violations;
     }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
@@ -20,10 +20,10 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
         Objects.requireNonNull(projectId, "projectId");
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(documentId, "documentId");
-        options = options == null ? RowSourceOptions.defaults() : options;
+        Objects.requireNonNull(options, "options");
         Objects.requireNonNull(entities, "entities");
         if (entities.isEmpty()) {
-            throw new IllegalArgumentException("a mapping builds no entity");
+            throw new EmptyExtractionMapping(id);
         }
         entities = Map.copyOf(entities);
         TargetModelRegistry.get(Objects.requireNonNull(model, "model"));
@@ -34,7 +34,7 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
             Objects.requireNonNull(type, "type");
             keys = List.copyOf(Objects.requireNonNull(keys, "keys"));
             if (keys.isEmpty()) {
-                throw new IllegalArgumentException("entity type '" + type + "' has no key column");
+                throw new InvalidEntityMapping(type);
             }
             properties = Map.copyOf(Objects.requireNonNull(properties, "properties"));
         }
@@ -45,14 +45,14 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
             columns = List.copyOf(columns == null ? List.of() : columns);
             long sources = (columns.isEmpty() ? 0 : 1) + (literal == null ? 0 : 1) + (entity == null ? 0 : 1);
             if (sources != 1) {
-                throw new IllegalArgumentException(
+                throw new InvalidPropertyMapping("sources",
                         "a property is filled from exactly one of columns, literal or entity, got " + sources);
             }
             if (join != null && columns.size() < 2) {
-                throw new IllegalArgumentException("'join' needs more than one column");
+                throw new InvalidPropertyMapping("join", "'join' needs more than one column");
             }
             if (format != null && columns.isEmpty()) {
-                throw new IllegalArgumentException("'format' applies to columns only");
+                throw new InvalidPropertyMapping("format", "'format' applies to columns only");
             }
         }
     }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
@@ -60,10 +60,11 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
         }
     }
 
-    /** Checks every entity type and property against the target model. Called on save, not on read,
-     *  so a mapping stored before the ontology moved underneath it still loads. Aliases and property
-     *  names are walked in sorted order, so the same mapping always reports the same violations in
-     *  the same order. */
+    /** Checks every entity type and property against the target model. The compact constructor only
+     *  checks the model is known, so this is the only complete structural check, and a writer that
+     *  skips it stores a mapping the model rejects. Called on save, not on read, so a mapping stored
+     *  before the ontology moved underneath it still loads. Aliases and property names are walked in
+     *  sorted order, so the same mapping always reports the same violations in the same order. */
     public List<TargetModel.Violation> validate() {
         TargetModel target = TargetModelRegistry.get(model);
         List<TargetModel.Violation> violations = new ArrayList<>();
@@ -95,7 +96,11 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
         if (target.type(entity.type()).isEmpty()) {
             return Optional.empty();
         }
-        String range = target.property(entity.type(), property).map(Property::range).orElse(null);
+        Optional<Property> declared = target.property(entity.type(), property);
+        if (declared.isEmpty()) {
+            return Optional.empty();
+        }
+        String range = declared.get().range();
         if (range == null) {
             return Optional.of(new TargetModel.Violation(on + "holds a value, not a reference to an entity"));
         }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
@@ -1,15 +1,16 @@
 package org.icij.datashare.tabular;
 
-import org.icij.datashare.model.EntityType;
-import org.icij.datashare.model.Property;
+import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.TargetModel;
 import org.icij.datashare.model.TargetModelRegistry;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 
 public record ExtractionMapping(String id, String projectId, String userId, String name, String model,
                                 String documentId, RowSourceOptions options,
@@ -20,8 +21,8 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
         Objects.requireNonNull(projectId, "projectId");
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(documentId, "documentId");
-        Objects.requireNonNull(options, "options");
         Objects.requireNonNull(entities, "entities");
+        options = options == null ? RowSourceOptions.defaults() : options;
         if (entities.isEmpty()) {
             throw new EmptyExtractionMapping(id);
         }
@@ -45,49 +46,47 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
             columns = List.copyOf(columns == null ? List.of() : columns);
             long sources = (columns.isEmpty() ? 0 : 1) + (literal == null ? 0 : 1) + (entity == null ? 0 : 1);
             if (sources != 1) {
-                throw new InvalidPropertyMapping("sources",
+                throw new InvalidPropertyMapping(
                         "a property is filled from exactly one of columns, literal or entity, got " + sources);
             }
             if (join != null && columns.size() < 2) {
-                throw new InvalidPropertyMapping("join", "'join' needs more than one column");
+                throw new InvalidPropertyMapping("'join' needs more than one column");
             }
             if (format != null && columns.isEmpty()) {
-                throw new InvalidPropertyMapping("format", "'format' applies to columns only");
+                throw new InvalidPropertyMapping("'format' applies to columns only");
             }
         }
     }
 
     /** Checks every entity type and property against the target model. Called on save, not on read,
-     *  so a mapping stored before the ontology moved underneath it still loads. */
+     *  so a mapping stored before the ontology moved underneath it still loads. Aliases and property
+     *  names are walked in sorted order, so the same mapping always reports the same violations in
+     *  the same order. */
     public List<TargetModel.Violation> validate() {
         TargetModel target = TargetModelRegistry.get(model);
         List<TargetModel.Violation> violations = new ArrayList<>();
-        entities.forEach((alias, entity) -> {
-            Optional<EntityType> type = target.type(entity.type());
-            if (type.isEmpty()) {
-                violations.add(new TargetModel.Violation(
-                        "unknown type '" + entity.type() + "' for entity '" + alias + "' in model '" + model + "'"));
-                return;
-            }
-            if (type.get().isAbstract()) {
-                violations.add(new TargetModel.Violation(
-                        "type '" + entity.type() + "' for entity '" + alias + "' is abstract and cannot be instantiated"));
-            }
-            entity.properties().forEach((name, mapping) -> {
-                Optional<Property> property = target.property(entity.type(), name);
-                if (property.isEmpty()) {
-                    violations.add(new TargetModel.Violation("no property '" + name + "' on '" + entity.type() + "'"));
-                } else if (property.get().stub()) {
-                    violations.add(new TargetModel.Violation(
-                            "property '" + name + "' on '" + entity.type() + "' is a stub: it is inferred from the '"
-                                    + property.get().range() + "' relation rather than written"));
+        for (String alias : new TreeSet<>(entities.keySet())) {
+            EntityMapping entity = entities.get(alias);
+            target.validate(probe(alias, entity)).forEach(violation ->
+                    violations.add(new TargetModel.Violation("entity '" + alias + "': " + violation.message())));
+            for (String property : new TreeSet<>(entity.properties().keySet())) {
+                String reference = entity.properties().get(property).entity();
+                if (reference != null && !entities.containsKey(reference)) {
+                    violations.add(new TargetModel.Violation("property '" + property + "' on entity '" + alias
+                            + "' references unknown entity '" + reference + "'"));
                 }
-                if (mapping.entity() != null && !entities.containsKey(mapping.entity())) {
-                    violations.add(new TargetModel.Violation(
-                            "property '" + name + "' on entity '" + alias + "' references unknown entity '" + mapping.entity() + "'"));
-                }
-            });
-        });
+            }
+        }
         return violations;
+    }
+
+    // A mapping declares which properties it fills, not what they will hold, so the model's own
+    // checker runs against a probe carrying a placeholder value per mapped property. That makes the
+    // model's "required property is blank" test read as "required property is not mapped", and picks
+    // up the required-property and edge-endpoint rules a mapping-only check would miss.
+    private ModelEntity probe(String alias, EntityMapping entity) {
+        Map<String, List<String>> properties = new LinkedHashMap<>();
+        new TreeSet<>(entity.properties().keySet()).forEach(property -> properties.put(property, List.of("?")));
+        return new ModelEntity(alias, Set.of(entity.type()), properties);
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
@@ -1,6 +1,7 @@
 package org.icij.datashare.tabular;
 
 import org.icij.datashare.model.ModelEntity;
+import org.icij.datashare.model.Property;
 import org.icij.datashare.model.TargetModel;
 import org.icij.datashare.model.TargetModelRegistry;
 
@@ -9,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -70,14 +72,37 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
             target.validate(probe(alias, entity)).forEach(violation ->
                     violations.add(new TargetModel.Violation("entity '" + alias + "': " + violation.message())));
             for (String property : new TreeSet<>(entity.properties().keySet())) {
-                String reference = entity.properties().get(property).entity();
-                if (reference != null && !entities.containsKey(reference)) {
-                    violations.add(new TargetModel.Violation("property '" + property + "' on entity '" + alias
-                            + "' references unknown entity '" + reference + "'"));
-                }
+                reference(target, alias, entity, property).ifPresent(violations::add);
             }
         }
         return violations;
+    }
+
+    /** A cross-reference has to point at an entity the mapping declares, through a property that
+     *  takes entities, whose declared range the referenced type satisfies: an edge pointing at the
+     *  wrong kind of entity is invalid in the target model, not just in this mapping. */
+    private Optional<TargetModel.Violation> reference(TargetModel target, String alias, EntityMapping entity,
+                                                      String property) {
+        String reference = entity.properties().get(property).entity();
+        if (reference == null) {
+            return Optional.empty();
+        }
+        String on = "property '" + property + "' on entity '" + alias + "' ";
+        EntityMapping referenced = entities.get(reference);
+        if (referenced == null) {
+            return Optional.of(new TargetModel.Violation(on + "references unknown entity '" + reference + "'"));
+        }
+        if (target.type(entity.type()).isEmpty()) {
+            return Optional.empty();
+        }
+        String range = target.property(entity.type(), property).map(Property::range).orElse(null);
+        if (range == null) {
+            return Optional.of(new TargetModel.Violation(on + "holds a value, not a reference to an entity"));
+        }
+        return target.type(referenced.type())
+                .filter(type -> !type.name().equals(range) && !type.ancestors().contains(range))
+                .map(type -> new TargetModel.Violation(on + "needs a '" + range + "', but entity '" + reference
+                        + "' is a '" + type.name() + "'"));
     }
 
     // A mapping declares which properties it fills, not what they will hold, so the model's own
@@ -87,6 +112,6 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
     private ModelEntity probe(String alias, EntityMapping entity) {
         Map<String, List<String>> properties = new LinkedHashMap<>();
         new TreeSet<>(entity.properties().keySet()).forEach(property -> properties.put(property, List.of("?")));
-        return new ModelEntity(alias, Set.of(entity.type()), properties);
+        return new ModelEntity(model, alias, Set.of(entity.type()), properties);
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMappingRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMappingRepository.java
@@ -11,9 +11,12 @@ public interface ExtractionMappingRepository {
      *  @throws InvalidExtractionMapping when the mapping does not validate against its target model. */
     boolean save(ExtractionMapping mapping);
 
-    Optional<ExtractionMapping> get(String id);
+    /** @throws UnreadableExtractionMapping when the stored row exists but its definition no longer
+     *  parses, e.g. against a model the mapping's own type or property has since dropped. */
+    Optional<ExtractionMapping> get(String projectId, String id);
 
+    /** Skips a row it cannot read rather than failing the whole list. */
     List<ExtractionMapping> list(String projectId);
 
-    boolean delete(String id);
+    boolean delete(String projectId, String id);
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMappingRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMappingRepository.java
@@ -1,0 +1,19 @@
+package org.icij.datashare.tabular;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Persists extraction mappings. Implementations own atomicity, as {@code ManifestRepository} does. */
+public interface ExtractionMappingRepository {
+    /** Saves a new mapping. Returns false when the id already exists: a mapping is immutable, so a
+     *  change is a new mapping with a new id, and a run's statements always resolve back to the
+     *  mapping that produced them.
+     *  @throws InvalidExtractionMapping when the mapping does not validate against its target model. */
+    boolean save(ExtractionMapping mapping);
+
+    Optional<ExtractionMapping> get(String id);
+
+    List<ExtractionMapping> list(String projectId);
+
+    boolean delete(String id);
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMappingRepository.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMappingRepository.java
@@ -5,14 +5,15 @@ import java.util.Optional;
 
 /** Persists extraction mappings. Implementations own atomicity, as {@code ManifestRepository} does. */
 public interface ExtractionMappingRepository {
-    /** Saves a new mapping. Returns false when the id already exists: a mapping is immutable, so a
-     *  change is a new mapping with a new id, and a run's statements always resolve back to the
-     *  mapping that produced them.
+    /** Saves a new mapping. Returns false when the project already holds that id: a mapping is
+     *  immutable, so a change is a new mapping with a new id. Ids are project-scoped, so two projects
+     *  can each hold one under the same id.
      *  @throws InvalidExtractionMapping when the mapping does not validate against its target model. */
     boolean save(ExtractionMapping mapping);
 
     /** @throws UnreadableExtractionMapping when the stored row exists but its definition no longer
-     *  parses, e.g. against a model the mapping's own type or property has since dropped. */
+     *  parses, e.g. against a model the registry no longer knows. A type or property the model has
+     *  since dropped still parses: {@link ExtractionMapping#validate()} runs on save, not on read. */
     Optional<ExtractionMapping> get(String projectId, String id);
 
     /** Skips a row it cannot read rather than failing the whole list. */

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidEntityMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidEntityMapping.java
@@ -1,0 +1,10 @@
+package org.icij.datashare.tabular;
+
+public class InvalidEntityMapping extends IllegalArgumentException {
+    public final String type;
+
+    public InvalidEntityMapping(String type) {
+        super("entity type '%s' has no key column".formatted(type));
+        this.type = type;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidEntityMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidEntityMapping.java
@@ -1,10 +1,7 @@
 package org.icij.datashare.tabular;
 
 public class InvalidEntityMapping extends IllegalArgumentException {
-    public final String type;
-
     public InvalidEntityMapping(String type) {
         super("entity type '%s' has no key column".formatted(type));
-        this.type = type;
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidExtractionMapping.java
@@ -1,0 +1,15 @@
+package org.icij.datashare.tabular;
+
+import org.icij.datashare.model.TargetModel;
+
+import java.util.List;
+
+public class InvalidExtractionMapping extends IllegalArgumentException {
+    public final List<TargetModel.Violation> violations;
+
+    public InvalidExtractionMapping(String id, List<TargetModel.Violation> violations) {
+        super("mapping '%s' does not validate: %s".formatted(id,
+                violations.stream().map(TargetModel.Violation::message).toList()));
+        this.violations = List.copyOf(violations);
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidPropertyMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidPropertyMapping.java
@@ -1,0 +1,10 @@
+package org.icij.datashare.tabular;
+
+public class InvalidPropertyMapping extends IllegalArgumentException {
+    public final String reason;
+
+    public InvalidPropertyMapping(String reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidPropertyMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/InvalidPropertyMapping.java
@@ -1,10 +1,7 @@
 package org.icij.datashare.tabular;
 
 public class InvalidPropertyMapping extends IllegalArgumentException {
-    public final String reason;
-
-    public InvalidPropertyMapping(String reason, String message) {
+    public InvalidPropertyMapping(String message) {
         super(message);
-        this.reason = reason;
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/RowSourceOptions.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/RowSourceOptions.java
@@ -30,12 +30,4 @@ public record RowSourceOptions(String contentType, Charset charset, Character de
     public RowSourceOptions withQuote(Character newQuote) {
         return new RowSourceOptions(contentType, charset, delimiter, newQuote, sheet, table);
     }
-
-    public RowSourceOptions withSheet(String newSheet) {
-        return new RowSourceOptions(contentType, charset, delimiter, quote, newSheet, table);
-    }
-
-    public RowSourceOptions withTable(Integer newTable) {
-        return new RowSourceOptions(contentType, charset, delimiter, quote, sheet, newTable);
-    }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/UnreadableExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/UnreadableExtractionMapping.java
@@ -1,0 +1,10 @@
+package org.icij.datashare.tabular;
+
+public class UnreadableExtractionMapping extends RuntimeException {
+    public final String id;
+
+    public UnreadableExtractionMapping(String id, Throwable cause) {
+        super("mapping '%s' could not be read: %s".formatted(id, cause.getMessage()), cause);
+        this.id = id;
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertThrows;
 public class ModelEntityTest {
     @Test
     public void test_the_entity_copies_the_collections_it_was_handed() {
-        ModelEntity entity = new ModelEntity("p-1", new HashSet<>(Set.of("Person")),
+        ModelEntity entity = new ModelEntity("ftm", "p-1", new HashSet<>(Set.of("Person")),
                 new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
 
         assertThrows(UnsupportedOperationException.class, () -> entity.types().add("Company"));
@@ -25,15 +25,16 @@ public class ModelEntityTest {
     }
 
     @Test
-    public void test_groups_the_values_of_a_property_in_order() {
+    public void test_groups_the_values_of_a_property_in_natural_order() {
         ModelEntity entity = ModelEntity.from(List.of(
                 statement("name", "Jane Doe", "full_name"),
                 statement("birthDate", "1980-04-02", "dob"),
                 statement("name", "J. Doe", "known_as")));
 
+        assertThat(entity.model()).isEqualTo("ftm");
         assertThat(entity.id()).isEqualTo("person-1");
         assertThat(entity.types()).containsOnly("Person");
-        assertThat(entity.properties().get("name")).containsExactly("Jane Doe", "J. Doe");
+        assertThat(entity.properties().get("name")).containsExactly("J. Doe", "Jane Doe");
         assertThat(entity.properties().get("birthDate")).containsExactly("1980-04-02");
     }
 
@@ -71,8 +72,9 @@ public class ModelEntityTest {
 
     @Test
     public void test_the_null_arguments_are_rejected() {
-        assertRejectsNull("id", () -> new ModelEntity(null, Set.of("Person"), Map.of("name", List.of("Jane Doe"))));
-        assertRejectsNull("types", () -> new ModelEntity("p-1", null, Map.of("name", List.of("Jane Doe"))));
+        assertRejectsNull("model", () -> new ModelEntity(null, "p-1", Set.of("Person"), Map.of("name", List.of("Jane Doe"))));
+        assertRejectsNull("id", () -> new ModelEntity("ftm", null, Set.of("Person"), Map.of("name", List.of("Jane Doe"))));
+        assertRejectsNull("types", () -> new ModelEntity("ftm", "p-1", null, Map.of("name", List.of("Jane Doe"))));
     }
 
     private static void assertRejectsNull(String field, Runnable construction) {
@@ -83,7 +85,7 @@ public class ModelEntityTest {
     public void test_refuses_statements_belonging_to_two_models() {
         String message = assertThrows(IllegalArgumentException.class, () ->
                 ModelEntity.from(List.of(statement("name", "Jane Doe", "full_name"),
-                        Statement.of("wikidata", "person-1", "Q5", "name", "Jane Q",
+                        new Statement("id-2", "wikidata", "person-1", "Q5", "name", "Jane Q",
                                 new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))))).getMessage();
 
         assertThat(message).contains("ftm");

--- a/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
@@ -97,6 +97,25 @@ public class StatementTest {
     }
 
     @Test
+    public void test_an_unknown_model_is_rejected_before_the_statement_exists() {
+        UnknownTargetModel thrown = assertThrows(UnknownTargetModel.class,
+                () -> Statement.of("wikidata", "person-1", "Q5", "name", "Jane Doe", provenance));
+
+        assertThat(thrown.name).isEqualTo("wikidata");
+    }
+
+    @Test
+    public void test_an_entity_id_longer_than_the_indexed_column_is_rejected() {
+        String tooLong = "x".repeat(Statement.MAX_ENTITY_ID_LENGTH + 1);
+
+        assertThat(assertThrows(IllegalArgumentException.class,
+                () -> Statement.of("ftm", tooLong, "Person", "name", "Jane Doe", provenance)).getMessage())
+                .contains("entityId");
+        assertThat(Statement.of("ftm", "x".repeat(Statement.MAX_ENTITY_ID_LENGTH), "Person", "name", "Jane Doe",
+                provenance).entityId().length()).isEqualTo(Statement.MAX_ENTITY_ID_LENGTH);
+    }
+
+    @Test
     public void test_the_qualified_property_prefixes_the_model() {
         Statement statement = Statement.of("ftm", "person-1", "Person", "birthDate", "1980-04-02", provenance);
 

--- a/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/StatementTest.java
@@ -88,6 +88,7 @@ public class StatementTest {
         assertRejectsNull("provenance", () -> new Statement("id", "ftm", "person-1", "Person", "name", "Jane Doe", null));
         assertRejectsNull("documentId", () -> new Statement.Provenance(null, "Sheet1", 12, "full_name"));
         assertRejectsNull("column", () -> new Statement.Provenance("doc-1", "Sheet1", 12, null));
+        assertRejectsNull("model", () -> Statement.of(null, "person-1", "Person", "name", "Jane Doe", provenance));
     }
 
     // Every component is guarded the same way, so the field the message names is the only thing worth

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
@@ -14,7 +14,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_a_valid_entity_has_no_violation() {
-        assertThat(model.validate(new ModelEntity("p-1", Set.of("Person"),
+        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person"),
                 Map.of("name", List.of("Jane Doe"))))).isEmpty();
     }
 
@@ -28,7 +28,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_an_unknown_type_is_a_violation() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("p-1", Set.of("Robot"), Map.of("name", List.of("Jane Doe"))));
+                new ModelEntity("fake", "p-1", Set.of("Robot"), Map.of("name", List.of("Jane Doe"))));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Robot");
@@ -38,7 +38,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_an_abstract_type_cannot_be_instantiated() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("t-1", Set.of("Thing"), Map.of("name", List.of("Jane Doe"))));
+                new ModelEntity("fake", "t-1", Set.of("Thing"), Map.of("name", List.of("Jane Doe"))));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Thing");
@@ -47,7 +47,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_an_undeclared_property_is_a_violation() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person"),
                 Map.of("name", List.of("Jane Doe"), "shoeSize", List.of("42"))));
 
         assertThat(violations).hasSize(1);
@@ -56,7 +56,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_a_stub_property_cannot_be_written() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person"),
                 Map.of("name", List.of("Jane Doe"), "employers", List.of("e-1"))));
 
         assertThat(violations).hasSize(1);
@@ -67,7 +67,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_a_missing_required_property_is_a_violation() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("p-1", Set.of("Person"), Map.of()));
+                new ModelEntity("fake", "p-1", Set.of("Person"), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Person");
@@ -77,7 +77,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_a_blank_required_property_is_a_violation() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("p-1", Set.of("Person"), Map.of("name", List.of(" "))));
+                new ModelEntity("fake", "p-1", Set.of("Person"), Map.of("name", List.of(" "))));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("name");
@@ -85,7 +85,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_an_edge_needs_both_of_its_ends() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("e-1", Set.of("Employment"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "e-1", Set.of("Employment"),
                 Map.of("employee", List.of("p-1"))));
 
         assertThat(violations).hasSize(1);
@@ -95,19 +95,19 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_a_multi_type_entity_may_use_a_property_of_either_type() {
-        assertThat(model.validate(new ModelEntity("p-1", Set.of("Person", "Company"),
+        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Company"),
                 Map.of("name", List.of("Jane Doe"), "vatNumber", List.of("FR123"))))).isEmpty();
     }
 
     @Test
     public void test_a_concrete_type_makes_its_abstract_ancestor_instantiable() {
-        assertThat(model.validate(new ModelEntity("p-1", Set.of("Person", "Thing"),
+        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Thing"),
                 Map.of("name", List.of("Jane Doe"))))).isEmpty();
     }
 
     @Test
     public void test_an_undeclared_property_names_the_types_in_a_stable_order() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person", "Company"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Company"),
                 Map.of("name", List.of("Jane Doe"), "shoeSize", List.of("42"))));
 
         assertThat(violations).hasSize(1);

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
@@ -154,11 +154,11 @@ public class TargetModelValidationTest {
         }
 
         private static Property property(String name) {
-            return new Property(name, "Fake:" + name, "string", null, false);
+            return new Property("Fake:" + name, null, false);
         }
 
         private static Property stub(String name) {
-            return new Property(name, "Fake:" + name, "entity", "Employment", true);
+            return new Property("Fake:" + name, "Employment", true);
         }
     }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
@@ -12,11 +12,11 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 public class FtmTargetModelSerializationTest {
-    private final TargetModel model = new FtmTargetModel();
+    private static final TargetModel model = new FtmTargetModel();
 
     @Test
     public void test_round_trips_a_person() {
-        ModelEntity person = new ModelEntity("person-1", Set.of("Person"),
+        ModelEntity person = new ModelEntity("ftm", "person-1", Set.of("Person"),
                 Map.of("name", List.of("Jane Doe", "J. Doe"), "birthDate", List.of("1980-04-02")));
 
         assertThat(model.parse(model.serialize(person))).isEqualTo(person);
@@ -24,7 +24,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_serializes_the_ftm_entity_shape() {
-        String json = model.serialize(new ModelEntity("person-1", Set.of("Person"),
+        String json = model.serialize(new ModelEntity("ftm", "person-1", Set.of("Person"),
                 Map.of("name", List.of("Jane Doe"))));
 
         assertThat(json).contains("\"id\":\"person-1\"");
@@ -34,7 +34,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_collapses_a_multi_type_entity_to_its_most_specific_type() {
-        String json = model.serialize(new ModelEntity("person-1", Set.of("Person", "LegalEntity", "Thing"),
+        String json = model.serialize(new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity", "Thing"),
                 Map.of("name", List.of("Jane Doe"))));
 
         assertThat(json).contains("\"schema\":\"Person\"");
@@ -42,7 +42,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_types_with_no_common_schema_are_a_violation() {
-        ModelEntity confused = new ModelEntity("x-1", Set.of("Person", "Company"),
+        ModelEntity confused = new ModelEntity("ftm", "x-1", Set.of("Person", "Company"),
                 Map.of("name", List.of("Jane Doe")));
 
         List<TargetModel.Violation> violations = model.validate(confused);
@@ -53,7 +53,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_serializing_types_with_no_common_schema_fails() {
-        assertThrowsContaining(() -> model.serialize(new ModelEntity("x-1", Set.of("Person", "Company"),
+        assertThrowsContaining(() -> model.serialize(new ModelEntity("ftm", "x-1", Set.of("Person", "Company"),
                 Map.of("name", List.of("Jane Doe")))), "Person", "Company");
     }
 
@@ -93,7 +93,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_the_multi_type_entity_it_collapses_is_valid() {
-        assertThat(model.validate(new ModelEntity("person-1", Set.of("Person", "LegalEntity", "Thing"),
+        assertThat(model.validate(new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity", "Thing"),
                 Map.of("name", List.of("Jane Doe"))))).isEmpty();
     }
 

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -4,7 +4,6 @@ import org.icij.datashare.model.EntityType;
 import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.Property;
 import org.icij.datashare.model.TargetModel;
-import org.icij.datashare.model.UnreadableModelResource;
 import org.junit.Test;
 
 import java.util.List;
@@ -12,10 +11,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 public class FtmTargetModelTest {
-    private final TargetModel model = new FtmTargetModel();
+    private static final TargetModel model = new FtmTargetModel();
 
     @Test
     public void test_loads_the_bundled_model() {
@@ -54,10 +52,16 @@ public class FtmTargetModelTest {
     }
 
     @Test
-    public void test_required_is_taken_verbatim_rather_than_inherited() {
+    public void test_required_is_inherited_from_the_ancestors_that_declare_it() {
         assertThat(model.type("Person").get().required()).containsOnly("name");
-        assertThat(model.type("Address").get().required()).isEmpty();
+        assertThat(model.type("Address").get().required()).containsOnly("name");
+        assertThat(model.type("Table").get().required()).containsOnly("name", "fileName");
         assertThat(model.type("Employment").get().required()).containsOnly("employee", "employer");
+    }
+
+    @Test
+    public void test_an_inherited_requirement_comes_after_the_type_s_own() {
+        assertThat(List.copyOf(model.type("Document").get().required())).isEqualTo(List.of("fileName", "name"));
     }
 
     @Test
@@ -89,7 +93,7 @@ public class FtmTargetModelTest {
 
     @Test
     public void test_a_stub_property_another_of_the_types_declares_as_written_is_no_violation() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("x-1",
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("ftm", "x-1",
                 Set.of("LegalEntity", "ContractAward"),
                 Map.of("name", List.of("Total"), "callForTenders", List.of("c-1"))));
 
@@ -99,7 +103,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_the_missing_required_properties_are_reported_in_the_model_s_order() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("e-1", Set.of("Employment"), Map.of()));
+                new ModelEntity("ftm", "e-1", Set.of("Employment"), Map.of()));
 
         assertThat(violations.get(0).message()).isEqualTo("type 'Employment' requires 'employer'");
     }
@@ -107,7 +111,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_a_property_required_by_several_types_is_reported_once() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("p-1", Set.of("Person", "LegalEntity"), Map.of()));
+                new ModelEntity("ftm", "p-1", Set.of("Person", "LegalEntity"), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("name");
@@ -116,7 +120,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_validating_a_company_with_no_properties_reports_the_missing_inherited_name() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("c-1", Set.of("Company"), Map.of()));
+                new ModelEntity("ftm", "c-1", Set.of("Company"), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Company");
@@ -126,7 +130,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_validating_an_interest_reports_that_the_type_is_abstract() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("i-1", Set.of("Interest"), Map.of()));
+                new ModelEntity("ftm", "i-1", Set.of("Interest"), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Interest");
@@ -135,7 +139,7 @@ public class FtmTargetModelTest {
 
     @Test
     public void test_validating_a_person_writing_the_stub_property_employers_reports_the_stub() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("p-1", Set.of("Person"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("ftm", "p-1", Set.of("Person"),
                 Map.of("name", List.of("Jane Doe"), "employers", List.of("e-1"))));
 
         assertThat(violations).hasSize(1);

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -34,7 +34,6 @@ public class FtmTargetModelTest {
         Property name = model.property("Person", "name").get();
 
         assertThat(name.qname()).isEqualTo("Thing:name");
-        assertThat(name.type()).isEqualTo("name");
     }
 
     @Test

--- a/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
@@ -77,6 +77,17 @@ public class ExtractionMappingTest {
     }
 
     @Test
+    public void test_a_mapping_needs_at_least_one_entity() {
+        assertThrows(IllegalArgumentException.class, () -> mapping("ftm", Map.of()));
+    }
+
+    @Test
+    public void test_an_entity_needs_at_least_one_key() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExtractionMapping.EntityMapping("Person", List.of(), Map.of()));
+    }
+
+    @Test
     public void test_entity_reference_needs_no_column() {
         ExtractionMapping.PropertyMapping reference =
                 new ExtractionMapping.PropertyMapping(List.of(), null, null, "member", null);

--- a/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
@@ -50,6 +50,27 @@ public class ExtractionMappingTest {
     }
 
     @Test
+    public void test_validate_reports_an_abstract_type() {
+        ExtractionMapping.EntityMapping thing =
+                new ExtractionMapping.EntityMapping("Thing", List.of("id"), Map.of("name", column("n")));
+        assertThat(mapping("ftm", Map.of("member", thing)).validate().toString()).contains("Thing");
+    }
+
+    @Test
+    public void test_validate_reports_a_stub_property() {
+        assertThat(mapping("ftm", Map.of("member", person(Map.of("eventsOrganized", column("e")))))
+                .validate().toString()).contains("eventsOrganized");
+    }
+
+    @Test
+    public void test_validate_reports_a_dangling_entity_alias() {
+        ExtractionMapping.PropertyMapping reference =
+                new ExtractionMapping.PropertyMapping(List.of(), null, null, "typo-alias", null);
+        assertThat(mapping("ftm", Map.of("member", person(Map.of("name", reference)))).validate().toString())
+                .contains("typo-alias");
+    }
+
+    @Test
     public void test_property_needs_exactly_one_source() {
         assertThrows(IllegalArgumentException.class,
                 () -> new ExtractionMapping.PropertyMapping(List.of(), null, null, null, null));

--- a/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
@@ -72,21 +72,21 @@ public class ExtractionMappingTest {
 
     @Test
     public void test_property_needs_exactly_one_source() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(InvalidPropertyMapping.class,
                 () -> new ExtractionMapping.PropertyMapping(List.of(), null, null, null, null));
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(InvalidPropertyMapping.class,
                 () -> new ExtractionMapping.PropertyMapping(List.of("a"), null, "SS", null, null));
     }
 
     @Test
     public void test_join_needs_more_than_one_column() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(InvalidPropertyMapping.class,
                 () -> new ExtractionMapping.PropertyMapping(List.of("a"), " ", null, null, null));
     }
 
     @Test
     public void test_format_needs_columns() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(InvalidPropertyMapping.class,
                 () -> new ExtractionMapping.PropertyMapping(List.of(), null, "SS", null, "%d.%m.%Y"));
     }
 
@@ -99,12 +99,12 @@ public class ExtractionMappingTest {
 
     @Test
     public void test_a_mapping_needs_at_least_one_entity() {
-        assertThrows(IllegalArgumentException.class, () -> mapping("ftm", Map.of()));
+        assertThrows(EmptyExtractionMapping.class, () -> mapping("ftm", Map.of()));
     }
 
     @Test
     public void test_an_entity_needs_at_least_one_key() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(InvalidEntityMapping.class,
                 () -> new ExtractionMapping.EntityMapping("Person", List.of(), Map.of()));
     }
 

--- a/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
@@ -1,0 +1,85 @@
+package org.icij.datashare.tabular;
+
+import org.icij.datashare.model.UnknownTargetModel;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class ExtractionMappingTest {
+
+    private static ExtractionMapping mapping(String model, Map<String, ExtractionMapping.EntityMapping> entities) {
+        return new ExtractionMapping("map-1", "prj", "jdoe", "members", model, "doc-1",
+                RowSourceOptions.defaults(), entities);
+    }
+
+    private static ExtractionMapping.EntityMapping person(Map<String, ExtractionMapping.PropertyMapping> properties) {
+        return new ExtractionMapping.EntityMapping("Person", List.of("id"), properties);
+    }
+
+    private static ExtractionMapping.PropertyMapping column(String name) {
+        return new ExtractionMapping.PropertyMapping(List.of(name), null, null, null, null);
+    }
+
+    @Test
+    public void test_unknown_model_is_rejected_at_construction() {
+        UnknownTargetModel thrown = assertThrows(UnknownTargetModel.class,
+                () -> mapping("wikidata", Map.of("member", person(Map.of("name", column("full_name"))))));
+        assertThat(thrown.name).isEqualTo("wikidata");
+    }
+
+    @Test
+    public void test_a_valid_mapping_reports_no_violation() {
+        assertThat(mapping("ftm", Map.of("member", person(Map.of("name", column("full_name"))))).validate()).isEmpty();
+    }
+
+    @Test
+    public void test_validate_reports_an_unknown_entity_type() {
+        ExtractionMapping.EntityMapping unknown =
+                new ExtractionMapping.EntityMapping("Unicorn", List.of("id"), Map.of("name", column("n")));
+        assertThat(mapping("ftm", Map.of("member", unknown)).validate().toString()).contains("Unicorn");
+    }
+
+    @Test
+    public void test_validate_reports_an_unknown_property_on_a_known_type() {
+        assertThat(mapping("ftm", Map.of("member", person(Map.of("hoofSize", column("h"))))).validate().toString())
+                .contains("hoofSize");
+    }
+
+    @Test
+    public void test_property_needs_exactly_one_source() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExtractionMapping.PropertyMapping(List.of(), null, null, null, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExtractionMapping.PropertyMapping(List.of("a"), null, "SS", null, null));
+    }
+
+    @Test
+    public void test_join_needs_more_than_one_column() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExtractionMapping.PropertyMapping(List.of("a"), " ", null, null, null));
+    }
+
+    @Test
+    public void test_format_needs_columns() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExtractionMapping.PropertyMapping(List.of(), null, "SS", null, "%d.%m.%Y"));
+    }
+
+    @Test
+    public void test_a_null_user_is_allowed() {
+        ExtractionMapping cliAuthored = new ExtractionMapping("map-1", "prj", null, "members", "ftm", "doc-1",
+                RowSourceOptions.defaults(), Map.of("member", person(Map.of("name", column("full_name")))));
+        assertThat(cliAuthored.userId()).isNull();
+    }
+
+    @Test
+    public void test_entity_reference_needs_no_column() {
+        ExtractionMapping.PropertyMapping reference =
+                new ExtractionMapping.PropertyMapping(List.of(), null, null, "member", null);
+        assertThat(reference.entity()).isEqualTo("member");
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.tabular;
 
+import org.icij.datashare.model.TargetModel;
 import org.icij.datashare.model.UnknownTargetModel;
 import org.junit.Test;
 
@@ -106,6 +107,40 @@ public class ExtractionMappingTest {
     public void test_an_entity_needs_at_least_one_key() {
         assertThrows(InvalidEntityMapping.class,
                 () -> new ExtractionMapping.EntityMapping("Person", List.of(), Map.of()));
+    }
+
+    @Test
+    public void test_validate_reports_a_required_property_the_mapping_never_fills() {
+        assertThat(mapping("ftm", Map.of("member", person(Map.of("birthDate", column("dob")))))
+                .validate().toString()).contains("requires 'name'");
+    }
+
+    @Test
+    public void test_validate_reports_the_unmapped_ends_of_an_edge_type() {
+        ExtractionMapping.EntityMapping ownership =
+                new ExtractionMapping.EntityMapping("Ownership", List.of("id"), Map.of("percentage", column("pct")));
+        String violations = mapping("ftm", Map.of("stake", ownership)).validate().toString();
+        assertThat(violations).contains("owner").contains("asset");
+    }
+
+    @Test
+    public void test_validate_reports_its_violations_in_a_stable_order() {
+        ExtractionMapping.EntityMapping unicorn =
+                new ExtractionMapping.EntityMapping("Unicorn", List.of("id"), Map.of("name", column("n")));
+        ExtractionMapping.EntityMapping dragon =
+                new ExtractionMapping.EntityMapping("Dragon", List.of("id"), Map.of("name", column("n")));
+        List<TargetModel.Violation> violations =
+                mapping("ftm", Map.of("zebra", unicorn, "aardvark", dragon)).validate();
+
+        assertThat(violations.get(0).message()).contains("aardvark");
+        assertThat(violations.get(1).message()).contains("zebra");
+    }
+
+    @Test
+    public void test_absent_reader_options_fall_back_to_the_defaults() {
+        ExtractionMapping mapping = new ExtractionMapping("map-1", "prj", "jdoe", "members", "ftm", "doc-1",
+                null, Map.of("member", person(Map.of("name", column("full_name")))));
+        assertThat(mapping.options()).isEqualTo(RowSourceOptions.defaults());
     }
 
     @Test

--- a/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
@@ -25,6 +25,10 @@ public class ExtractionMappingTest {
         return new ExtractionMapping.PropertyMapping(List.of(name), null, null, null, null);
     }
 
+    private static ExtractionMapping.PropertyMapping reference(String alias) {
+        return new ExtractionMapping.PropertyMapping(List.of(), null, null, alias, null);
+    }
+
     @Test
     public void test_unknown_model_is_rejected_at_construction() {
         UnknownTargetModel thrown = assertThrows(UnknownTargetModel.class,
@@ -65,10 +69,8 @@ public class ExtractionMappingTest {
 
     @Test
     public void test_validate_reports_a_dangling_entity_alias() {
-        ExtractionMapping.PropertyMapping reference =
-                new ExtractionMapping.PropertyMapping(List.of(), null, null, "typo-alias", null);
-        assertThat(mapping("ftm", Map.of("member", person(Map.of("name", reference)))).validate().toString())
-                .contains("typo-alias");
+        assertThat(mapping("ftm", Map.of("member", person(Map.of("name", reference("typo-alias")))))
+                .validate().toString()).contains("typo-alias");
     }
 
     @Test
@@ -115,12 +117,43 @@ public class ExtractionMappingTest {
                 .validate().toString()).contains("requires 'name'");
     }
 
+    // Debt requires only its source end (debtor), so its target end (creditor) is reported by the
+    // edge rule alone: on an edge type whose both ends are required, the required-property rule
+    // reports them first and the edge rule never runs.
     @Test
     public void test_validate_reports_the_unmapped_ends_of_an_edge_type() {
-        ExtractionMapping.EntityMapping ownership =
-                new ExtractionMapping.EntityMapping("Ownership", List.of("id"), Map.of("percentage", column("pct")));
-        String violations = mapping("ftm", Map.of("stake", ownership)).validate().toString();
-        assertThat(violations).contains("owner").contains("asset");
+        ExtractionMapping.EntityMapping debt =
+                new ExtractionMapping.EntityMapping("Debt", List.of("id"), Map.of("amount", column("amt")));
+        String violations = mapping("ftm", Map.of("owed", debt)).validate().toString();
+        assertThat(violations).contains("edge type 'Debt' needs 'creditor'");
+    }
+
+    @Test
+    public void test_validate_reports_a_reference_to_the_wrong_kind_of_entity() {
+        ExtractionMapping.EntityMapping ownership = new ExtractionMapping.EntityMapping("Ownership",
+                List.of("id"), Map.of("owner", reference("home"), "asset", column("a")));
+        ExtractionMapping.EntityMapping address =
+                new ExtractionMapping.EntityMapping("Address", List.of("id"), Map.of("city", column("c")));
+        String violations = mapping("ftm", Map.of("stake", ownership, "home", address)).validate().toString();
+        assertThat(violations).contains("needs a 'LegalEntity', but entity 'home' is a 'Address'");
+    }
+
+    @Test
+    public void test_validate_accepts_a_reference_to_a_descendant_of_the_declared_range() {
+        ExtractionMapping.EntityMapping ownership = new ExtractionMapping.EntityMapping("Ownership",
+                List.of("id"), Map.of("owner", reference("boss"), "asset", column("a")));
+        ExtractionMapping.EntityMapping person = new ExtractionMapping.EntityMapping("Person",
+                List.of("id"), Map.of("name", column("n")));
+        String violations = mapping("ftm", Map.of("stake", ownership, "boss", person)).validate().toString();
+        assertThat(violations).excludes("needs a");
+    }
+
+    @Test
+    public void test_validate_reports_a_reference_on_a_property_that_holds_a_value() {
+        ExtractionMapping.EntityMapping person = new ExtractionMapping.EntityMapping("Person",
+                List.of("id"), Map.of("name", reference("member")));
+        String violations = mapping("ftm", Map.of("member", person)).validate().toString();
+        assertThat(violations).contains("holds a value, not a reference to an entity");
     }
 
     @Test
@@ -145,8 +178,6 @@ public class ExtractionMappingTest {
 
     @Test
     public void test_entity_reference_needs_no_column() {
-        ExtractionMapping.PropertyMapping reference =
-                new ExtractionMapping.PropertyMapping(List.of(), null, null, "member", null);
-        assertThat(reference.entity()).isEqualTo("member");
+        assertThat(reference("member").entity()).isEqualTo("member");
     }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/tabular/ExtractionMappingTest.java
@@ -157,6 +157,16 @@ public class ExtractionMappingTest {
     }
 
     @Test
+    public void test_validate_reports_a_reference_on_an_undeclared_property_once() {
+        ExtractionMapping.EntityMapping person = new ExtractionMapping.EntityMapping("Person",
+                List.of("id"), Map.of("name", column("n"), "sidekick", reference("member")));
+        String violations = mapping("ftm", Map.of("member", person)).validate().toString();
+
+        assertThat(violations).contains("no property 'sidekick'");
+        assertThat(violations).excludes("holds a value");
+    }
+
+    @Test
     public void test_validate_reports_its_violations_in_a_stable_order() {
         ExtractionMapping.EntityMapping unicorn =
                 new ExtractionMapping.EntityMapping("Unicorn", List.of("id"), Map.of("name", column("n")));

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -5,7 +5,6 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
 import java.io.BufferedInputStream;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -24,6 +23,8 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static org.apache.commons.io.IOUtils.closeQuietly;
 
 public class DelimitedRowSource implements RowSource {
     /** text/tsv is the type Tika 3.3.0 writes when its sniffer finds a tab delimiter in a file whose
@@ -57,6 +58,8 @@ public class DelimitedRowSource implements RowSource {
             List<String> headers = Row.headers(withoutBom(records.next().toList()));
             return stream(records, headers).onClose(() -> close(parser));
         } catch (RuntimeException failure) {
+            // Swallowing the close: the read already failed, so a close failure on top of it adds
+            // nothing the caller can act on and must not mask the failure that matters.
             closeQuietly(parser);
             throw failure;
         }
@@ -183,14 +186,6 @@ public class DelimitedRowSource implements RowSource {
             parser.close();
         } catch (IOException e) {
             throw new UncheckedIOException("closing the delimited source failed", e);
-        }
-    }
-
-    private static void closeQuietly(Closeable closeable) {
-        try {
-            closeable.close();
-        } catch (IOException ignored) {
-            // the read already failed; the close failure adds nothing the caller can act on
         }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/DelimitedRowSource.java
@@ -58,8 +58,6 @@ public class DelimitedRowSource implements RowSource {
             List<String> headers = Row.headers(withoutBom(records.next().toList()));
             return stream(records, headers).onClose(() -> close(parser));
         } catch (RuntimeException failure) {
-            // Swallowing the close: the read already failed, so a close failure on top of it adds
-            // nothing the caller can act on and must not mask the failure that matters.
             closeQuietly(parser);
             throw failure;
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.icij.datashare.json.JsonObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,9 +37,11 @@ public class JsonRowSource implements RowSource {
 
     public static final Set<String> SUPPORTED = Set.of("application/json", NDJSON_CONTENT_TYPE);
 
-    // The shared mapper rather than a private one: its StreamReadConstraints cap nesting depth and
-    // string length, which a user-supplied dump is exactly the input those guards exist for.
-    private final ObjectMapper mapper = JsonObjectMapper.getMapper();
+    // A private mapper rather than the shared one: JsonObjectMapper's StreamReadConstraints are cut
+    // for HTTP request bodies, and on a data dump they are wrong in both directions. They raise the
+    // single-string cap from 20 MB to 1 GB, which is the guard that matters for a user-supplied file,
+    // and they lower the nesting cap from 1000 to 20, which flatten() is built to handle.
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Override
     public boolean supports(String contentType) {
@@ -56,20 +57,21 @@ public class JsonRowSource implements RowSource {
             // the array as a single value; for NDJSON the parser is already where it needs to be.
             // An empty source is a failed export, not an empty one: every sibling reader refuses it,
             // and importing zero rows out of a truncated file would report the loss as a success. An
-            // explicitly empty array is different, and stays a successful read of nothing.
+            // explicitly empty array is different, and stays a successful read of nothing, but it is
+            // still refused when something follows it: readValues cannot be handed a parser sitting
+            // on the array's closing bracket, so this path runs that check itself.
             JsonToken first = parser.nextToken();
             if (first == null) {
                 throw new IllegalArgumentException("no records: the source is empty");
             }
             if (first == JsonToken.START_ARRAY && parser.nextToken() == JsonToken.END_ARRAY) {
+                refuseTrailingContent(parser);
                 close(parser);
                 return Stream.empty();
             }
             records = mapper.readerFor(JsonNode.class).readValues(parser);
         } catch (IOException | RuntimeException failure) {
-            // The parser does not own a stream it was handed, so releasing it is not enough. Both
-            // closes swallow: the read already failed, and a close failure on top of it adds nothing
-            // the caller can act on and must not mask the failure that matters.
+            // The parser does not own a stream it was handed, so releasing it is not enough.
             closeQuietly(parser);
             closeQuietly(source);
             throw failure;
@@ -85,7 +87,7 @@ public class JsonRowSource implements RowSource {
                 // first and report success.
                 boolean more = hasNextRecord();
                 if (!more) {
-                    refuseTrailingContent();
+                    refuseTrailingContent(parser);
                 }
                 return more;
             }
@@ -96,17 +98,6 @@ public class JsonRowSource implements RowSource {
                 } catch (RuntimeException malformed) {
                     throw new IllegalArgumentException(
                             "malformed record " + (number + 1) + ": " + malformed.getMessage(), malformed);
-                }
-            }
-
-            private void refuseTrailingContent() {
-                try {
-                    if (parser.nextToken() != null) {
-                        throw new IllegalArgumentException(
-                                "content after the end of the json array, at " + parser.currentLocation());
-                    }
-                } catch (IOException unreadable) {
-                    throw new UncheckedIOException("reading past the json array failed", unreadable);
                 }
             }
 
@@ -151,6 +142,17 @@ public class JsonRowSource implements RowSource {
                 values.put(column, value.isNull() ? "" : value.asText());
             }
         });
+    }
+
+    private static void refuseTrailingContent(JsonParser parser) {
+        try {
+            if (parser.nextToken() != null) {
+                throw new IllegalArgumentException(
+                        "content after the end of the json array, at " + parser.currentLocation());
+            }
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException("reading past the json array failed", unreadable);
+        }
     }
 
     private static void close(JsonParser parser) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -1,10 +1,13 @@
 package org.icij.datashare.tabular;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.icij.datashare.json.JsonObjectMapper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,10 +41,13 @@ public class JsonRowSource implements RowSource {
     public static final Set<String> SUPPORTED = Set.of("application/json", NDJSON_CONTENT_TYPE);
 
     // A private mapper rather than the shared one: JsonObjectMapper's StreamReadConstraints are cut
-    // for HTTP request bodies, and on a data dump they are wrong in both directions. They raise the
-    // single-string cap from 20 MB to 1 GB, which is the guard that matters for a user-supplied file,
-    // and they lower the nesting cap from 1000 to 20, which flatten() is built to handle.
-    private final ObjectMapper mapper = new ObjectMapper();
+    // for HTTP request bodies, and a data dump needs only half of them. Its single-string cap of 1 GB
+    // is the guard that matters for a user-supplied file, so it is reused here; its nesting cap of 20
+    // is not, and Jackson's default of 1000 stands, since flatten() is built to handle the depth.
+    private final ObjectMapper mapper = new ObjectMapper(JsonFactory.builder()
+            .streamReadConstraints(StreamReadConstraints.builder()
+                    .maxStringLength(JsonObjectMapper.MAX_STRING_LENGTH).build())
+            .build());
 
     @Override
     public boolean supports(String contentType) {

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/JsonRowSource.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.icij.datashare.json.JsonObjectMapper;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -19,6 +19,8 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static org.apache.commons.io.IOUtils.closeQuietly;
 
 /**
  * Reads flat records out of JSON. One reader covers both shapes a dump comes in: peeking the first
@@ -36,7 +38,9 @@ public class JsonRowSource implements RowSource {
 
     public static final Set<String> SUPPORTED = Set.of("application/json", NDJSON_CONTENT_TYPE);
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    // The shared mapper rather than a private one: its StreamReadConstraints cap nesting depth and
+    // string length, which a user-supplied dump is exactly the input those guards exist for.
+    private final ObjectMapper mapper = JsonObjectMapper.getMapper();
 
     @Override
     public boolean supports(String contentType) {
@@ -63,7 +67,9 @@ public class JsonRowSource implements RowSource {
             }
             records = mapper.readerFor(JsonNode.class).readValues(parser);
         } catch (IOException | RuntimeException failure) {
-            // The parser does not own a stream it was handed, so releasing it is not enough.
+            // The parser does not own a stream it was handed, so releasing it is not enough. Both
+            // closes swallow: the read already failed, and a close failure on top of it adds nothing
+            // the caller can act on and must not mask the failure that matters.
             closeQuietly(parser);
             closeQuietly(source);
             throw failure;
@@ -152,14 +158,6 @@ public class JsonRowSource implements RowSource {
             parser.close();
         } catch (IOException e) {
             throw new UncheckedIOException("closing the json source failed", e);
-        }
-    }
-
-    private static void closeQuietly(Closeable closeable) {
-        try {
-            closeable.close();
-        } catch (IOException ignored) {
-            // the read already failed; the close failure adds nothing the caller can act on
         }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
@@ -98,8 +98,6 @@ public class TabularRowReader {
         try {
             return reader.rows(source, resolved).onClose(() -> closeQuietly(source));
         } catch (IOException | RuntimeException failure) {
-            // Swallowing the close: the read already failed or already finished, so a failure to
-            // release the source adds nothing the caller can act on and must not mask the real one.
             closeQuietly(source);
             throw failure;
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/TabularRowReader.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.commons.io.IOUtils.closeQuietly;
+
 /**
  * Turns the document a mapping names into rows. Addressing the source by document id rather than by
  * path is what buys embedded sources (a CSV inside a ZIP, a workbook attached to an email) through
@@ -67,20 +69,14 @@ public class TabularRowReader {
     private final Indexer indexer;
     private final SourceExtractor sourceExtractor;
     private final List<RowSource> readers;
-    private final RowSource fallback;
 
     public TabularRowReader(Indexer indexer, SourceExtractor sourceExtractor) {
-        this(indexer, sourceExtractor,
-                List.of(new DelimitedRowSource(), new WorkbookRowSource(), new JsonRowSource()),
-                new TikaTableRowSource());
-    }
-
-    TabularRowReader(Indexer indexer, SourceExtractor sourceExtractor, List<RowSource> readers,
-                     RowSource fallback) {
         this.indexer = indexer;
         this.sourceExtractor = sourceExtractor;
-        this.readers = readers;
-        this.fallback = fallback;
+        // Tika last: it is the tier-2 fallback, and only the types it was confirmed to render as
+        // table markup reach it, so it never displaces a tier-1 reader that claims the same type.
+        this.readers = List.of(new DelimitedRowSource(), new WorkbookRowSource(), new JsonRowSource(),
+                new TikaTableRowSource());
     }
 
     /**
@@ -102,6 +98,8 @@ public class TabularRowReader {
         try {
             return reader.rows(source, resolved).onClose(() -> closeQuietly(source));
         } catch (IOException | RuntimeException failure) {
+            // Swallowing the close: the read already failed or already finished, so a failure to
+            // release the source adds nothing the caller can act on and must not mask the real one.
             closeQuietly(source);
             throw failure;
         }
@@ -138,9 +136,6 @@ public class TabularRowReader {
             if (reader.supports(contentType)) {
                 return reader;
             }
-        }
-        if (fallback.supports(contentType)) {
-            return fallback;
         }
         throw new IllegalArgumentException(
                 "no reader supports " + contentType + ", supported content types: " + SUPPORTED_CONTENT_TYPES);
@@ -184,13 +179,5 @@ public class TabularRowReader {
         }
         Object name = metadata.get(DELIMITER_METADATA_KEY);
         return name == null ? null : DELIMITER_BY_TIKA_NAME.get(name.toString().toLowerCase(Locale.ROOT));
-    }
-
-    private static void closeQuietly(InputStream source) {
-        try {
-            source.close();
-        } catch (IOException ignored) {
-            // the read already failed or already finished; the close failure adds nothing actionable
-        }
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
@@ -53,8 +53,6 @@ public class WorkbookRowSource implements RowSource {
         try {
             workbook = WorkbookFactory.create(source);
         } catch (IOException | RuntimeException failure) {
-            // Swallowing the close: the workbook never opened, so a close failure on top of that adds
-            // nothing the caller can act on and must not mask the failure that matters.
             closeQuietly(source);
             throw failure;
         }

--- a/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tabular/WorkbookRowSource.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.commons.io.IOUtils.closeQuietly;
+
 /**
  * Reads a workbook with POI. The whole workbook is loaded in memory, roughly 5 to 10 times the file
  * size in heap: streaming would mean two Excel code paths, since HSSF has no practical streaming
@@ -51,6 +53,8 @@ public class WorkbookRowSource implements RowSource {
         try {
             workbook = WorkbookFactory.create(source);
         } catch (IOException | RuntimeException failure) {
+            // Swallowing the close: the workbook never opened, so a close failure on top of that adds
+            // nothing the caller can act on and must not mask the failure that matters.
             closeQuietly(source);
             throw failure;
         }
@@ -175,14 +179,6 @@ public class WorkbookRowSource implements RowSource {
             workbook.close();
         } catch (IOException e) {
             throw new UncheckedIOException("closing the workbook failed", e);
-        }
-    }
-
-    private static void closeQuietly(InputStream source) {
-        try {
-            source.close();
-        } catch (IOException ignored) {
-            // the workbook already failed to open; the close failure adds nothing actionable
         }
     }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
@@ -158,4 +158,14 @@ public class JsonRowSourceTest {
         }
     }
 
+    // The reader takes a user-supplied dump, not an HTTP body, so a single field larger than
+    // Jackson's 20 MB default cap has to read rather than fail the whole import.
+    @Test
+    public void test_reads_a_string_larger_than_jacksons_default_cap() throws Exception {
+        String blob = "x".repeat(20_000_001);
+
+        List<Row> rows = read("{\"blob\":\"" + blob + "\"}");
+
+        assertThat(rows.get(0).values().get("blob")).isEqualTo(blob);
+    }
 }

--- a/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tabular/JsonRowSourceTest.java
@@ -124,6 +124,29 @@ public class JsonRowSourceTest {
     }
 
     @Test
+    public void test_content_after_an_empty_root_array_is_refused() throws Exception {
+        try {
+            read("[]\n[{\"id\":1}]");
+            fail("an empty array must not turn off the trailing-content check");
+        } catch (IllegalArgumentException failure) {
+            assertThat(failure.getMessage()).contains("content after the end of the json array");
+        }
+    }
+
+    @Test
+    public void test_a_deeply_nested_record_still_flattens() throws Exception {
+        StringBuilder open = new StringBuilder("[{");
+        for (int level = 0; level < 30; level++) {
+            open.append("\"k").append(level).append("\":{");
+        }
+        String json = open + "\"leaf\":1" + "}".repeat(31) + "]";
+
+        assertThat(read(json).get(0).values().keySet().iterator().next())
+                .isEqualTo("k0.k1.k2.k3.k4.k5.k6.k7.k8.k9.k10.k11.k12.k13.k14.k15.k16.k17.k18.k19"
+                        + ".k20.k21.k22.k23.k24.k25.k26.k27.k28.k29.leaf");
+    }
+
+    @Test
     public void test_an_empty_source_is_refused() throws Exception {
         for (String empty : List.of("", "   ")) {
             try {

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqCasbinRuleAdapter.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqCasbinRuleAdapter.java
@@ -41,7 +41,7 @@ public class JooqCasbinRuleAdapter implements CasbinRuleAdapter {
         this.batchSize = batchSize;
     }
 
-    private static int determineBatchSize(SQLDialect dialect) {
+    static int determineBatchSize(SQLDialect dialect) {
         if (dialect.getName().contains("SQLite")) {
             return SQLITE_BATCHSIZE;  // SQLite: prefer larger batches in single transaction
         } else if (dialect.getName().contains("Postgres")) {

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
@@ -1,6 +1,6 @@
 package org.icij.datashare.db;
 
-import com.fasterxml.jackson.databind.DatabindException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.model.TargetModel;
 import org.icij.datashare.tabular.ExtractionMapping;
@@ -100,7 +100,7 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
     private static ExtractionMapping read(String id, String definition) {
         try {
             return JsonObjectMapper.readValue(definition, ExtractionMapping.class);
-        } catch (DatabindException e) {
+        } catch (JsonProcessingException e) {
             throw new UnreadableExtractionMapping(id, e);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
@@ -1,15 +1,19 @@
 package org.icij.datashare.db;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DatabindException;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.model.TargetModel;
 import org.icij.datashare.tabular.ExtractionMapping;
 import org.icij.datashare.tabular.ExtractionMappingRepository;
 import org.icij.datashare.tabular.InvalidExtractionMapping;
+import org.icij.datashare.tabular.UnreadableExtractionMapping;
 import org.icij.datashare.time.DatashareTime;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.io.IOException;
@@ -17,10 +21,12 @@ import java.io.UncheckedIOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.icij.datashare.db.Tables.EXTRACTION_MAPPING;
 
 public class JooqExtractionMappingRepository implements ExtractionMappingRepository {
+    private static final Logger logger = LoggerFactory.getLogger(JooqExtractionMappingRepository.class);
     private final DataSource dataSource;
     private final SQLDialect dialect;
 
@@ -43,26 +49,36 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
                 .set(EXTRACTION_MAPPING.DEFINITION, write(mapping))
                 .set(EXTRACTION_MAPPING.CREATED_AT,
                         new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime())
-                .onConflictDoNothing().execute() > 0;
+                .onConflict(EXTRACTION_MAPPING.ID, EXTRACTION_MAPPING.PRJ_ID).doNothing().execute() > 0;
     }
 
     @Override
-    public Optional<ExtractionMapping> get(String id) {
+    public Optional<ExtractionMapping> get(String projectId, String id) {
         return Optional.ofNullable(create().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
-                .where(EXTRACTION_MAPPING.ID.eq(id)).fetchOne()).map(row -> read(row.value1()));
+                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).fetchOne())
+                .map(row -> read(id, row.value1()));
     }
 
     @Override
     public List<ExtractionMapping> list(String projectId) {
-        return create().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
+        return create().select(EXTRACTION_MAPPING.ID, EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
                 .where(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
                 .orderBy(EXTRACTION_MAPPING.CREATED_AT)
-                .fetch().map(row -> read(row.value1()));
+                .fetch().stream()
+                .flatMap(row -> {
+                    try {
+                        return Stream.of(read(row.value1(), row.value2()));
+                    } catch (UnreadableExtractionMapping e) {
+                        logger.warn("skipping unreadable extraction mapping '{}'", row.value1(), e);
+                        return Stream.empty();
+                    }
+                }).toList();
     }
 
     @Override
-    public boolean delete(String id) {
-        return create().deleteFrom(EXTRACTION_MAPPING).where(EXTRACTION_MAPPING.ID.eq(id)).execute() > 0;
+    public boolean delete(String projectId, String id) {
+        return create().deleteFrom(EXTRACTION_MAPPING)
+                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).execute() > 0;
     }
 
     private DSLContext create() {
@@ -81,9 +97,11 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
         }
     }
 
-    private static ExtractionMapping read(String definition) {
+    private static ExtractionMapping read(String id, String definition) {
         try {
             return JsonObjectMapper.readValue(definition, new TypeReference<ExtractionMapping>() {});
+        } catch (DatabindException e) {
+            throw new UnreadableExtractionMapping(id, e);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.db;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DatabindException;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.model.TargetModel;
@@ -54,9 +53,10 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
 
     @Override
     public Optional<ExtractionMapping> get(String projectId, String id) {
-        return Optional.ofNullable(create().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
-                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).fetchOne())
-                .map(row -> read(id, row.value1()));
+        return create().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
+                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
+                .fetchOptional(EXTRACTION_MAPPING.DEFINITION)
+                .map(definition -> read(id, definition));
     }
 
     @Override
@@ -99,7 +99,7 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
 
     private static ExtractionMapping read(String id, String definition) {
         try {
-            return JsonObjectMapper.readValue(definition, new TypeReference<ExtractionMapping>() {});
+            return JsonObjectMapper.readValue(definition, ExtractionMapping.class);
         } catch (DatabindException e) {
             throw new UnreadableExtractionMapping(id, e);
         } catch (IOException e) {

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
@@ -1,0 +1,91 @@
+package org.icij.datashare.db;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.model.TargetModel;
+import org.icij.datashare.tabular.ExtractionMapping;
+import org.icij.datashare.tabular.ExtractionMappingRepository;
+import org.icij.datashare.tabular.InvalidExtractionMapping;
+import org.icij.datashare.time.DatashareTime;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Optional;
+
+import static org.icij.datashare.db.Tables.EXTRACTION_MAPPING;
+
+public class JooqExtractionMappingRepository implements ExtractionMappingRepository {
+    private final DataSource dataSource;
+    private final SQLDialect dialect;
+
+    public JooqExtractionMappingRepository(DataSource dataSource, SQLDialect dialect) {
+        this.dataSource = dataSource;
+        this.dialect = dialect;
+    }
+
+    @Override
+    public boolean save(ExtractionMapping mapping) {
+        List<TargetModel.Violation> violations = mapping.validate();
+        if (!violations.isEmpty()) {
+            throw new InvalidExtractionMapping(mapping.id(), violations);
+        }
+        return create().insertInto(EXTRACTION_MAPPING)
+                .set(EXTRACTION_MAPPING.ID, mapping.id())
+                .set(EXTRACTION_MAPPING.PRJ_ID, mapping.projectId())
+                .set(EXTRACTION_MAPPING.USER_ID, mapping.userId())
+                .set(EXTRACTION_MAPPING.NAME, mapping.name())
+                .set(EXTRACTION_MAPPING.DEFINITION, write(mapping))
+                .set(EXTRACTION_MAPPING.CREATED_AT,
+                        new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime())
+                .onConflictDoNothing().execute() > 0;
+    }
+
+    @Override
+    public Optional<ExtractionMapping> get(String id) {
+        return Optional.ofNullable(create().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
+                .where(EXTRACTION_MAPPING.ID.eq(id)).fetchOne()).map(row -> read(row.value1()));
+    }
+
+    @Override
+    public List<ExtractionMapping> list(String projectId) {
+        return create().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
+                .where(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
+                .orderBy(EXTRACTION_MAPPING.CREATED_AT)
+                .fetch().map(row -> read(row.value1()));
+    }
+
+    @Override
+    public boolean delete(String id) {
+        return create().deleteFrom(EXTRACTION_MAPPING).where(EXTRACTION_MAPPING.ID.eq(id)).execute() > 0;
+    }
+
+    private DSLContext create() {
+        return DSL.using(dataSource, dialect);
+    }
+
+    // The definition column holds one concrete record type, not a Map<String, Object>, so there is
+    // no @type marker to force: the plain mapper round-trips it, and it also spares Charset (e.g.
+    // sun.nio.cs.UTF_8) from the typed mapper's polymorphic deserialization, which has no
+    // string-argument constructor to satisfy.
+    private static String write(ExtractionMapping mapping) {
+        try {
+            return JsonObjectMapper.writeValueAsString(mapping);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static ExtractionMapping read(String definition) {
+        try {
+            return JsonObjectMapper.readValue(definition, new TypeReference<ExtractionMapping>() {});
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
@@ -8,6 +8,7 @@ import org.icij.datashare.tabular.InvalidExtractionMapping;
 import org.icij.datashare.tabular.UnreadableExtractionMapping;
 import org.icij.datashare.time.DatashareTime;
 import org.jooq.DSLContext;
+import org.jooq.Record3;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
@@ -17,6 +18,8 @@ import javax.sql.DataSource;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -58,17 +61,22 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
                 .map(definition -> read(id, definition));
     }
 
+    // created_at holds milliseconds, so two mappings authored in the same millisecond tie and the
+    // order falls to id. That tie is broken here rather than in the ORDER BY, because a database
+    // collation would otherwise decide it, and SQLite and Postgres do not sort text alike.
     @Override
     public List<ExtractionMapping> list(String projectId) {
-        return create().select(EXTRACTION_MAPPING.ID, EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
+        return create().select(EXTRACTION_MAPPING.CREATED_AT, EXTRACTION_MAPPING.ID, EXTRACTION_MAPPING.DEFINITION)
+                .from(EXTRACTION_MAPPING)
                 .where(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
-                .orderBy(EXTRACTION_MAPPING.CREATED_AT, EXTRACTION_MAPPING.ID)
                 .fetch().stream()
+                .sorted(Comparator.<Record3<LocalDateTime, String, String>, LocalDateTime>comparing(Record3::value1)
+                        .thenComparing(Record3::value2, Comparator.naturalOrder()))
                 .flatMap(row -> {
                     try {
-                        return Stream.of(read(row.value1(), row.value2()));
+                        return Stream.of(read(row.value2(), row.value3()));
                     } catch (UnreadableExtractionMapping e) {
-                        logger.warn("skipping unreadable extraction mapping '{}'", row.value1(), e);
+                        logger.warn("skipping unreadable extraction mapping '{}'", row.value2(), e);
                         return Stream.empty();
                     }
                 }).toList();

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqExtractionMappingRepository.java
@@ -1,6 +1,5 @@
 package org.icij.datashare.db;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.model.TargetModel;
 import org.icij.datashare.tabular.ExtractionMapping;
@@ -63,7 +62,7 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
     public List<ExtractionMapping> list(String projectId) {
         return create().select(EXTRACTION_MAPPING.ID, EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
                 .where(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
-                .orderBy(EXTRACTION_MAPPING.CREATED_AT)
+                .orderBy(EXTRACTION_MAPPING.CREATED_AT, EXTRACTION_MAPPING.ID)
                 .fetch().stream()
                 .flatMap(row -> {
                     try {
@@ -100,10 +99,8 @@ public class JooqExtractionMappingRepository implements ExtractionMappingReposit
     private static ExtractionMapping read(String id, String definition) {
         try {
             return JsonObjectMapper.readValue(definition, ExtractionMapping.class);
-        } catch (JsonProcessingException e) {
-            throw new UnreadableExtractionMapping(id, e);
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new UnreadableExtractionMapping(id, e);
         }
     }
 }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqRepository.java
@@ -40,7 +40,9 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.icij.datashare.UserEvent.Type.fromId;
 import static org.icij.datashare.db.Tables.CASBIN_RULE;
+import static org.icij.datashare.db.Tables.EXTRACTION_MAPPING;
 import static org.icij.datashare.db.Tables.PATH_BANNER;
+import static org.icij.datashare.db.Tables.STATEMENT;
 import static org.icij.datashare.db.Tables.USER_HISTORY_PROJECT;
 import static org.icij.datashare.db.tables.Document.DOCUMENT;
 import static org.icij.datashare.db.tables.DocumentTag.DOCUMENT_TAG;
@@ -411,8 +413,12 @@ public class JooqRepository implements Repository {
             int deleteUserRecommendationResult = inner.deleteFrom(DOCUMENT_USER_RECOMMENDATION).where(DOCUMENT_USER_RECOMMENDATION.PRJ_ID.eq(projectId)).execute();
             List<Integer> deletedUserHistoryProjectIds = inner.deleteFrom(USER_HISTORY_PROJECT).where(USER_HISTORY_PROJECT.PRJ_ID.eq(projectId)).returning().fetch().getValues(USER_HISTORY_PROJECT.USER_HISTORY_ID);
             int deleteUserHistoryResult = inner.deleteFrom(USER_HISTORY).where(USER_HISTORY.ID.in(deletedUserHistoryProjectIds)).execute();
+            int deleteStatementResult = inner.deleteFrom(STATEMENT).where(STATEMENT.PRJ_ID.eq(projectId)).execute();
+            int deleteExtractionMappingResult = inner.deleteFrom(EXTRACTION_MAPPING).where(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).execute();
             int deleteProject = inner.deleteFrom(PROJECT).where(PROJECT.ID.eq(projectId)).execute();
-            return deleteStarResult + deleteTagResult + deleteUserRecommendationResult + deletedUserHistoryProjectIds.size() + deleteUserHistoryResult + deleteProject > 0;
+            return deleteStarResult + deleteTagResult + deleteUserRecommendationResult
+                    + deletedUserHistoryProjectIds.size() + deleteUserHistoryResult
+                    + deleteStatementResult + deleteExtractionMappingResult + deleteProject > 0;
         });
 
     }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -15,11 +15,17 @@ import org.jooq.impl.DSL;
 import javax.sql.DataSource;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.icij.datashare.db.Tables.STATEMENT;
 
@@ -69,12 +75,63 @@ public class JooqStatementRepository implements StatementRepository {
     }
 
     @Override
-    public Stream<ModelEntity> entities(String projectId) {
-        throw new UnsupportedOperationException("task 5");
+    public Optional<ModelEntity> entity(String projectId, String entityId) {
+        List<Statement> statements = DSL.using(dataSource, dialect)
+                .selectFrom(STATEMENT)
+                .where(STATEMENT.PRJ_ID.eq(projectId)).and(STATEMENT.ENTITY_ID.eq(entityId))
+                .fetch().map(JooqStatementRepository::toStatement);
+        return statements.isEmpty() ? Optional.empty() : Optional.of(ModelEntity.from(statements));
     }
 
     @Override
-    public Optional<ModelEntity> entity(String projectId, String entityId) {
-        throw new UnsupportedOperationException("task 5");
+    public Stream<ModelEntity> entities(String projectId) {
+        Stream<Statement> rows = DSL.using(dataSource, dialect)
+                .selectFrom(STATEMENT)
+                .where(STATEMENT.PRJ_ID.eq(projectId))
+                .orderBy(STATEMENT.ENTITY_ID)
+                .fetchLazy().stream()
+                .map(JooqStatementRepository::toStatement);
+        return group(rows);
+    }
+
+    private static Statement toStatement(StatementRecord row) {
+        return new Statement(row.getId(), row.getModel(), row.getEntityId(), row.getEntityType(),
+                row.getProperty().substring(row.getModel().length() + 1), row.getValue(),
+                new Statement.Provenance(row.getDocId(), row.getSheet(), row.getRowNumber(), row.getColumnName()));
+    }
+
+    // The query is ordered by entity_id, so an entity's statements are consecutive and each group can
+    // be emitted without holding the whole project in memory: one CSV can produce 100k+ entities.
+    private static Stream<ModelEntity> group(Stream<Statement> statements) {
+        Iterator<Statement> rows = statements.iterator();
+        Iterator<ModelEntity> entities = new Iterator<>() {
+            private Statement pending = rows.hasNext() ? rows.next() : null;
+
+            @Override
+            public boolean hasNext() {
+                return pending != null;
+            }
+
+            @Override
+            public ModelEntity next() {
+                if (pending == null) {
+                    throw new NoSuchElementException();
+                }
+                List<Statement> group = new ArrayList<>(List.of(pending));
+                String entityId = pending.entityId();
+                pending = null;
+                while (rows.hasNext()) {
+                    Statement row = rows.next();
+                    if (!row.entityId().equals(entityId)) {
+                        pending = row;
+                        break;
+                    }
+                    group.add(row);
+                }
+                return ModelEntity.from(group);
+            }
+        };
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(entities, Spliterator.ORDERED), false)
+                .onClose(statements::close);
     }
 }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -64,7 +64,8 @@ public class JooqStatementRepository implements StatementRepository {
                 .set(STATEMENT.LAST_SEEN, now)
                 .onConflict(STATEMENT.ID).doUpdate()
                 .set(STATEMENT.LAST_SEEN, now)
-                .set(STATEMENT.RUN_ID, runId);
+                .set(STATEMENT.RUN_ID, runId)
+                .set(STATEMENT.MODEL_VERSION, TargetModelRegistry.get(statement.model()).version());
     }
 
     @Override

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -119,9 +119,21 @@ public class JooqStatementRepository implements StatementRepository {
     // A DataSource-bound DSLContext never sets autoCommit(false), and pgjdbc only opens a
     // server-side cursor when fetchSize > 0 AND autoCommit is false: without both, the driver
     // buffers the whole result before the first row is emitted. So this holds one connection,
-    // outside the pool's default autocommit, for the stream's lifetime.
+    // outside the pool's default autocommit, for the stream's lifetime. xerial's SQLite driver
+    // ignores fetchSize entirely, so the same treatment there is pure cost: a held read
+    // transaction on the shared-cache SQLite database, which makes a concurrent writer fail with
+    // SQLITE_LOCKED instead of retrying.
     @Override
     public Stream<ModelEntity> entities(String projectId) {
+        if (dialect != SQLDialect.POSTGRES) {
+            Stream<Statement> rows = create()
+                    .selectFrom(STATEMENT)
+                    .where(STATEMENT.PRJ_ID.eq(projectId))
+                    .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
+                    .fetchStream()
+                    .map(JooqStatementRepository::toStatement);
+            return group(rows);
+        }
         Connection connection = openStreamingConnection();
         try {
             Cursor<StatementRecord> cursor = DSL.using(connection, dialect)
@@ -230,9 +242,5 @@ public class JooqStatementRepository implements StatementRepository {
         };
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(entities, Spliterator.ORDERED), false)
                 .onClose(statements::close);
-    }
-
-    int chunkSize() {
-        return chunkSize;
     }
 }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -7,7 +7,6 @@ import org.icij.datashare.model.StatementRepository;
 import org.icij.datashare.model.TargetModelRegistry;
 import org.icij.datashare.time.DatashareTime;
 import org.jooq.DSLContext;
-import org.jooq.InsertOnDuplicateSetMoreStep;
 import org.jooq.Query;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
@@ -23,6 +22,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -42,18 +42,21 @@ public class JooqStatementRepository implements StatementRepository {
     @Override
     public int save(String projectId, String runId, Collection<Statement> statements) {
         LocalDateTime now = new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime();
-        return DSL.using(dataSource, dialect).transactionResult(configuration -> {
-            DSLContext create = DSL.using(configuration);
-            List<Query> queries = statements.stream().map(statement -> (Query) upsert(create, projectId, runId, statement, now)).toList();
-            int written = 0;
-            for (int from = 0; from < queries.size(); from += CHUNK) {
-                written += IntStream.of(create.batch(queries.subList(from, Math.min(from + CHUNK, queries.size()))).execute()).sum();
-            }
-            return written;
-        });
+        List<Statement> ordered = List.copyOf(statements);
+        int written = 0;
+        for (int from = 0; from < ordered.size(); from += CHUNK) {
+            List<Statement> chunk = ordered.subList(from, Math.min(from + CHUNK, ordered.size()));
+            written += DSL.using(dataSource, dialect).transactionResult(configuration -> {
+                DSLContext create = DSL.using(configuration);
+                List<Query> queries = chunk.stream()
+                        .map(statement -> upsert(create, projectId, runId, statement, now)).toList();
+                return IntStream.of(create.batch(queries).execute()).sum();
+            });
+        }
+        return written;
     }
 
-    private InsertOnDuplicateSetMoreStep<StatementRecord> upsert(DSLContext create, String projectId, String runId, Statement statement, LocalDateTime now) {
+    private Query upsert(DSLContext create, String projectId, String runId, Statement statement, LocalDateTime now) {
         return create.insertInto(STATEMENT)
                 .set(STATEMENT.ID, statement.id())
                 .set(STATEMENT.PRJ_ID, projectId)
@@ -70,10 +73,7 @@ public class JooqStatementRepository implements StatementRepository {
                 .set(STATEMENT.COLUMN_NAME, statement.provenance().column())
                 .set(STATEMENT.FIRST_SEEN, now)
                 .set(STATEMENT.LAST_SEEN, now)
-                .onConflict(STATEMENT.PRJ_ID, STATEMENT.ID).doUpdate()
-                .set(STATEMENT.LAST_SEEN, now)
-                .set(STATEMENT.RUN_ID, runId)
-                .set(STATEMENT.MODEL_VERSION, TargetModelRegistry.get(statement.model()).version());
+                .onConflictDoNothing();
     }
 
     @Override
@@ -81,6 +81,7 @@ public class JooqStatementRepository implements StatementRepository {
         List<Statement> statements = DSL.using(dataSource, dialect)
                 .selectFrom(STATEMENT)
                 .where(STATEMENT.PRJ_ID.eq(projectId)).and(STATEMENT.ENTITY_ID.eq(entityId))
+                .orderBy(STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
                 .fetch().map(JooqStatementRepository::toStatement);
         return statements.isEmpty() ? Optional.empty() : Optional.of(ModelEntity.from(statements));
     }
@@ -90,10 +91,17 @@ public class JooqStatementRepository implements StatementRepository {
         Stream<Statement> rows = DSL.using(dataSource, dialect)
                 .selectFrom(STATEMENT)
                 .where(STATEMENT.PRJ_ID.eq(projectId))
-                .orderBy(STATEMENT.ENTITY_ID)
+                .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
                 .fetchLazy().stream()
                 .map(JooqStatementRepository::toStatement);
         return group(rows);
+    }
+
+    @Override
+    public <R> R entities(String projectId, Function<Stream<ModelEntity>, R> consumer) {
+        try (Stream<ModelEntity> entities = entities(projectId)) {
+            return consumer.apply(entities);
+        }
     }
 
     private static Statement toStatement(StatementRecord row) {
@@ -102,8 +110,10 @@ public class JooqStatementRepository implements StatementRepository {
                 new Statement.Provenance(row.getDocId(), row.getSheet(), row.getRowNumber(), row.getColumnName()));
     }
 
-    // The query is ordered by entity_id, so an entity's statements are consecutive and each group can
-    // be emitted without holding the whole project in memory: one CSV can produce 100k+ entities.
+    // The query is ordered by (entity_id, model), so an entity's statements are consecutive and each
+    // group can be emitted without holding the whole project in memory: one CSV can produce 100k+
+    // entities. Grouping on entity_id alone would let a same-id entity spanning two models reach
+    // ModelEntity.from, which throws on a multi-model group.
     private static Stream<ModelEntity> group(Stream<Statement> statements) {
         Iterator<Statement> rows = statements.iterator();
         Iterator<ModelEntity> entities = new Iterator<>() {
@@ -126,10 +136,11 @@ public class JooqStatementRepository implements StatementRepository {
                 }
                 List<Statement> group = new ArrayList<>(List.of(pending));
                 String entityId = pending.entityId();
+                String model = pending.model();
                 pending = null;
                 while (rows.hasNext()) {
                     Statement row = rows.next();
-                    if (!row.entityId().equals(entityId)) {
+                    if (!row.entityId().equals(entityId) || !row.model().equals(model)) {
                         pending = row;
                         break;
                     }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -1,0 +1,79 @@
+package org.icij.datashare.db;
+
+import org.icij.datashare.db.tables.records.StatementRecord;
+import org.icij.datashare.model.ModelEntity;
+import org.icij.datashare.model.Statement;
+import org.icij.datashare.model.StatementRepository;
+import org.icij.datashare.model.TargetModelRegistry;
+import org.icij.datashare.time.DatashareTime;
+import org.jooq.DSLContext;
+import org.jooq.InsertOnDuplicateSetMoreStep;
+import org.jooq.Query;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
+import javax.sql.DataSource;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.icij.datashare.db.Tables.STATEMENT;
+
+public class JooqStatementRepository implements StatementRepository {
+    private static final int CHUNK = 1_000;
+    private final DataSource dataSource;
+    private final SQLDialect dialect;
+
+    public JooqStatementRepository(DataSource dataSource, SQLDialect dialect) {
+        this.dataSource = dataSource;
+        this.dialect = dialect;
+    }
+
+    @Override
+    public int save(String projectId, String runId, Collection<Statement> statements) {
+        LocalDateTime now = new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime();
+        DSLContext create = DSL.using(dataSource, dialect);
+        List<Query> queries = statements.stream().map(statement -> (Query) upsert(create, projectId, runId, statement, now)).toList();
+        int written = 0;
+        for (int from = 0; from < queries.size(); from += CHUNK) {
+            written += IntStream.of(create.batch(queries.subList(from, Math.min(from + CHUNK, queries.size()))).execute()).sum();
+        }
+        return written;
+    }
+
+    private InsertOnDuplicateSetMoreStep<StatementRecord> upsert(DSLContext create, String projectId, String runId, Statement statement, LocalDateTime now) {
+        return create.insertInto(STATEMENT)
+                .set(STATEMENT.ID, statement.id())
+                .set(STATEMENT.PRJ_ID, projectId)
+                .set(STATEMENT.RUN_ID, runId)
+                .set(STATEMENT.MODEL, statement.model())
+                .set(STATEMENT.MODEL_VERSION, TargetModelRegistry.get(statement.model()).version())
+                .set(STATEMENT.ENTITY_ID, statement.entityId())
+                .set(STATEMENT.ENTITY_TYPE, statement.entityType())
+                .set(STATEMENT.PROPERTY, statement.qualifiedProperty())
+                .set(STATEMENT.VALUE, statement.value())
+                .set(STATEMENT.DOC_ID, statement.provenance().documentId())
+                .set(STATEMENT.SHEET, statement.provenance().sheet())
+                .set(STATEMENT.ROW_NUMBER, statement.provenance().rowNumber())
+                .set(STATEMENT.COLUMN_NAME, statement.provenance().column())
+                .set(STATEMENT.FIRST_SEEN, now)
+                .set(STATEMENT.LAST_SEEN, now)
+                .onConflict(STATEMENT.ID).doUpdate()
+                .set(STATEMENT.LAST_SEEN, now)
+                .set(STATEMENT.RUN_ID, runId);
+    }
+
+    @Override
+    public Stream<ModelEntity> entities(String projectId) {
+        throw new UnsupportedOperationException("task 5");
+    }
+
+    @Override
+    public Optional<ModelEntity> entity(String projectId, String entityId) {
+        throw new UnsupportedOperationException("task 5");
+    }
+}

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -42,13 +42,15 @@ public class JooqStatementRepository implements StatementRepository {
     @Override
     public int save(String projectId, String runId, Collection<Statement> statements) {
         LocalDateTime now = new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime();
-        DSLContext create = DSL.using(dataSource, dialect);
-        List<Query> queries = statements.stream().map(statement -> (Query) upsert(create, projectId, runId, statement, now)).toList();
-        int written = 0;
-        for (int from = 0; from < queries.size(); from += CHUNK) {
-            written += IntStream.of(create.batch(queries.subList(from, Math.min(from + CHUNK, queries.size()))).execute()).sum();
-        }
-        return written;
+        return DSL.using(dataSource, dialect).transactionResult(configuration -> {
+            DSLContext create = DSL.using(configuration);
+            List<Query> queries = statements.stream().map(statement -> (Query) upsert(create, projectId, runId, statement, now)).toList();
+            int written = 0;
+            for (int from = 0; from < queries.size(); from += CHUNK) {
+                written += IntStream.of(create.batch(queries.subList(from, Math.min(from + CHUNK, queries.size()))).execute()).sum();
+            }
+            return written;
+        });
     }
 
     private InsertOnDuplicateSetMoreStep<StatementRecord> upsert(DSLContext create, String projectId, String runId, Statement statement, LocalDateTime now) {
@@ -68,7 +70,7 @@ public class JooqStatementRepository implements StatementRepository {
                 .set(STATEMENT.COLUMN_NAME, statement.provenance().column())
                 .set(STATEMENT.FIRST_SEEN, now)
                 .set(STATEMENT.LAST_SEEN, now)
-                .onConflict(STATEMENT.ID).doUpdate()
+                .onConflict(STATEMENT.PRJ_ID, STATEMENT.ID).doUpdate()
                 .set(STATEMENT.LAST_SEEN, now)
                 .set(STATEMENT.RUN_ID, runId)
                 .set(STATEMENT.MODEL_VERSION, TargetModelRegistry.get(statement.model()).version());
@@ -105,16 +107,21 @@ public class JooqStatementRepository implements StatementRepository {
     private static Stream<ModelEntity> group(Stream<Statement> statements) {
         Iterator<Statement> rows = statements.iterator();
         Iterator<ModelEntity> entities = new Iterator<>() {
-            private Statement pending = rows.hasNext() ? rows.next() : null;
+            private Statement pending;
+            private boolean primed;
 
             @Override
             public boolean hasNext() {
+                if (!primed) {
+                    pending = rows.hasNext() ? rows.next() : null;
+                    primed = true;
+                }
                 return pending != null;
             }
 
             @Override
             public ModelEntity next() {
-                if (pending == null) {
+                if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
                 List<Statement> group = new ArrayList<>(List.of(pending));

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -11,6 +11,7 @@ import org.jooq.Cursor;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
+import org.jooq.ResultQuery;
 import org.jooq.SQLDialect;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -22,8 +23,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -42,8 +41,6 @@ public class JooqStatementRepository implements StatementRepository {
     private static final Field<?>[] READ_FIELDS = {
             STATEMENT.ID, STATEMENT.MODEL, STATEMENT.ENTITY_ID, STATEMENT.ENTITY_TYPE, STATEMENT.PROPERTY,
             STATEMENT.VALUE, STATEMENT.DOC_ID, STATEMENT.SHEET, STATEMENT.ROW_NUMBER, STATEMENT.COLUMN_NAME};
-    private static final Comparator<Statement> BY_PROPERTY_THEN_VALUE =
-            Comparator.comparing(Statement::property).thenComparing(Statement::value);
     private final DataSource dataSource;
     private final SQLDialect dialect;
     private final int chunkSize;
@@ -61,18 +58,21 @@ public class JooqStatementRepository implements StatementRepository {
     private record Write(String projectId, String runId, LocalDateTime now) { }
 
     @Override
-    public int save(String projectId, String runId, Collection<Statement> statements) {
+    public int save(String projectId, String runId, Stream<Statement> statements) {
         Write write = new Write(projectId, runId,
                 new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime());
-        Iterator<Statement> source = statements.iterator();
+        DSLContext create = create();
         int written = 0;
-        while (source.hasNext()) {
-            List<Statement> chunk = new ArrayList<>(Math.min(chunkSize, statements.size()));
-            while (chunk.size() < chunkSize && source.hasNext()) {
-                chunk.add(source.next());
+        try (statements) {
+            Iterator<Statement> source = statements.iterator();
+            while (source.hasNext()) {
+                List<Statement> chunk = new ArrayList<>(chunkSize);
+                while (chunk.size() < chunkSize && source.hasNext()) {
+                    chunk.add(source.next());
+                }
+                written += create.transactionResult(configuration ->
+                        saveChunk(DSL.using(configuration), write, chunk));
             }
-            written += create().transactionResult(configuration ->
-                    saveChunk(DSL.using(configuration), write, chunk));
         }
         return written;
     }
@@ -81,10 +81,14 @@ public class JooqStatementRepository implements StatementRepository {
     // (jOOQ's "batch multiple"); a batch built from one bound template query and repeated .bind()
     // calls ("batch single") reuses the same PreparedStatement and lets Postgres plan it once. Both
     // the template's column list and each row's positional binds come from the same record, so they
-    // cannot drift.
+    // cannot drift, and the conflict branch reads the row being inserted through EXCLUDED rather than
+    // binding its own values, which would not line up with the record's positional binds.
     private static int saveChunk(DSLContext create, Write write, List<Statement> chunk) {
-        BatchBindStep batch = create.batch(
-                create.insertInto(STATEMENT).set(row(write, chunk.get(0))).onConflictDoNothing());
+        BatchBindStep batch = create.batch(create.insertInto(STATEMENT).set(row(write, chunk.get(0)))
+                .onConflict(STATEMENT.ID, STATEMENT.PRJ_ID).doUpdate()
+                .set(STATEMENT.RUN_ID, DSL.excluded(STATEMENT.RUN_ID))
+                .set(STATEMENT.MODEL_VERSION, DSL.excluded(STATEMENT.MODEL_VERSION))
+                .set(STATEMENT.LAST_SEEN, DSL.excluded(STATEMENT.LAST_SEEN)));
         for (Statement statement : chunk) {
             batch.bind(row(write, statement).intoArray());
         }
@@ -107,6 +111,7 @@ public class JooqStatementRepository implements StatementRepository {
         row.setRowNumber(statement.provenance().rowNumber());
         row.setColumnName(statement.provenance().column());
         row.setFirstSeen(write.now());
+        row.setLastSeen(write.now());
         return row;
     }
 
@@ -122,11 +127,12 @@ public class JooqStatementRepository implements StatementRepository {
         List<Statement> statements = create()
                 .select(READ_FIELDS).from(STATEMENT)
                 .where(STATEMENT.PRJ_ID.eq(projectId)).and(STATEMENT.ENTITY_ID.eq(entityId))
-                .orderBy(STATEMENT.MODEL)
-                .fetch().map(JooqStatementRepository::toStatement);
-        try (Stream<ModelEntity> entities = group(statements.stream())) {
-            return entities.findFirst();
-        }
+                .fetch(JooqStatementRepository::toStatement);
+        // The model an id shared by two models resolves to is picked here rather than with an ORDER
+        // BY, because a database collation would otherwise decide it, and SQLite and Postgres do not
+        // sort text alike.
+        return statements.stream().map(Statement::model).min(String::compareTo).map(model ->
+                ModelEntity.from(statements.stream().filter(row -> model.equals(row.model())).toList()));
     }
 
     @Override
@@ -136,17 +142,19 @@ public class JooqStatementRepository implements StatementRepository {
         }
     }
 
-    // A DataSource-bound DSLContext never sets autoCommit(false), and pgjdbc only opens a server-side
-    // cursor when fetchSize > 0 AND autoCommit is false: without both, the driver buffers the whole
-    // result before the first row is emitted. So this holds one connection, outside the pool's
-    // default autocommit, for the stream's lifetime.
+    // Only pgjdbc streams, and only when fetchSize > 0 AND autoCommit is false: without both, the
+    // driver buffers the whole result before the first row is emitted. So Postgres holds one
+    // connection, outside the pool's default autocommit, for the stream's lifetime. SQLite ignores
+    // fetchSize and has no server-side cursor, and a read it keeps open holds a shared lock on the
+    // whole file until the consumer returns, which makes every concurrent writer fail "database is
+    // locked": the embedded database buffers instead.
     private Stream<ModelEntity> entities(String projectId) {
+        if (dialect != SQLDialect.POSTGRES) {
+            return group(read(create(), projectId).fetch(JooqStatementRepository::toStatement).stream());
+        }
         Connection connection = openStreamingConnection();
         try {
-            Cursor<Record> cursor = DSL.using(connection, dialect)
-                    .select(READ_FIELDS).from(STATEMENT)
-                    .where(STATEMENT.PRJ_ID.eq(projectId))
-                    .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL)
+            Cursor<Record> cursor = read(DSL.using(connection, dialect), projectId)
                     .fetchSize(FETCH_SIZE)
                     .fetchLazy();
             return group(cursor.stream()
@@ -156,6 +164,12 @@ public class JooqStatementRepository implements StatementRepository {
             JDBCUtils.safeClose(connection);
             throw e;
         }
+    }
+
+    private static ResultQuery<Record> read(DSLContext create, String projectId) {
+        return create.select(READ_FIELDS).from(STATEMENT)
+                .where(STATEMENT.PRJ_ID.eq(projectId))
+                .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL);
     }
 
     private Connection openStreamingConnection() {
@@ -204,49 +218,71 @@ public class JooqStatementRepository implements StatementRepository {
     }
 
     // The query is ordered by (entity_id, model), so an entity's statements are consecutive and each
-    // group can be emitted without holding the whole project in memory: one CSV can produce 100k+
-    // entities. Grouping on entity_id alone would let a same-id entity spanning two models reach
-    // ModelEntity.from, which throws on a multi-model group. Property and value are then sorted here
-    // rather than in the ORDER BY, because a database collation would otherwise decide the order of
-    // an entity's values, and SQLite and Postgres do not sort text alike.
+    // one is folded into its entity as it is read: one CSV can produce 100k+ entities, and a mapping
+    // keyed on a low-cardinality column puts every one of its rows under a single entity, so neither
+    // the project nor one group is ever collected first. Grouping on entity_id alone would let a
+    // same-id entity spanning two models reach ModelEntity.from, which throws on a multi-model group.
     private static Stream<ModelEntity> group(Stream<Statement> statements) {
-        Iterator<Statement> rows = statements.iterator();
-        Iterator<ModelEntity> entities = new Iterator<>() {
-            private Statement pending;
-            private boolean primed;
-
-            @Override
-            public boolean hasNext() {
-                if (!primed) {
-                    pending = rows.hasNext() ? rows.next() : null;
-                    primed = true;
-                }
-                return pending != null;
-            }
-
-            @Override
-            public ModelEntity next() {
-                if (!hasNext()) {
-                    throw new NoSuchElementException();
-                }
-                List<Statement> group = new ArrayList<>();
-                group.add(pending);
-                String entityId = pending.entityId();
-                String model = pending.model();
-                pending = null;
-                while (rows.hasNext()) {
-                    Statement row = rows.next();
-                    if (!row.entityId().equals(entityId) || !row.model().equals(model)) {
-                        pending = row;
-                        break;
-                    }
-                    group.add(row);
-                }
-                group.sort(BY_PROPERTY_THEN_VALUE);
-                return ModelEntity.from(group);
-            }
-        };
+        Iterator<ModelEntity> entities = new Groups(statements.iterator());
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(entities, Spliterator.ORDERED), false)
                 .onClose(statements::close);
+    }
+
+    private static class Groups implements Iterator<ModelEntity> {
+        private final Iterator<Statement> rows;
+        private Statement pending;
+        private boolean primed;
+
+        Groups(Iterator<Statement> rows) {
+            this.rows = rows;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (!primed) {
+                pending = rows.hasNext() ? rows.next() : null;
+                primed = true;
+            }
+            return pending != null;
+        }
+
+        @Override
+        public ModelEntity next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return ModelEntity.from(this::group);
+        }
+
+        // The row that ends a group is the first row of the next one, so it is held back as pending
+        // rather than read twice.
+        private Iterator<Statement> group() {
+            Statement first = pending;
+            pending = null;
+            return new Iterator<>() {
+                private Statement next = first;
+
+                @Override
+                public boolean hasNext() {
+                    return next != null;
+                }
+
+                @Override
+                public Statement next() {
+                    Statement current = next;
+                    next = rows.hasNext() ? sameGroupAs(current) : null;
+                    return current;
+                }
+
+                private Statement sameGroupAs(Statement current) {
+                    Statement row = rows.next();
+                    if (row.entityId().equals(current.entityId()) && row.model().equals(current.model())) {
+                        return row;
+                    }
+                    pending = row;
+                    return null;
+                }
+            };
+        }
     }
 }

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -9,10 +9,12 @@ import org.icij.datashare.time.DatashareTime;
 import org.jooq.BatchBindStep;
 import org.jooq.Cursor;
 import org.jooq.DSLContext;
-import org.jooq.Query;
+import org.jooq.Field;
+import org.jooq.Record;
 import org.jooq.SQLDialect;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
+import org.jooq.tools.jdbc.JDBCUtils;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -21,6 +23,7 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -36,119 +39,93 @@ import static org.icij.datashare.db.Tables.STATEMENT;
 
 public class JooqStatementRepository implements StatementRepository {
     private static final int FETCH_SIZE = 1_000;
+    private static final Field<?>[] READ_FIELDS = {
+            STATEMENT.ID, STATEMENT.MODEL, STATEMENT.ENTITY_ID, STATEMENT.ENTITY_TYPE, STATEMENT.PROPERTY,
+            STATEMENT.VALUE, STATEMENT.DOC_ID, STATEMENT.SHEET, STATEMENT.ROW_NUMBER, STATEMENT.COLUMN_NAME};
+    private static final Comparator<Statement> BY_PROPERTY_THEN_VALUE =
+            Comparator.comparing(Statement::property).thenComparing(Statement::value);
     private final DataSource dataSource;
     private final SQLDialect dialect;
     private final int chunkSize;
 
     public JooqStatementRepository(DataSource dataSource, SQLDialect dialect) {
+        this(dataSource, dialect, JooqCasbinRuleAdapter.determineBatchSize(dialect));
+    }
+
+    JooqStatementRepository(DataSource dataSource, SQLDialect dialect, int chunkSize) {
         this.dataSource = dataSource;
         this.dialect = dialect;
-        this.chunkSize = JooqCasbinRuleAdapter.determineBatchSize(dialect);
+        this.chunkSize = chunkSize;
     }
+
+    private record Write(String projectId, String runId, LocalDateTime now) { }
 
     @Override
     public int save(String projectId, String runId, Collection<Statement> statements) {
-        LocalDateTime now = new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime();
+        Write write = new Write(projectId, runId,
+                new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime());
         Iterator<Statement> source = statements.iterator();
         int written = 0;
         while (source.hasNext()) {
-            List<Statement> chunk = new ArrayList<>(chunkSize);
+            List<Statement> chunk = new ArrayList<>(Math.min(chunkSize, statements.size()));
             while (chunk.size() < chunkSize && source.hasNext()) {
                 chunk.add(source.next());
             }
             written += create().transactionResult(configuration ->
-                    saveChunk(DSL.using(configuration), projectId, runId, chunk, now));
+                    saveChunk(DSL.using(configuration), write, chunk));
         }
         return written;
     }
 
     // A batch built from Query...values(...) inlines every row's SQL and ships it as literal text
     // (jOOQ's "batch multiple"); a batch built from one bound template query and repeated .bind()
-    // calls ("batch single") reuses the same PreparedStatement and lets Postgres plan it once.
-    private static int saveChunk(DSLContext create, String projectId, String runId, List<Statement> chunk, LocalDateTime now) {
-        BatchBindStep batch = create.batch(upsert(create, projectId, runId, chunk.get(0), now));
+    // calls ("batch single") reuses the same PreparedStatement and lets Postgres plan it once. Both
+    // the template's column list and each row's positional binds come from the same record, so they
+    // cannot drift.
+    private static int saveChunk(DSLContext create, Write write, List<Statement> chunk) {
+        BatchBindStep batch = create.batch(
+                create.insertInto(STATEMENT).set(row(write, chunk.get(0))).onConflictDoNothing());
         for (Statement statement : chunk) {
-            batch.bind(bindValues(projectId, runId, statement, now));
+            batch.bind(row(write, statement).intoArray());
         }
-        return IntStream.of(batch.execute()).sum();
+        return inserted(batch.execute());
     }
 
-    private static Query upsert(DSLContext create, String projectId, String runId, Statement statement, LocalDateTime now) {
-        return create.insertInto(STATEMENT)
-                .set(STATEMENT.ID, statement.id())
-                .set(STATEMENT.PRJ_ID, projectId)
-                .set(STATEMENT.RUN_ID, runId)
-                .set(STATEMENT.MODEL, statement.model())
-                .set(STATEMENT.MODEL_VERSION, TargetModelRegistry.get(statement.model()).version())
-                .set(STATEMENT.ENTITY_ID, statement.entityId())
-                .set(STATEMENT.ENTITY_TYPE, statement.entityType())
-                .set(STATEMENT.PROPERTY, statement.qualifiedProperty())
-                .set(STATEMENT.VALUE, statement.value())
-                .set(STATEMENT.DOC_ID, statement.provenance().documentId())
-                .set(STATEMENT.SHEET, statement.provenance().sheet())
-                .set(STATEMENT.ROW_NUMBER, statement.provenance().rowNumber())
-                .set(STATEMENT.COLUMN_NAME, statement.provenance().column())
-                .set(STATEMENT.FIRST_SEEN, now)
-                .set(STATEMENT.LAST_SEEN, now)
-                .onConflictDoNothing();
+    private static StatementRecord row(Write write, Statement statement) {
+        StatementRecord row = new StatementRecord();
+        row.setId(statement.id());
+        row.setPrjId(write.projectId());
+        row.setRunId(write.runId());
+        row.setModel(statement.model());
+        row.setModelVersion(TargetModelRegistry.get(statement.model()).version());
+        row.setEntityId(statement.entityId());
+        row.setEntityType(statement.entityType());
+        row.setProperty(statement.qualifiedProperty());
+        row.setValue(statement.value());
+        row.setDocId(statement.provenance().documentId());
+        row.setSheet(statement.provenance().sheet());
+        row.setRowNumber(statement.provenance().rowNumber());
+        row.setColumnName(statement.provenance().column());
+        row.setFirstSeen(write.now());
+        return row;
     }
 
-    // Bind order must match upsert()'s set(...) chain exactly: jOOQ's batch-single binds are
-    // positional, not named.
-    private static Object[] bindValues(String projectId, String runId, Statement statement, LocalDateTime now) {
-        return new Object[]{
-                statement.id(), projectId, runId, statement.model(),
-                TargetModelRegistry.get(statement.model()).version(),
-                statement.entityId(), statement.entityType(), statement.qualifiedProperty(), statement.value(),
-                statement.provenance().documentId(), statement.provenance().sheet(),
-                statement.provenance().rowNumber(), statement.provenance().column(),
-                now, now
-        };
+    // A driver that rewrites a batch into one multi-row insert (pgjdbc's reWriteBatchedInserts)
+    // reports SUCCESS_NO_INFO rather than a per-row count, so a negative entry has to contribute
+    // nothing instead of subtracting from the total.
+    private static int inserted(int[] results) {
+        return IntStream.of(results).filter(result -> result > 0).sum();
     }
 
     @Override
     public Optional<ModelEntity> entity(String projectId, String entityId) {
         List<Statement> statements = create()
-                .selectFrom(STATEMENT)
+                .select(READ_FIELDS).from(STATEMENT)
                 .where(STATEMENT.PRJ_ID.eq(projectId)).and(STATEMENT.ENTITY_ID.eq(entityId))
-                .orderBy(STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
+                .orderBy(STATEMENT.MODEL)
                 .fetch().map(JooqStatementRepository::toStatement);
-        return statements.isEmpty() ? Optional.empty() : Optional.of(ModelEntity.from(statements));
-    }
-
-    // A DataSource-bound DSLContext never sets autoCommit(false), and pgjdbc only opens a
-    // server-side cursor when fetchSize > 0 AND autoCommit is false: without both, the driver
-    // buffers the whole result before the first row is emitted. So this holds one connection,
-    // outside the pool's default autocommit, for the stream's lifetime. xerial's SQLite driver
-    // ignores fetchSize entirely, so the same treatment there is pure cost: a held read
-    // transaction on the shared-cache SQLite database, which makes a concurrent writer fail with
-    // SQLITE_LOCKED instead of retrying.
-    @Override
-    public Stream<ModelEntity> entities(String projectId) {
-        if (dialect != SQLDialect.POSTGRES) {
-            Stream<Statement> rows = create()
-                    .selectFrom(STATEMENT)
-                    .where(STATEMENT.PRJ_ID.eq(projectId))
-                    .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
-                    .fetchStream()
-                    .map(JooqStatementRepository::toStatement);
-            return group(rows);
-        }
-        Connection connection = openStreamingConnection();
-        try {
-            Cursor<StatementRecord> cursor = DSL.using(connection, dialect)
-                    .selectFrom(STATEMENT)
-                    .where(STATEMENT.PRJ_ID.eq(projectId))
-                    .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
-                    .fetchSize(FETCH_SIZE)
-                    .fetchLazy();
-            Stream<Statement> rows = cursor.stream()
-                    .map(JooqStatementRepository::toStatement)
-                    .onClose(() -> release(connection, cursor));
-            return group(rows);
-        } catch (RuntimeException e) {
-            closeQuietly(connection);
-            throw e;
+        try (Stream<ModelEntity> entities = group(statements.stream())) {
+            return entities.findFirst();
         }
     }
 
@@ -156,6 +133,28 @@ public class JooqStatementRepository implements StatementRepository {
     public <R> R entities(String projectId, Function<Stream<ModelEntity>, R> consumer) {
         try (Stream<ModelEntity> entities = entities(projectId)) {
             return consumer.apply(entities);
+        }
+    }
+
+    // A DataSource-bound DSLContext never sets autoCommit(false), and pgjdbc only opens a server-side
+    // cursor when fetchSize > 0 AND autoCommit is false: without both, the driver buffers the whole
+    // result before the first row is emitted. So this holds one connection, outside the pool's
+    // default autocommit, for the stream's lifetime.
+    private Stream<ModelEntity> entities(String projectId) {
+        Connection connection = openStreamingConnection();
+        try {
+            Cursor<Record> cursor = DSL.using(connection, dialect)
+                    .select(READ_FIELDS).from(STATEMENT)
+                    .where(STATEMENT.PRJ_ID.eq(projectId))
+                    .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL)
+                    .fetchSize(FETCH_SIZE)
+                    .fetchLazy();
+            return group(cursor.stream()
+                    .map(JooqStatementRepository::toStatement)
+                    .onClose(() -> release(connection, cursor)));
+        } catch (RuntimeException e) {
+            JDBCUtils.safeClose(connection);
+            throw e;
         }
     }
 
@@ -169,25 +168,20 @@ public class JooqStatementRepository implements StatementRepository {
         try {
             connection.setAutoCommit(false);
         } catch (SQLException e) {
-            closeQuietly(connection);
+            JDBCUtils.safeClose(connection);
             throw new DataAccessException("could not open a streaming connection", e);
         }
         return connection;
     }
 
+    // Cursor.close() throws unchecked, so closing it through safeClose keeps the rollback on the
+    // path where it fails: the connection goes back to the pool without an open read transaction.
     private static void release(Connection connection, Cursor<?> cursor) {
         try (connection) {
-            cursor.close();
+            JDBCUtils.safeClose(cursor);
             connection.rollback();
         } catch (SQLException e) {
             throw new DataAccessException("could not release the streaming connection", e);
-        }
-    }
-
-    private static void closeQuietly(Connection connection) {
-        try {
-            connection.close();
-        } catch (SQLException ignored) {
         }
     }
 
@@ -195,16 +189,26 @@ public class JooqStatementRepository implements StatementRepository {
         return DSL.using(dataSource, dialect);
     }
 
-    private static Statement toStatement(StatementRecord row) {
-        return new Statement(row.getId(), row.getModel(), row.getEntityId(), row.getEntityType(),
-                row.getProperty().substring(row.getModel().length() + 1), row.getValue(),
-                new Statement.Provenance(row.getDocId(), row.getSheet(), row.getRowNumber(), row.getColumnName()));
+    private static Statement toStatement(Record row) {
+        String model = row.get(STATEMENT.MODEL);
+        String prefix = model + ":";
+        String property = row.get(STATEMENT.PROPERTY);
+        if (!property.startsWith(prefix)) {
+            throw new DataAccessException("statement '" + row.get(STATEMENT.ID) + "' holds property '" + property
+                    + "', which is not namespaced under its model '" + model + "'");
+        }
+        return new Statement(row.get(STATEMENT.ID), model, row.get(STATEMENT.ENTITY_ID),
+                row.get(STATEMENT.ENTITY_TYPE), property.substring(prefix.length()), row.get(STATEMENT.VALUE),
+                new Statement.Provenance(row.get(STATEMENT.DOC_ID), row.get(STATEMENT.SHEET),
+                        row.get(STATEMENT.ROW_NUMBER), row.get(STATEMENT.COLUMN_NAME)));
     }
 
     // The query is ordered by (entity_id, model), so an entity's statements are consecutive and each
     // group can be emitted without holding the whole project in memory: one CSV can produce 100k+
     // entities. Grouping on entity_id alone would let a same-id entity spanning two models reach
-    // ModelEntity.from, which throws on a multi-model group.
+    // ModelEntity.from, which throws on a multi-model group. Property and value are then sorted here
+    // rather than in the ORDER BY, because a database collation would otherwise decide the order of
+    // an entity's values, and SQLite and Postgres do not sort text alike.
     private static Stream<ModelEntity> group(Stream<Statement> statements) {
         Iterator<Statement> rows = statements.iterator();
         Iterator<ModelEntity> entities = new Iterator<>() {
@@ -225,7 +229,8 @@ public class JooqStatementRepository implements StatementRepository {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
-                List<Statement> group = new ArrayList<>(List.of(pending));
+                List<Statement> group = new ArrayList<>();
+                group.add(pending);
                 String entityId = pending.entityId();
                 String model = pending.model();
                 pending = null;
@@ -237,6 +242,7 @@ public class JooqStatementRepository implements StatementRepository {
                     }
                     group.add(row);
                 }
+                group.sort(BY_PROPERTY_THEN_VALUE);
                 return ModelEntity.from(group);
             }
         };

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -6,12 +6,17 @@ import org.icij.datashare.model.Statement;
 import org.icij.datashare.model.StatementRepository;
 import org.icij.datashare.model.TargetModelRegistry;
 import org.icij.datashare.time.DatashareTime;
+import org.jooq.BatchBindStep;
+import org.jooq.Cursor;
 import org.jooq.DSLContext;
 import org.jooq.Query;
 import org.jooq.SQLDialect;
+import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -30,33 +35,45 @@ import java.util.stream.StreamSupport;
 import static org.icij.datashare.db.Tables.STATEMENT;
 
 public class JooqStatementRepository implements StatementRepository {
-    private static final int CHUNK = 1_000;
+    private static final int FETCH_SIZE = 1_000;
     private final DataSource dataSource;
     private final SQLDialect dialect;
+    private final int chunkSize;
 
     public JooqStatementRepository(DataSource dataSource, SQLDialect dialect) {
         this.dataSource = dataSource;
         this.dialect = dialect;
+        this.chunkSize = JooqCasbinRuleAdapter.determineBatchSize(dialect);
     }
 
     @Override
     public int save(String projectId, String runId, Collection<Statement> statements) {
         LocalDateTime now = new Timestamp(DatashareTime.getInstance().currentTimeMillis()).toLocalDateTime();
-        List<Statement> ordered = List.copyOf(statements);
+        Iterator<Statement> source = statements.iterator();
         int written = 0;
-        for (int from = 0; from < ordered.size(); from += CHUNK) {
-            List<Statement> chunk = ordered.subList(from, Math.min(from + CHUNK, ordered.size()));
-            written += DSL.using(dataSource, dialect).transactionResult(configuration -> {
-                DSLContext create = DSL.using(configuration);
-                List<Query> queries = chunk.stream()
-                        .map(statement -> upsert(create, projectId, runId, statement, now)).toList();
-                return IntStream.of(create.batch(queries).execute()).sum();
-            });
+        while (source.hasNext()) {
+            List<Statement> chunk = new ArrayList<>(chunkSize);
+            while (chunk.size() < chunkSize && source.hasNext()) {
+                chunk.add(source.next());
+            }
+            written += create().transactionResult(configuration ->
+                    saveChunk(DSL.using(configuration), projectId, runId, chunk, now));
         }
         return written;
     }
 
-    private Query upsert(DSLContext create, String projectId, String runId, Statement statement, LocalDateTime now) {
+    // A batch built from Query...values(...) inlines every row's SQL and ships it as literal text
+    // (jOOQ's "batch multiple"); a batch built from one bound template query and repeated .bind()
+    // calls ("batch single") reuses the same PreparedStatement and lets Postgres plan it once.
+    private static int saveChunk(DSLContext create, String projectId, String runId, List<Statement> chunk, LocalDateTime now) {
+        BatchBindStep batch = create.batch(upsert(create, projectId, runId, chunk.get(0), now));
+        for (Statement statement : chunk) {
+            batch.bind(bindValues(projectId, runId, statement, now));
+        }
+        return IntStream.of(batch.execute()).sum();
+    }
+
+    private static Query upsert(DSLContext create, String projectId, String runId, Statement statement, LocalDateTime now) {
         return create.insertInto(STATEMENT)
                 .set(STATEMENT.ID, statement.id())
                 .set(STATEMENT.PRJ_ID, projectId)
@@ -76,9 +93,22 @@ public class JooqStatementRepository implements StatementRepository {
                 .onConflictDoNothing();
     }
 
+    // Bind order must match upsert()'s set(...) chain exactly: jOOQ's batch-single binds are
+    // positional, not named.
+    private static Object[] bindValues(String projectId, String runId, Statement statement, LocalDateTime now) {
+        return new Object[]{
+                statement.id(), projectId, runId, statement.model(),
+                TargetModelRegistry.get(statement.model()).version(),
+                statement.entityId(), statement.entityType(), statement.qualifiedProperty(), statement.value(),
+                statement.provenance().documentId(), statement.provenance().sheet(),
+                statement.provenance().rowNumber(), statement.provenance().column(),
+                now, now
+        };
+    }
+
     @Override
     public Optional<ModelEntity> entity(String projectId, String entityId) {
-        List<Statement> statements = DSL.using(dataSource, dialect)
+        List<Statement> statements = create()
                 .selectFrom(STATEMENT)
                 .where(STATEMENT.PRJ_ID.eq(projectId)).and(STATEMENT.ENTITY_ID.eq(entityId))
                 .orderBy(STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
@@ -86,15 +116,28 @@ public class JooqStatementRepository implements StatementRepository {
         return statements.isEmpty() ? Optional.empty() : Optional.of(ModelEntity.from(statements));
     }
 
+    // A DataSource-bound DSLContext never sets autoCommit(false), and pgjdbc only opens a
+    // server-side cursor when fetchSize > 0 AND autoCommit is false: without both, the driver
+    // buffers the whole result before the first row is emitted. So this holds one connection,
+    // outside the pool's default autocommit, for the stream's lifetime.
     @Override
     public Stream<ModelEntity> entities(String projectId) {
-        Stream<Statement> rows = DSL.using(dataSource, dialect)
-                .selectFrom(STATEMENT)
-                .where(STATEMENT.PRJ_ID.eq(projectId))
-                .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
-                .fetchLazy().stream()
-                .map(JooqStatementRepository::toStatement);
-        return group(rows);
+        Connection connection = openStreamingConnection();
+        try {
+            Cursor<StatementRecord> cursor = DSL.using(connection, dialect)
+                    .selectFrom(STATEMENT)
+                    .where(STATEMENT.PRJ_ID.eq(projectId))
+                    .orderBy(STATEMENT.ENTITY_ID, STATEMENT.MODEL, STATEMENT.PROPERTY, STATEMENT.VALUE)
+                    .fetchSize(FETCH_SIZE)
+                    .fetchLazy();
+            Stream<Statement> rows = cursor.stream()
+                    .map(JooqStatementRepository::toStatement)
+                    .onClose(() -> release(connection, cursor));
+            return group(rows);
+        } catch (RuntimeException e) {
+            closeQuietly(connection);
+            throw e;
+        }
     }
 
     @Override
@@ -102,6 +145,42 @@ public class JooqStatementRepository implements StatementRepository {
         try (Stream<ModelEntity> entities = entities(projectId)) {
             return consumer.apply(entities);
         }
+    }
+
+    private Connection openStreamingConnection() {
+        Connection connection;
+        try {
+            connection = dataSource.getConnection();
+        } catch (SQLException e) {
+            throw new DataAccessException("could not open a streaming connection", e);
+        }
+        try {
+            connection.setAutoCommit(false);
+        } catch (SQLException e) {
+            closeQuietly(connection);
+            throw new DataAccessException("could not open a streaming connection", e);
+        }
+        return connection;
+    }
+
+    private static void release(Connection connection, Cursor<?> cursor) {
+        try (connection) {
+            cursor.close();
+            connection.rollback();
+        } catch (SQLException e) {
+            throw new DataAccessException("could not release the streaming connection", e);
+        }
+    }
+
+    private static void closeQuietly(Connection connection) {
+        try {
+            connection.close();
+        } catch (SQLException ignored) {
+        }
+    }
+
+    private DSLContext create() {
+        return DSL.using(dataSource, dialect);
     }
 
     private static Statement toStatement(StatementRecord row) {
@@ -151,5 +230,9 @@ public class JooqStatementRepository implements StatementRepository {
         };
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(entities, Spliterator.ORDERED), false)
                 .onClose(statements::close);
+    }
+
+    int chunkSize() {
+        return chunkSize;
     }
 }

--- a/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
@@ -1,0 +1,136 @@
+databaseChangeLog:
+  - changeSet:
+      id: 81
+      author: pirhoo
+      changes:
+        - createTable:
+            tableName: statement
+            columns:
+              - column:
+                  name: id
+                  type: varchar(96)
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: prj_id
+                  type: varchar(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: run_id
+                  type: varchar(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: model
+                  type: varchar(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: model_version
+                  type: varchar(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_id
+                  type: varchar(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_type
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: property
+                  type: varchar(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: value
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: doc_id
+                  type: varchar(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sheet
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: row_number
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: column_name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: first_seen
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_seen
+                  type: datetime
+                  constraints:
+                    nullable: false
+        - createIndex:
+            indexName: statement_prj_entity
+            tableName: statement
+            columns:
+              - column:
+                  name: prj_id
+                  type: varchar(96)
+              - column:
+                  name: entity_id
+                  type: varchar(96)
+
+  - changeSet:
+      id: 82
+      author: pirhoo
+      changes:
+        - createTable:
+            tableName: extraction_mapping
+            columns:
+              - column:
+                  name: id
+                  type: varchar(96)
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: prj_id
+                  type: varchar(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: varchar(96)
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: definition
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+        - createIndex:
+            indexName: extraction_mapping_prj_id
+            tableName: extraction_mapping
+            columns:
+              - column:
+                  name: prj_id
+                  type: varchar(96)

--- a/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
@@ -10,12 +10,14 @@ databaseChangeLog:
                   name: id
                   type: varchar(96)
                   constraints:
+                    nullable: false
                     primaryKey: true
               - column:
                   name: prj_id
                   type: varchar(96)
                   constraints:
                     nullable: false
+                    primaryKey: true
               - column:
                   name: run_id
                   type: varchar(96)
@@ -58,7 +60,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: sheet
-                  type: varchar(255)
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -68,7 +70,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: column_name
-                  type: varchar(255)
+                  type: text
                   constraints:
                     nullable: false
               - column:

--- a/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
@@ -35,7 +35,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: entity_id
-                  type: text
+                  type: varchar(512)
                   constraints:
                     nullable: false
               - column:
@@ -78,6 +78,11 @@ databaseChangeLog:
                   type: datetime
                   constraints:
                     nullable: false
+              - column:
+                  name: last_seen
+                  type: datetime
+                  constraints:
+                    nullable: false
         - createIndex:
             indexName: statement_prj_entity
             tableName: statement
@@ -87,7 +92,7 @@ databaseChangeLog:
                   type: varchar(96)
               - column:
                   name: entity_id
-                  type: text
+                  type: varchar(512)
 
   - changeSet:
       id: 82

--- a/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
@@ -35,17 +35,17 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: entity_id
-                  type: varchar(96)
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: entity_type
-                  type: varchar(64)
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: property
-                  type: varchar(96)
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -92,7 +92,7 @@ databaseChangeLog:
                   type: varchar(96)
               - column:
                   name: entity_id
-                  type: varchar(96)
+                  type: text
 
   - changeSet:
       id: 82
@@ -105,18 +105,20 @@ databaseChangeLog:
                   name: id
                   type: varchar(96)
                   constraints:
+                    nullable: false
                     primaryKey: true
               - column:
                   name: prj_id
                   type: varchar(96)
                   constraints:
                     nullable: false
+                    primaryKey: true
               - column:
                   name: user_id
                   type: varchar(96)
               - column:
                   name: name
-                  type: varchar(255)
+                  type: text
                   constraints:
                     nullable: false
               - column:

--- a/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/changes/047-add-extraction-mapping-and-statement.yml
@@ -78,11 +78,6 @@ databaseChangeLog:
                   type: datetime
                   constraints:
                     nullable: false
-              - column:
-                  name: last_seen
-                  type: datetime
-                  constraints:
-                    nullable: false
         - createIndex:
             indexName: statement_prj_entity
             tableName: statement

--- a/datashare-db/src/main/resources/liquibase/changelog/db.changelog.yml
+++ b/datashare-db/src/main/resources/liquibase/changelog/db.changelog.yml
@@ -140,3 +140,6 @@ databaseChangeLog:
   - include:
       file: changes/046-add-tasks-type.yml
       relativeToChangelogFile: true
+  - include:
+      file: changes/047-add-extraction-mapping-and-statement.yml
+      relativeToChangelogFile: true

--- a/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
@@ -9,6 +9,8 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asynctasks.bus.amqp.UriResult;
 import org.icij.datashare.json.JsonObjectMapper;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
 import org.junit.rules.ExternalResource;
 
 import javax.sql.DataSource;
@@ -68,8 +70,8 @@ public class DbSetupRule extends ExternalResource {
         return new JooqExtractionMappingRepository(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }
 
-    org.jooq.DSLContext dsl() {
-        return org.jooq.impl.DSL.using(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
+    DSLContext dsl() {
+        return DSL.using(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }
 
     private static DataSource createDatasource(final String jdbcUrl) {

--- a/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
@@ -60,6 +60,10 @@ public class DbSetupRule extends ExternalResource {
         return new JooqTaskRepository(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }
 
+    public JooqStatementRepository createStatementRepository() {
+        return new JooqStatementRepository(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
+    }
+
     org.jooq.DSLContext dsl() {
         return org.jooq.impl.DSL.using(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }

--- a/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
@@ -25,7 +25,7 @@ public class DbSetupRule extends ExternalResource {
     private static final Operation DELETE_ALL = deleteAllFrom(
             "document", "named_entity", "document_user_star", "document_tag", "batch_search_project", "batch_search", "user_inventory",
             "batch_search_query", "batch_search_result", "project", "path_banner", "document_user_recommendation", "api_key",
-            "user_history_project", "user_history_project", "user_history", "casbin_rule");
+            "user_history_project", "user_history_project", "user_history", "casbin_rule", "statement", "extraction_mapping");
     private static final SqlOperation RESET_USER_HISTORY_ID_SEQ_POSTGRES = sql("ALTER SEQUENCE user_history_id_seq RESTART WITH 1;");
     private static final SqlOperation RESET_ID_SEQ_SQLITE = sql("DELETE FROM `sqlite_sequence`;");
 
@@ -58,6 +58,10 @@ public class DbSetupRule extends ExternalResource {
 
     public JooqTaskRepository createTaskRepository() {
         return new JooqTaskRepository(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
+    }
+
+    org.jooq.DSLContext dsl() {
+        return org.jooq.impl.DSL.using(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }
 
     private static DataSource createDatasource(final String jdbcUrl) {

--- a/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/DbSetupRule.java
@@ -64,6 +64,10 @@ public class DbSetupRule extends ExternalResource {
         return new JooqStatementRepository(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }
 
+    public JooqExtractionMappingRepository createExtractionMappingRepository() {
+        return new JooqExtractionMappingRepository(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
+    }
+
     org.jooq.DSLContext dsl() {
         return org.jooq.impl.DSL.using(dataSource, RepositoryFactoryImpl.guessSqlDialectFrom(dataSourceUrl));
     }

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.db.Tables.EXTRACTION_MAPPING;
 import static org.junit.Assert.assertThrows;
 
 @RunWith(Parameterized.class)
@@ -77,6 +78,16 @@ public class JooqExtractionMappingRepositoryTest {
     @Test
     public void test_get_is_empty_for_an_unknown_id() {
         assertThat(repository.get("nope").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_the_user_id_column_is_written() {
+        repository.save(mapping("map-1", "prj", null, "Person"));
+        repository.save(mapping("map-2", "prj", "jdoe", "Person"));
+        assertThat(dbRule.dsl().select(EXTRACTION_MAPPING.USER_ID).from(EXTRACTION_MAPPING)
+                .where(EXTRACTION_MAPPING.ID.eq("map-1")).fetchOne(EXTRACTION_MAPPING.USER_ID)).isNull();
+        assertThat(dbRule.dsl().select(EXTRACTION_MAPPING.USER_ID).from(EXTRACTION_MAPPING)
+                .where(EXTRACTION_MAPPING.ID.eq("map-2")).fetchOne(EXTRACTION_MAPPING.USER_ID)).isEqualTo("jdoe");
     }
 
     @Test

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
@@ -156,11 +156,31 @@ public class JooqExtractionMappingRepositoryTest {
         assertThat(thrown.id).isEqualTo("map-1");
     }
 
-    private void poison(String id, String projectId) {
-        String definition = dbRule.dsl().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
+    @Test
+    public void test_a_stored_definition_without_reader_options_reads_with_the_defaults() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        stripOptions("map-1", "prj");
+
+        assertThat(repository.get("prj", "map-1").orElseThrow().options())
+                .isEqualTo(RowSourceOptions.defaults());
+    }
+
+    private void stripOptions(String id, String projectId) {
+        String definition = definitionOf(id, projectId);
+        String stripped = definition.replaceAll("\"options\":\\{[^}]*},", "");
+        assertThat(stripped).isNotEqualTo(definition);
+        dbRule.dsl().update(EXTRACTION_MAPPING).set(EXTRACTION_MAPPING.DEFINITION, stripped)
+                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).execute();
+    }
+
+    private String definitionOf(String id, String projectId) {
+        return dbRule.dsl().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
                 .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
                 .fetchOne(EXTRACTION_MAPPING.DEFINITION);
-        String poisoned = definition.replace("\"model\":\"ftm\"", "\"model\":\"bogus\"");
+    }
+
+    private void poison(String id, String projectId) {
+        String poisoned = definitionOf(id, projectId).replace("\"model\":\"ftm\"", "\"model\":\"bogus\"");
         dbRule.dsl().update(EXTRACTION_MAPPING).set(EXTRACTION_MAPPING.DEFINITION, poisoned)
                 .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).execute();
     }

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
@@ -1,0 +1,102 @@
+package org.icij.datashare.db;
+
+import org.icij.datashare.tabular.ExtractionMapping;
+import org.icij.datashare.tabular.InvalidExtractionMapping;
+import org.icij.datashare.tabular.RowSourceOptions;
+import org.icij.datashare.test.DatashareTimeRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(Parameterized.class)
+public class JooqExtractionMappingRepositoryTest {
+    @Rule public DbSetupRule dbRule;
+    @Rule public DatashareTimeRule time = new DatashareTimeRule("2020-07-08T12:13:14Z");
+    private final JooqExtractionMappingRepository repository;
+
+    private static ExtractionMapping mapping(String id, String projectId, String userId, String type) {
+        return new ExtractionMapping(id, projectId, userId, "members", "ftm", "doc-1",
+                RowSourceOptions.defaults().withDelimiter(';').withCharset(StandardCharsets.UTF_8),
+                Map.of("member", new ExtractionMapping.EntityMapping(type, List.of("id"),
+                        Map.of("name", new ExtractionMapping.PropertyMapping(List.of("full_name"), null, null, null, null)))));
+    }
+
+    @Test
+    public void test_save_and_get_round_trips_the_mapping() {
+        ExtractionMapping expected = mapping("map-1", "prj", "jdoe", "Person");
+        assertThat(repository.save(expected)).isTrue();
+        assertThat(repository.get("map-1").orElseThrow()).isEqualTo(expected);
+    }
+
+    @Test
+    public void test_the_reader_options_survive_the_round_trip() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        RowSourceOptions options = repository.get("map-1").orElseThrow().options();
+        assertThat(options.delimiter()).isEqualTo(';');
+        assertThat(options.charset()).isEqualTo(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void test_a_cli_authored_mapping_has_no_user() {
+        repository.save(mapping("map-1", "prj", null, "Person"));
+        assertThat(repository.get("map-1").orElseThrow().userId()).isNull();
+    }
+
+    @Test
+    public void test_a_mapping_is_immutable_once_saved() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        assertThat(repository.save(mapping("map-1", "prj", "someone-else", "LegalEntity"))).isFalse();
+        assertThat(repository.get("map-1").orElseThrow().userId()).isEqualTo("jdoe");
+    }
+
+    @Test
+    public void test_an_invalid_mapping_is_refused_rather_than_stored() {
+        InvalidExtractionMapping thrown = assertThrows(InvalidExtractionMapping.class,
+                () -> repository.save(mapping("map-1", "prj", "jdoe", "Unicorn")));
+        assertThat(thrown.violations.toString()).contains("Unicorn");
+        assertThat(repository.get("map-1").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_list_is_project_scoped() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        repository.save(mapping("map-2", "other", "jdoe", "Person"));
+        assertThat(repository.list("prj").stream().map(ExtractionMapping::id).toList()).containsOnly("map-1");
+    }
+
+    @Test
+    public void test_get_is_empty_for_an_unknown_id() {
+        assertThat(repository.get("nope").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_delete_removes_the_mapping() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        assertThat(repository.delete("map-1")).isTrue();
+        assertThat(repository.get("map-1").isPresent()).isFalse();
+        assertThat(repository.delete("map-1")).isFalse();
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> dataSources() {
+        return asList(new Object[][]{
+                {DbTestRuleProvider.getSqliteRule()},
+                {DbTestRuleProvider.getPostgresRule()}
+        });
+    }
+
+    public JooqExtractionMappingRepositoryTest(DbSetupRule rule) {
+        dbRule = rule;
+        repository = rule.createExtractionMappingRepository();
+    }
+}

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
@@ -4,7 +4,6 @@ import org.icij.datashare.tabular.ExtractionMapping;
 import org.icij.datashare.tabular.InvalidExtractionMapping;
 import org.icij.datashare.tabular.RowSourceOptions;
 import org.icij.datashare.tabular.UnreadableExtractionMapping;
-import org.icij.datashare.test.DatashareTimeRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +22,6 @@ import static org.junit.Assert.assertThrows;
 @RunWith(Parameterized.class)
 public class JooqExtractionMappingRepositoryTest {
     @Rule public DbSetupRule dbRule;
-    @Rule public DatashareTimeRule time = new DatashareTimeRule("2020-07-08T12:13:14Z");
     private final JooqExtractionMappingRepository repository;
 
     private static ExtractionMapping mapping(String id, String projectId, String userId, String type) {

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
@@ -137,12 +137,40 @@ public class JooqExtractionMappingRepositoryTest {
         assertThat(thrown.id).isEqualTo("map-1");
     }
 
+    @Test
+    public void test_list_skips_a_row_with_truncated_json_and_returns_the_others() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        repository.save(mapping("map-2", "prj", "jdoe", "Person"));
+        truncate("map-2", "prj");
+
+        assertThat(repository.list("prj").stream().map(ExtractionMapping::id).toList()).containsOnly("map-1");
+    }
+
+    @Test
+    public void test_get_on_a_row_with_truncated_json_throws_unreadable_extraction_mapping() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        truncate("map-1", "prj");
+
+        UnreadableExtractionMapping thrown = assertThrows(UnreadableExtractionMapping.class,
+                () -> repository.get("prj", "map-1"));
+        assertThat(thrown.id).isEqualTo("map-1");
+    }
+
     private void poison(String id, String projectId) {
         String definition = dbRule.dsl().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
                 .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
                 .fetchOne(EXTRACTION_MAPPING.DEFINITION);
         String poisoned = definition.replace("\"model\":\"ftm\"", "\"model\":\"bogus\"");
         dbRule.dsl().update(EXTRACTION_MAPPING).set(EXTRACTION_MAPPING.DEFINITION, poisoned)
+                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).execute();
+    }
+
+    // A single "{" fails inside Jackson's raw field-name loop, so the parser raises the low-level
+    // JsonEOFException unwrapped. A cut further in (mid string value) fails instead inside a
+    // property's own deserializer call, which Jackson's bean deserializer wraps into a
+    // DatabindException, so it would not distinguish this fixture from the poisoned-model one.
+    private void truncate(String id, String projectId) {
+        dbRule.dsl().update(EXTRACTION_MAPPING).set(EXTRACTION_MAPPING.DEFINITION, "{")
                 .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).execute();
     }
 

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
@@ -4,6 +4,7 @@ import org.icij.datashare.tabular.ExtractionMapping;
 import org.icij.datashare.tabular.InvalidExtractionMapping;
 import org.icij.datashare.tabular.RowSourceOptions;
 import org.icij.datashare.tabular.UnreadableExtractionMapping;
+import org.icij.datashare.test.DatashareTimeRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +23,7 @@ import static org.junit.Assert.assertThrows;
 @RunWith(Parameterized.class)
 public class JooqExtractionMappingRepositoryTest {
     @Rule public DbSetupRule dbRule;
+    @Rule public DatashareTimeRule time = new DatashareTimeRule("2020-07-08T12:13:14Z");
     private final JooqExtractionMappingRepository repository;
 
     private static ExtractionMapping mapping(String id, String projectId, String userId, String type) {
@@ -72,6 +74,18 @@ public class JooqExtractionMappingRepositoryTest {
         repository.save(mapping("map-1", "prj", "jdoe", "Person"));
         repository.save(mapping("map-2", "other", "jdoe", "Person"));
         assertThat(repository.list("prj").stream().map(ExtractionMapping::id).toList()).containsOnly("map-1");
+    }
+
+    // created_at holds milliseconds, so mappings authored in the same one tie and the order falls to
+    // id: 'M' sorts before 'm' in Java and in SQLite's BINARY collation, but after it under a
+    // Postgres locale collation, so this is only stable while the tie is broken outside SQL.
+    @Test
+    public void test_list_orders_two_mappings_of_the_same_millisecond_the_same_way_on_every_dialect() {
+        repository.save(mapping("map-a", "prj", "jdoe", "Person"));
+        repository.save(mapping("Map-b", "prj", "jdoe", "Person"));
+
+        assertThat(repository.list("prj").stream().map(ExtractionMapping::id).toList())
+                .isEqualTo(List.of("Map-b", "map-a"));
     }
 
     @Test

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqExtractionMappingRepositoryTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare.db;
 import org.icij.datashare.tabular.ExtractionMapping;
 import org.icij.datashare.tabular.InvalidExtractionMapping;
 import org.icij.datashare.tabular.RowSourceOptions;
+import org.icij.datashare.tabular.UnreadableExtractionMapping;
 import org.icij.datashare.test.DatashareTimeRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,13 +37,13 @@ public class JooqExtractionMappingRepositoryTest {
     public void test_save_and_get_round_trips_the_mapping() {
         ExtractionMapping expected = mapping("map-1", "prj", "jdoe", "Person");
         assertThat(repository.save(expected)).isTrue();
-        assertThat(repository.get("map-1").orElseThrow()).isEqualTo(expected);
+        assertThat(repository.get("prj", "map-1").orElseThrow()).isEqualTo(expected);
     }
 
     @Test
     public void test_the_reader_options_survive_the_round_trip() {
         repository.save(mapping("map-1", "prj", "jdoe", "Person"));
-        RowSourceOptions options = repository.get("map-1").orElseThrow().options();
+        RowSourceOptions options = repository.get("prj", "map-1").orElseThrow().options();
         assertThat(options.delimiter()).isEqualTo(';');
         assertThat(options.charset()).isEqualTo(StandardCharsets.UTF_8);
     }
@@ -50,14 +51,14 @@ public class JooqExtractionMappingRepositoryTest {
     @Test
     public void test_a_cli_authored_mapping_has_no_user() {
         repository.save(mapping("map-1", "prj", null, "Person"));
-        assertThat(repository.get("map-1").orElseThrow().userId()).isNull();
+        assertThat(repository.get("prj", "map-1").orElseThrow().userId()).isNull();
     }
 
     @Test
     public void test_a_mapping_is_immutable_once_saved() {
         repository.save(mapping("map-1", "prj", "jdoe", "Person"));
         assertThat(repository.save(mapping("map-1", "prj", "someone-else", "LegalEntity"))).isFalse();
-        assertThat(repository.get("map-1").orElseThrow().userId()).isEqualTo("jdoe");
+        assertThat(repository.get("prj", "map-1").orElseThrow().userId()).isEqualTo("jdoe");
     }
 
     @Test
@@ -65,7 +66,7 @@ public class JooqExtractionMappingRepositoryTest {
         InvalidExtractionMapping thrown = assertThrows(InvalidExtractionMapping.class,
                 () -> repository.save(mapping("map-1", "prj", "jdoe", "Unicorn")));
         assertThat(thrown.violations.toString()).contains("Unicorn");
-        assertThat(repository.get("map-1").isPresent()).isFalse();
+        assertThat(repository.get("prj", "map-1").isPresent()).isFalse();
     }
 
     @Test
@@ -77,7 +78,28 @@ public class JooqExtractionMappingRepositoryTest {
 
     @Test
     public void test_get_is_empty_for_an_unknown_id() {
-        assertThat(repository.get("nope").isPresent()).isFalse();
+        assertThat(repository.get("prj", "nope").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_get_does_not_see_another_projects_mapping() {
+        repository.save(mapping("map-1", "prj-a", "jdoe", "Person"));
+        assertThat(repository.get("prj-b", "map-1").isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_delete_does_not_remove_another_projects_mapping() {
+        repository.save(mapping("map-1", "prj-a", "jdoe", "Person"));
+        assertThat(repository.delete("prj-b", "map-1")).isFalse();
+        assertThat(repository.get("prj-a", "map-1").isPresent()).isTrue();
+    }
+
+    @Test
+    public void test_two_projects_can_each_hold_a_mapping_under_the_same_id() {
+        assertThat(repository.save(mapping("map-1", "prj-a", "jdoe", "Person"))).isTrue();
+        assertThat(repository.save(mapping("map-1", "prj-b", "jdoe", "LegalEntity"))).isTrue();
+        assertThat(repository.get("prj-a", "map-1").orElseThrow().entities().get("member").type()).isEqualTo("Person");
+        assertThat(repository.get("prj-b", "map-1").orElseThrow().entities().get("member").type()).isEqualTo("LegalEntity");
     }
 
     @Test
@@ -93,9 +115,37 @@ public class JooqExtractionMappingRepositoryTest {
     @Test
     public void test_delete_removes_the_mapping() {
         repository.save(mapping("map-1", "prj", "jdoe", "Person"));
-        assertThat(repository.delete("map-1")).isTrue();
-        assertThat(repository.get("map-1").isPresent()).isFalse();
-        assertThat(repository.delete("map-1")).isFalse();
+        assertThat(repository.delete("prj", "map-1")).isTrue();
+        assertThat(repository.get("prj", "map-1").isPresent()).isFalse();
+        assertThat(repository.delete("prj", "map-1")).isFalse();
+    }
+
+    @Test
+    public void test_list_skips_a_row_it_cannot_read_and_returns_the_others() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        repository.save(mapping("map-2", "prj", "jdoe", "Person"));
+        poison("map-2", "prj");
+
+        assertThat(repository.list("prj").stream().map(ExtractionMapping::id).toList()).containsOnly("map-1");
+    }
+
+    @Test
+    public void test_get_on_a_poisoned_row_names_the_failure_rather_than_disguising_it_as_io() {
+        repository.save(mapping("map-1", "prj", "jdoe", "Person"));
+        poison("map-1", "prj");
+
+        UnreadableExtractionMapping thrown = assertThrows(UnreadableExtractionMapping.class,
+                () -> repository.get("prj", "map-1"));
+        assertThat(thrown.id).isEqualTo("map-1");
+    }
+
+    private void poison(String id, String projectId) {
+        String definition = dbRule.dsl().select(EXTRACTION_MAPPING.DEFINITION).from(EXTRACTION_MAPPING)
+                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId))
+                .fetchOne(EXTRACTION_MAPPING.DEFINITION);
+        String poisoned = definition.replace("\"model\":\"ftm\"", "\"model\":\"bogus\"");
+        dbRule.dsl().update(EXTRACTION_MAPPING).set(EXTRACTION_MAPPING.DEFINITION, poisoned)
+                .where(EXTRACTION_MAPPING.ID.eq(id)).and(EXTRACTION_MAPPING.PRJ_ID.eq(projectId)).execute();
     }
 
     @Parameterized.Parameters

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -4,6 +4,9 @@ import org.icij.datashare.DocumentUserRecommendation;
 import org.icij.datashare.PathBanner;
 import org.icij.datashare.Repository;
 import org.icij.datashare.UserEvent;
+import org.icij.datashare.model.Statement;
+import org.icij.datashare.tabular.ExtractionMapping;
+import org.icij.datashare.tabular.RowSourceOptions;
 import org.icij.datashare.test.DatashareTimeRule;
 import org.icij.datashare.text.*;
 import org.icij.datashare.user.User;
@@ -416,6 +419,22 @@ public class JooqRepositoryTest {
         assertThat(repository.getRecommendationsBy(project("prj"), List.of(user))).isEmpty();
         assertThat(repository.getUserHistory(user, DOCUMENT, 0, 10, "modification_date",true, "prj")).isEmpty();
         assertThat(repository.getUserEvents(user)).isEmpty();
+    }
+
+    @Test
+    public void test_delete_all_project_purges_its_statements_and_extraction_mappings() {
+        JooqStatementRepository statements = dbRule.createStatementRepository();
+        statements.save("prj", "run-1", List.of(Statement.of("ftm", "e-1", "Person", "name", "Ada",
+                new Statement.Provenance("doc-1", "", 12L, "name"))));
+        dbRule.createExtractionMappingRepository().save(new ExtractionMapping("map-1", "prj", "jdoe", "members",
+                "ftm", "doc-1", RowSourceOptions.defaults(),
+                Map.of("member", new ExtractionMapping.EntityMapping("Person", List.of("id"),
+                        Map.of("name", new ExtractionMapping.PropertyMapping(List.of("full_name"), null, null, null, null))))));
+
+        assertThat(repository.deleteAll("prj")).isTrue();
+
+        assertThat(statements.entity("prj", "e-1").isPresent()).isFalse();
+        assertThat(dbRule.createExtractionMappingRepository().list("prj")).isEmpty();
     }
 
     @Test

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqRepositoryTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -424,7 +425,7 @@ public class JooqRepositoryTest {
     @Test
     public void test_delete_all_project_purges_its_statements_and_extraction_mappings() {
         JooqStatementRepository statements = dbRule.createStatementRepository();
-        statements.save("prj", "run-1", List.of(Statement.of("ftm", "e-1", "Person", "name", "Ada",
+        statements.save("prj", "run-1", Stream.of(Statement.of("ftm", "e-1", "Person", "name", "Ada",
                 new Statement.Provenance("doc-1", "", 12L, "name"))));
         dbRule.createExtractionMappingRepository().save(new ExtractionMapping("map-1", "prj", "jdoe", "members",
                 "ftm", "doc-1", RowSourceOptions.defaults(),

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -1,29 +1,83 @@
 package org.icij.datashare.db;
 
+import org.icij.datashare.model.Statement;
+import org.icij.datashare.test.DatashareTimeRule;
+import org.icij.datashare.time.DatashareTime;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Collection;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
-import static org.icij.datashare.db.Tables.EXTRACTION_MAPPING;
 import static org.icij.datashare.db.Tables.STATEMENT;
 
 @RunWith(Parameterized.class)
 public class JooqStatementRepositoryTest {
     @Rule public DbSetupRule dbRule;
+    @Rule public DatashareTimeRule time = new DatashareTimeRule("2020-07-08T12:13:14Z");
+    private final JooqStatementRepository repository;
 
-    @Test
-    public void test_statement_table_exists() {
-        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(0);
+    private static Statement birthDate(String value) {
+        return Statement.of("ftm", "entity-1", "Person", "birthDate", value,
+                new Statement.Provenance("doc-1", "", 12L, "dob"));
     }
 
     @Test
-    public void test_extraction_mapping_table_exists() {
-        assertThat(dbRule.dsl().fetchCount(EXTRACTION_MAPPING)).isEqualTo(0);
+    public void test_save_writes_one_row_per_statement() {
+        assertThat(repository.save("prj", "run-1", List.of(birthDate("1970-01-01")))).isEqualTo(1);
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(1);
+    }
+
+    @Test
+    public void test_save_fills_the_ontology_version_without_the_caller_supplying_it() {
+        repository.save("prj", "run-1", List.of(birthDate("1970-01-01")));
+        assertThat(dbRule.dsl().select(STATEMENT.MODEL_VERSION).from(STATEMENT).fetchOne().value1())
+                .isEqualTo("4.10.2");
+    }
+
+    @Test
+    public void test_save_stores_the_property_namespaced() {
+        repository.save("prj", "run-1", List.of(birthDate("1970-01-01")));
+        assertThat(dbRule.dsl().select(STATEMENT.PROPERTY).from(STATEMENT).fetchOne().value1())
+                .isEqualTo("ftm:birthDate");
+    }
+
+    @Test
+    public void test_save_stores_the_provenance() {
+        repository.save("prj", "run-1", List.of(birthDate("1970-01-01")));
+        var row = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
+        assertThat(row.getDocId()).isEqualTo("doc-1");
+        assertThat(row.getSheet()).isEqualTo("");
+        assertThat(row.getRowNumber()).isEqualTo(12L);
+        assertThat(row.getColumnName()).isEqualTo("dob");
+        assertThat(row.getRunId()).isEqualTo("run-1");
+        assertThat(row.getPrjId()).isEqualTo("prj");
+    }
+
+    @Test
+    public void test_saving_the_same_data_twice_changes_nothing_except_last_seen() {
+        Collection<Statement> statements = List.of(birthDate("1970-01-01"));
+        repository.save("prj", "run-1", statements);
+        var first = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
+
+        DatashareTime.getInstance().addMilliseconds(60_000);
+        repository.save("prj", "run-2", statements);
+
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(1);
+        var second = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
+        assertThat(second.getId()).isEqualTo(first.getId());
+        assertThat(second.getFirstSeen()).isEqualTo(first.getFirstSeen());
+        assertThat(second.getLastSeen().isAfter(first.getLastSeen())).isTrue();
+    }
+
+    @Test
+    public void test_a_different_value_is_a_different_statement() {
+        repository.save("prj", "run-1", List.of(birthDate("1970-01-01"), birthDate("1980-02-02")));
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
     }
 
     @Parameterized.Parameters
@@ -36,5 +90,6 @@ public class JooqStatementRepositoryTest {
 
     public JooqStatementRepositoryTest(DbSetupRule rule) {
         dbRule = rule;
+        repository = rule.createStatementRepository();
     }
 }

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.db;
 
+import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.Statement;
 import org.icij.datashare.test.DatashareTimeRule;
 import org.icij.datashare.time.DatashareTime;
@@ -10,6 +11,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
@@ -91,6 +94,76 @@ public class JooqStatementRepositoryTest {
     public void test_a_different_value_is_a_different_statement() {
         assertThat(repository.save("prj", "run-1", List.of(birthDate("1970-01-01"), birthDate("1980-02-02")))).isEqualTo(2);
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
+    }
+
+    private static Statement statement(String entityId, String type, String property, String value) {
+        return Statement.of("ftm", entityId, type, property, value,
+                new Statement.Provenance("doc-1", "", 12L, property));
+    }
+
+    @Test
+    public void test_entity_regroups_its_statements() {
+        repository.save("prj", "run-1", List.of(
+                statement("e-1", "Person", "name", "Ada"),
+                statement("e-1", "Person", "birthDate", "1815-12-10")));
+
+        ModelEntity entity = repository.entity("prj", "e-1").orElseThrow();
+        assertThat(entity.id()).isEqualTo("e-1");
+        assertThat(entity.properties().get("name")).containsExactly("Ada");
+        assertThat(entity.properties().get("birthDate")).containsExactly("1815-12-10");
+    }
+
+    @Test
+    public void test_an_entity_keeps_every_one_of_its_types() {
+        repository.save("prj", "run-1", List.of(
+                statement("e-1", "Person", "name", "Ada"),
+                statement("e-1", "LegalEntity", "name", "Ada")));
+
+        assertThat(repository.entity("prj", "e-1").orElseThrow().types()).contains("Person", "LegalEntity");
+    }
+
+    @Test
+    public void test_a_property_keeps_every_one_of_its_values() {
+        repository.save("prj", "run-1", List.of(
+                statement("e-1", "Person", "name", "Ada"),
+                statement("e-1", "Person", "name", "Ada Lovelace")));
+
+        assertThat(repository.entity("prj", "e-1").orElseThrow().properties().get("name"))
+                .containsOnly("Ada", "Ada Lovelace");
+    }
+
+    @Test
+    public void test_entity_is_empty_when_the_project_holds_no_statement_for_it() {
+        repository.save("prj", "run-1", List.of(statement("e-1", "Person", "name", "Ada")));
+        assertThat(repository.entity("other", "e-1")).isEqualTo(Optional.empty());
+        assertThat(repository.entity("prj", "e-2")).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void test_entities_returns_every_entity_of_the_project_and_no_other() {
+        repository.save("prj", "run-1", List.of(
+                statement("e-1", "Person", "name", "Ada"),
+                statement("e-2", "Person", "name", "Grace")));
+        repository.save("other", "run-2", List.of(statement("e-3", "Person", "name", "Alan")));
+
+        try (Stream<ModelEntity> entities = repository.entities("prj")) {
+            assertThat(entities.map(ModelEntity::id).toList()).containsOnly("e-1", "e-2");
+        }
+    }
+
+    @Test
+    public void test_entities_does_not_split_an_entity_across_two_results() {
+        repository.save("prj", "run-1", List.of(
+                statement("e-1", "Person", "name", "Ada"),
+                statement("e-2", "Person", "name", "Grace"),
+                statement("e-1", "Person", "birthDate", "1815-12-10")));
+
+        try (Stream<ModelEntity> entities = repository.entities("prj")) {
+            List<ModelEntity> found = entities.toList();
+            assertThat(found.size()).isEqualTo(2);
+            assertThat(found.stream().filter(e -> e.id().equals("e-1")).findFirst().orElseThrow()
+                    .properties().keySet()).containsOnly("name", "birthDate");
+        }
     }
 
     @Parameterized.Parameters

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -59,24 +59,37 @@ public class JooqStatementRepositoryTest {
     }
 
     @Test
-    public void test_saving_the_same_data_twice_changes_nothing_except_last_seen() {
+    public void test_saving_the_same_data_twice_changes_nothing_except_last_seen_and_run_id() {
         Collection<Statement> statements = List.of(birthDate("1970-01-01"));
         repository.save("prj", "run-1", statements);
         var first = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
 
         DatashareTime.getInstance().addMilliseconds(60_000);
-        repository.save("prj", "run-2", statements);
+        assertThat(repository.save("prj", "run-2", statements)).isEqualTo(1);
 
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(1);
         var second = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
         assertThat(second.getId()).isEqualTo(first.getId());
         assertThat(second.getFirstSeen()).isEqualTo(first.getFirstSeen());
         assertThat(second.getLastSeen().isAfter(first.getLastSeen())).isTrue();
+        assertThat(second.getRunId()).isEqualTo("run-2");
+    }
+
+    @Test
+    public void test_saving_the_same_data_twice_refreshes_the_model_version() {
+        Collection<Statement> statements = List.of(birthDate("1970-01-01"));
+        repository.save("prj", "run-1", statements);
+        dbRule.dsl().update(STATEMENT).set(STATEMENT.MODEL_VERSION, "stale").execute();
+
+        repository.save("prj", "run-2", statements);
+
+        assertThat(dbRule.dsl().select(STATEMENT.MODEL_VERSION).from(STATEMENT).fetchOne().value1())
+                .isEqualTo("4.10.2");
     }
 
     @Test
     public void test_a_different_value_is_a_different_statement() {
-        repository.save("prj", "run-1", List.of(birthDate("1970-01-01"), birthDate("1980-02-02")));
+        assertThat(repository.save("prj", "run-1", List.of(birthDate("1970-01-01"), birthDate("1980-02-02")))).isEqualTo(2);
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
     }
 

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -9,10 +9,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
@@ -25,46 +34,47 @@ public class JooqStatementRepositoryTest {
     @Rule public DatashareTimeRule time = new DatashareTimeRule("2020-07-08T12:13:14Z");
     private final JooqStatementRepository repository;
 
-    private static Statement birthDate(String value) {
-        return Statement.of("ftm", "entity-1", "Person", "birthDate", value,
-                new Statement.Provenance("doc-1", "", 12L, "dob"));
+    private static Statement statement(String entityId, String type, String property, String value) {
+        return Statement.of("ftm", entityId, type, property, value,
+                new Statement.Provenance("doc-1", "", 12L, property));
     }
 
     @Test
     public void test_save_writes_one_row_per_statement() {
-        assertThat(repository.save("prj", "run-1", List.of(birthDate("1970-01-01")))).isEqualTo(1);
+        Collection<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
+        assertThat(repository.save("prj", "run-1", statements)).isEqualTo(1);
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(1);
     }
 
     @Test
     public void test_save_fills_the_ontology_version_without_the_caller_supplying_it() {
-        repository.save("prj", "run-1", List.of(birthDate("1970-01-01")));
+        repository.save("prj", "run-1", List.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
         assertThat(dbRule.dsl().select(STATEMENT.MODEL_VERSION).from(STATEMENT).fetchOne().value1())
                 .isEqualTo("4.10.2");
     }
 
     @Test
     public void test_save_stores_the_property_namespaced() {
-        repository.save("prj", "run-1", List.of(birthDate("1970-01-01")));
+        repository.save("prj", "run-1", List.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
         assertThat(dbRule.dsl().select(STATEMENT.PROPERTY).from(STATEMENT).fetchOne().value1())
                 .isEqualTo("ftm:birthDate");
     }
 
     @Test
     public void test_save_stores_the_provenance() {
-        repository.save("prj", "run-1", List.of(birthDate("1970-01-01")));
+        repository.save("prj", "run-1", List.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
         var row = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
         assertThat(row.getDocId()).isEqualTo("doc-1");
         assertThat(row.getSheet()).isEqualTo("");
         assertThat(row.getRowNumber()).isEqualTo(12L);
-        assertThat(row.getColumnName()).isEqualTo("dob");
+        assertThat(row.getColumnName()).isEqualTo("birthDate");
         assertThat(row.getRunId()).isEqualTo("run-1");
         assertThat(row.getPrjId()).isEqualTo("prj");
     }
 
     @Test
     public void test_saving_the_same_data_twice_is_a_no_op() {
-        Collection<Statement> statements = List.of(birthDate("1970-01-01"));
+        Collection<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
         repository.save("prj", "run-1", statements);
         var first = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
 
@@ -81,13 +91,16 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_a_different_value_is_a_different_statement() {
-        assertThat(repository.save("prj", "run-1", List.of(birthDate("1970-01-01"), birthDate("1980-02-02")))).isEqualTo(2);
+        Collection<Statement> statements = List.of(
+                statement("entity-1", "Person", "birthDate", "1970-01-01"),
+                statement("entity-1", "Person", "birthDate", "1980-02-02"));
+        assertThat(repository.save("prj", "run-1", statements)).isEqualTo(2);
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
     }
 
     @Test
     public void test_the_same_statement_saved_under_two_projects_keeps_both_rows() {
-        Collection<Statement> statements = List.of(birthDate("1970-01-01"));
+        Collection<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
         repository.save("prj-a", "run-1", statements);
         repository.save("prj-b", "run-2", statements);
 
@@ -98,11 +111,6 @@ public class JooqStatementRepositoryTest {
                 .where(STATEMENT.PRJ_ID.eq("prj-a")).fetchOne().value1()).isEqualTo("run-1");
         assertThat(dbRule.dsl().select(STATEMENT.RUN_ID).from(STATEMENT)
                 .where(STATEMENT.PRJ_ID.eq("prj-b")).fetchOne().value1()).isEqualTo("run-2");
-    }
-
-    private static Statement statement(String entityId, String type, String property, String value) {
-        return Statement.of("ftm", entityId, type, property, value,
-                new Statement.Provenance("doc-1", "", 12L, property));
     }
 
     @Test
@@ -231,6 +239,76 @@ public class JooqStatementRepositoryTest {
         }
 
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(3);
+    }
+
+    @Test
+    public void test_save_crosses_the_chunk_boundary() {
+        int size = repository.chunkSize() + 1;
+        List<Statement> statements = IntStream.range(0, size)
+                .mapToObj(i -> statement("e-" + i, "Person", "name", "v" + i))
+                .toList();
+
+        assertThat(repository.save("prj", "run-1", statements)).isEqualTo(size);
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(size);
+    }
+
+    @Test
+    public void test_entities_streams_with_a_non_autocommit_connection_and_a_fetch_size() {
+        repository.save("prj", "run-1", List.of(statement("e-1", "Person", "name", "Ada")));
+
+        AtomicBoolean autoCommit = new AtomicBoolean(true);
+        AtomicInteger fetchSize = new AtomicInteger(-1);
+        JooqStatementRepository capturingRepository = new JooqStatementRepository(
+                capturingDataSource(dbRule.dataSource, autoCommit, fetchSize),
+                RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl));
+
+        try (Stream<ModelEntity> entities = capturingRepository.entities("prj")) {
+            entities.findFirst();
+            assertThat(autoCommit.get()).isFalse();
+            assertThat(fetchSize.get()).isEqualTo(1_000);
+        }
+    }
+
+    // No mocking framework is wired into this module: a JDK dynamic proxy delegating to the real
+    // JDBC objects lets the test observe setAutoCommit/setFetchSize calls without faking the whole
+    // driver's query behaviour.
+    private static DataSource capturingDataSource(DataSource real, AtomicBoolean autoCommit, AtomicInteger fetchSize) {
+        return (DataSource) Proxy.newProxyInstance(DataSource.class.getClassLoader(), new Class<?>[]{DataSource.class},
+                (proxy, method, args) -> {
+                    Object result = invokeReal(real, method, args);
+                    return "getConnection".equals(method.getName()) && result instanceof Connection connection
+                            ? capturingConnection(connection, autoCommit, fetchSize) : result;
+                });
+    }
+
+    private static Connection capturingConnection(Connection real, AtomicBoolean autoCommit, AtomicInteger fetchSize) {
+        return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    if ("setAutoCommit".equals(method.getName())) {
+                        autoCommit.set((Boolean) args[0]);
+                    }
+                    Object result = invokeReal(real, method, args);
+                    return result instanceof PreparedStatement statement
+                            ? capturingStatement(statement, fetchSize) : result;
+                });
+    }
+
+    private static PreparedStatement capturingStatement(PreparedStatement real, AtomicInteger fetchSize) {
+        return (PreparedStatement) Proxy.newProxyInstance(PreparedStatement.class.getClassLoader(), new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> {
+                    if ("setFetchSize".equals(method.getName())) {
+                        fetchSize.set((Integer) args[0]);
+                    }
+                    return invokeReal(real, method, args);
+                });
+    }
+
+    private static Object invokeReal(Object target, Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
     }
 
     @Parameterized.Parameters

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -96,6 +96,21 @@ public class JooqStatementRepositoryTest {
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
     }
 
+    @Test
+    public void test_the_same_statement_saved_under_two_projects_keeps_both_rows() {
+        Collection<Statement> statements = List.of(birthDate("1970-01-01"));
+        repository.save("prj-a", "run-1", statements);
+        repository.save("prj-b", "run-2", statements);
+
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
+        assertThat(repository.entity("prj-a", "entity-1")).isNotEqualTo(Optional.empty());
+        assertThat(repository.entity("prj-b", "entity-1")).isNotEqualTo(Optional.empty());
+        assertThat(dbRule.dsl().select(STATEMENT.RUN_ID).from(STATEMENT)
+                .where(STATEMENT.PRJ_ID.eq("prj-a")).fetchOne().value1()).isEqualTo("run-1");
+        assertThat(dbRule.dsl().select(STATEMENT.RUN_ID).from(STATEMENT)
+                .where(STATEMENT.PRJ_ID.eq("prj-b")).fetchOne().value1()).isEqualTo("run-2");
+    }
+
     private static Statement statement(String entityId, String type, String property, String value) {
         return Statement.of("ftm", entityId, type, property, value,
                 new Statement.Provenance("doc-1", "", 12L, property));

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -4,6 +4,7 @@ import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.Statement;
 import org.icij.datashare.test.DatashareTimeRule;
 import org.icij.datashare.time.DatashareTime;
+import org.jooq.SQLDialect;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -243,7 +244,7 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_save_crosses_the_chunk_boundary() {
-        int size = repository.chunkSize() + 1;
+        int size = JooqCasbinRuleAdapter.determineBatchSize(RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl)) + 1;
         List<Statement> statements = IntStream.range(0, size)
                 .mapToObj(i -> statement("e-" + i, "Person", "name", "v" + i))
                 .toList();
@@ -253,19 +254,24 @@ public class JooqStatementRepositoryTest {
     }
 
     @Test
-    public void test_entities_streams_with_a_non_autocommit_connection_and_a_fetch_size() {
+    public void test_entities_uses_a_non_autocommit_connection_and_a_fetch_size_only_on_postgres() {
         repository.save("prj", "run-1", List.of(statement("e-1", "Person", "name", "Ada")));
 
         AtomicBoolean autoCommit = new AtomicBoolean(true);
         AtomicInteger fetchSize = new AtomicInteger(-1);
+        SQLDialect dialect = RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl);
         JooqStatementRepository capturingRepository = new JooqStatementRepository(
-                capturingDataSource(dbRule.dataSource, autoCommit, fetchSize),
-                RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl));
+                capturingDataSource(dbRule.dataSource, autoCommit, fetchSize), dialect);
 
         try (Stream<ModelEntity> entities = capturingRepository.entities("prj")) {
             entities.findFirst();
-            assertThat(autoCommit.get()).isFalse();
-            assertThat(fetchSize.get()).isEqualTo(1_000);
+            if (dialect == SQLDialect.POSTGRES) {
+                assertThat(autoCommit.get()).isFalse();
+                assertThat(fetchSize.get()).isEqualTo(1_000);
+            } else {
+                assertThat(autoCommit.get()).isTrue();
+                assertThat(fetchSize.get()).isEqualTo(-1);
+            }
         }
     }
 

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -1,10 +1,12 @@
 package org.icij.datashare.db;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.model.Statement;
 import org.icij.datashare.test.DatashareTimeRule;
 import org.icij.datashare.time.DatashareTime;
 import org.jooq.SQLDialect;
+import org.jooq.exception.DataAccessException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,12 +24,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.db.Tables.STATEMENT;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(Parameterized.class)
 public class JooqStatementRepositoryTest {
@@ -86,7 +88,6 @@ public class JooqStatementRepositoryTest {
         var second = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
         assertThat(second.getId()).isEqualTo(first.getId());
         assertThat(second.getFirstSeen()).isEqualTo(first.getFirstSeen());
-        assertThat(second.getLastSeen()).isEqualTo(first.getLastSeen());
         assertThat(second.getRunId()).isEqualTo(first.getRunId());
     }
 
@@ -159,9 +160,8 @@ public class JooqStatementRepositoryTest {
                 statement("e-2", "Person", "name", "Grace")));
         repository.save("other", "run-2", List.of(statement("e-3", "Person", "name", "Alan")));
 
-        try (Stream<ModelEntity> entities = repository.entities("prj")) {
-            assertThat(entities.map(ModelEntity::id).toList()).containsOnly("e-1", "e-2");
-        }
+        List<ModelEntity> found = repository.entities("prj", Stream::toList);
+        assertThat(found.stream().map(ModelEntity::id).toList()).containsOnly("e-1", "e-2");
     }
 
     @Test
@@ -171,12 +171,10 @@ public class JooqStatementRepositoryTest {
                 statement("e-2", "Person", "name", "Grace"),
                 statement("e-1", "Person", "birthDate", "1815-12-10")));
 
-        try (Stream<ModelEntity> entities = repository.entities("prj")) {
-            List<ModelEntity> found = entities.toList();
-            assertThat(found.size()).isEqualTo(2);
-            assertThat(found.stream().filter(e -> e.id().equals("e-1")).findFirst().orElseThrow()
-                    .properties().keySet()).containsOnly("name", "birthDate");
-        }
+        List<ModelEntity> found = repository.entities("prj", Stream::toList);
+        assertThat(found.size()).isEqualTo(2);
+        assertThat(found.stream().filter(e -> e.id().equals("e-1")).findFirst().orElseThrow()
+                .properties().keySet()).containsOnly("name", "birthDate");
     }
 
     @Test
@@ -196,6 +194,18 @@ public class JooqStatementRepositoryTest {
     }
 
     @Test
+    public void test_property_values_are_ordered_the_same_way_on_every_dialect() {
+        repository.save("prj", "run-1", List.of(
+                statement("e-1", "Person", "tag", "b-c"),
+                statement("e-1", "Person", "tag", "Zoe"),
+                statement("e-1", "Person", "tag", "abc"),
+                statement("e-1", "Person", "tag", "Abc")));
+
+        assertThat(repository.entity("prj", "e-1").orElseThrow().properties().get("tag"))
+                .isEqualTo(List.of("Abc", "Zoe", "abc", "b-c"));
+    }
+
+    @Test
     public void test_entities_splits_an_entity_id_shared_by_two_models_into_two_entities() {
         LocalDateTime now = LocalDateTime.now();
         insertRawStatement("id-1", "ftm", "shared", "Person", "ftm:name", "Ada", now);
@@ -205,6 +215,27 @@ public class JooqStatementRepositoryTest {
 
         assertThat(entities.size()).isEqualTo(2);
         assertThat(entities.stream().allMatch(entity -> entity.id().equals("shared"))).isTrue();
+    }
+
+    @Test
+    public void test_entity_serves_the_first_model_of_an_entity_id_shared_by_two() {
+        LocalDateTime now = LocalDateTime.now();
+        insertRawStatement("id-1", "ftm", "shared", "Person", "ftm:name", "Ada", now);
+        insertRawStatement("id-2", "other", "shared", "Thing", "other:name", "Grace", now);
+
+        ModelEntity entity = repository.entity("prj", "shared").orElseThrow();
+        assertThat(entity.id()).isEqualTo("shared");
+        assertThat(entity.types()).containsOnly("Person");
+        assertThat(entity.properties().get("name")).containsOnly("Ada");
+    }
+
+    @Test
+    public void test_a_property_that_is_not_namespaced_under_its_model_names_the_row_it_came_from() {
+        insertRawStatement("id-1", "ftm", "e-1", "Person", "nm", "Ada", LocalDateTime.now());
+
+        DataAccessException thrown = assertThrows(DataAccessException.class,
+                () -> repository.entity("prj", "e-1"));
+        assertThat(thrown.getMessage()).contains("id-1").contains("nm").contains("ftm");
     }
 
     private void insertRawStatement(String id, String model, String entityId, String entityType,
@@ -224,55 +255,49 @@ public class JooqStatementRepositoryTest {
                 .set(STATEMENT.ROW_NUMBER, 1L)
                 .set(STATEMENT.COLUMN_NAME, "name")
                 .set(STATEMENT.FIRST_SEEN, now)
-                .set(STATEMENT.LAST_SEEN, now)
                 .execute();
     }
 
     @Test
-    public void test_the_safe_entities_overload_releases_the_connection_on_a_short_circuit() {
+    public void test_entities_gives_the_connection_back_to_the_pool_on_a_short_circuit() {
         repository.save("prj", "run-1", List.of(
                 statement("e-1", "Person", "name", "Ada"),
-                statement("e-2", "Person", "name", "Grace"),
-                statement("e-3", "Person", "name", "Alan")));
+                statement("e-2", "Person", "name", "Grace")));
 
-        for (int i = 0; i < 12; i++) {
-            repository.entities("prj", Stream::findFirst);
-        }
-
-        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(3);
+        assertThat(repository.entities("prj", Stream::findFirst).isPresent()).isTrue();
+        assertThat(activeConnections()).isEqualTo(0);
     }
 
     @Test
     public void test_save_crosses_the_chunk_boundary() {
-        int size = JooqCasbinRuleAdapter.determineBatchSize(RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl)) + 1;
-        List<Statement> statements = IntStream.range(0, size)
-                .mapToObj(i -> statement("e-" + i, "Person", "name", "v" + i))
-                .toList();
+        SQLDialect dialect = RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl);
+        JooqStatementRepository chunked = new JooqStatementRepository(dbRule.dataSource, dialect, 2);
+        List<Statement> statements = List.of(
+                statement("e-1", "Person", "name", "Ada"),
+                statement("e-2", "Person", "name", "Grace"),
+                statement("e-3", "Person", "name", "Alan"));
 
-        assertThat(repository.save("prj", "run-1", statements)).isEqualTo(size);
-        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(size);
+        assertThat(chunked.save("prj", "run-1", statements)).isEqualTo(3);
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(3);
     }
 
     @Test
-    public void test_entities_uses_a_non_autocommit_connection_and_a_fetch_size_only_on_postgres() {
+    public void test_entities_streams_on_a_non_autocommit_connection_with_a_fetch_size() {
         repository.save("prj", "run-1", List.of(statement("e-1", "Person", "name", "Ada")));
 
         AtomicBoolean autoCommit = new AtomicBoolean(true);
         AtomicInteger fetchSize = new AtomicInteger(-1);
-        SQLDialect dialect = RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl);
         JooqStatementRepository capturingRepository = new JooqStatementRepository(
-                capturingDataSource(dbRule.dataSource, autoCommit, fetchSize), dialect);
+                capturingDataSource(dbRule.dataSource, autoCommit, fetchSize),
+                RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl));
 
-        try (Stream<ModelEntity> entities = capturingRepository.entities("prj")) {
-            entities.findFirst();
-            if (dialect == SQLDialect.POSTGRES) {
-                assertThat(autoCommit.get()).isFalse();
-                assertThat(fetchSize.get()).isEqualTo(1_000);
-            } else {
-                assertThat(autoCommit.get()).isTrue();
-                assertThat(fetchSize.get()).isEqualTo(-1);
-            }
-        }
+        assertThat(capturingRepository.entities("prj", Stream::findFirst).isPresent()).isTrue();
+        assertThat(autoCommit.get()).isFalse();
+        assertThat(fetchSize.get()).isEqualTo(1_000);
+    }
+
+    private int activeConnections() {
+        return ((HikariDataSource) dbRule.dataSource).getHikariPoolMXBean().getActiveConnections();
     }
 
     // No mocking framework is wired into this module: a JDK dynamic proxy delegating to the real

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -1,0 +1,40 @@
+package org.icij.datashare.db;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.db.Tables.EXTRACTION_MAPPING;
+import static org.icij.datashare.db.Tables.STATEMENT;
+
+@RunWith(Parameterized.class)
+public class JooqStatementRepositoryTest {
+    @Rule public DbSetupRule dbRule;
+
+    @Test
+    public void test_statement_table_exists() {
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(0);
+    }
+
+    @Test
+    public void test_extraction_mapping_table_exists() {
+        assertThat(dbRule.dsl().fetchCount(EXTRACTION_MAPPING)).isEqualTo(0);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> dataSources() {
+        return asList(new Object[][]{
+                {DbTestRuleProvider.getSqliteRule()},
+                {DbTestRuleProvider.getPostgresRule()}
+        });
+    }
+
+    public JooqStatementRepositoryTest(DbSetupRule rule) {
+        dbRule = rule;
+    }
+}

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -62,32 +63,20 @@ public class JooqStatementRepositoryTest {
     }
 
     @Test
-    public void test_saving_the_same_data_twice_changes_nothing_except_last_seen_and_run_id() {
+    public void test_saving_the_same_data_twice_is_a_no_op() {
         Collection<Statement> statements = List.of(birthDate("1970-01-01"));
         repository.save("prj", "run-1", statements);
         var first = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
 
         DatashareTime.getInstance().addMilliseconds(60_000);
-        assertThat(repository.save("prj", "run-2", statements)).isEqualTo(1);
+        assertThat(repository.save("prj", "run-2", statements)).isEqualTo(0);
 
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(1);
         var second = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
         assertThat(second.getId()).isEqualTo(first.getId());
         assertThat(second.getFirstSeen()).isEqualTo(first.getFirstSeen());
-        assertThat(second.getLastSeen().isAfter(first.getLastSeen())).isTrue();
-        assertThat(second.getRunId()).isEqualTo("run-2");
-    }
-
-    @Test
-    public void test_saving_the_same_data_twice_refreshes_the_model_version() {
-        Collection<Statement> statements = List.of(birthDate("1970-01-01"));
-        repository.save("prj", "run-1", statements);
-        dbRule.dsl().update(STATEMENT).set(STATEMENT.MODEL_VERSION, "stale").execute();
-
-        repository.save("prj", "run-2", statements);
-
-        assertThat(dbRule.dsl().select(STATEMENT.MODEL_VERSION).from(STATEMENT).fetchOne().value1())
-                .isEqualTo("4.10.2");
+        assertThat(second.getLastSeen()).isEqualTo(first.getLastSeen());
+        assertThat(second.getRunId()).isEqualTo(first.getRunId());
     }
 
     @Test
@@ -179,6 +168,69 @@ public class JooqStatementRepositoryTest {
             assertThat(found.stream().filter(e -> e.id().equals("e-1")).findFirst().orElseThrow()
                     .properties().keySet()).containsOnly("name", "birthDate");
         }
+    }
+
+    @Test
+    public void test_property_values_come_back_in_a_stable_order_across_a_resave() {
+        Collection<Statement> statements = List.of(
+                statement("e-1", "Person", "tag", "b"),
+                statement("e-1", "Person", "tag", "a"),
+                statement("e-1", "Person", "tag", "c"));
+
+        repository.save("prj", "run-1", statements);
+        assertThat(repository.entity("prj", "e-1").orElseThrow().properties().get("tag"))
+                .isEqualTo(List.of("a", "b", "c"));
+
+        repository.save("prj", "run-2", statements);
+        assertThat(repository.entity("prj", "e-1").orElseThrow().properties().get("tag"))
+                .isEqualTo(List.of("a", "b", "c"));
+    }
+
+    @Test
+    public void test_entities_splits_an_entity_id_shared_by_two_models_into_two_entities() {
+        LocalDateTime now = LocalDateTime.now();
+        insertRawStatement("id-1", "ftm", "shared", "Person", "ftm:name", "Ada", now);
+        insertRawStatement("id-2", "other", "shared", "Thing", "other:name", "Ada", now);
+
+        List<ModelEntity> entities = repository.entities("prj", Stream::toList);
+
+        assertThat(entities.size()).isEqualTo(2);
+        assertThat(entities.stream().allMatch(entity -> entity.id().equals("shared"))).isTrue();
+    }
+
+    private void insertRawStatement(String id, String model, String entityId, String entityType,
+                                     String property, String value, LocalDateTime now) {
+        dbRule.dsl().insertInto(STATEMENT)
+                .set(STATEMENT.ID, id)
+                .set(STATEMENT.PRJ_ID, "prj")
+                .set(STATEMENT.RUN_ID, "run-1")
+                .set(STATEMENT.MODEL, model)
+                .set(STATEMENT.MODEL_VERSION, "1.0")
+                .set(STATEMENT.ENTITY_ID, entityId)
+                .set(STATEMENT.ENTITY_TYPE, entityType)
+                .set(STATEMENT.PROPERTY, property)
+                .set(STATEMENT.VALUE, value)
+                .set(STATEMENT.DOC_ID, "doc-1")
+                .set(STATEMENT.SHEET, "")
+                .set(STATEMENT.ROW_NUMBER, 1L)
+                .set(STATEMENT.COLUMN_NAME, "name")
+                .set(STATEMENT.FIRST_SEEN, now)
+                .set(STATEMENT.LAST_SEEN, now)
+                .execute();
+    }
+
+    @Test
+    public void test_the_safe_entities_overload_releases_the_connection_on_a_short_circuit() {
+        repository.save("prj", "run-1", List.of(
+                statement("e-1", "Person", "name", "Ada"),
+                statement("e-2", "Person", "name", "Grace"),
+                statement("e-3", "Person", "name", "Alan")));
+
+        for (int i = 0; i < 12; i++) {
+            repository.entities("prj", Stream::findFirst);
+        }
+
+        assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(3);
     }
 
     @Parameterized.Parameters

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -44,28 +44,28 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_save_writes_one_row_per_statement() {
-        Collection<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
-        assertThat(repository.save("prj", "run-1", statements)).isEqualTo(1);
+        List<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
+        assertThat(repository.save("prj", "run-1", statements.stream())).isEqualTo(1);
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(1);
     }
 
     @Test
     public void test_save_fills_the_ontology_version_without_the_caller_supplying_it() {
-        repository.save("prj", "run-1", List.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
+        repository.save("prj", "run-1", Stream.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
         assertThat(dbRule.dsl().select(STATEMENT.MODEL_VERSION).from(STATEMENT).fetchOne().value1())
                 .isEqualTo("4.10.2");
     }
 
     @Test
     public void test_save_stores_the_property_namespaced() {
-        repository.save("prj", "run-1", List.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
+        repository.save("prj", "run-1", Stream.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
         assertThat(dbRule.dsl().select(STATEMENT.PROPERTY).from(STATEMENT).fetchOne().value1())
                 .isEqualTo("ftm:birthDate");
     }
 
     @Test
     public void test_save_stores_the_provenance() {
-        repository.save("prj", "run-1", List.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
+        repository.save("prj", "run-1", Stream.of(statement("entity-1", "Person", "birthDate", "1970-01-01")));
         var row = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
         assertThat(row.getDocId()).isEqualTo("doc-1");
         assertThat(row.getSheet()).isEqualTo("");
@@ -76,35 +76,36 @@ public class JooqStatementRepositoryTest {
     }
 
     @Test
-    public void test_saving_the_same_data_twice_is_a_no_op() {
-        Collection<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
-        repository.save("prj", "run-1", statements);
+    public void test_saving_the_same_data_twice_keeps_one_row_and_dates_the_new_observation() {
+        List<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
+        repository.save("prj", "run-1", statements.stream());
         var first = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
 
         DatashareTime.getInstance().addMilliseconds(60_000);
-        assertThat(repository.save("prj", "run-2", statements)).isEqualTo(0);
+        assertThat(repository.save("prj", "run-2", statements.stream())).isEqualTo(1);
 
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(1);
         var second = dbRule.dsl().selectFrom(STATEMENT).fetchOne();
         assertThat(second.getId()).isEqualTo(first.getId());
         assertThat(second.getFirstSeen()).isEqualTo(first.getFirstSeen());
-        assertThat(second.getRunId()).isEqualTo(first.getRunId());
+        assertThat(second.getLastSeen()).isNotEqualTo(first.getLastSeen());
+        assertThat(second.getRunId()).isEqualTo("run-2");
     }
 
     @Test
     public void test_a_different_value_is_a_different_statement() {
-        Collection<Statement> statements = List.of(
+        List<Statement> statements = List.of(
                 statement("entity-1", "Person", "birthDate", "1970-01-01"),
                 statement("entity-1", "Person", "birthDate", "1980-02-02"));
-        assertThat(repository.save("prj", "run-1", statements)).isEqualTo(2);
+        assertThat(repository.save("prj", "run-1", statements.stream())).isEqualTo(2);
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
     }
 
     @Test
     public void test_the_same_statement_saved_under_two_projects_keeps_both_rows() {
-        Collection<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
-        repository.save("prj-a", "run-1", statements);
-        repository.save("prj-b", "run-2", statements);
+        List<Statement> statements = List.of(statement("entity-1", "Person", "birthDate", "1970-01-01"));
+        repository.save("prj-a", "run-1", statements.stream());
+        repository.save("prj-b", "run-2", statements.stream());
 
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(2);
         assertThat(repository.entity("prj-a", "entity-1")).isNotEqualTo(Optional.empty());
@@ -117,7 +118,7 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_entity_regroups_its_statements() {
-        repository.save("prj", "run-1", List.of(
+        repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "name", "Ada"),
                 statement("e-1", "Person", "birthDate", "1815-12-10")));
 
@@ -129,7 +130,7 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_an_entity_keeps_every_one_of_its_types() {
-        repository.save("prj", "run-1", List.of(
+        repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "name", "Ada"),
                 statement("e-1", "LegalEntity", "name", "Ada")));
 
@@ -138,7 +139,7 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_a_property_keeps_every_one_of_its_values() {
-        repository.save("prj", "run-1", List.of(
+        repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "name", "Ada"),
                 statement("e-1", "Person", "name", "Ada Lovelace")));
 
@@ -148,17 +149,17 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_entity_is_empty_when_the_project_holds_no_statement_for_it() {
-        repository.save("prj", "run-1", List.of(statement("e-1", "Person", "name", "Ada")));
+        repository.save("prj", "run-1", Stream.of(statement("e-1", "Person", "name", "Ada")));
         assertThat(repository.entity("other", "e-1")).isEqualTo(Optional.empty());
         assertThat(repository.entity("prj", "e-2")).isEqualTo(Optional.empty());
     }
 
     @Test
     public void test_entities_returns_every_entity_of_the_project_and_no_other() {
-        repository.save("prj", "run-1", List.of(
+        repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "name", "Ada"),
                 statement("e-2", "Person", "name", "Grace")));
-        repository.save("other", "run-2", List.of(statement("e-3", "Person", "name", "Alan")));
+        repository.save("other", "run-2", Stream.of(statement("e-3", "Person", "name", "Alan")));
 
         List<ModelEntity> found = repository.entities("prj", Stream::toList);
         assertThat(found.stream().map(ModelEntity::id).toList()).containsOnly("e-1", "e-2");
@@ -166,7 +167,7 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_entities_does_not_split_an_entity_across_two_results() {
-        repository.save("prj", "run-1", List.of(
+        repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "name", "Ada"),
                 statement("e-2", "Person", "name", "Grace"),
                 statement("e-1", "Person", "birthDate", "1815-12-10")));
@@ -179,23 +180,23 @@ public class JooqStatementRepositoryTest {
 
     @Test
     public void test_property_values_come_back_in_a_stable_order_across_a_resave() {
-        Collection<Statement> statements = List.of(
+        List<Statement> statements = List.of(
                 statement("e-1", "Person", "tag", "b"),
                 statement("e-1", "Person", "tag", "a"),
                 statement("e-1", "Person", "tag", "c"));
 
-        repository.save("prj", "run-1", statements);
+        repository.save("prj", "run-1", statements.stream());
         assertThat(repository.entity("prj", "e-1").orElseThrow().properties().get("tag"))
                 .isEqualTo(List.of("a", "b", "c"));
 
-        repository.save("prj", "run-2", statements);
+        repository.save("prj", "run-2", statements.stream());
         assertThat(repository.entity("prj", "e-1").orElseThrow().properties().get("tag"))
                 .isEqualTo(List.of("a", "b", "c"));
     }
 
     @Test
     public void test_property_values_are_ordered_the_same_way_on_every_dialect() {
-        repository.save("prj", "run-1", List.of(
+        repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "tag", "b-c"),
                 statement("e-1", "Person", "tag", "Zoe"),
                 statement("e-1", "Person", "tag", "abc"),
@@ -215,6 +216,7 @@ public class JooqStatementRepositoryTest {
 
         assertThat(entities.size()).isEqualTo(2);
         assertThat(entities.stream().allMatch(entity -> entity.id().equals("shared"))).isTrue();
+        assertThat(entities.stream().map(ModelEntity::model).toList()).containsOnly("ftm", "other");
     }
 
     @Test
@@ -255,12 +257,13 @@ public class JooqStatementRepositoryTest {
                 .set(STATEMENT.ROW_NUMBER, 1L)
                 .set(STATEMENT.COLUMN_NAME, "name")
                 .set(STATEMENT.FIRST_SEEN, now)
+                .set(STATEMENT.LAST_SEEN, now)
                 .execute();
     }
 
     @Test
     public void test_entities_gives_the_connection_back_to_the_pool_on_a_short_circuit() {
-        repository.save("prj", "run-1", List.of(
+        repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "name", "Ada"),
                 statement("e-2", "Person", "name", "Grace")));
 
@@ -277,23 +280,35 @@ public class JooqStatementRepositoryTest {
                 statement("e-2", "Person", "name", "Grace"),
                 statement("e-3", "Person", "name", "Alan"));
 
-        assertThat(chunked.save("prj", "run-1", statements)).isEqualTo(3);
+        assertThat(chunked.save("prj", "run-1", statements.stream())).isEqualTo(3);
         assertThat(dbRule.dsl().fetchCount(STATEMENT)).isEqualTo(3);
     }
 
+    // Only pgjdbc opens a server-side cursor, and only outside autocommit. SQLite ignores fetchSize
+    // and would hold a shared lock on the whole file for as long as the consumer runs, so it must be
+    // left in autocommit: this pins both halves of that split.
     @Test
-    public void test_entities_streams_on_a_non_autocommit_connection_with_a_fetch_size() {
-        repository.save("prj", "run-1", List.of(statement("e-1", "Person", "name", "Ada")));
+    public void test_entities_streams_out_of_autocommit_on_postgres_only() {
+        repository.save("prj", "run-1", Stream.of(statement("e-1", "Person", "name", "Ada")));
+        SQLDialect dialect = RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl);
 
         AtomicBoolean autoCommit = new AtomicBoolean(true);
         AtomicInteger fetchSize = new AtomicInteger(-1);
         JooqStatementRepository capturingRepository = new JooqStatementRepository(
-                capturingDataSource(dbRule.dataSource, autoCommit, fetchSize),
-                RepositoryFactoryImpl.guessSqlDialectFrom(dbRule.dataSourceUrl));
+                capturingDataSource(dbRule.dataSource, autoCommit, fetchSize), dialect);
 
         assertThat(capturingRepository.entities("prj", Stream::findFirst).isPresent()).isTrue();
-        assertThat(autoCommit.get()).isFalse();
-        assertThat(fetchSize.get()).isEqualTo(1_000);
+        assertThat(autoCommit.get()).isEqualTo(dialect != SQLDialect.POSTGRES);
+        assertThat(fetchSize.get()).isEqualTo(dialect == SQLDialect.POSTGRES ? 1_000 : -1);
+    }
+
+    @Test
+    public void test_an_entity_names_the_model_it_was_rebuilt_from() {
+        repository.save("prj", "run-1", Stream.of(statement("e-1", "Person", "name", "Ada")));
+
+        assertThat(repository.entity("prj", "e-1").orElseThrow().model()).isEqualTo("ftm");
+        List<String> models = repository.entities("prj", entities -> entities.map(ModelEntity::model).toList());
+        assertThat(models).containsOnly("ftm");
     }
 
     private int activeConnections() {


### PR DESCRIPTION
Adds the `statement` and `extraction_mapping` tables with their jOOQ repositories, so extracted facts get an idempotent system of record and the mapping that produced them is persisted. Part of #2194.

- feat: add changeset 047 with the `statement` and `extraction_mapping` tables
- feat: add `StatementRepository`, upserting by statement id so a re-run is a no-op
- feat: rebuild whole entities by grouping a project's statements, streamed rather than buffered
- feat: add `ExtractionMapping`, an immutable mapping persisted as JSON and validated on save
- fix: scope both tables to their project with a composite `(id, prj_id)` primary key
- fix: purge both tables on project deletion
- test: cover both repositories on SQLite and Postgres

Requires Postgres 13 or later: `entities` streams via Incremental Sort over `statement_prj_entity`, and the pre-13 planner falls back to a full external merge sort.

Reviewers: run `make reset-db` before building. Changesets 81 and 82 were edited in place during review, so Liquibase reports a checksum mismatch against an earlier build of this branch. 047 has never shipped, so a reset is the right remedy rather than a `validCheckSum`.
