### PR TITLE
feat: <project>.entities index and ExtractedEntity type

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ModelEntity.java
@@ -10,14 +10,19 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-public record ModelEntity(String model, String id, Set<String> types, Map<String, List<String>> properties) {
+public record ModelEntity(String model, String id, Set<String> types, Set<String> modelVersions,
+                          Set<String> documentIds, Map<String, List<String>> properties) {
 
     public ModelEntity {
         Objects.requireNonNull(model, "model");
         Objects.requireNonNull(id, "id");
         Objects.requireNonNull(types, "types");
+        Objects.requireNonNull(modelVersions, "modelVersions");
+        Objects.requireNonNull(documentIds, "documentIds");
         Objects.requireNonNull(properties, "properties");
         types = Set.copyOf(types);
+        modelVersions = Set.copyOf(modelVersions);
+        documentIds = Set.copyOf(documentIds);
         Map<String, List<String>> copy = new LinkedHashMap<>();
         properties.forEach((property, values) -> copy.put(property, List.copyOf(values)));
         properties = Collections.unmodifiableMap(copy);
@@ -27,15 +32,17 @@ public record ModelEntity(String model, String id, Set<String> types, Map<String
      *  held, so a group larger than memory is not built to be collapsed. Properties and values come
      *  out in natural order, not in the order the statements arrived, so a database collation never
      *  decides what an entity looks like. */
-    public static ModelEntity from(Iterable<Statement> statements) {
+    public static ModelEntity from(Iterable<Statement> statements, Set<String> modelVersions) {
         SortedSet<String> ids = new TreeSet<>();
         SortedSet<String> models = new TreeSet<>();
         Set<String> types = new TreeSet<>();
+        Set<String> documentIds = new TreeSet<>();
         Map<String, SortedSet<String>> values = new TreeMap<>();
         for (Statement statement : statements) {
             ids.add(statement.entityId());
             models.add(statement.model());
             types.add(statement.entityType());
+            documentIds.add(statement.provenance().documentId());
             values.computeIfAbsent(statement.property(), property -> new TreeSet<>()).add(statement.value());
         }
         if (ids.isEmpty()) {
@@ -49,6 +56,6 @@ public record ModelEntity(String model, String id, Set<String> types, Map<String
         }
         Map<String, List<String>> properties = new LinkedHashMap<>();
         values.forEach((property, distinct) -> properties.put(property, List.copyOf(distinct)));
-        return new ModelEntity(models.first(), ids.first(), types, properties);
+        return new ModelEntity(models.first(), ids.first(), types, modelVersions, documentIds, properties);
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
+++ b/datashare-api/src/main/java/org/icij/datashare/model/ftm/FtmTargetModel.java
@@ -101,7 +101,7 @@ public class FtmTargetModel implements TargetModel {
                 throw new IllegalArgumentException("property '" + property + "' has a null value in FtM JSON");
             }
         });
-        return new ModelEntity(name(), read.id(), Set.of(read.schema()), properties);
+        return new ModelEntity(name(), read.id(), Set.of(read.schema()), Set.of(), Set.of(), properties);
     }
 
     @Override

--- a/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
+++ b/datashare-api/src/main/java/org/icij/datashare/tabular/ExtractionMapping.java
@@ -117,6 +117,6 @@ public record ExtractionMapping(String id, String projectId, String userId, Stri
     private ModelEntity probe(String alias, EntityMapping entity) {
         Map<String, List<String>> properties = new LinkedHashMap<>();
         new TreeSet<>(entity.properties().keySet()).forEach(property -> properties.put(property, List.of("?")));
-        return new ModelEntity(model, alias, Set.of(entity.type()), properties);
+        return new ModelEntity(model, alias, Set.of(entity.type()), Set.of(), Set.of(documentId), properties);
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
@@ -1,0 +1,27 @@
+package org.icij.datashare.text;
+
+import org.icij.datashare.Entity;
+import org.icij.datashare.model.ModelEntity;
+import org.icij.datashare.text.indexing.IndexId;
+import org.icij.datashare.text.indexing.IndexType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** An entity rebuilt from the statement store, in the shape the "&lt;project&gt;.entities" index holds:
+ *  the property keys are the namespaced wire form ("ftm:birthDate") the statements were stored under. */
+@IndexType("ExtractedEntity")
+public record ExtractedEntity(@IndexId String id, String model, Set<String> modelVersions, Set<String> types,
+                              Set<String> documentIds, Map<String, List<String>> properties) implements Entity {
+
+    public static ExtractedEntity from(ModelEntity entity) {
+        return new ExtractedEntity(entity.id(), entity.model(), entity.modelVersions(), entity.types(),
+                entity.documentIds(), entity.properties());
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
@@ -1,5 +1,6 @@
 package org.icij.datashare.text;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.icij.datashare.Entity;
 import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.text.indexing.IndexId;
@@ -33,8 +34,10 @@ public record ExtractedEntity(@IndexId String entityId, String model, Set<String
     }
 
     /** The document id, which the entity id alone cannot be: the statement store emits one entity per
-     *  (entity id, model) pair, so two models describing the same entity would overwrite each other. */
+     *  (entity id, model) pair, so two models describing the same entity would overwrite each other.
+     *  Hidden from the source like {@link NamedEntity#getId()}: it already lives in the _id. */
     @Override
+    @JsonIgnore
     public String getId() {
         return model + NAMESPACE_SEPARATOR + entityId;
     }

--- a/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
@@ -11,10 +11,14 @@ import java.util.Map;
 import java.util.Set;
 
 /** An entity rebuilt from the statement store, in the shape the "&lt;project&gt;.entities" index holds:
- *  the property keys are the namespaced wire form ("ftm:birthDate") the statements were stored under. */
+ *  the property keys are the namespaced wire form ("ftm_birthDate") the statements were stored under. */
 @IndexType("ExtractedEntity")
-public record ExtractedEntity(@IndexId String id, String model, Set<String> types, Set<String> modelVersions,
+public record ExtractedEntity(@IndexId String entityId, String model, Set<String> types, Set<String> modelVersions,
                               Set<String> documentIds, Map<String, List<String>> properties) implements Entity {
+    /** Not the colon {@link org.icij.datashare.model.Statement#qualifiedProperty()} stores: a colon is
+     *  the field/value delimiter of elasticsearch's query_string, so "properties.ftm:name:Jane" is a
+     *  parse error and every client would have to escape the separator to reach a single property. */
+    private static final String NAMESPACE_SEPARATOR = "_";
 
     // ModelEntity's keys are bare ("birthDate"): JooqStatementRepository.toRow strips the model
     // prefix a statement's property is stored under. The namespace goes back on here, at the index
@@ -22,13 +26,16 @@ public record ExtractedEntity(@IndexId String id, String model, Set<String> type
     // consume on the bare form.
     public static ExtractedEntity from(ModelEntity entity) {
         Map<String, List<String>> namespaced = new LinkedHashMap<>();
-        entity.properties().forEach((property, values) -> namespaced.put(entity.model() + ":" + property, values));
+        entity.properties().forEach((property, values) ->
+                namespaced.put(entity.model() + NAMESPACE_SEPARATOR + property, values));
         return new ExtractedEntity(entity.id(), entity.model(), entity.types(), entity.modelVersions(),
                 entity.documentIds(), namespaced);
     }
 
+    /** The document id, which the entity id alone cannot be: the statement store emits one entity per
+     *  (entity id, model) pair, so two models describing the same entity would overwrite each other. */
     @Override
     public String getId() {
-        return id;
+        return model + NAMESPACE_SEPARATOR + entityId;
     }
 }

--- a/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
@@ -13,7 +13,7 @@ import java.util.Set;
 /** An entity rebuilt from the statement store, in the shape the "&lt;project&gt;.entities" index holds:
  *  the property keys are the namespaced wire form ("ftm:birthDate") the statements were stored under. */
 @IndexType("ExtractedEntity")
-public record ExtractedEntity(@IndexId String id, String model, Set<String> modelVersions, Set<String> types,
+public record ExtractedEntity(@IndexId String id, String model, Set<String> types, Set<String> modelVersions,
                               Set<String> documentIds, Map<String, List<String>> properties) implements Entity {
 
     // ModelEntity's keys are bare ("birthDate"): JooqStatementRepository.toRow strips the model
@@ -23,7 +23,7 @@ public record ExtractedEntity(@IndexId String id, String model, Set<String> mode
     public static ExtractedEntity from(ModelEntity entity) {
         Map<String, List<String>> namespaced = new LinkedHashMap<>();
         entity.properties().forEach((property, values) -> namespaced.put(entity.model() + ":" + property, values));
-        return new ExtractedEntity(entity.id(), entity.model(), entity.modelVersions(), entity.types(),
+        return new ExtractedEntity(entity.id(), entity.model(), entity.types(), entity.modelVersions(),
                 entity.documentIds(), namespaced);
     }
 

--- a/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/ExtractedEntity.java
@@ -5,6 +5,7 @@ import org.icij.datashare.model.ModelEntity;
 import org.icij.datashare.text.indexing.IndexId;
 import org.icij.datashare.text.indexing.IndexType;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -15,9 +16,15 @@ import java.util.Set;
 public record ExtractedEntity(@IndexId String id, String model, Set<String> modelVersions, Set<String> types,
                               Set<String> documentIds, Map<String, List<String>> properties) implements Entity {
 
+    // ModelEntity's keys are bare ("birthDate"): JooqStatementRepository.toRow strips the model
+    // prefix a statement's property is stored under. The namespace goes back on here, at the index
+    // boundary, rather than in ModelEntity, which TargetModel.validate and ExtractionMapping.probe
+    // consume on the bare form.
     public static ExtractedEntity from(ModelEntity entity) {
+        Map<String, List<String>> namespaced = new LinkedHashMap<>();
+        entity.properties().forEach((property, values) -> namespaced.put(entity.model() + ":" + property, values));
         return new ExtractedEntity(entity.id(), entity.model(), entity.modelVersions(), entity.types(),
-                entity.documentIds(), entity.properties());
+                entity.documentIds(), namespaced);
     }
 
     @Override

--- a/datashare-api/src/main/java/org/icij/datashare/text/Project.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/Project.java
@@ -8,6 +8,7 @@ import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING;
@@ -21,6 +22,12 @@ public class Project extends ProjectProxy {
     public static final String ALLOW_FROM_MASK_REGEX = "^[\\d*]{1,3}(\\.[\\d*]{1,3}){3}$";
     public static final Pattern NAME_PATTERN = Pattern.compile(NAME_REGEX);
     public static final Pattern ALLOW_FROM_MASK_PATTERN = Pattern.compile(ALLOW_FROM_MASK_REGEX);
+    /** Suffix of an index derived from a project: "myproject.entities" is granted to whoever is granted "myproject". */
+    public static final String ENTITIES_INDEX_SUFFIX = ".entities";
+
+    public static String entitiesIndex(String projectId) {
+        return Objects.requireNonNull(projectId, "projectId") + ENTITIES_INDEX_SUFFIX;
+    }
 
     public final Path sourcePath;
     @JsonIgnore

--- a/datashare-api/src/main/java/org/icij/datashare/text/StructuredEntity.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/StructuredEntity.java
@@ -13,8 +13,8 @@ import java.util.Set;
 
 /** An entity rebuilt from the statement store, in the shape the "&lt;project&gt;.entities" index holds:
  *  the property keys are the namespaced wire form ("ftm_birthDate") the statements were stored under. */
-@IndexType("ExtractedEntity")
-public record ExtractedEntity(@IndexId String entityId, String model, Set<String> types, Set<String> modelVersions,
+@IndexType("StructuredEntity")
+public record StructuredEntity(@IndexId String entityId, String model, Set<String> types, Set<String> modelVersions,
                               Set<String> documentIds, Map<String, List<String>> properties) implements Entity {
     /** Not the colon {@link org.icij.datashare.model.Statement#qualifiedProperty()} stores: a colon is
      *  the field/value delimiter of elasticsearch's query_string, so "properties.ftm:name:Jane" is a
@@ -25,11 +25,11 @@ public record ExtractedEntity(@IndexId String entityId, String model, Set<String
     // prefix a statement's property is stored under. The namespace goes back on here, at the index
     // boundary, rather than in ModelEntity, which TargetModel.validate and ExtractionMapping.probe
     // consume on the bare form.
-    public static ExtractedEntity from(ModelEntity entity) {
+    public static StructuredEntity from(ModelEntity entity) {
         Map<String, List<String>> namespaced = new LinkedHashMap<>();
         entity.properties().forEach((property, values) ->
                 namespaced.put(entity.model() + NAMESPACE_SEPARATOR + property, values));
-        return new ExtractedEntity(entity.id(), entity.model(), entity.types(), entity.modelVersions(),
+        return new StructuredEntity(entity.id(), entity.model(), entity.types(), entity.modelVersions(),
                 entity.documentIds(), namespaced);
     }
 

--- a/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
@@ -24,7 +24,7 @@ public interface Indexer extends Closeable {
     Searcher search(List<String> indexesNames, Class<? extends Entity> entityClass, SearchQuery query);
 
     boolean createIndex(String indexName) throws IOException;
-    /** Creates the "<projectId>.entities" index holding the project's extracted entities, with the
+    /** Creates the "&lt;projectId&gt;.entities" index holding the project's extracted entities, with the
      *  entity mappings rather than the document ones. Returns false when it already exists. */
     boolean createEntitiesIndex(String projectId) throws IOException;
     boolean deleteAll(String indexName) throws IOException;

--- a/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
@@ -23,10 +23,16 @@ public interface Indexer extends Closeable {
     QueryBuilderSearcher search(List<String> indexesNames, Class<? extends Entity> entityClass);
     Searcher search(List<String> indexesNames, Class<? extends Entity> entityClass, SearchQuery query);
 
+    /** Creates {@code indexName} and, unless it is itself a "&lt;project&gt;.entities" name, the entities
+     *  index derived from it, so every creation path pairs the two. Returns false when {@code indexName}
+     *  already exists, and creates neither index if either creation fails. */
     boolean createIndex(String indexName) throws IOException;
     /** Creates the "&lt;projectId&gt;.entities" index holding the project's extracted entities, with the
      *  entity mappings rather than the document ones. Returns false when it already exists. */
     boolean createEntitiesIndex(String projectId) throws IOException;
+    /** Drops {@code indexName}, mappings included, and returns false when it does not exist. Unlike
+     *  {@link #deleteAll} this discards the mappings, so it is how an index gets re-created with new ones. */
+    boolean deleteIndex(String indexName) throws IOException;
     boolean deleteAll(String indexName) throws IOException;
     /**
      * Returns the number of documents indexed in {@code indexName}, or 0 if the index

--- a/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/indexing/Indexer.java
@@ -24,6 +24,9 @@ public interface Indexer extends Closeable {
     Searcher search(List<String> indexesNames, Class<? extends Entity> entityClass, SearchQuery query);
 
     boolean createIndex(String indexName) throws IOException;
+    /** Creates the "<projectId>.entities" index holding the project's extracted entities, with the
+     *  entity mappings rather than the document ones. Returns false when it already exists. */
+    boolean createEntitiesIndex(String projectId) throws IOException;
     boolean deleteAll(String indexName) throws IOException;
     /**
      * Returns the number of documents indexed in {@code indexName}, or 0 if the index

--- a/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ModelEntityTest.java
@@ -16,9 +16,12 @@ public class ModelEntityTest {
     @Test
     public void test_the_entity_copies_the_collections_it_was_handed() {
         ModelEntity entity = new ModelEntity("ftm", "p-1", new HashSet<>(Set.of("Person")),
+                new HashSet<>(Set.of("4.10.2")), new HashSet<>(Set.of("doc-1")),
                 new HashMap<>(Map.of("name", new ArrayList<>(List.of("Jane Doe")))));
 
         assertThrows(UnsupportedOperationException.class, () -> entity.types().add("Company"));
+        assertThrows(UnsupportedOperationException.class, () -> entity.modelVersions().add("4.11.0"));
+        assertThrows(UnsupportedOperationException.class, () -> entity.documentIds().add("doc-2"));
         assertThrows(UnsupportedOperationException.class,
                 () -> entity.properties().put("birthDate", List.of("1980-04-02")));
         assertThrows(UnsupportedOperationException.class, () -> entity.properties().get("name").add("J. Doe"));
@@ -29,7 +32,7 @@ public class ModelEntityTest {
         ModelEntity entity = ModelEntity.from(List.of(
                 statement("name", "Jane Doe", "full_name"),
                 statement("birthDate", "1980-04-02", "dob"),
-                statement("name", "J. Doe", "known_as")));
+                statement("name", "J. Doe", "known_as")), Set.of("4.10.2"));
 
         assertThat(entity.model()).isEqualTo("ftm");
         assertThat(entity.id()).isEqualTo("person-1");
@@ -43,7 +46,7 @@ public class ModelEntityTest {
         ModelEntity entity = ModelEntity.from(List.of(
                 statement("name", "Jane Doe", "full_name"),
                 Statement.of("ftm", "person-1", "LegalEntity", "name", "Jane Doe",
-                        new Statement.Provenance("doc-2", null, 3, "counterparty"))));
+                        new Statement.Provenance("doc-2", null, 3, "counterparty"))), Set.of("4.10.2"));
 
         assertThat(entity.types()).containsOnly("Person", "LegalEntity");
     }
@@ -52,7 +55,7 @@ public class ModelEntityTest {
     public void test_the_same_value_from_two_cells_is_two_statements_but_one_value() {
         ModelEntity entity = ModelEntity.from(List.of(
                 statement("name", "Jane Doe", "full_name"),
-                statement("name", "Jane Doe", "legal_name")));
+                statement("name", "Jane Doe", "legal_name")), Set.of("4.10.2"));
 
         assertThat(entity.properties().get("name")).containsExactly("Jane Doe");
     }
@@ -62,19 +65,25 @@ public class ModelEntityTest {
         ModelEntity.from(List.of(
                 statement("name", "Jane Doe", "full_name"),
                 Statement.of("ftm", "person-2", "Person", "name", "John Doe",
-                        new Statement.Provenance("doc-1", "Sheet1", 13, "full_name"))));
+                        new Statement.Provenance("doc-1", "Sheet1", 13, "full_name"))), Set.of("4.10.2"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_refuses_an_empty_collection() {
-        ModelEntity.from(List.of());
+        ModelEntity.from(List.of(), Set.of("4.10.2"));
     }
 
     @Test
     public void test_the_null_arguments_are_rejected() {
-        assertRejectsNull("model", () -> new ModelEntity(null, "p-1", Set.of("Person"), Map.of("name", List.of("Jane Doe"))));
-        assertRejectsNull("id", () -> new ModelEntity("ftm", null, Set.of("Person"), Map.of("name", List.of("Jane Doe"))));
-        assertRejectsNull("types", () -> new ModelEntity("ftm", "p-1", null, Map.of("name", List.of("Jane Doe"))));
+        Set<String> versions = Set.of("4.10.2");
+        Set<String> documents = Set.of("doc-1");
+        Map<String, List<String>> name = Map.of("name", List.of("Jane Doe"));
+
+        assertRejectsNull("model", () -> new ModelEntity(null, "p-1", Set.of("Person"), versions, documents, name));
+        assertRejectsNull("id", () -> new ModelEntity("ftm", null, Set.of("Person"), versions, documents, name));
+        assertRejectsNull("types", () -> new ModelEntity("ftm", "p-1", null, versions, documents, name));
+        assertRejectsNull("modelVersions", () -> new ModelEntity("ftm", "p-1", Set.of("Person"), null, documents, name));
+        assertRejectsNull("documentIds", () -> new ModelEntity("ftm", "p-1", Set.of("Person"), versions, null, name));
     }
 
     private static void assertRejectsNull(String field, Runnable construction) {
@@ -86,10 +95,38 @@ public class ModelEntityTest {
         String message = assertThrows(IllegalArgumentException.class, () ->
                 ModelEntity.from(List.of(statement("name", "Jane Doe", "full_name"),
                         new Statement("id-2", "wikidata", "person-1", "Q5", "name", "Jane Q",
-                                new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))))).getMessage();
+                                new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))),
+                        Set.of("4.10.2"))).getMessage();
 
         assertThat(message).contains("ftm");
         assertThat(message).contains("wikidata");
+    }
+
+    @Test
+    public void test_unions_the_document_ids_of_the_statements() {
+        ModelEntity entity = ModelEntity.from(List.of(
+                statement("name", "Jane Doe", "full_name"),
+                Statement.of("ftm", "person-1", "Person", "birthDate", "1980-04-02",
+                        new Statement.Provenance("doc-2", "Sheet1", 3, "dob"))), Set.of("4.10.2"));
+
+        assertThat(entity.documentIds()).containsOnly("doc-1", "doc-2");
+    }
+
+    @Test
+    public void test_the_same_document_seen_twice_is_one_document_id() {
+        ModelEntity entity = ModelEntity.from(List.of(
+                statement("name", "Jane Doe", "full_name"),
+                statement("name", "J. Doe", "known_as")), Set.of("4.10.2"));
+
+        assertThat(entity.documentIds()).containsOnly("doc-1");
+    }
+
+    @Test
+    public void test_keeps_the_model_versions_it_is_given() {
+        ModelEntity entity = ModelEntity.from(List.of(statement("name", "Jane Doe", "full_name")),
+                Set.of("4.10.2", "4.11.0"));
+
+        assertThat(entity.modelVersions()).containsOnly("4.10.2", "4.11.0");
     }
 
     private Statement statement(String property, String value, String column) {

--- a/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/TargetModelValidationTest.java
@@ -14,7 +14,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_a_valid_entity_has_no_violation() {
-        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person"),
+        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"))))).isEmpty();
     }
 
@@ -28,7 +28,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_an_unknown_type_is_a_violation() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("fake", "p-1", Set.of("Robot"), Map.of("name", List.of("Jane Doe"))));
+                new ModelEntity("fake", "p-1", Set.of("Robot"), Set.of(), Set.of(), Map.of("name", List.of("Jane Doe"))));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Robot");
@@ -38,7 +38,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_an_abstract_type_cannot_be_instantiated() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("fake", "t-1", Set.of("Thing"), Map.of("name", List.of("Jane Doe"))));
+                new ModelEntity("fake", "t-1", Set.of("Thing"), Set.of(), Set.of(), Map.of("name", List.of("Jane Doe"))));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Thing");
@@ -47,7 +47,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_an_undeclared_property_is_a_violation() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"), "shoeSize", List.of("42"))));
 
         assertThat(violations).hasSize(1);
@@ -56,7 +56,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_a_stub_property_cannot_be_written() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"), "employers", List.of("e-1"))));
 
         assertThat(violations).hasSize(1);
@@ -67,7 +67,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_a_missing_required_property_is_a_violation() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("fake", "p-1", Set.of("Person"), Map.of()));
+                new ModelEntity("fake", "p-1", Set.of("Person"), Set.of(), Set.of(), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Person");
@@ -77,7 +77,7 @@ public class TargetModelValidationTest {
     @Test
     public void test_a_blank_required_property_is_a_violation() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("fake", "p-1", Set.of("Person"), Map.of("name", List.of(" "))));
+                new ModelEntity("fake", "p-1", Set.of("Person"), Set.of(), Set.of(), Map.of("name", List.of(" "))));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("name");
@@ -85,7 +85,7 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_an_edge_needs_both_of_its_ends() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "e-1", Set.of("Employment"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "e-1", Set.of("Employment"), Set.of(), Set.of(),
                 Map.of("employee", List.of("p-1"))));
 
         assertThat(violations).hasSize(1);
@@ -95,19 +95,19 @@ public class TargetModelValidationTest {
 
     @Test
     public void test_a_multi_type_entity_may_use_a_property_of_either_type() {
-        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Company"),
+        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Company"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"), "vatNumber", List.of("FR123"))))).isEmpty();
     }
 
     @Test
     public void test_a_concrete_type_makes_its_abstract_ancestor_instantiable() {
-        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Thing"),
+        assertThat(model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Thing"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"))))).isEmpty();
     }
 
     @Test
     public void test_an_undeclared_property_names_the_types_in_a_stable_order() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Company"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("fake", "p-1", Set.of("Person", "Company"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"), "shoeSize", List.of("42"))));
 
         assertThat(violations).hasSize(1);

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelSerializationTest.java
@@ -16,7 +16,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_round_trips_a_person() {
-        ModelEntity person = new ModelEntity("ftm", "person-1", Set.of("Person"),
+        ModelEntity person = new ModelEntity("ftm", "person-1", Set.of("Person"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe", "J. Doe"), "birthDate", List.of("1980-04-02")));
 
         assertThat(model.parse(model.serialize(person))).isEqualTo(person);
@@ -24,7 +24,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_serializes_the_ftm_entity_shape() {
-        String json = model.serialize(new ModelEntity("ftm", "person-1", Set.of("Person"),
+        String json = model.serialize(new ModelEntity("ftm", "person-1", Set.of("Person"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"))));
 
         assertThat(json).contains("\"id\":\"person-1\"");
@@ -34,7 +34,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_collapses_a_multi_type_entity_to_its_most_specific_type() {
-        String json = model.serialize(new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity", "Thing"),
+        String json = model.serialize(new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity", "Thing"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"))));
 
         assertThat(json).contains("\"schema\":\"Person\"");
@@ -42,7 +42,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_types_with_no_common_schema_are_a_violation() {
-        ModelEntity confused = new ModelEntity("ftm", "x-1", Set.of("Person", "Company"),
+        ModelEntity confused = new ModelEntity("ftm", "x-1", Set.of("Person", "Company"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe")));
 
         List<TargetModel.Violation> violations = model.validate(confused);
@@ -53,7 +53,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_serializing_types_with_no_common_schema_fails() {
-        assertThrowsContaining(() -> model.serialize(new ModelEntity("ftm", "x-1", Set.of("Person", "Company"),
+        assertThrowsContaining(() -> model.serialize(new ModelEntity("ftm", "x-1", Set.of("Person", "Company"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe")))), "Person", "Company");
     }
 
@@ -93,7 +93,7 @@ public class FtmTargetModelSerializationTest {
 
     @Test
     public void test_the_multi_type_entity_it_collapses_is_valid() {
-        assertThat(model.validate(new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity", "Thing"),
+        assertThat(model.validate(new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity", "Thing"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"))))).isEmpty();
     }
 

--- a/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/model/ftm/FtmTargetModelTest.java
@@ -94,7 +94,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_a_stub_property_another_of_the_types_declares_as_written_is_no_violation() {
         List<TargetModel.Violation> violations = model.validate(new ModelEntity("ftm", "x-1",
-                Set.of("LegalEntity", "ContractAward"),
+                Set.of("LegalEntity", "ContractAward"), Set.of(), Set.of(),
                 Map.of("name", List.of("Total"), "callForTenders", List.of("c-1"))));
 
         assertThat(violations.stream().anyMatch(violation -> violation.message().contains("stub"))).isFalse();
@@ -103,7 +103,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_the_missing_required_properties_are_reported_in_the_model_s_order() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("ftm", "e-1", Set.of("Employment"), Map.of()));
+                new ModelEntity("ftm", "e-1", Set.of("Employment"), Set.of(), Set.of(), Map.of()));
 
         assertThat(violations.get(0).message()).isEqualTo("type 'Employment' requires 'employer'");
     }
@@ -111,7 +111,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_a_property_required_by_several_types_is_reported_once() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("ftm", "p-1", Set.of("Person", "LegalEntity"), Map.of()));
+                new ModelEntity("ftm", "p-1", Set.of("Person", "LegalEntity"), Set.of(), Set.of(), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("name");
@@ -120,7 +120,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_validating_a_company_with_no_properties_reports_the_missing_inherited_name() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("ftm", "c-1", Set.of("Company"), Map.of()));
+                new ModelEntity("ftm", "c-1", Set.of("Company"), Set.of(), Set.of(), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Company");
@@ -130,7 +130,7 @@ public class FtmTargetModelTest {
     @Test
     public void test_validating_an_interest_reports_that_the_type_is_abstract() {
         List<TargetModel.Violation> violations = model.validate(
-                new ModelEntity("ftm", "i-1", Set.of("Interest"), Map.of()));
+                new ModelEntity("ftm", "i-1", Set.of("Interest"), Set.of(), Set.of(), Map.of()));
 
         assertThat(violations).hasSize(1);
         assertThat(violations.get(0).message()).contains("Interest");
@@ -139,7 +139,7 @@ public class FtmTargetModelTest {
 
     @Test
     public void test_validating_a_person_writing_the_stub_property_employers_reports_the_stub() {
-        List<TargetModel.Violation> violations = model.validate(new ModelEntity("ftm", "p-1", Set.of("Person"),
+        List<TargetModel.Violation> violations = model.validate(new ModelEntity("ftm", "p-1", Set.of("Person"), Set.of(), Set.of(),
                 Map.of("name", List.of("Jane Doe"), "employers", List.of("e-1"))));
 
         assertThat(violations).hasSize(1);

--- a/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
@@ -11,44 +11,45 @@ import java.util.Set;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class ExtractedEntityTest {
-    // Bare keys, the shape JooqStatementRepository.toRow actually produces once it strips the
-    // model prefix off the stored property.
-    private final ModelEntity source = new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity"),
+    private final ModelEntity bareKeyedSource = new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity"),
             Set.of("4.10.2"), Set.of("doc-1", "doc-2"),
             Map.of("name", List.of("Jane Doe", "J. Doe"), "birthDate", List.of("1980-04-02")));
 
     @Test
     public void test_projects_every_field_of_the_model_entity() {
-        ExtractedEntity entity = ExtractedEntity.from(source);
+        ExtractedEntity entity = ExtractedEntity.from(bareKeyedSource);
 
-        assertThat(entity.getId()).isEqualTo("person-1");
+        assertThat(entity.entityId()).isEqualTo("person-1");
+        assertThat(entity.getId()).isEqualTo("ftm_person-1");
         assertThat(entity.model()).isEqualTo("ftm");
         assertThat(entity.modelVersions()).containsOnly("4.10.2");
         assertThat(entity.types()).containsOnly("Person", "LegalEntity");
         assertThat(entity.documentIds()).containsOnly("doc-1", "doc-2");
-        assertThat(entity.properties().get("ftm:name")).containsExactly("Jane Doe", "J. Doe");
-        assertThat(entity.properties().get("ftm:birthDate")).containsExactly("1980-04-02");
+        assertThat(entity.properties().get("ftm_name")).containsExactly("Jane Doe", "J. Doe");
+        assertThat(entity.properties().get("ftm_birthDate")).containsExactly("1980-04-02");
     }
 
     @Test
     public void test_the_index_type_is_the_class_name() {
-        assertThat(JsonObjectMapper.getType(ExtractedEntity.from(source))).isEqualTo("ExtractedEntity");
+        assertThat(JsonObjectMapper.getType(ExtractedEntity.from(bareKeyedSource))).isEqualTo("ExtractedEntity");
     }
 
     @Test
     public void test_serializes_the_namespaced_properties_as_written() {
-        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(source));
+        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(bareKeyedSource));
 
         assertThat(json.get("model")).isEqualTo("ftm");
-        assertThat(((Map<?, ?>) json.get("properties")).get("ftm:birthDate")).isEqualTo(List.of("1980-04-02"));
+        assertThat(json.get("entityId")).isEqualTo("person-1");
+        assertThat(json.get("id")).isEqualTo("ftm_person-1");
+        assertThat(((Map<?, ?>) json.get("properties")).get("ftm_birthDate")).isEqualTo(List.of("1980-04-02"));
     }
 
     @Test
     public void test_reads_back_the_document_it_wrote() {
-        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(source));
+        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(bareKeyedSource));
 
         ExtractedEntity read = JsonObjectMapper.getObject(json, ExtractedEntity.class);
 
-        assertThat(read).isEqualTo(ExtractedEntity.from(source));
+        assertThat(read).isEqualTo(ExtractedEntity.from(bareKeyedSource));
     }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
@@ -1,0 +1,52 @@
+package org.icij.datashare.text;
+
+import org.icij.datashare.json.JsonObjectMapper;
+import org.icij.datashare.model.ModelEntity;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ExtractedEntityTest {
+    private final ModelEntity source = new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity"),
+            Set.of("4.10.2"), Set.of("doc-1", "doc-2"),
+            Map.of("ftm:name", List.of("Jane Doe", "J. Doe"), "ftm:birthDate", List.of("1980-04-02")));
+
+    @Test
+    public void test_projects_every_field_of_the_model_entity() {
+        ExtractedEntity entity = ExtractedEntity.from(source);
+
+        assertThat(entity.getId()).isEqualTo("person-1");
+        assertThat(entity.model()).isEqualTo("ftm");
+        assertThat(entity.modelVersions()).containsOnly("4.10.2");
+        assertThat(entity.types()).containsOnly("Person", "LegalEntity");
+        assertThat(entity.documentIds()).containsOnly("doc-1", "doc-2");
+        assertThat(entity.properties().get("ftm:name")).containsExactly("Jane Doe", "J. Doe");
+        assertThat(entity.properties().get("ftm:birthDate")).containsExactly("1980-04-02");
+    }
+
+    @Test
+    public void test_the_index_type_is_the_class_name() {
+        assertThat(JsonObjectMapper.getType(ExtractedEntity.from(source))).isEqualTo("ExtractedEntity");
+    }
+
+    @Test
+    public void test_serializes_the_namespaced_properties_as_written() {
+        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(source));
+
+        assertThat(json.get("model")).isEqualTo("ftm");
+        assertThat(((Map<?, ?>) json.get("properties")).get("ftm:birthDate")).isEqualTo(List.of("1980-04-02"));
+    }
+
+    @Test
+    public void test_reads_back_the_document_it_wrote() {
+        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(source));
+
+        ExtractedEntity read = JsonObjectMapper.getObject(json, ExtractedEntity.class);
+
+        assertThat(read).isEqualTo(ExtractedEntity.from(source));
+    }
+}

--- a/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
@@ -40,7 +40,8 @@ public class ExtractedEntityTest {
 
         assertThat(json.get("model")).isEqualTo("ftm");
         assertThat(json.get("entityId")).isEqualTo("person-1");
-        assertThat(json.get("id")).isEqualTo("ftm_person-1");
+        // the namespaced id lives in the _id alone, like NamedEntity's and Document's
+        assertThat(json.keySet()).excludes("id");
         assertThat(((Map<?, ?>) json.get("properties")).get("ftm_birthDate")).isEqualTo(List.of("1980-04-02"));
     }
 

--- a/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/ExtractedEntityTest.java
@@ -11,9 +11,11 @@ import java.util.Set;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class ExtractedEntityTest {
+    // Bare keys, the shape JooqStatementRepository.toRow actually produces once it strips the
+    // model prefix off the stored property.
     private final ModelEntity source = new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity"),
             Set.of("4.10.2"), Set.of("doc-1", "doc-2"),
-            Map.of("ftm:name", List.of("Jane Doe", "J. Doe"), "ftm:birthDate", List.of("1980-04-02")));
+            Map.of("name", List.of("Jane Doe", "J. Doe"), "birthDate", List.of("1980-04-02")));
 
     @Test
     public void test_projects_every_field_of_the_model_entity() {

--- a/datashare-api/src/test/java/org/icij/datashare/text/ProjectTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/ProjectTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.Date;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 
 public class ProjectTest {
@@ -38,5 +39,19 @@ public class ProjectTest {
         assertThat(project.maintainerName).isEqualTo("Jane Doe");
         assertThat(project.publisherName).isEqualTo("ICIJ");
         assertThat(project.allowFromMask).isEqualTo("*.*.*.*");
+    }
+    @Test
+    public void test_entities_index_of_a_project() {
+        assertThat(Project.entitiesIndex("foo")).isEqualTo("foo.entities");
+    }
+
+    @Test
+    public void test_entities_index_rejects_a_null_project() {
+        try {
+            Project.entitiesIndex(null);
+            fail("should have rejected a null project id");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage()).contains("projectId");
+        }
     }
 }

--- a/datashare-api/src/test/java/org/icij/datashare/text/StructuredEntityTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/StructuredEntityTest.java
@@ -10,14 +10,14 @@ import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-public class ExtractedEntityTest {
+public class StructuredEntityTest {
     private final ModelEntity bareKeyedSource = new ModelEntity("ftm", "person-1", Set.of("Person", "LegalEntity"),
             Set.of("4.10.2"), Set.of("doc-1", "doc-2"),
             Map.of("name", List.of("Jane Doe", "J. Doe"), "birthDate", List.of("1980-04-02")));
 
     @Test
     public void test_projects_every_field_of_the_model_entity() {
-        ExtractedEntity entity = ExtractedEntity.from(bareKeyedSource);
+        StructuredEntity entity = StructuredEntity.from(bareKeyedSource);
 
         assertThat(entity.entityId()).isEqualTo("person-1");
         assertThat(entity.getId()).isEqualTo("ftm_person-1");
@@ -31,12 +31,12 @@ public class ExtractedEntityTest {
 
     @Test
     public void test_the_index_type_is_the_class_name() {
-        assertThat(JsonObjectMapper.getType(ExtractedEntity.from(bareKeyedSource))).isEqualTo("ExtractedEntity");
+        assertThat(JsonObjectMapper.getType(StructuredEntity.from(bareKeyedSource))).isEqualTo("StructuredEntity");
     }
 
     @Test
     public void test_serializes_the_namespaced_properties_as_written() {
-        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(bareKeyedSource));
+        Map<String, Object> json = JsonObjectMapper.getJson(StructuredEntity.from(bareKeyedSource));
 
         assertThat(json.get("model")).isEqualTo("ftm");
         assertThat(json.get("entityId")).isEqualTo("person-1");
@@ -47,10 +47,10 @@ public class ExtractedEntityTest {
 
     @Test
     public void test_reads_back_the_document_it_wrote() {
-        Map<String, Object> json = JsonObjectMapper.getJson(ExtractedEntity.from(bareKeyedSource));
+        Map<String, Object> json = JsonObjectMapper.getJson(StructuredEntity.from(bareKeyedSource));
 
-        ExtractedEntity read = JsonObjectMapper.getObject(json, ExtractedEntity.class);
+        StructuredEntity read = JsonObjectMapper.getObject(json, StructuredEntity.class);
 
-        assertThat(read).isEqualTo(ExtractedEntity.from(bareKeyedSource));
+        assertThat(read).isEqualTo(StructuredEntity.from(bareKeyedSource));
     }
 }

--- a/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
@@ -1,6 +1,6 @@
 package org.icij.datashare.model;
 
-import org.icij.datashare.text.ExtractedEntity;
+import org.icij.datashare.text.StructuredEntity;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 
@@ -44,9 +44,9 @@ public class EntitiesIndexRebuilder {
     private int index(String indexName, Iterator<ModelEntity> entities) {
         int written = 0;
         while (entities.hasNext()) {
-            List<ExtractedEntity> chunk = new ArrayList<>(CHUNK_SIZE);
+            List<StructuredEntity> chunk = new ArrayList<>(CHUNK_SIZE);
             while (chunk.size() < CHUNK_SIZE && entities.hasNext()) {
-                chunk.add(ExtractedEntity.from(entities.next()));
+                chunk.add(StructuredEntity.from(entities.next()));
             }
             try {
                 if (!indexer.bulkAdd(indexName, chunk)) {

--- a/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
@@ -44,7 +44,10 @@ public class EntitiesIndexRebuilder {
                 chunk.add(ExtractedEntity.from(entities.next()));
             }
             try {
-                indexer.bulkAdd(indexName, chunk);
+                if (!indexer.bulkAdd(indexName, chunk)) {
+                    throw new UncheckedIOException(
+                            new IOException("bulk add rejected in " + indexName + " for a chunk of " + chunk.size() + " entities"));
+                }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
@@ -22,13 +22,18 @@ public class EntitiesIndexRebuilder {
         this.statements = statements;
     }
 
-    /** Empties the index and refills it, so an entity that left the store leaves the index too, and
-     *  returns how many entities were indexed. Creates the index first, which is what gives a project
-     *  created before the entities index existed one. */
+    /** Drops the index and refills it, so an entity that left the store leaves the index too, and
+     *  returns how many entities were indexed. Dropping rather than emptying repairs an index created
+     *  before the entity mappings existed, which holds the document ones and rejects every entity, and
+     *  re-creating it is what gives a project older than the entities index one at all. */
     public int rebuild(String projectId) throws IOException {
+        if (!Project.NAME_PATTERN.matcher(projectId).matches()) {
+            // an unvalidated id reaches a _delete_by_query URL path, where "*" is a whole-cluster wipe
+            throw new IllegalArgumentException("Bad format for project id : '" + projectId + "'");
+        }
         String indexName = Project.entitiesIndex(projectId);
+        indexer.deleteIndex(indexName);
         indexer.createEntitiesIndex(projectId);
-        indexer.deleteAll(indexName);
         try {
             return statements.entities(projectId, entities -> index(indexName, entities.iterator()));
         } catch (UncheckedIOException e) {

--- a/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
@@ -1,0 +1,55 @@
+package org.icij.datashare.model;
+
+import org.icij.datashare.text.ExtractedEntity;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.Indexer;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/** Rebuilds a project's entities index from the statement store, which is the system of record: the
+ *  index is a disposable projection and this is the only thing that writes it. */
+public class EntitiesIndexRebuilder {
+    private static final int CHUNK_SIZE = 1_000;
+    private final Indexer indexer;
+    private final StatementRepository statements;
+
+    public EntitiesIndexRebuilder(Indexer indexer, StatementRepository statements) {
+        this.indexer = indexer;
+        this.statements = statements;
+    }
+
+    /** Empties the index and refills it, so an entity that left the store leaves the index too, and
+     *  returns how many entities were indexed. Creates the index first, which is what gives a project
+     *  created before the entities index existed one. */
+    public int rebuild(String projectId) throws IOException {
+        String indexName = Project.entitiesIndex(projectId);
+        indexer.createEntitiesIndex(projectId);
+        indexer.deleteAll(indexName);
+        try {
+            return statements.entities(projectId, entities -> index(indexName, entities.iterator()));
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private int index(String indexName, Iterator<ModelEntity> entities) {
+        int written = 0;
+        while (entities.hasNext()) {
+            List<ExtractedEntity> chunk = new ArrayList<>(CHUNK_SIZE);
+            while (chunk.size() < CHUNK_SIZE && entities.hasNext()) {
+                chunk.add(ExtractedEntity.from(entities.next()));
+            }
+            try {
+                indexer.bulkAdd(indexName, chunk);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            written += chunk.size();
+        }
+        return written;
+    }
+}

--- a/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
+++ b/datashare-app/src/main/java/org/icij/datashare/model/EntitiesIndexRebuilder.java
@@ -27,7 +27,7 @@ public class EntitiesIndexRebuilder {
      *  before the entity mappings existed, which holds the document ones and rejects every entity, and
      *  re-creating it is what gives a project older than the entities index one at all. */
     public int rebuild(String projectId) throws IOException {
-        if (!Project.NAME_PATTERN.matcher(projectId).matches()) {
+        if (projectId == null || !Project.NAME_PATTERN.matcher(projectId).matches()) {
             // an unvalidated id reaches a _delete_by_query URL path, where "*" is a whole-cluster wipe
             throw new IllegalArgumentException("Bad format for project id : '" + projectId + "'");
         }

--- a/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
+++ b/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
@@ -353,7 +353,11 @@ public class ProjectAdminServiceImpl implements ProjectAdminService {
         boolean indexDeleted = !options.keepIndex()
                 && runStep("index", name, () -> {
                     boolean documents = indexer.deleteAll(name);
-                    indexer.deleteAll(Project.entitiesIndex(name));
+                    try {
+                        indexer.deleteAll(Project.entitiesIndex(name));
+                    } catch (IOException e) {
+                        LOGGER.error("cannot delete entities index for project {}", name, e);
+                    }
                     return documents;
                 });
         boolean dbDeleted = runStep("db", name, () -> repository.deleteAll(name));

--- a/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
+++ b/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
@@ -351,7 +351,11 @@ public class ProjectAdminServiceImpl implements ProjectAdminService {
         String name = project.getName();
 
         boolean indexDeleted = !options.keepIndex()
-                && runStep("index", name, () -> indexer.deleteAll(name));
+                && runStep("index", name, () -> {
+                    boolean documents = indexer.deleteAll(name);
+                    indexer.deleteAll(Project.entitiesIndex(name));
+                    return documents;
+                });
         boolean dbDeleted = runStep("db", name, () -> repository.deleteAll(name));
         boolean queuesDeleted = runStep("queues", name, () -> deleteQueues(project));
         boolean reportMapDeleted = runStep("report map", name, () -> deleteReportMap(project));

--- a/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
+++ b/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
@@ -512,6 +512,7 @@ public class ProjectAdminServiceImpl implements ProjectAdminService {
     private boolean createIndexOrRollback(String name) throws IOException {
         try {
             indexer.createIndex(name);
+            indexer.createEntitiesIndex(name);
             return true;
         } catch (RuntimeException | IOException e) {
             try {

--- a/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
+++ b/datashare-app/src/main/java/org/icij/datashare/project/admin/ProjectAdminServiceImpl.java
@@ -350,16 +350,14 @@ public class ProjectAdminServiceImpl implements ProjectAdminService {
         // intact is a sticky state if the cascade aborts mid-stream.
         String name = project.getName();
 
-        boolean indexDeleted = !options.keepIndex()
-                && runStep("index", name, () -> {
-                    boolean documents = indexer.deleteAll(name);
-                    try {
-                        indexer.deleteAll(Project.entitiesIndex(name));
-                    } catch (IOException e) {
-                        LOGGER.error("cannot delete entities index for project {}", name, e);
-                    }
-                    return documents;
-                });
+        // two steps rather than one, and combined only once both have run: a failure on either index
+        // must neither hide the other nor stop it from being deleted. A project older than the
+        // entities index has none, which is nothing to report.
+        boolean documentsDeleted = !options.keepIndex() && runStep("index", name, () -> indexer.deleteAll(name));
+        String entitiesIndex = Project.entitiesIndex(name);
+        boolean entitiesDeleted = !options.keepIndex() && runStep("entities index", name,
+                () -> !indexer.exists(entitiesIndex) || indexer.deleteAll(entitiesIndex));
+        boolean indexDeleted = documentsDeleted && entitiesDeleted;
         boolean dbDeleted = runStep("db", name, () -> repository.deleteAll(name));
         boolean queuesDeleted = runStep("queues", name, () -> deleteQueues(project));
         boolean reportMapDeleted = runStep("report map", name, () -> deleteReportMap(project));
@@ -520,7 +518,6 @@ public class ProjectAdminServiceImpl implements ProjectAdminService {
     private boolean createIndexOrRollback(String name) throws IOException {
         try {
             indexer.createIndex(name);
-            indexer.createEntitiesIndex(name);
             return true;
         } catch (RuntimeException | IOException e) {
             try {

--- a/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
+++ b/datashare-app/src/main/java/org/icij/datashare/utils/IndexAccessVerifier.java
@@ -4,6 +4,7 @@ import net.codestory.http.Context;
 import net.codestory.http.Query;
 import net.codestory.http.errors.UnauthorizedException;
 import org.icij.datashare.session.DatashareUser;
+import org.icij.datashare.text.Project;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -19,8 +20,6 @@ public class IndexAccessVerifier {
      *  granted what: a project row named "_all" is grantable, so a grant check alone would let it pass. */
     private static final String INDEX_NAME = "[-a-zA-Z0-9][-a-zA-Z0-9_]*(\\.[-a-zA-Z0-9_]+)*";
     private static final Pattern INDICES = Pattern.compile("^" + INDEX_NAME + "(," + INDEX_NAME + ")*$");
-    /** Suffix of an index derived from a project: "myproject.entities" is granted to whoever is granted "myproject". */
-    private static final String ENTITIES_SUFFIX = ".entities";
 
     static public String checkIndices(String indices) {
         if( indices == null) {
@@ -86,7 +85,8 @@ public class IndexAccessVerifier {
      *  or the base project it derives from. Suffix match on the whole remainder, never a prefix match,
      *  so "myproject-other" doesn't inherit "myproject". */
     public static List<String> baseProjects(String indices) {
-        return stream(indices.split(",")).map(i -> i.endsWith(ENTITIES_SUFFIX) ? i.substring(0, i.length() - ENTITIES_SUFFIX.length()) : i).toList();
+        return stream(indices.split(",")).map(i -> i.endsWith(Project.ENTITIES_INDEX_SUFFIX)
+                ? i.substring(0, i.length() - Project.ENTITIES_INDEX_SUFFIX.length()) : i).toList();
     }
 
     public static String getUrlString(Context context, String s) {

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import net.codestory.http.Context;
 import net.codestory.http.annotations.*;
 import net.codestory.http.constants.HttpStatus;
+import net.codestory.http.errors.HttpException;
 import net.codestory.http.payload.Payload;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.asyncsearch.AsyncSearchOwner;
@@ -84,7 +85,11 @@ public class IndexResource {
             // a ".entities" name is granted through its base project, so it reaches here; createIndex
             // picks the entity mappings for it rather than the document ones
             return indexer.createIndex(checkGrantedIndices(index, context)) ? created() : ok();
-        } catch (IllegalArgumentException e){
+        } catch (HttpException e){
+            // checkGrantedIndices refuses an ungranted project with a 403 that must not collapse to 400
+            throw e;
+        } catch (RuntimeException e){
+            // the ES indexer reports entities-index creation failures as ConfigurationException
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }
     }

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -19,6 +19,7 @@ import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
 import org.icij.datashare.cli.Mode;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.session.DatashareUser;
+import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.utils.IndexAccessVerifier;
 import org.icij.datashare.utils.ModeVerifier;
@@ -81,7 +82,13 @@ public class IndexResource {
     public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index, Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try{
-            return indexer.createIndex(checkGrantedIndices(index, context)) ? created() : ok();
+            String granted = checkGrantedIndices(index, context);
+            // a ".entities" name is granted through its base project, so it reaches here and has to be
+            // created with the entity mappings rather than the document ones
+            boolean created = granted.endsWith(Project.ENTITIES_INDEX_SUFFIX)
+                    ? indexer.createEntitiesIndex(granted.substring(0, granted.length() - Project.ENTITIES_INDEX_SUFFIX.length()))
+                    : indexer.createIndex(granted);
+            return created ? created() : ok();
         } catch (IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -86,7 +86,7 @@ public class IndexResource {
             // a ".entities" name is granted through its base project, so it reaches here and has to be
             // created with the entity mappings rather than the document ones
             boolean created = granted.endsWith(Project.ENTITIES_INDEX_SUFFIX)
-                    ? indexer.createEntitiesIndex(granted.substring(0, granted.length() - Project.ENTITIES_INDEX_SUFFIX.length()))
+                    ? indexer.createEntitiesIndex(IndexAccessVerifier.baseProjects(granted).get(0))
                     : indexer.createIndex(granted);
             return created ? created() : ok();
         } catch (IllegalArgumentException e){

--- a/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/IndexResource.java
@@ -19,7 +19,6 @@ import org.icij.datashare.asyncsearch.MemoryAsyncSearchStore;
 import org.icij.datashare.cli.Mode;
 import org.icij.datashare.json.JsonObjectMapper;
 import org.icij.datashare.session.DatashareUser;
-import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.utils.IndexAccessVerifier;
 import org.icij.datashare.utils.ModeVerifier;
@@ -82,13 +81,9 @@ public class IndexResource {
     public Payload createIndex(@Parameter(name = "index", description = "index to create", in = ParameterIn.PATH) final String index, Context context) throws IOException {
         modeVerifier.checkAllowedMode(Mode.LOCAL, Mode.EMBEDDED);
         try{
-            String granted = checkGrantedIndices(index, context);
-            // a ".entities" name is granted through its base project, so it reaches here and has to be
-            // created with the entity mappings rather than the document ones
-            boolean created = granted.endsWith(Project.ENTITIES_INDEX_SUFFIX)
-                    ? indexer.createEntitiesIndex(IndexAccessVerifier.baseProjects(granted).get(0))
-                    : indexer.createIndex(granted);
-            return created ? created() : ok();
+            // a ".entities" name is granted through its base project, so it reaches here; createIndex
+            // picks the entity mappings for it rather than the document ones
+            return indexer.createIndex(checkGrantedIndices(index, context)) ? created() : ok();
         } catch (IllegalArgumentException e){
             return PayloadFormatter.error(e, HttpStatus.BAD_REQUEST);
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -113,7 +113,7 @@
             Project effectiveProject = isProjectSourcePathNull(project) ? withDefaultSourcePath(project) : project;
             if (!dataDirVerifier.allowed(effectiveProject.getSourcePath())) {
                 return PayloadFormatter.error(String.format("`sourcePath` must not be outside %s.", dataDirVerifier.value()), HttpStatus.BAD_REQUEST);
-            } else if (!repository.save(effectiveProject) || !this.createIndexOnce(effectiveProject.getId())) {
+            } else if (!saveAndCreateIndex(effectiveProject)) {
                 return PayloadFormatter.error("Unable to create the project", HttpStatus.INTERNAL_SERVER_ERROR);
             }
             return new Payload(effectiveProject).withCode(HttpStatus.CREATED);
@@ -166,7 +166,7 @@
             }
 
             if (isCreate) {
-                if (!repository.save(effectiveProject) || !createIndexOnce(effectiveProject.getId())) {
+                if (!saveAndCreateIndex(effectiveProject)) {
                     return PayloadFormatter.error("Unable to create the project", HttpStatus.INTERNAL_SERVER_ERROR);
                 }
                 return new Payload(effectiveProject).withCode(HttpStatus.CREATED);
@@ -199,7 +199,7 @@
             Logger logger = LoggerFactory.getLogger(getClass());
             logger.info("Deleted {}'s record: {}", id, repository.deleteAll(id));
             logger.info("Deleted {}'s index: {}", id, indexer.deleteAll(id));
-            logger.info("Deleted {}'s entities index: {}", id, indexer.deleteAll(Project.entitiesIndex(id)));
+            logger.info("Deleted {}'s entities index: {}", id, deleteEntitiesIndex(id));
             logger.info("Deleted {}'s queues: {}", id, deleteQueues(project));
             logger.info("Deleted {}'s report map: {}", id, deleteReportMap(project));
             propertiesProvider.get(DatashareCliOptions.ARTIFACT_DIR_OPT).ifPresent(dir -> {
@@ -282,6 +282,17 @@
             return getQueues(project).stream().allMatch(DocumentQueue::delete);
         }
 
+        // contained like the CLI cascade does it (ProjectAdminServiceImpl#cascade): a disposable
+        // projection must not abort the delete and leave the queues, report map and artifacts behind
+        boolean deleteEntitiesIndex(String id) {
+            try {
+                return indexer.deleteAll(Project.entitiesIndex(id));
+            } catch (RuntimeException | IOException e) {
+                LoggerFactory.getLogger(getClass()).error("cannot delete entities index for project {}", id, e);
+                return false;
+            }
+        }
+
         boolean deleteReportMap(Project project) {
             return getReportMap(project).delete();
         }
@@ -308,13 +319,26 @@
             return getReportMap(reportMapName);
         }
 
+        /** Saves the row and creates the indices, undoing the row if index creation fails: a row left
+         *  behind makes {@code projectExists} true, so every retry would answer 409 instead. */
+        boolean saveAndCreateIndex(Project project) {
+            if (!repository.save(project)) {
+                return false;
+            }
+            if (createIndexOnce(project.getId())) {
+                return true;
+            }
+            repository.deleteAll(project.getId());
+            return false;
+        }
+
         boolean createIndexOnce(String name) {
             try {
-                String checked = IndexAccessVerifier.checkIndices(name);
-                this.indexer.createIndex(checked);
-                this.indexer.createEntitiesIndex(checked);
+                this.indexer.createIndex(IndexAccessVerifier.checkIndices(name));
                 return true;
-            } catch (IllegalArgumentException | IOException e){
+            } catch (RuntimeException | IOException e){
+                // the ES indexer reports failures as ConfigurationException, a RuntimeException
+                LoggerFactory.getLogger(getClass()).error("cannot create the index for project {}", name, e);
                 return false;
             }
         }

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -310,6 +310,7 @@
         boolean createIndexOnce(String name) {
             try {
                 this.indexer.createIndex(IndexAccessVerifier.checkIndices(name));
+                this.indexer.createEntitiesIndex(name);
                 return true;
             } catch (IllegalArgumentException | IOException e){
                 return false;

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -199,6 +199,7 @@
             Logger logger = LoggerFactory.getLogger(getClass());
             logger.info("Deleted {}'s record: {}", id, repository.deleteAll(id));
             logger.info("Deleted {}'s index: {}", id, indexer.deleteAll(id));
+            logger.info("Deleted {}'s entities index: {}", id, indexer.deleteAll(Project.entitiesIndex(id)));
             logger.info("Deleted {}'s queues: {}", id, deleteQueues(project));
             logger.info("Deleted {}'s report map: {}", id, deleteReportMap(project));
             propertiesProvider.get(DatashareCliOptions.ARTIFACT_DIR_OPT).ifPresent(dir -> {

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -310,8 +310,9 @@
 
         boolean createIndexOnce(String name) {
             try {
-                this.indexer.createIndex(IndexAccessVerifier.checkIndices(name));
-                this.indexer.createEntitiesIndex(name);
+                String checked = IndexAccessVerifier.checkIndices(name);
+                this.indexer.createIndex(checked);
+                this.indexer.createEntitiesIndex(checked);
                 return true;
             } catch (IllegalArgumentException | IOException e){
                 return false;

--- a/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
+++ b/datashare-app/src/main/java/org/icij/datashare/web/ProjectResource.java
@@ -328,7 +328,10 @@
             if (createIndexOnce(project.getId())) {
                 return true;
             }
-            repository.deleteAll(project.getId());
+            if (!repository.deleteAll(project.getId())) {
+                // the stale row makes projectExists answer 409 to every retry, so leave a trace of it
+                LoggerFactory.getLogger(getClass()).error("could not roll back project row for {} after index creation failed", project.getId());
+            }
             return false;
         }
 

--- a/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
@@ -133,6 +133,18 @@ public class EntitiesIndexRebuilderTest {
     }
 
     @Test
+    public void test_rebuild_refuses_a_null_project_id() {
+        try {
+            rebuilder.rebuild(null);
+            fail("should have refused a null project id");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("null");
+        } catch (IOException e) {
+            fail("should have refused the id before reaching elasticsearch");
+        }
+    }
+
+    @Test
     public void test_rebuild_refuses_a_project_id_that_is_not_a_project_name() {
         try {
             rebuilder.rebuild("*");

--- a/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
@@ -88,6 +88,18 @@ public class EntitiesIndexRebuilderTest {
     }
 
     @Test
+    public void test_a_date_shaped_value_does_not_poison_a_later_non_date_value_in_the_same_property() throws Exception {
+        statements.entities.add(birthDate("person-1", "1980-04-02"));
+        statements.entities.add(birthDate("person-2", "circa 1980"));
+
+        rebuilder.rebuild("prj");
+
+        String all = search("{\"query\":{\"match_all\":{}}}");
+        assertThat(all).contains("person-1");
+        assertThat(all).contains("person-2");
+    }
+
+    @Test
     public void test_indexes_more_entities_than_one_chunk() throws Exception {
         IntStream.range(0, 2500).forEach(i -> statements.entities.add(entity("person-" + i, "Name " + i)));
 
@@ -112,6 +124,11 @@ public class EntitiesIndexRebuilderTest {
     private static ModelEntity entity(String id, String name) {
         return new ModelEntity("ftm", id, Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
                 Map.of("ftm:name", List.of(name)));
+    }
+
+    private static ModelEntity birthDate(String id, String value) {
+        return new ModelEntity(id, "ftm", Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
+                Map.of("ftm:birthDate", List.of(value)));
     }
 
     private static class InMemoryStatements implements StatementRepository {

--- a/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
@@ -1,0 +1,120 @@
+package org.icij.datashare.model;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import org.icij.datashare.PropertiesProvider;
+import org.icij.datashare.test.ElasticsearchRule;
+import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class EntitiesIndexRebuilderTest {
+    @ClassRule public static ElasticsearchRule es = new ElasticsearchRule();
+    private final ElasticsearchIndexer indexer = new ElasticsearchIndexer(es.client, new PropertiesProvider())
+            .withRefresh(Refresh.True);
+    private final InMemoryStatements statements = new InMemoryStatements();
+    private final EntitiesIndexRebuilder rebuilder = new EntitiesIndexRebuilder(indexer, statements);
+
+    @After
+    public void tearDown() throws IOException {
+        es.delete(Project.entitiesIndex("prj"));
+    }
+
+    @Test
+    public void test_rebuild_creates_the_index_when_it_does_not_exist() throws Exception {
+        statements.entities.add(entity("person-1", "Jane Doe"));
+
+        assertThat(rebuilder.rebuild("prj")).isEqualTo(1);
+
+        assertThat(indexer.exists(Project.entitiesIndex("prj"))).isTrue();
+    }
+
+    @Test
+    public void test_the_rebuilt_entity_is_searchable_by_an_exact_property_value() throws Exception {
+        statements.entities.add(entity("person-1", "Jane Doe"));
+        rebuilder.rebuild("prj");
+
+        assertThat(search("{\"query\":{\"term\":{\"properties.ftm:name\":\"Jane Doe\"}}}")).contains("person-1");
+    }
+
+    @Test
+    public void test_the_rebuilt_entity_is_searchable_by_a_folded_property_value() throws Exception {
+        statements.entities.add(entity("person-2", "Émile Zola"));
+        rebuilder.rebuild("prj");
+
+        assertThat(search("{\"query\":{\"match\":{\"properties.ftm:name.text\":\"emile\"}}}")).contains("person-2");
+    }
+
+    @Test
+    public void test_the_rebuilt_entity_is_searchable_by_type_and_document() throws Exception {
+        statements.entities.add(entity("person-1", "Jane Doe"));
+        rebuilder.rebuild("prj");
+
+        assertThat(search("{\"query\":{\"term\":{\"types\":\"Person\"}}}")).contains("person-1");
+        assertThat(search("{\"query\":{\"term\":{\"documentIds\":\"doc-1\"}}}")).contains("person-1");
+    }
+
+    @Test
+    public void test_a_second_rebuild_drops_an_entity_that_left_the_store() throws Exception {
+        statements.entities.add(entity("person-1", "Jane Doe"));
+        statements.entities.add(entity("person-2", "John Doe"));
+        rebuilder.rebuild("prj");
+
+        statements.entities.remove(1);
+        assertThat(rebuilder.rebuild("prj")).isEqualTo(1);
+
+        String all = search("{\"query\":{\"match_all\":{}}}");
+        assertThat(all).contains("person-1");
+        assertThat(all).doesNotContain("person-2");
+    }
+
+    @Test
+    public void test_indexes_more_entities_than_one_chunk() throws Exception {
+        IntStream.range(0, 2500).forEach(i -> statements.entities.add(entity("person-" + i, "Name " + i)));
+
+        assertThat(rebuilder.rebuild("prj")).isEqualTo(2500);
+
+        assertThat(search("{\"query\":{\"match_all\":{}},\"track_total_hits\":true}")).contains("\"value\":2500");
+    }
+
+    private String search(String query) throws IOException {
+        return indexer.executeRaw("POST", Project.entitiesIndex("prj") + "/_search", query);
+    }
+
+    private static ModelEntity entity(String id, String name) {
+        return new ModelEntity("ftm", id, Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
+                Map.of("ftm:name", List.of(name)));
+    }
+
+    private static class InMemoryStatements implements StatementRepository {
+        private final List<ModelEntity> entities = new ArrayList<>();
+
+        @Override
+        public int save(String projectId, String runId, java.util.Collection<Statement> statements) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <R> R entities(String projectId, Function<Stream<ModelEntity>, R> consumer) {
+            return consumer.apply(entities.stream());
+        }
+
+        @Override
+        public Optional<ModelEntity> entity(String projectId, String entityId) {
+            return entities.stream().filter(e -> e.id().equals(entityId)).findFirst();
+        }
+    }
+}

--- a/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
@@ -4,6 +4,7 @@ import co.elastic.clients.elasticsearch._types.Refresh;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.Project;
+import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 import org.junit.After;
 import org.junit.ClassRule;
@@ -20,6 +21,10 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 public class EntitiesIndexRebuilderTest {
     @ClassRule public static ElasticsearchRule es = new ElasticsearchRule();
@@ -40,6 +45,7 @@ public class EntitiesIndexRebuilderTest {
         assertThat(rebuilder.rebuild("prj")).isEqualTo(1);
 
         assertThat(indexer.exists(Project.entitiesIndex("prj"))).isTrue();
+        assertThat(search("{\"query\":{\"match_all\":{}}}")).contains("person-1");
     }
 
     @Test
@@ -88,6 +94,15 @@ public class EntitiesIndexRebuilderTest {
         assertThat(rebuilder.rebuild("prj")).isEqualTo(2500);
 
         assertThat(search("{\"query\":{\"match_all\":{}},\"track_total_hits\":true}")).contains("\"value\":2500");
+    }
+
+    @Test(expected = IOException.class)
+    public void test_rebuild_fails_when_a_bulk_write_is_rejected() throws Exception {
+        statements.entities.add(entity("person-1", "Jane Doe"));
+        Indexer rejecting = spy(indexer);
+        doReturn(false).when(rejecting).bulkAdd(anyString(), anyList());
+
+        new EntitiesIndexRebuilder(rejecting, statements).rebuild("prj");
     }
 
     private String search(String query) throws IOException {

--- a/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
@@ -7,6 +7,7 @@ import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.elasticsearch.ElasticsearchIndexer;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -32,6 +33,11 @@ public class EntitiesIndexRebuilderTest {
             .withRefresh(Refresh.True);
     private final InMemoryStatements statements = new InMemoryStatements();
     private final EntitiesIndexRebuilder rebuilder = new EntitiesIndexRebuilder(indexer, statements);
+
+    @Before
+    public void setUp() throws IOException {
+        es.delete(Project.entitiesIndex("prj"));
+    }
 
     @After
     public void tearDown() throws IOException {

--- a/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
@@ -1,6 +1,8 @@
 package org.icij.datashare.model;
 
 import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.elasticsearch.client.Request;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.test.ElasticsearchRule;
 import org.icij.datashare.text.Project;
@@ -22,6 +24,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -59,7 +62,7 @@ public class EntitiesIndexRebuilderTest {
         statements.entities.add(entity("person-1", "Jane Doe"));
         rebuilder.rebuild("prj");
 
-        assertThat(search("{\"query\":{\"term\":{\"properties.ftm:name\":\"Jane Doe\"}}}")).contains("person-1");
+        assertThat(search("{\"query\":{\"term\":{\"properties.ftm_name\":\"Jane Doe\"}}}")).contains("person-1");
     }
 
     @Test
@@ -67,7 +70,7 @@ public class EntitiesIndexRebuilderTest {
         statements.entities.add(entity("person-2", "Émile Zola"));
         rebuilder.rebuild("prj");
 
-        assertThat(search("{\"query\":{\"match\":{\"properties.ftm:name.text\":\"emile\"}}}")).contains("person-2");
+        assertThat(search("{\"query\":{\"match\":{\"properties.ftm_name.text\":\"emile\"}}}")).contains("person-2");
     }
 
     @Test
@@ -111,39 +114,81 @@ public class EntitiesIndexRebuilderTest {
 
         assertThat(rebuilder.rebuild("prj")).isEqualTo(2500);
 
-        assertThat(search("{\"query\":{\"match_all\":{}},\"track_total_hits\":true}")).contains("\"value\":2500");
+        assertThat(search("{\"query\":{\"match_all\":{}},\"track_total_hits\":true}"))
+                .contains("\"value\":2500,\"relation\":\"eq\"");
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void test_rebuild_fails_when_a_bulk_write_is_rejected() throws Exception {
         statements.entities.add(entity("person-1", "Jane Doe"));
         Indexer rejecting = spy(indexer);
         doReturn(false).when(rejecting).bulkAdd(anyString(), anyList());
 
-        new EntitiesIndexRebuilder(rejecting, statements).rebuild("prj");
+        try {
+            new EntitiesIndexRebuilder(rejecting, statements).rebuild("prj");
+            fail("should have reported the rejected bulk write");
+        } catch (IOException e) {
+            assertThat(e.getMessage()).contains("bulk add rejected");
+        }
+    }
+
+    @Test
+    public void test_rebuild_refuses_a_project_id_that_is_not_a_project_name() {
+        try {
+            rebuilder.rebuild("*");
+            fail("should have refused a wildcard project id");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).contains("*");
+        } catch (IOException e) {
+            fail("should have refused the id before reaching elasticsearch");
+        }
+    }
+
+    @Test
+    public void test_rebuild_repairs_an_index_created_with_the_wrong_mappings() throws Exception {
+        Request create = new Request("PUT", "/" + Project.entitiesIndex("prj"));
+        create.setJsonEntity("{\"mappings\":{\"properties\":{\"id\":{\"type\":\"integer\"}}}}");
+        ((RestClientTransport) es.client._transport()).restClient().performRequest(create);
+        statements.entities.add(entity("person-1", "Jane Doe"));
+
+        assertThat(rebuilder.rebuild("prj")).isEqualTo(1);
+
+        assertThat(search("{\"query\":{\"term\":{\"properties.ftm_name\":\"Jane Doe\"}}}")).contains("person-1");
+    }
+
+    // a "properties.*" default_field would pass this and still blow the 1024-clause limit in production
+    @Test
+    public void test_the_rebuilt_entity_is_searchable_without_naming_a_field() throws Exception {
+        statements.entities.add(entity("person-1", "Jane Doe"));
+        rebuilder.rebuild("prj");
+
+        assertThat(search("{\"query\":{\"query_string\":{\"query\":\"jane OR nobody\"}}}")).contains("person-1");
+        assertThat(search("{\"query\":{\"query_string\":{\"query\":\"Person\"}}}")).contains("person-1");
+        assertThat(search("{\"query\":{\"query_string\":{\"query\":\"doc-1\"}}}")).contains("person-1");
     }
 
     private String search(String query) throws IOException {
         return indexer.executeRaw("POST", Project.entitiesIndex("prj") + "/_search", query);
     }
 
-    // Bare keys, the shape JooqStatementRepository.entities(...) actually produces: ExtractedEntity
-    // is what adds the "ftm:" namespace back before indexing.
-    private static ModelEntity entity(String id, String name) {
+    private static ModelEntity bareKeyed(String id, String property, String value) {
         return new ModelEntity("ftm", id, Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
-                Map.of("name", List.of(name)));
+                Map.of(property, List.of(value)));
+    }
+
+    private static ModelEntity entity(String id, String name) {
+        return bareKeyed(id, "name", name);
     }
 
     private static ModelEntity birthDate(String id, String value) {
-        return new ModelEntity("ftm", id, Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
-                Map.of("birthDate", List.of(value)));
+        return bareKeyed(id, "birthDate", value);
     }
 
     private static class InMemoryStatements implements StatementRepository {
         private final List<ModelEntity> entities = new ArrayList<>();
 
         @Override
-        public int save(String projectId, String runId, java.util.Collection<Statement> statements) {
+        public int save(String projectId, String runId, Stream<Statement> statements) {
             throw new UnsupportedOperationException();
         }
 

--- a/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/model/EntitiesIndexRebuilderTest.java
@@ -121,14 +121,16 @@ public class EntitiesIndexRebuilderTest {
         return indexer.executeRaw("POST", Project.entitiesIndex("prj") + "/_search", query);
     }
 
+    // Bare keys, the shape JooqStatementRepository.entities(...) actually produces: ExtractedEntity
+    // is what adds the "ftm:" namespace back before indexing.
     private static ModelEntity entity(String id, String name) {
         return new ModelEntity("ftm", id, Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
-                Map.of("ftm:name", List.of(name)));
+                Map.of("name", List.of(name)));
     }
 
     private static ModelEntity birthDate(String id, String value) {
-        return new ModelEntity(id, "ftm", Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
-                Map.of("ftm:birthDate", List.of(value)));
+        return new ModelEntity("ftm", id, Set.of("Person"), Set.of("4.10.2"), Set.of("doc-1"),
+                Map.of("birthDate", List.of(value)));
     }
 
     private static class InMemoryStatements implements StatementRepository {

--- a/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
@@ -197,6 +197,36 @@ public class ProjectAdminServiceImplTest {
     }
 
     @Test
+    public void test_create_creates_the_entities_index_too() throws Exception {
+        when(repository.getProject("foo")).thenReturn(null);
+        when(repository.save(any(Project.class))).thenReturn(true);
+
+        service.create(minimalRequest("foo"));
+
+        verify(indexer).createIndex("foo");
+        verify(indexer).createEntitiesIndex("foo");
+    }
+
+    @Test
+    public void test_create_compensates_db_when_the_entities_index_fails() throws Exception {
+        when(repository.getProject("foo")).thenReturn(null);
+        when(repository.save(any(Project.class))).thenReturn(true);
+        when(indexer.createEntitiesIndex("foo")).thenThrow(new IOException("ES down"));
+
+        try {
+            service.create(minimalRequest("foo"));
+            fail("expected IOException");
+        } catch (IOException e) {
+            assertThat(e.getMessage()).contains("ES down");
+        }
+
+        InOrder inOrder = Mockito.inOrder(repository, indexer);
+        inOrder.verify(repository).save(any(Project.class));
+        inOrder.verify(indexer).createEntitiesIndex("foo");
+        inOrder.verify(repository).deleteAll("foo");
+    }
+
+    @Test
     public void test_create_logs_suppressed_when_compensating_delete_also_fails() throws Exception {
         when(repository.getProject("foo")).thenReturn(null);
         when(repository.save(any(Project.class))).thenReturn(true);

--- a/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
@@ -416,20 +416,24 @@ public class ProjectAdminServiceImplTest {
     }
 
     @Test
-    public void test_delete_keeping_the_index_keeps_the_entities_index_too() throws Exception {
+    public void test_delete_reports_index_deleted_when_only_the_entities_index_fails() throws Exception {
         Project project = new Project("foo");
         when(repository.getProject("foo")).thenReturn(project);
         when(repository.deleteAll("foo")).thenReturn(true);
+        when(indexer.deleteAll("foo")).thenReturn(true);
+        when(indexer.deleteAll("foo.entities")).thenThrow(new IOException("ES down"));
         DocumentQueue<Path> queue = mock(DocumentQueue.class);
+        when(queue.delete()).thenReturn(true);
         when(documentCollectionFactory.getQueues(any(String.class), eq(Path.class))).thenReturn(List.of(queue));
         ReportMap reportMap = mock(ReportMap.class);
+        when(reportMap.delete()).thenReturn(true);
         when(documentCollectionFactory.createMap(any())).thenReturn(reportMap);
         when(propertiesProvider.createOverriddenWith(any())).thenReturn(new Properties());
         when(propertiesProvider.get(any())).thenReturn(Optional.empty());
 
-        service.delete("foo", new ProjectDeleteOptions(true));
+        ProjectDeleted deleted = service.delete("foo", new ProjectDeleteOptions(false));
 
-        verify(indexer, never()).deleteAll(any());
+        assertThat(deleted.indexDeleted()).isTrue();
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
@@ -197,36 +197,6 @@ public class ProjectAdminServiceImplTest {
     }
 
     @Test
-    public void test_create_creates_the_entities_index_too() throws Exception {
-        when(repository.getProject("foo")).thenReturn(null);
-        when(repository.save(any(Project.class))).thenReturn(true);
-
-        service.create(minimalRequest("foo"));
-
-        verify(indexer).createIndex("foo");
-        verify(indexer).createEntitiesIndex("foo");
-    }
-
-    @Test
-    public void test_create_compensates_db_when_the_entities_index_fails() throws Exception {
-        when(repository.getProject("foo")).thenReturn(null);
-        when(repository.save(any(Project.class))).thenReturn(true);
-        when(indexer.createEntitiesIndex("foo")).thenThrow(new IOException("ES down"));
-
-        try {
-            service.create(minimalRequest("foo"));
-            fail("expected IOException");
-        } catch (IOException e) {
-            assertThat(e.getMessage()).contains("ES down");
-        }
-
-        InOrder inOrder = Mockito.inOrder(repository, indexer);
-        inOrder.verify(repository).save(any(Project.class));
-        inOrder.verify(indexer).createEntitiesIndex("foo");
-        inOrder.verify(repository).deleteAll("foo");
-    }
-
-    @Test
     public void test_create_logs_suppressed_when_compensating_delete_also_fails() throws Exception {
         when(repository.getProject("foo")).thenReturn(null);
         when(repository.save(any(Project.class))).thenReturn(true);
@@ -366,6 +336,8 @@ public class ProjectAdminServiceImplTest {
         when(repository.getProject("foo")).thenReturn(project);
         when(repository.deleteAll("foo")).thenReturn(true);
         when(indexer.deleteAll("foo")).thenReturn(true);
+        when(indexer.exists("foo.entities")).thenReturn(true);
+        when(indexer.deleteAll("foo.entities")).thenReturn(true);
         DocumentQueue<Path> queue = mock(DocumentQueue.class);
         when(queue.delete()).thenReturn(true);
         when(documentCollectionFactory.getQueues(any(String.class), eq(Path.class))).thenReturn(List.of(queue));
@@ -400,6 +372,8 @@ public class ProjectAdminServiceImplTest {
         when(repository.getProject("foo")).thenReturn(project);
         when(repository.deleteAll("foo")).thenReturn(true);
         when(indexer.deleteAll("foo")).thenReturn(true);
+        when(indexer.exists("foo.entities")).thenReturn(true);
+        when(indexer.deleteAll("foo.entities")).thenReturn(true);
         DocumentQueue<Path> queue = mock(DocumentQueue.class);
         when(queue.delete()).thenReturn(true);
         when(documentCollectionFactory.getQueues(any(String.class), eq(Path.class))).thenReturn(List.of(queue));
@@ -411,16 +385,18 @@ public class ProjectAdminServiceImplTest {
 
         ProjectDeleted deleted = service.delete("foo", new ProjectDeleteOptions(false));
 
+        verify(indexer).deleteAll("foo");
         verify(indexer).deleteAll("foo.entities");
         assertThat(deleted.indexDeleted()).isTrue();
     }
 
     @Test
-    public void test_delete_reports_index_deleted_when_only_the_entities_index_fails() throws Exception {
+    public void test_delete_reports_the_index_step_failed_when_only_the_entities_index_fails() throws Exception {
         Project project = new Project("foo");
         when(repository.getProject("foo")).thenReturn(project);
         when(repository.deleteAll("foo")).thenReturn(true);
         when(indexer.deleteAll("foo")).thenReturn(true);
+        when(indexer.exists("foo.entities")).thenReturn(true);
         when(indexer.deleteAll("foo.entities")).thenThrow(new IOException("ES down"));
         DocumentQueue<Path> queue = mock(DocumentQueue.class);
         when(queue.delete()).thenReturn(true);
@@ -433,6 +409,28 @@ public class ProjectAdminServiceImplTest {
 
         ProjectDeleted deleted = service.delete("foo", new ProjectDeleteOptions(false));
 
+        verify(indexer).deleteAll("foo.entities");
+        assertThat(deleted.indexDeleted()).isFalse();
+        assertThat(deleted.dbDeleted()).isTrue();
+        assertThat(deleted.queuesDeleted()).isTrue();
+    }
+
+    @Test
+    public void test_delete_reports_index_deleted_when_the_project_has_no_entities_index() throws Exception {
+        when(repository.getProject("foo")).thenReturn(new Project("foo"));
+        when(repository.deleteAll("foo")).thenReturn(true);
+        when(indexer.deleteAll("foo")).thenReturn(true);
+        when(indexer.exists("foo.entities")).thenReturn(false);
+        when(documentCollectionFactory.getQueues(any(String.class), eq(Path.class))).thenReturn(List.of());
+        ReportMap reportMap = mock(ReportMap.class);
+        when(reportMap.delete()).thenReturn(true);
+        when(documentCollectionFactory.createMap(any())).thenReturn(reportMap);
+        when(propertiesProvider.createOverriddenWith(any())).thenReturn(new Properties());
+        when(propertiesProvider.get(any())).thenReturn(Optional.empty());
+
+        ProjectDeleted deleted = service.delete("foo", new ProjectDeleteOptions(false));
+
+        verify(indexer, never()).deleteAll("foo.entities");
         assertThat(deleted.indexDeleted()).isTrue();
     }
 
@@ -484,6 +482,8 @@ public class ProjectAdminServiceImplTest {
     public void test_delete_continues_cascade_when_db_delete_fails() throws Exception {
         when(repository.getProject("foo")).thenReturn(new Project("foo"));
         when(indexer.deleteAll("foo")).thenReturn(true);
+        when(indexer.exists("foo.entities")).thenReturn(true);
+        when(indexer.deleteAll("foo.entities")).thenReturn(true);
         when(repository.deleteAll("foo")).thenThrow(new RuntimeException("DB down"));
         DocumentQueue<Path> queue = mock(DocumentQueue.class);
         when(queue.delete()).thenReturn(true);

--- a/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/project/admin/ProjectAdminServiceImplTest.java
@@ -395,6 +395,44 @@ public class ProjectAdminServiceImplTest {
     }
 
     @Test
+    public void test_delete_empties_the_entities_index_too() throws Exception {
+        Project project = new Project("foo");
+        when(repository.getProject("foo")).thenReturn(project);
+        when(repository.deleteAll("foo")).thenReturn(true);
+        when(indexer.deleteAll("foo")).thenReturn(true);
+        DocumentQueue<Path> queue = mock(DocumentQueue.class);
+        when(queue.delete()).thenReturn(true);
+        when(documentCollectionFactory.getQueues(any(String.class), eq(Path.class))).thenReturn(List.of(queue));
+        ReportMap reportMap = mock(ReportMap.class);
+        when(reportMap.delete()).thenReturn(true);
+        when(documentCollectionFactory.createMap(any())).thenReturn(reportMap);
+        when(propertiesProvider.createOverriddenWith(any())).thenReturn(new Properties());
+        when(propertiesProvider.get(any())).thenReturn(Optional.empty());
+
+        ProjectDeleted deleted = service.delete("foo", new ProjectDeleteOptions(false));
+
+        verify(indexer).deleteAll("foo.entities");
+        assertThat(deleted.indexDeleted()).isTrue();
+    }
+
+    @Test
+    public void test_delete_keeping_the_index_keeps_the_entities_index_too() throws Exception {
+        Project project = new Project("foo");
+        when(repository.getProject("foo")).thenReturn(project);
+        when(repository.deleteAll("foo")).thenReturn(true);
+        DocumentQueue<Path> queue = mock(DocumentQueue.class);
+        when(documentCollectionFactory.getQueues(any(String.class), eq(Path.class))).thenReturn(List.of(queue));
+        ReportMap reportMap = mock(ReportMap.class);
+        when(documentCollectionFactory.createMap(any())).thenReturn(reportMap);
+        when(propertiesProvider.createOverriddenWith(any())).thenReturn(new Properties());
+        when(propertiesProvider.get(any())).thenReturn(Optional.empty());
+
+        service.delete("foo", new ProjectDeleteOptions(true));
+
+        verify(indexer, never()).deleteAll(any());
+    }
+
+    @Test
     public void test_delete_skips_index_when_keepIndex_true() throws Exception {
         when(repository.getProject("foo")).thenReturn(new Project("foo"));
         when(repository.deleteAll("foo")).thenReturn(true);

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -208,7 +208,8 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
                 .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
         put("/api/index/cecile-datashare").withPreemptiveAuthentication("cecile", "").should().respond(201);
-        put("/api/index/cecile-datashare.entities").withPreemptiveAuthentication("cecile", "").should().respond(201);
+        // 200, not 201: creating the project index already created the entities index derived from it
+        put("/api/index/cecile-datashare.entities").withPreemptiveAuthentication("cecile", "").should().respond(200);
     }
 
     @Test

--- a/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/IndexResourceTest.java
@@ -212,6 +212,18 @@ public class IndexResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_put_create_entities_index_uses_the_entity_mappings() throws IOException {
+        configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
+                .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));
+
+        put("/api/index/cecile-datashare.entities").withPreemptiveAuthentication("cecile", "pass")
+                .should().respond(201);
+
+        String mapping = indexer.executeRaw("GET", "cecile-datashare.entities/_mapping", null);
+        assertThat(mapping).contains("entity_properties");
+    }
+
+    @Test
     public void test_put_createIndex_refuses_ungranted_project() {
         configure(routes -> routes.add(new IndexResource(indexer, propertiesProvider))
                 .filter(new BasicAuthFilter("/", "icij", DatashareUser.singleUser("cecile"))));

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -167,26 +167,16 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
                 .contain("\"sourcePath\":\"file:///vault/foo\"");
     }
     @Test
-    public void test_create_project_creates_the_entities_index() throws IOException {
+    public void test_create_project_undoes_the_row_when_the_index_cannot_be_created() throws IOException {
         String body = "{ \"name\": \"foo\", \"sourcePath\": \"/vault/foo\" }";
-        when(indexer.createIndex("foo")).thenReturn(true);
-        when(repository.getProject("foo")).thenReturn(null);
-        when(repository.save((Project) any())).thenReturn(true);
-
-        post("/api/project/", body).should().respond(201);
-
-        verify(indexer).createEntitiesIndex("foo");
-    }
-
-    @Test
-    public void test_create_project_fails_when_the_entities_index_cannot_be_created() throws IOException {
-        String body = "{ \"name\": \"foo\", \"sourcePath\": \"/vault/foo\" }";
-        when(indexer.createIndex("foo")).thenReturn(true);
-        when(indexer.createEntitiesIndex("foo")).thenThrow(new IOException("ES down"));
+        // the ES indexer reports a failure as ConfigurationException, a RuntimeException
+        when(indexer.createIndex("foo")).thenThrow(new RuntimeException("ES down"));
         when(repository.getProject("foo")).thenReturn(null);
         when(repository.save((Project) any())).thenReturn(true);
 
         post("/api/project/", body).should().respond(500);
+
+        verify(repository).deleteAll("foo");
     }
 
     @Test
@@ -616,6 +606,21 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
         delete("/api/project/local-datashare").should().respond(204);
 
         verify(indexer).deleteAll("local-datashare");
+        verify(indexer).deleteAll("local-datashare.entities");
+    }
+
+    @Test
+    public void test_delete_project_finishes_the_cascade_when_the_entities_index_fails() throws Exception {
+        Project foo = new Project("local-datashare");
+        when(repository.getProjects(any())).thenReturn(List.of(foo));
+        when(repository.deleteAll("local-datashare")).thenReturn(true);
+        when(indexer.deleteAll("local-datashare")).thenReturn(true);
+        when(indexer.deleteAll("local-datashare.entities")).thenThrow(new IOException("ES down"));
+
+        // 204 rather than the 500 an uncontained failure would return: the queue, report-map and
+        // artifact steps that come after this one still run
+        delete("/api/project/local-datashare").should().respond(204);
+
         verify(indexer).deleteAll("local-datashare.entities");
     }
 

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -607,6 +607,19 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
     }
 
     @Test
+    public void test_delete_project_deletes_the_entities_index_too() throws Exception {
+        Project foo = new Project("local-datashare");
+        when(repository.getProjects(any())).thenReturn(List.of(foo));
+        when(repository.deleteAll("local-datashare")).thenReturn(true);
+        when(indexer.deleteAll("local-datashare")).thenReturn(true);
+
+        delete("/api/project/local-datashare").should().respond(204);
+
+        verify(indexer).deleteAll("local-datashare");
+        verify(indexer).deleteAll("local-datashare.entities");
+    }
+
+    @Test
     public void test_delete_project_delete_artifacts() throws Exception {
         configure(routes -> {
             propertiesProvider = new PropertiesProvider(new HashMap<>() {{

--- a/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/web/ProjectResourceTest.java
@@ -36,6 +36,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.Project.project;
 import static org.icij.datashare.user.User.localUser;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -165,6 +166,29 @@ public class ProjectResourceTest extends AbstractProdWebServerTest {
                 .contain("\"publisherName\":\"ICIJ\"")
                 .contain("\"sourcePath\":\"file:///vault/foo\"");
     }
+    @Test
+    public void test_create_project_creates_the_entities_index() throws IOException {
+        String body = "{ \"name\": \"foo\", \"sourcePath\": \"/vault/foo\" }";
+        when(indexer.createIndex("foo")).thenReturn(true);
+        when(repository.getProject("foo")).thenReturn(null);
+        when(repository.save((Project) any())).thenReturn(true);
+
+        post("/api/project/", body).should().respond(201);
+
+        verify(indexer).createEntitiesIndex("foo");
+    }
+
+    @Test
+    public void test_create_project_fails_when_the_entities_index_cannot_be_created() throws IOException {
+        String body = "{ \"name\": \"foo\", \"sourcePath\": \"/vault/foo\" }";
+        when(indexer.createIndex("foo")).thenReturn(true);
+        when(indexer.createEntitiesIndex("foo")).thenThrow(new IOException("ES down"));
+        when(repository.getProject("foo")).thenReturn(null);
+        when(repository.save((Project) any())).thenReturn(true);
+
+        post("/api/project/", body).should().respond(500);
+    }
+
     @Test
     public void test_cannot_create_project_twice() throws IOException {
         String body = "{ \"name\": \"foo\", \"sourcePath\": \"/vault/foo\" }";

--- a/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
+++ b/datashare-db/src/main/java/org/icij/datashare/db/JooqStatementRepository.java
@@ -27,20 +27,24 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static java.util.stream.Collectors.toCollection;
 import static org.icij.datashare.db.Tables.STATEMENT;
 
 public class JooqStatementRepository implements StatementRepository {
     private static final int FETCH_SIZE = 1_000;
     private static final Field<?>[] READ_FIELDS = {
-            STATEMENT.ID, STATEMENT.MODEL, STATEMENT.ENTITY_ID, STATEMENT.ENTITY_TYPE, STATEMENT.PROPERTY,
-            STATEMENT.VALUE, STATEMENT.DOC_ID, STATEMENT.SHEET, STATEMENT.ROW_NUMBER, STATEMENT.COLUMN_NAME};
+            STATEMENT.ID, STATEMENT.MODEL, STATEMENT.MODEL_VERSION, STATEMENT.ENTITY_ID, STATEMENT.ENTITY_TYPE,
+            STATEMENT.PROPERTY, STATEMENT.VALUE, STATEMENT.DOC_ID, STATEMENT.SHEET, STATEMENT.ROW_NUMBER,
+            STATEMENT.COLUMN_NAME};
     private final DataSource dataSource;
     private final SQLDialect dialect;
     private final int chunkSize;
@@ -56,6 +60,8 @@ public class JooqStatementRepository implements StatementRepository {
     }
 
     private record Write(String projectId, String runId, LocalDateTime now) { }
+
+    private record Row(Statement statement, String modelVersion) { }
 
     @Override
     public int save(String projectId, String runId, Stream<Statement> statements) {
@@ -124,15 +130,17 @@ public class JooqStatementRepository implements StatementRepository {
 
     @Override
     public Optional<ModelEntity> entity(String projectId, String entityId) {
-        List<Statement> statements = create()
+        List<Row> rows = create()
                 .select(READ_FIELDS).from(STATEMENT)
                 .where(STATEMENT.PRJ_ID.eq(projectId)).and(STATEMENT.ENTITY_ID.eq(entityId))
-                .fetch(JooqStatementRepository::toStatement);
+                .fetch(JooqStatementRepository::toRow);
         // The model an id shared by two models resolves to is picked here rather than with an ORDER
         // BY, because a database collation would otherwise decide it, and SQLite and Postgres do not
         // sort text alike.
-        return statements.stream().map(Statement::model).min(String::compareTo).map(model ->
-                ModelEntity.from(statements.stream().filter(row -> model.equals(row.model())).toList()));
+        return rows.stream().map(row -> row.statement().model()).min(String::compareTo).map(model -> {
+            List<Row> group = rows.stream().filter(row -> model.equals(row.statement().model())).toList();
+            return ModelEntity.from(group.stream().map(Row::statement).toList(), versions(group));
+        });
     }
 
     @Override
@@ -150,7 +158,7 @@ public class JooqStatementRepository implements StatementRepository {
     // locked": the embedded database buffers instead.
     private Stream<ModelEntity> entities(String projectId) {
         if (dialect != SQLDialect.POSTGRES) {
-            return group(read(create(), projectId).fetch(JooqStatementRepository::toStatement).stream());
+            return group(read(create(), projectId).fetch(JooqStatementRepository::toRow).stream());
         }
         Connection connection = openStreamingConnection();
         try {
@@ -158,7 +166,7 @@ public class JooqStatementRepository implements StatementRepository {
                     .fetchSize(FETCH_SIZE)
                     .fetchLazy();
             return group(cursor.stream()
-                    .map(JooqStatementRepository::toStatement)
+                    .map(JooqStatementRepository::toRow)
                     .onClose(() -> release(connection, cursor)));
         } catch (RuntimeException e) {
             JDBCUtils.safeClose(connection);
@@ -203,7 +211,7 @@ public class JooqStatementRepository implements StatementRepository {
         return DSL.using(dataSource, dialect);
     }
 
-    private static Statement toStatement(Record row) {
+    private static Row toRow(Record row) {
         String model = row.get(STATEMENT.MODEL);
         String prefix = model + ":";
         String property = row.get(STATEMENT.PROPERTY);
@@ -211,10 +219,15 @@ public class JooqStatementRepository implements StatementRepository {
             throw new DataAccessException("statement '" + row.get(STATEMENT.ID) + "' holds property '" + property
                     + "', which is not namespaced under its model '" + model + "'");
         }
-        return new Statement(row.get(STATEMENT.ID), model, row.get(STATEMENT.ENTITY_ID),
+        return new Row(new Statement(row.get(STATEMENT.ID), model, row.get(STATEMENT.ENTITY_ID),
                 row.get(STATEMENT.ENTITY_TYPE), property.substring(prefix.length()), row.get(STATEMENT.VALUE),
                 new Statement.Provenance(row.get(STATEMENT.DOC_ID), row.get(STATEMENT.SHEET),
-                        row.get(STATEMENT.ROW_NUMBER), row.get(STATEMENT.COLUMN_NAME)));
+                        row.get(STATEMENT.ROW_NUMBER), row.get(STATEMENT.COLUMN_NAME))),
+                row.get(STATEMENT.MODEL_VERSION));
+    }
+
+    private static Set<String> versions(List<Row> rows) {
+        return rows.stream().map(Row::modelVersion).collect(toCollection(TreeSet::new));
     }
 
     // The query is ordered by (entity_id, model), so an entity's statements are consecutive and each
@@ -222,18 +235,18 @@ public class JooqStatementRepository implements StatementRepository {
     // keyed on a low-cardinality column puts every one of its rows under a single entity, so neither
     // the project nor one group is ever collected first. Grouping on entity_id alone would let a
     // same-id entity spanning two models reach ModelEntity.from, which throws on a multi-model group.
-    private static Stream<ModelEntity> group(Stream<Statement> statements) {
-        Iterator<ModelEntity> entities = new Groups(statements.iterator());
+    private static Stream<ModelEntity> group(Stream<Row> rows) {
+        Iterator<ModelEntity> entities = new Groups(rows.iterator());
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(entities, Spliterator.ORDERED), false)
-                .onClose(statements::close);
+                .onClose(rows::close);
     }
 
     private static class Groups implements Iterator<ModelEntity> {
-        private final Iterator<Statement> rows;
-        private Statement pending;
+        private final Iterator<Row> rows;
+        private Row pending;
         private boolean primed;
 
-        Groups(Iterator<Statement> rows) {
+        Groups(Iterator<Row> rows) {
             this.rows = rows;
         }
 
@@ -251,16 +264,19 @@ public class JooqStatementRepository implements StatementRepository {
             if (!hasNext()) {
                 throw new NoSuchElementException();
             }
-            return ModelEntity.from(this::group);
+            // The versions the group was written under are collected as it is folded, and read once
+            // the fold is over, so a group is still never held whole to be counted.
+            Set<String> modelVersions = new TreeSet<>();
+            return ModelEntity.from(() -> group(modelVersions), modelVersions);
         }
 
         // The row that ends a group is the first row of the next one, so it is held back as pending
         // rather than read twice.
-        private Iterator<Statement> group() {
-            Statement first = pending;
+        private Iterator<Statement> group(Set<String> modelVersions) {
+            Row first = pending;
             pending = null;
             return new Iterator<>() {
-                private Statement next = first;
+                private Row next = first;
 
                 @Override
                 public boolean hasNext() {
@@ -269,14 +285,16 @@ public class JooqStatementRepository implements StatementRepository {
 
                 @Override
                 public Statement next() {
-                    Statement current = next;
-                    next = rows.hasNext() ? sameGroupAs(current) : null;
-                    return current;
+                    Row current = next;
+                    modelVersions.add(current.modelVersion());
+                    next = rows.hasNext() ? sameGroupAs(current.statement()) : null;
+                    return current.statement();
                 }
 
-                private Statement sameGroupAs(Statement current) {
-                    Statement row = rows.next();
-                    if (row.entityId().equals(current.entityId()) && row.model().equals(current.model())) {
+                private Row sameGroupAs(Statement current) {
+                    Row row = rows.next();
+                    if (row.statement().entityId().equals(current.entityId())
+                            && row.statement().model().equals(current.model())) {
                         return row;
                     }
                     pending = row;

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -178,6 +178,18 @@ public class JooqStatementRepositoryTest {
                 .properties().keySet()).containsOnly("name", "birthDate");
     }
 
+    // ExtractedEntity.from relies on the property keys coming back bare: it is the one that adds the
+    // model namespace before indexing. If toRow ever stopped stripping the prefix, this would fail
+    // here instead of surfacing as a silently double-namespaced index field.
+    @Test
+    public void test_entities_produces_bare_property_keys_not_namespaced() {
+        repository.save("prj", "run-1", Stream.of(statement("e-1", "Person", "name", "Ada")));
+
+        List<ModelEntity> found = repository.entities("prj", Stream::toList);
+
+        assertThat(found.get(0).properties().keySet()).containsOnly("name");
+    }
+
     @Test
     public void test_property_values_come_back_in_a_stable_order_across_a_resave() {
         List<Statement> statements = List.of(

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -262,6 +262,44 @@ public class JooqStatementRepositoryTest {
     }
 
     @Test
+    public void test_an_entity_carries_the_model_version_of_its_statements() {
+        repository.save("prj", "run-1", Stream.of(
+                Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                        new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))));
+
+        ModelEntity entity = repository.entity("prj", "person-1").orElseThrow();
+
+        assertThat(entity.model()).isEqualTo("ftm");
+        assertThat(entity.modelVersions()).containsOnly("4.10.2");
+    }
+
+    @Test
+    public void test_an_entity_carries_the_documents_its_statements_came_from() {
+        repository.save("prj", "run-1", Stream.of(
+                Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                        new Statement.Provenance("doc-1", "Sheet1", 12, "full_name")),
+                Statement.of("ftm", "person-1", "Person", "birthDate", "1980-04-02",
+                        new Statement.Provenance("doc-2", "Sheet1", 3, "dob"))));
+
+        ModelEntity entity = repository.entity("prj", "person-1").orElseThrow();
+
+        assertThat(entity.documentIds()).containsOnly("doc-1", "doc-2");
+    }
+
+    @Test
+    public void test_the_streamed_entities_carry_the_model_version_too() {
+        repository.save("prj", "run-1", Stream.of(
+                Statement.of("ftm", "person-1", "Person", "name", "Jane Doe",
+                        new Statement.Provenance("doc-1", "Sheet1", 12, "full_name"))));
+
+        List<ModelEntity> entities = repository.entities("prj", Stream::toList);
+
+        assertThat(entities).hasSize(1);
+        assertThat(entities.get(0).modelVersions()).containsOnly("4.10.2");
+        assertThat(entities.get(0).documentIds()).containsOnly("doc-1");
+    }
+
+    @Test
     public void test_entities_gives_the_connection_back_to_the_pool_on_a_short_circuit() {
         repository.save("prj", "run-1", Stream.of(
                 statement("e-1", "Person", "name", "Ada"),

--- a/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
+++ b/datashare-db/src/test/java/org/icij/datashare/db/JooqStatementRepositoryTest.java
@@ -178,9 +178,6 @@ public class JooqStatementRepositoryTest {
                 .properties().keySet()).containsOnly("name", "birthDate");
     }
 
-    // ExtractedEntity.from relies on the property keys coming back bare: it is the one that adds the
-    // model namespace before indexing. If toRow ever stopped stripping the prefix, this would fail
-    // here instead of surfacing as a silently double-namespaced index field.
     @Test
     public void test_entities_produces_bare_property_keys_not_namespaced() {
         repository.save("prj", "run-1", Stream.of(statement("e-1", "Person", "name", "Ada")));

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfiguration.java
@@ -36,6 +36,8 @@ public class ElasticsearchConfiguration {
     static final String MAPPING_RESOURCE_NAME = "datashare_index_mappings.json";
     static final String SETTINGS_RESOURCE_NAME = "datashare_index_settings.json";
     static final String SETTINGS_RESOURCE_NAME_WINDOWS = "datashare_index_settings_windows.json";
+    static final String ENTITIES_MAPPING_RESOURCE_NAME = "datashare_entities_index_mappings.json";
+    static final String ENTITIES_SETTINGS_RESOURCE_NAME = "datashare_entities_index_settings.json";
     static final int INDEX_MAX_RESULT_WINDOW = 100000;
     static Logger LOGGER = LoggerFactory.getLogger(ElasticsearchConfiguration.class);
 
@@ -116,13 +118,19 @@ public class ElasticsearchConfiguration {
     }
 
     public static boolean createIndex(ElasticsearchClient client, String indexName) {
+        String settingsResource = IS_OS_WINDOWS ? SETTINGS_RESOURCE_NAME_WINDOWS : SETTINGS_RESOURCE_NAME;
+        return createIndex(client, indexName, MAPPING_RESOURCE_NAME, settingsResource);
+    }
+
+    public static boolean createIndex(ElasticsearchClient client, String indexName,
+                                      String mappingsResource, String settingsResource) {
         ExistsRequest existsRequest = ExistsRequest.of(er -> er.index(indexName));
         try {
             if (!client.indices().exists(existsRequest).value()) {
                 LOGGER.info("index {} does not exist, creating one", indexName);
                 RestClient restClient = ((RestClientTransport) client._transport()).restClient();
                 Request request = new Request("PUT", "/" + indexName);
-                request.setJsonEntity(createIndexBody());
+                request.setJsonEntity(createIndexBody(mappingsResource, settingsResource));
                 restClient.performRequest(request);
                 return true;
             }
@@ -132,12 +140,11 @@ public class ElasticsearchConfiguration {
         return false;
     }
 
-    static String createIndexBody() throws JsonProcessingException {
-        String settingsResource = IS_OS_WINDOWS ? SETTINGS_RESOURCE_NAME_WINDOWS : SETTINGS_RESOURCE_NAME;
+    static String createIndexBody(String mappingsResource, String settingsResource) throws JsonProcessingException {
         ObjectMapper mapper = JsonObjectMapper.getMapper();
         ObjectNode body = mapper.createObjectNode();
         body.set("settings", mapper.readTree(getResourceContent(settingsResource)));
-        body.set("mappings", mapper.readTree(getResourceContent(MAPPING_RESOURCE_NAME)));
+        body.set("mappings", mapper.readTree(getResourceContent(mappingsResource)));
         return mapper.writeValueAsString(body);
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -537,21 +537,23 @@ public class ElasticsearchIndexer implements Indexer {
         if (indexName.endsWith(Project.ENTITIES_INDEX_SUFFIX)) {
             return createEntitiesIndex(baseProject(indexName));
         }
-        boolean created = ElasticsearchConfiguration.createIndex(client, indexName);
+        if (!ElasticsearchConfiguration.createIndex(client, indexName)) {
+            // an existing index keeps this call a side-effect-free no-op, as IndexTask relies on:
+            // retrofitting an entities index onto an older project is EntitiesIndexRebuilder's job
+            return false;
+        }
         try {
             createEntitiesIndex(indexName);
         } catch (RuntimeException e) {
             // all-or-nothing, so a caller compensating a failed create only has its own DB row left to undo
-            if (created) {
-                try {
-                    deleteIndex(indexName);
-                } catch (IOException rollback) {
-                    e.addSuppressed(rollback);
-                }
+            try {
+                deleteIndex(indexName);
+            } catch (IOException rollback) {
+                e.addSuppressed(rollback);
             }
             throw e;
         }
-        return created;
+        return true;
     }
 
     @Override

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -538,6 +538,13 @@ public class ElasticsearchIndexer implements Indexer {
     }
 
     @Override
+    public boolean createEntitiesIndex(String projectId) {
+        return ElasticsearchConfiguration.createIndex(client, Project.entitiesIndex(projectId),
+                ElasticsearchConfiguration.ENTITIES_MAPPING_RESOURCE_NAME,
+                ElasticsearchConfiguration.ENTITIES_SETTINGS_RESOURCE_NAME);
+    }
+
+    @Override
     public boolean deleteAll(String indexName) throws IOException {
         if (!exists(indexName)) return false;
         Request post = new Request("POST", indexName + "/_delete_by_query?refresh");

--- a/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexer.java
@@ -534,7 +534,24 @@ public class ElasticsearchIndexer implements Indexer {
 
     @Override
     public boolean createIndex(final String indexName) {
-        return ElasticsearchConfiguration.createIndex(client, indexName);
+        if (indexName.endsWith(Project.ENTITIES_INDEX_SUFFIX)) {
+            return createEntitiesIndex(baseProject(indexName));
+        }
+        boolean created = ElasticsearchConfiguration.createIndex(client, indexName);
+        try {
+            createEntitiesIndex(indexName);
+        } catch (RuntimeException e) {
+            // all-or-nothing, so a caller compensating a failed create only has its own DB row left to undo
+            if (created) {
+                try {
+                    deleteIndex(indexName);
+                } catch (IOException rollback) {
+                    e.addSuppressed(rollback);
+                }
+            }
+            throw e;
+        }
+        return created;
     }
 
     @Override
@@ -542,6 +559,18 @@ public class ElasticsearchIndexer implements Indexer {
         return ElasticsearchConfiguration.createIndex(client, Project.entitiesIndex(projectId),
                 ElasticsearchConfiguration.ENTITIES_MAPPING_RESOURCE_NAME,
                 ElasticsearchConfiguration.ENTITIES_SETTINGS_RESOURCE_NAME);
+    }
+
+    private static String baseProject(String entitiesIndexName) {
+        return entitiesIndexName.substring(0, entitiesIndexName.length() - Project.ENTITIES_INDEX_SUFFIX.length());
+    }
+
+    @Override
+    public boolean deleteIndex(String indexName) throws IOException {
+        if (!exists(indexName)) return false;
+        Request delete = new Request("DELETE", "/" + indexName);
+        RestClient restClient = ((RestClientTransport) client._transport()).restClient();
+        return restClient.performRequest(delete).getStatusLine().getStatusCode() == 200;
     }
 
     @Override

--- a/datashare-index/src/main/resources/datashare_entities_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_entities_index_mappings.json
@@ -1,0 +1,33 @@
+{
+  "dynamic": "strict",
+  "dynamic_templates": [
+    {
+      "entity_properties": {
+        "path_match": "properties.*",
+        "match_mapping_type": "string",
+        "mapping": {
+          "type": "keyword",
+          "ignore_above": 8191,
+          "fields": {
+            "text": {
+              "type": "text",
+              "analyzer": "folding"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "type": { "type": "keyword" },
+    "id": { "type": "keyword" },
+    "model": { "type": "keyword" },
+    "modelVersions": { "type": "keyword" },
+    "types": { "type": "keyword" },
+    "documentIds": { "type": "keyword" },
+    "properties": {
+      "type": "object",
+      "dynamic": true
+    }
+  }
+}

--- a/datashare-index/src/main/resources/datashare_entities_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_entities_index_mappings.json
@@ -1,5 +1,6 @@
 {
   "dynamic": "strict",
+  "date_detection": false,
   "dynamic_templates": [
     {
       "entity_properties": {

--- a/datashare-index/src/main/resources/datashare_entities_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_entities_index_mappings.json
@@ -1,5 +1,5 @@
 {
-  "dynamic": "strict",
+  "dynamic": "false",
   "date_detection": false,
   "dynamic_templates": [
     {
@@ -9,6 +9,7 @@
         "mapping": {
           "type": "keyword",
           "ignore_above": 8191,
+          "copy_to": "propertiesAll",
           "fields": {
             "text": {
               "type": "text",
@@ -28,10 +29,15 @@
       }
     },
     "id": { "type": "keyword" },
+    "entityId": { "type": "keyword" },
     "model": { "type": "keyword" },
     "modelVersions": { "type": "keyword" },
     "types": { "type": "keyword" },
     "documentIds": { "type": "keyword" },
+    "propertiesAll": {
+      "type": "text",
+      "analyzer": "folding"
+    },
     "properties": {
       "type": "object",
       "dynamic": true

--- a/datashare-index/src/main/resources/datashare_entities_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_entities_index_mappings.json
@@ -28,7 +28,6 @@
         "name": { "type": "keyword" }
       }
     },
-    "id": { "type": "keyword" },
     "entityId": { "type": "keyword" },
     "model": { "type": "keyword" },
     "modelVersions": { "type": "keyword" },

--- a/datashare-index/src/main/resources/datashare_entities_index_mappings.json
+++ b/datashare-index/src/main/resources/datashare_entities_index_mappings.json
@@ -20,6 +20,12 @@
   ],
   "properties": {
     "type": { "type": "keyword" },
+    "join": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "keyword" }
+      }
+    },
     "id": { "type": "keyword" },
     "model": { "type": "keyword" },
     "modelVersions": { "type": "keyword" },

--- a/datashare-index/src/main/resources/datashare_entities_index_settings.json
+++ b/datashare-index/src/main/resources/datashare_entities_index_settings.json
@@ -1,0 +1,14 @@
+{
+  "index.mapping.total_fields.limit": 100000,
+  "index.number_of_shards": 1,
+  "index.query.default_field": ["properties.*"],
+  "analysis": {
+    "analyzer": {
+      "folding": {
+        "type": "custom",
+        "tokenizer": "standard",
+        "filter": ["lowercase", "asciifolding"]
+      }
+    }
+  }
+}

--- a/datashare-index/src/main/resources/datashare_entities_index_settings.json
+++ b/datashare-index/src/main/resources/datashare_entities_index_settings.json
@@ -1,7 +1,7 @@
 {
   "index.mapping.total_fields.limit": 100000,
   "index.number_of_shards": 1,
-  "index.query.default_field": ["properties.*"],
+  "index.query.default_field": ["propertiesAll", "entityId", "model", "modelVersions", "types", "documentIds"],
   "analysis": {
     "analyzer": {
       "folding": {

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfigurationTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchConfigurationTest.java
@@ -16,7 +16,11 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration.MAPPING_RESOURCE_NAME;
+import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration.SETTINGS_RESOURCE_NAME;
+import static org.icij.datashare.text.indexing.elasticsearch.ElasticsearchConfiguration.SETTINGS_RESOURCE_NAME_WINDOWS;
 
 public class ElasticsearchConfigurationTest {
     @ClassRule
@@ -68,7 +72,9 @@ public class ElasticsearchConfigurationTest {
 
     @Test
     public void test_create_index_body_keeps_match_mapping_type_scalar() throws Exception {
-        JsonNode body = JsonObjectMapper.getMapper().readTree(ElasticsearchConfiguration.createIndexBody());
+        String settingsResource = IS_OS_WINDOWS ? SETTINGS_RESOURCE_NAME_WINDOWS : SETTINGS_RESOURCE_NAME;
+        JsonNode body = JsonObjectMapper.getMapper().readTree(
+                ElasticsearchConfiguration.createIndexBody(MAPPING_RESOURCE_NAME, settingsResource));
 
         JsonNode matchMappingType = null;
         for (JsonNode template : body.at("/mappings/dynamic_templates")) {

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
@@ -9,7 +9,6 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.icij.datashare.Entity;
 import org.icij.datashare.PropertiesProvider;
@@ -24,6 +23,7 @@ import org.icij.datashare.text.indexing.ExtractedText;
 import org.icij.datashare.text.indexing.Indexer;
 import org.icij.datashare.text.indexing.SearchQuery;
 import org.icij.datashare.text.indexing.SearchedText;
+import org.junit.Before;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -73,9 +73,16 @@ public class ElasticsearchIndexerTest {
         es.removeAll();
     }
 
+    // both hooks, not just @After: a run killed before the teardown leaves the index behind and
+    // createEntitiesIndex would then answer false
+    @Before
+    public void setUpEntities() throws IOException {
+        es.delete("prj-entities", "prj-entities.entities");
+    }
+
     @After
     public void tearDownEntities() throws IOException {
-        es.delete("prj-entities.entities");
+        es.delete("prj-entities", "prj-entities.entities");
     }
 
     @Test
@@ -963,18 +970,48 @@ public class ElasticsearchIndexerTest {
         assertThat(indexer.createEntitiesIndex("prj-entities")).isFalse();
     }
 
+    // "dynamic": false rather than "strict": indexJoinFieldName and indexTypeFieldName are
+    // configurable, so a deployment that renames either must not have every write refused
     @Test
-    public void test_the_entities_index_refuses_an_unmapped_top_level_field() throws Exception {
+    public void test_the_entities_index_ignores_an_unmapped_top_level_field() throws Exception {
         indexer.createEntitiesIndex("prj-entities");
 
         RestClient restClient = ((RestClientTransport) es.client._transport()).restClient();
         Request request = new Request("PUT", "/prj-entities.entities/_doc/e-1");
         request.setJsonEntity("{\"surprise\": \"value\"}");
-        try {
-            restClient.performRequest(request);
-            fail("strict mapping should have refused an unmapped field");
-        } catch (ResponseException e) {
-            assertThat(e.getResponse().getStatusLine().getStatusCode()).isEqualTo(400);
-        }
+        restClient.performRequest(request);
+
+        String mapping = EntityUtils.toString(restClient.performRequest(
+                new Request("GET", "/prj-entities.entities/_mapping")).getEntity());
+        assertThat(mapping).excludes("surprise");
+    }
+
+    @Test
+    public void test_create_index_creates_the_entities_index_too() throws Exception {
+        assertThat(indexer.createIndex("prj-entities")).isTrue();
+
+        assertThat(indexer.exists("prj-entities.entities")).isTrue();
+        assertThat(indexer.createEntitiesIndex("prj-entities")).isFalse();
+    }
+
+    @Test
+    public void test_create_index_of_an_entities_name_uses_the_entity_mappings() throws Exception {
+        assertThat(indexer.createIndex("prj-entities.entities")).isTrue();
+
+        RestClient restClient = ((RestClientTransport) es.client._transport()).restClient();
+        String mapping = EntityUtils.toString(restClient.performRequest(
+                new Request("GET", "/prj-entities.entities/_mapping")).getEntity());
+        assertThat(mapping).contains("entity_properties");
+        assertThat(indexer.exists("prj-entities.entities.entities")).isFalse();
+    }
+
+    @Test
+    public void test_delete_index_drops_the_mappings_so_they_can_be_replaced() throws Exception {
+        indexer.createIndex("prj-entities.entities");
+
+        assertThat(indexer.deleteIndex("prj-entities.entities")).isTrue();
+
+        assertThat(indexer.exists("prj-entities.entities")).isFalse();
+        assertThat(indexer.deleteIndex("prj-entities.entities")).isFalse();
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
@@ -5,7 +5,12 @@ import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch.core.GetRequest;
 import co.elastic.clients.elasticsearch.core.UpdateRequest;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.ConnectionClosedException;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
 import org.icij.datashare.Entity;
 import org.icij.datashare.PropertiesProvider;
 import org.icij.datashare.test.ElasticsearchRule;
@@ -66,6 +71,11 @@ public class ElasticsearchIndexerTest {
     @After
     public void tearDown() throws Exception {
         es.removeAll();
+    }
+
+    @After
+    public void tearDownEntities() throws IOException {
+        es.delete("prj-entities.entities");
     }
 
     @Test
@@ -932,5 +942,39 @@ public class ElasticsearchIndexerTest {
         // THEN the document is still indexed (before the fix this threw
         // mapper_parsing_exception and dropped the whole document)
         assertThat((Document) indexer.get(es.getIndexName(), "sigdate-malformed")).isNotNull();
+    }
+
+    @Test
+    public void test_create_entities_index_maps_a_namespaced_property() throws Exception {
+        assertThat(indexer.createEntitiesIndex("prj-entities")).isTrue();
+
+        RestClient restClient = ((RestClientTransport) es.client._transport()).restClient();
+        String mapping = EntityUtils.toString(restClient.performRequest(
+                new Request("GET", "/prj-entities.entities/_mapping")).getEntity());
+
+        assertThat(mapping).contains("dynamic_templates");
+        assertThat(mapping).contains("entity_properties");
+    }
+
+    @Test
+    public void test_create_entities_index_twice_is_a_no_op() throws Exception {
+        assertThat(indexer.createEntitiesIndex("prj-entities")).isTrue();
+
+        assertThat(indexer.createEntitiesIndex("prj-entities")).isFalse();
+    }
+
+    @Test
+    public void test_the_entities_index_refuses_an_unmapped_top_level_field() throws Exception {
+        indexer.createEntitiesIndex("prj-entities");
+
+        RestClient restClient = ((RestClientTransport) es.client._transport()).restClient();
+        Request request = new Request("PUT", "/prj-entities.entities/_doc/e-1");
+        request.setJsonEntity("{\"surprise\": \"value\"}");
+        try {
+            restClient.performRequest(request);
+            fail("strict mapping should have refused an unmapped field");
+        } catch (ResponseException e) {
+            assertThat(e.getResponse().getStatusLine().getStatusCode()).isEqualTo(400);
+        }
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchIndexerTest.java
@@ -995,6 +995,15 @@ public class ElasticsearchIndexerTest {
     }
 
     @Test
+    public void test_create_index_on_an_existing_index_stays_a_no_op() throws Exception {
+        ElasticsearchConfiguration.createIndex(es.client, "prj-entities");
+
+        assertThat(indexer.createIndex("prj-entities")).isFalse();
+        // without the created gate, IndexTask's no-op call would reach out for the entities index too
+        assertThat(indexer.exists("prj-entities.entities")).isFalse();
+    }
+
+    @Test
     public void test_create_index_of_an_entities_name_uses_the_entity_mappings() throws Exception {
         assertThat(indexer.createIndex("prj-entities.entities")).isTrue();
 


### PR DESCRIPTION
Projects a project's extracted entities from the statement store into a searchable `<project>.entities` index, created next to the documents index and deleted with it. Part of #2194, closes #2205.

**Nothing triggers indexing in this PR.** `EntitiesIndexRebuilder` is inert plumbing with no task, no endpoint and no Guice wiring: #2206 wraps it in a task, #2207 exposes it via REST and CLI. Until those land, the entities index is created but stays empty. Stacked on #2359.

- feat: carry the model, its versions and the source documents on `ModelEntity`
- feat: rebuild an entity with its `model_version` and source documents in `JooqStatementRepository`
- feat: add `datashare_entities_index_mappings.json` and its settings, plus a mappings-per-index seam on `ElasticsearchConfiguration.createIndex`, still on the raw REST path
- feat: add `ExtractedEntity`, the indexable projection, namespacing the property keys back to their wire form
- feat: add `EntitiesIndexRebuilder`, purging then refilling the index from the statement stream in chunks
- feat: create the entities index with the project, and lazily on rebuild for projects that predate it
- fix: delete a project's entities index with the project, contained so a failure there cannot mask the documents result
- fix: fail a rebuild whose bulk write is rejected, rather than reporting a count it did not write
- fix: create an entities index with the entity mappings over `PUT /api/index/:index`
- fix: turn off date detection, so a date-shaped value cannot mint a `date` mapping that wedges every later rebuild
- refactor: name the entities index in one place, `Project.entitiesIndex`

Requires `make reset-db` if your build database carries #2204's `original_value` column: jOOQ codegen reads the live schema and this branch's changeset 047 does not define it.