### PR TITLE
feat(artifacts): record the producing task id in the manifest

### DIFF
--- a/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
+++ b/datashare-api/src/main/java/org/icij/datashare/text/artifact/ManifestEntry.java
@@ -15,32 +15,40 @@ public record ManifestEntry(
         String contentType,
         String filename,
         Double confidence,
-        String label) {
+        String label,
+        String taskId) {
 
     public static ManifestEntry singleFile(Map<String, Object> taskInput, String contentType, String filename) {
-        return new ManifestEntry(null, taskInput, null, contentType, filename, null, null);
+        return new ManifestEntry(null, taskInput, null, contentType, filename, null, null, null);
     }
 
     /** A payload split into one file per page (see {@link FilesystemPagination}). */
     public static ManifestEntry paginated(Map<String, Object> taskInput, int total) {
-        return new ManifestEntry(null, taskInput, new Pages(total, new FilesystemPagination()), null, null, null, null);
+        return new ManifestEntry(null, taskInput, new Pages(total, new FilesystemPagination()), null, null, null, null, null);
     }
 
     /** A single content file split by half-open byte ranges, one per page. `total` is derived from the
      *  offsets themselves, so a producer cannot record a count that disagrees with the ranges it wrote. */
     public static ManifestEntry paginated(Map<String, Object> taskInput, List<long[]> ranges) {
         return new ManifestEntry(null, taskInput, new Pages(ranges.size(), new ByteRangePagination(ranges)),
-                null, null, null, null);
+                null, null, null, null, null);
     }
 
     /** A node that was processed but has no payload to serve from its own dir (e.g. a root
      *  document whose source is the on-disk original). Recorded so it is not reprocessed. */
     public static ManifestEntry empty(Map<String, Object> taskInput) {
-        return new ManifestEntry(ManifestEntryStatus.EMPTY, taskInput, null, null, null, null, null);
+        return new ManifestEntry(ManifestEntryStatus.EMPTY, taskInput, null, null, null, null, null, null);
     }
 
     public ManifestEntry withStatus(ManifestEntryStatus status) {
-        return new ManifestEntry(status, taskInput, pages, contentType, filename, confidence, label);
+        return new ManifestEntry(status, taskInput, pages, contentType, filename, confidence, label, taskId);
+    }
+
+    /** Stamps the id of the task that produced this entry, so an artifact can be traced back to its run.
+     *  Not part of {@link #isCurrentFor}: keying skip-if-current on it would regenerate the whole corpus
+     *  on every run, since every run has a new task id. */
+    public ManifestEntry withTaskId(String taskId) {
+        return new ManifestEntry(status, taskInput, pages, contentType, filename, confidence, label, taskId);
     }
 
     /** Producers return EMPTY as-is; any other (status-less) entry becomes COMPLETE. Callers stamp

--- a/datashare-api/src/test/java/org/icij/datashare/text/artifact/ManifestEntryTest.java
+++ b/datashare-api/src/test/java/org/icij/datashare/text/artifact/ManifestEntryTest.java
@@ -93,6 +93,47 @@ public class ManifestEntryTest {
     }
 
     @Test
+    public void test_with_task_id_stamps_the_producing_task_and_keeps_the_other_fields() {
+        ManifestEntry entry = ManifestEntry.singleFile(Map.of("type", "raw", "version", 1),
+                "application/pdf", "report.pdf").withStatus(ManifestEntryStatus.COMPLETE);
+
+        ManifestEntry stamped = entry.withTaskId("org.icij.datashare.tasks.IndexTask-a1b2c3");
+
+        assertThat(stamped.taskId()).isEqualTo("org.icij.datashare.tasks.IndexTask-a1b2c3");
+        assertThat(stamped.status()).isEqualTo(ManifestEntryStatus.COMPLETE);
+        assertThat(stamped.taskInput()).isEqualTo(Map.of("type", "raw", "version", 1));
+        assertThat(stamped.filename()).isEqualTo("report.pdf");
+    }
+
+    @Test
+    public void test_task_id_round_trips_as_task_id() throws Exception {
+        ManifestEntry entry = ManifestEntry.paginated(Map.of("pipeline", "tika"), 2)
+                .withTerminalStatus().withTaskId("artifact-task-1");
+
+        String json = mapper.writeValueAsString(entry);
+
+        assertThat(json).contains("\"taskId\":\"artifact-task-1\"");
+        assertThat(mapper.readValue(json, ManifestEntry.class).taskId()).isEqualTo("artifact-task-1");
+    }
+
+    @Test
+    public void test_an_entry_written_before_task_ids_reads_back_with_a_null_task_id() throws Exception {
+        assertThat(mapper.readValue("{\"status\":\"complete\"}", ManifestEntry.class).taskId()).isNull();
+    }
+
+    @Test
+    public void test_an_unstamped_entry_does_not_serialize_a_task_id() throws Exception {
+        ManifestEntry entry = ManifestEntry.empty(Map.of("type", "raw", "version", 1));
+        assertThat(mapper.writeValueAsString(entry)).excludes("taskId");
+    }
+
+    @Test
+    public void test_the_task_id_is_not_part_of_skip_if_current() {
+        ManifestEntry entry = ManifestEntry.empty(Map.of("type", "raw", "version", 1)).withTaskId("another-run");
+        assertThat(entry.isCurrentFor(Map.of("type", "raw", "version", 1))).isTrue();
+    }
+
+    @Test
     public void test_convenience_predicates_are_not_serialized() throws Exception {
         ManifestEntry entry = ManifestEntry.paginated(Map.of("pipeline", "tika"), 2)
                 .withStatus(ManifestEntryStatus.COMPLETE);

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/ArtifactTask.java
@@ -53,11 +53,13 @@ public class ArtifactTask extends PipelineTask<String> {
     private final Path artifactDir;
     private final int parallelism;
     private final ExecutorService executor;
+    private final String taskId;
 
     @Inject
     public ArtifactTask(DocumentCollectionFactory<String> factory, Indexer indexer, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> updateCallback) {
         super(Stage.ARTIFACT, taskView.getUser(), factory, new PropertiesProvider(taskView.args), String.class, gateFactory.forTask(taskView));
         this.indexer = indexer;
+        taskId = taskView.id;
         project = Project.project(ArtifactStages.resolveProjectName(propertiesProvider));
         parallelism = Math.max(1, propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(1));
         artifactDir = Path.of(propertiesProvider.get(ARTIFACT_DIR_OPT).orElseThrow(() -> new IllegalArgumentException(String.format("cannot create artifact task with empty %s", ARTIFACT_DIR_OPT))));
@@ -138,7 +140,7 @@ public class ArtifactTask extends PipelineTask<String> {
         boolean force = ArtifactStages.force(propertiesProvider);
         // The producer owns what counts as a cancellation (see ArtifactProducer#isCancellation), so this
         // loop and the produce loop it drives cannot disagree about it.
-        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), executor::isShutdown);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), executor::isShutdown, taskId);
         Path projectRoot = ArtifactPath.projectRoot(artifactDir, project.name);
         // The interrupt check keeps cancellation prompt, since cancel() calls executor.shutdownNow()
         // while a worker may sit between two non-blocking polls.

--- a/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
+++ b/datashare-app/src/main/java/org/icij/datashare/tasks/IndexTask.java
@@ -70,11 +70,13 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
     private final AtomicInteger skipped = new AtomicInteger(0);
     private final Integer parallelism;
     private final Integer indexTimeout;
+    private final String taskId;
 
     @Inject
     public IndexTask(final ElasticsearchSpewer spewer, final DocumentCollectionFactory<Path> factory, final UpstreamGate.Factory gateFactory, @Assisted Task<Long> taskView, @Assisted final Function<Double, Void> progressCallback) throws IOException {
         super(Stage.INDEX, taskView.getUser(), factory, new PropertiesProvider(taskView.args), Path.class, gateFactory.forTask(taskView));
         this.spewer = spewer;
+        taskId = taskView.id;
         parallelism = propertiesProvider.get(PARALLELISM_OPT).map(Integer::parseInt).orElse(Runtime.getRuntime().availableProcessors());
         indexTimeout = getIndexTimeout();
         warnIfParseTimeoutDisabled();
@@ -144,7 +146,7 @@ public class IndexTask extends PipelineTask<Path> implements Monitorable{
             if (rawSelected || artifactStageRuns) {
                 extractor.setEmbedOutputPath(projectRoot);
             }
-            spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, ArtifactStages.force(propertiesProvider)));
+            spewer.setManifestRecorder(new ManifestRecorder(new FilesystemManifestRepository(), projectRoot, selected, ArtifactStages.force(propertiesProvider), taskId));
         });
         logger.info("Processing up to {} file(s) in parallel", parallelism);
         try {

--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -152,6 +152,23 @@ public class ArtifactTaskTest {
     }
 
     @Test(timeout = 10000)
+    public void test_the_recorded_entry_carries_the_id_of_the_running_task() throws Exception {
+        indexEmbeddedPdfUnderItsRoot();
+        DocumentQueue<String> queue = factory.createQueue("extract:queue:artifact", String.class);
+        queue.add(EMBEDDED_PDF_SHA256 + "|" + EMBEDDED_DOC_SHA256);
+        // The task itself, not a literal: this is what pins the wiring from Task.id down to the manifest.
+        Task<Long> task = ArtifactTaskFixture.taskWith(Map.of(
+                "artifactDir", artifactDir.getRoot().toString(),
+                "defaultProject", "prj",
+                "artifacts", "true"));
+
+        new ArtifactTask(factory, mockEs, new UpstreamGate.Factory(taskRepository), task, null).call();
+
+        Path docArtifactDir = artifactDir.getRoot().toPath().resolve("prj/6a/bb/" + EMBEDDED_PDF_SHA256);
+        assertThat(new FilesystemManifestRepository().get(docArtifactDir, "structure").taskId()).isEqualTo(task.id);
+    }
+
+    @Test(timeout = 10000)
     public void test_workers_run_concurrently() throws Exception {
         indexEmbeddedDoc();
         String secondId = "1111111111111111111111111111111111111111111111111111111111111111";

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ArtifactProducer.java
@@ -17,10 +17,12 @@ public class ArtifactProducer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactProducer.class);
     private final ManifestRepository repository;
     private final BooleanSupplier cancelRequested;
+    private final String taskId;
 
-    public ArtifactProducer(ManifestRepository repository, BooleanSupplier cancelRequested) {
+    public ArtifactProducer(ManifestRepository repository, BooleanSupplier cancelRequested, String taskId) {
         this.repository = repository;
         this.cancelRequested = cancelRequested;
+        this.taskId = taskId;
     }
 
     public boolean run(List<Artifact> artifacts, ArtifactContext context, boolean force) {
@@ -58,9 +60,7 @@ public class ArtifactProducer {
             // lock): real concurrency on the same document is rare and, when it happens, at worst
             // duplicates work (accepted for now). Only the manifest write below is serialised.
             ManifestEntry produced = artifact.produce(context);
-            // put() holds the per-doc write lock while it merges the entry, so the recorded manifest
-            // stays consistent (and cross-process/host safe) with the payload just written.
-            repository.put(context.docArtifactDir(), type.token(), produced.withTerminalStatus());
+            record(context, type, produced.withTerminalStatus());
             return true;
         } catch (UnreadableContentException unreadable) {
             // The cancel question comes first: a cancelled Tika parse arrives as a parse failure too, and
@@ -76,6 +76,13 @@ public class ArtifactProducer {
             LOGGER.error("failed to produce artifact '{}' for document {}", type.token(), context.document().getId(), failure);
             return false;
         }
+    }
+
+    // The one manifest-write point for every path, so no artifact is recorded without the id of the run
+    // that produced it. put() holds the per-doc write lock while it merges the entry, so the recorded
+    // manifest stays consistent (and cross-process/host safe) with the payload just written.
+    private void record(ArtifactContext context, ArtifactType type, ManifestEntry entry) throws IOException {
+        repository.put(context.docArtifactDir(), type.token(), entry.withTaskId(taskId));
     }
 
     // Restoring the flag is what ends ArtifactTask's while(!isInterrupted()) loop instead of polling the
@@ -97,8 +104,7 @@ public class ArtifactProducer {
         // No stack trace: these are benign, and a corpus holds enough of them to bury the real failures.
         LOGGER.warn("{}: recording an empty '{}' entry so it is not parsed again", failure.getMessage(), type.token());
         try {
-            repository.put(context.docArtifactDir(), type.token(),
-                    ManifestEntry.empty(artifact.taskInput(context.document())));
+            record(context, type, ManifestEntry.empty(artifact.taskInput(context.document())));
             return true;
         } catch (IOException recordFailure) {
             LOGGER.error("failed to record artifact '{}' for document {}", type.token(), context.document().getId(), recordFailure);

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/ManifestRecorder.java
@@ -20,12 +20,14 @@ public class ManifestRecorder {
     private final Path projectRoot;
     private final boolean force;
     private final boolean rawSelected;
+    private final String taskId;
     private final RawArtifact raw = new RawArtifact();
 
-    public ManifestRecorder(ManifestRepository repository, Path projectRoot, List<Artifact> selected, boolean force) {
+    public ManifestRecorder(ManifestRepository repository, Path projectRoot, List<Artifact> selected, boolean force, String taskId) {
         this.repository = repository;
         this.projectRoot = projectRoot;
         this.force = force;
+        this.taskId = taskId;
         this.rawSelected = selected.stream().anyMatch(artifact -> artifact.type() == ArtifactType.RAW);
     }
 
@@ -49,6 +51,6 @@ public class ManifestRecorder {
                 return;
             }
         }
-        repository.put(docArtifactDir, ArtifactType.RAW.token(), entry.withTerminalStatus());
+        repository.put(docArtifactDir, ArtifactType.RAW.token(), entry.withTerminalStatus().withTaskId(taskId));
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactProducerTest.java
@@ -19,10 +19,11 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
 
 public class ArtifactProducerTest {
+    private static final String TASK_ID = "org.icij.datashare.tasks.ArtifactTask-a1b2c3";
     @Rule public TemporaryFolder dir = new TemporaryFolder();
     private final ManifestRepository repository = new FilesystemManifestRepository();
     // No cancellation asked for: the cases below that do simulate one say so explicitly.
-    private final ArtifactProducer producer = new ArtifactProducer(repository, () -> false);
+    private final ArtifactProducer producer = new ArtifactProducer(repository, () -> false, TASK_ID);
 
     // The interrupt flag is the JDK's cancellation mechanism and the producer restores it on purpose, so
     // it survives the test that set it: cleared once here rather than in every case's finally.
@@ -70,6 +71,18 @@ public class ArtifactProducerTest {
         producer.run(List.of(raw), ctx(), false);
         assertThat(raw.produced.get()).isEqualTo(1);
         assertThat(repository.get(dir.getRoot().toPath(), "raw").isComplete()).isTrue();
+    }
+
+    @Test public void test_records_the_producing_task_id() throws Exception {
+        producer.run(List.of(new CountingArtifact("raw", 1)), ctx(), false);
+        assertThat(repository.get(dir.getRoot().toPath(), "raw").taskId()).isEqualTo(TASK_ID);
+    }
+
+    @Test public void test_records_the_producing_task_id_on_an_empty_entry() throws Exception {
+        CountingArtifact raw = new CountingArtifact("raw", 1);
+        raw.producesEmpty = true;
+        producer.run(List.of(raw), ctx(), false);
+        assertThat(repository.get(dir.getRoot().toPath(), "raw").taskId()).isEqualTo(TASK_ID);
     }
 
     @Test public void test_skips_when_task_input_matches() throws Exception {
@@ -142,7 +155,7 @@ public class ArtifactProducerTest {
     @Test public void test_unreadable_content_during_a_cancellation_records_nothing() throws Exception {
         // Tika reports a cancelled parse as a parse failure too, and recording "this document has no
         // structure" because the operator pressed cancel is a lie only --artifactsForce could undo.
-        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true);
+        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true, TASK_ID);
         CountingArtifact structure = new CountingArtifact("structure", 1) {
             public ManifestEntry produce(ArtifactContext ctx) throws ArtifactException {
                 Thread.interrupted(); // cleared already, as Tika leaves it
@@ -189,7 +202,7 @@ public class ArtifactProducerTest {
     @Test public void test_a_cancel_stops_the_remaining_types() throws Exception {
         // Flag still set when we catch, so the top-of-produce guard stops the next type before it tries.
         // It counts as a cancellation because the task reports one, not because of the flag.
-        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true);
+        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true, TASK_ID);
         CountingArtifact structure = new CountingArtifact("structure", 1);
 
         boolean allSucceeded = cancelledProducer.run(List.of(interruptingArtifact(), structure), ctx(), false);
@@ -211,7 +224,7 @@ public class ArtifactProducerTest {
     }
 
     @Test public void test_a_cancel_recognised_from_the_cause_chain_stops_the_remaining_types() throws Exception {
-        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true);
+        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true, TASK_ID);
         CountingArtifact structure = new CountingArtifact("structure", 1);
 
         boolean allSucceeded = cancelledProducer.run(
@@ -238,7 +251,7 @@ public class ArtifactProducerTest {
     @Test public void test_a_cancel_recognised_from_an_interrupted_io_exception_stops_the_remaining_types() throws Exception {
         // extract-lib's cancellation path surfaces this one, and being an IOException rather than an
         // InterruptedException it would otherwise be counted as a failed document.
-        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true);
+        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true, TASK_ID);
         CountingArtifact structure = new CountingArtifact("structure", 1);
 
         boolean allSucceeded = cancelledProducer.run(
@@ -251,7 +264,7 @@ public class ArtifactProducerTest {
     @Test(timeout = 5000) public void test_a_self_referential_cause_chain_does_not_spin_forever() throws Exception {
         // A custom or deserialised exception can return itself from getCause(), which hangs the worker
         // inside its own catch block until the task's one-day timeout, with nothing logged to say so.
-        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true);
+        ArtifactProducer cancelledProducer = new ArtifactProducer(repository, () -> true, TASK_ID);
         CountingArtifact selfCaused = new CountingArtifact("raw", 1) {
             public ManifestEntry produce(ArtifactContext ctx) throws ArtifactException {
                 throw new ArtifactException("boom", null) {

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ArtifactReaderTest.java
@@ -24,7 +24,7 @@ public class ArtifactReaderTest {
     // production factory for it: the read side is exercised from a hand-built entry.
     private static ManifestEntry byteRangeEntry(int total, List<long[]> ranges) {
         Pages pages = new Pages(total, new ByteRangePagination(ByteRangePagination.TYPE, ranges));
-        return new ManifestEntry(null, Map.of(), pages, null, null, null, null);
+        return new ManifestEntry(null, Map.of(), pages, null, null, null, null, null);
     }
 
     private Path withFilesystemPages(int total, String... pages) throws Exception {

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/ManifestRecorderTest.java
@@ -15,6 +15,7 @@ import static org.icij.datashare.text.DocumentBuilder.createDoc;
 
 public class ManifestRecorderTest {
     private static final String EMBEDDED_ID = "eeee1111222233334444555566667777";
+    private static final String TASK_ID = "org.icij.datashare.tasks.IndexTask-a1b2c3";
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
     private final ManifestRepository repository = new FilesystemManifestRepository();
     private final RawArtifact raw = new RawArtifact();
@@ -24,7 +25,7 @@ public class ManifestRecorderTest {
     }
 
     private ManifestRecorder recorder(boolean force) {
-        return new ManifestRecorder(repository, projectRoot(), List.of(raw), force);
+        return new ManifestRecorder(repository, projectRoot(), List.of(raw), force, TASK_ID);
     }
 
     private Document embedded(String id) {
@@ -53,6 +54,26 @@ public class ManifestRecorderTest {
     }
 
     @Test
+    public void test_records_the_indexing_task_id() throws Exception {
+        Document doc = embedded(EMBEDDED_ID);
+        writePayload(doc.getId());
+
+        recorder(false).record(doc);
+
+        assertThat(repository.get(ArtifactPath.dir(projectRoot(), doc.getId()), "raw").taskId()).isEqualTo(TASK_ID);
+    }
+
+    @Test
+    public void test_records_the_indexing_task_id_on_an_empty_root_entry() throws Exception {
+        Document root = createDoc("rootrootrootroot").with(Path.of("/tmp/root.pdf"))
+                .ofContentType("application/pdf").withExtractionLevel((short) 0).build();
+
+        recorder(false).record(root);
+
+        assertThat(repository.get(ArtifactPath.dir(projectRoot(), root.getId()), "raw").taskId()).isEqualTo(TASK_ID);
+    }
+
+    @Test
     public void test_skips_embedded_when_payload_missing() throws Exception {
         Document doc = embedded(EMBEDDED_ID);
 
@@ -65,7 +86,7 @@ public class ManifestRecorderTest {
     public void test_null_task_input_entry_is_not_current() throws Exception {
         Document doc = embedded(EMBEDDED_ID);
         Path dir = ArtifactPath.dir(projectRoot(), doc.getId());
-        repository.put(dir, "raw", new ManifestEntry(ManifestEntryStatus.COMPLETE, null, null, null, null, null, null));
+        repository.put(dir, "raw", new ManifestEntry(ManifestEntryStatus.COMPLETE, null, null, null, null, null, null, null));
         writePayload(doc.getId());
 
         recorder(false).record(doc);
@@ -114,7 +135,7 @@ public class ManifestRecorderTest {
     @Test
     public void test_no_op_when_raw_not_selected() throws Exception {
         Document doc = embedded(EMBEDDED_ID);
-        ManifestRecorder recorder = new ManifestRecorder(repository, projectRoot(), List.of(), false);
+        ManifestRecorder recorder = new ManifestRecorder(repository, projectRoot(), List.of(), false, TASK_ID);
 
         recorder.record(doc);
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/PageArtifactTest.java
@@ -504,7 +504,7 @@ public class PageArtifactTest {
     public void test_a_document_reindexed_with_ocr_is_paginated_again() throws Exception {
         Path pdf = twoPagePdf();
         ArtifactContext context = rootContext(pdf);
-        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false, null);
         producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false);
         Files.delete(contentTxt(context)); // regenerated only if the second run does not skip
         Document reindexedWithOcr = createDoc(context.document().getId()).with(pdf).ofContentType("application/pdf")
@@ -607,7 +607,7 @@ public class PageArtifactTest {
     @Test
     public void test_the_written_manifest_matches_the_convention_shape() throws Exception {
         ArtifactContext context = rootContext(twoPagePdf());
-        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false, null);
 
         assertThat(producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false)).isTrue();
 
@@ -631,7 +631,7 @@ public class PageArtifactTest {
     @Test
     public void test_a_second_run_skips_a_document_already_produced_with_the_same_task_input() throws Exception {
         ArtifactContext context = rootContext(twoPagePdf());
-        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false, null);
         producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false);
         // Overwritten, not deleted: skip-if-current re-produces a payload that left the disk
         // (ArtifactPayload#isMissing), so an absent content.txt would prove nothing about the skip.
@@ -645,7 +645,7 @@ public class PageArtifactTest {
     @Test
     public void test_a_second_run_produces_again_when_the_page_payload_left_the_disk() throws Exception {
         ArtifactContext context = rootContext(twoPagePdf());
-        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false, null);
         producer.run(List.of(new PageArtifact(new PropertiesProvider())), context, false);
         Files.delete(contentTxt(context));
 

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/StructureArtifactTest.java
@@ -300,7 +300,7 @@ public class StructureArtifactTest {
 
     @Test
     public void test_manifest_written_by_the_real_producer_loop_matches_the_convention() throws Exception {
-        boolean produced = new ArtifactProducer(new FilesystemManifestRepository(), () -> false)
+        boolean produced = new ArtifactProducer(new FilesystemManifestRepository(), () -> false, null)
                 .run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
 
         assertThat(produced).isTrue();
@@ -316,7 +316,7 @@ public class StructureArtifactTest {
 
     @Test
     public void test_second_producer_run_skips_a_document_whose_payload_is_still_there() throws Exception {
-        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false, null);
         producer.run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
         // Overwrite rather than delete: a deleted page is now a repair trigger, not proof of a skip.
         Files.writeString(page(1, "md"), "sentinel");
@@ -328,7 +328,7 @@ public class StructureArtifactTest {
 
     @Test
     public void test_a_re_run_repairs_pages_stranded_in_a_holding_pen() throws Exception {
-        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false);
+        ArtifactProducer producer = new ArtifactProducer(new FilesystemManifestRepository(), () -> false, null);
         producer.run(List.of(new StructureArtifact(new PropertiesProvider())), contextFor(HTML), false);
         // What a failed AtomicDirectorySwap.restore leaves behind: the only copy of the pages in a holding
         // pen while the target is gone, until now recoverable only by hand (#2300).

--- a/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/indexing/elasticsearch/ElasticsearchSpewerTest.java
@@ -69,7 +69,7 @@ public class ElasticsearchSpewerTest {
     public void test_write_records_raw_manifest_when_recorder_set() throws Exception {
         Path projectRoot = artifactDir.getRoot().toPath().resolve("prj");
         ManifestRepository repository = new FilesystemManifestRepository();
-        spewer.setManifestRecorder(new ManifestRecorder(repository, projectRoot, List.of(new RawArtifact()), false));
+        spewer.setManifestRecorder(new ManifestRecorder(repository, projectRoot, List.of(new RawArtifact()), false, null));
         final TikaDocument document = new DocumentFactory().withIdentifier(new PathIdentifier()).create(get("recorded-file.txt"));
         document.setReader(new ParsingReader(new ByteArrayInputStream("test".getBytes())));
 


### PR DESCRIPTION
Stamps every manifest entry with the id of the task that produced it, so an artifact can be traced back to its run.

- feat: add `taskId` to `ManifestEntry`, stamped by `ManifestRecorder` and by each producer through `ArtifactProducer`
- fix: keep `taskId` out of `isCurrentFor`, since keying skip-if-current on it would regenerate the whole corpus on every run

Closes #2293
