### PR TITLE
fix(structure): keep the rendering when the output cap is reached

### DIFF
--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -7,6 +7,7 @@ import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
 import com.vladsch.flexmark.util.data.MutableDataSet;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.exception.WriteLimitReachedException;
 import org.apache.tika.extractor.DocumentSelector;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
@@ -26,6 +27,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.safety.Safelist;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -45,6 +48,8 @@ import java.util.regex.Pattern;
  * the caller passes it and records it in the artifact's fingerprint.
  */
 public class StructureMarkdownExtractor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StructureMarkdownExtractor.class);
 
     /** The OCR the INDEX stage applied to this document, so a page holds the text the content field
      *  holds. Two knobs because two parsers are, as extract-lib splits them: {@code --ocr} for a
@@ -243,9 +248,19 @@ public class StructureMarkdownExtractor {
     String toXhtml(InputStream source, Metadata metadata, OcrSettings ocr)
             throws IOException, SAXException, TikaException {
         ToXMLContentHandler xhtmlHandler = new ToXMLContentHandler();
-        new AutoDetectParser(RESILIENT_PARSER).parse(source,
-                new WriteOutContentHandler(xhtmlHandler, maxOutputChars),
-                metadata, buildParseContext(ocr));
+        try {
+            new AutoDetectParser(RESILIENT_PARSER).parse(source,
+                    new WriteOutContentHandler(xhtmlHandler, maxOutputChars),
+                    metadata, buildParseContext(ocr));
+        } catch (SAXException failure) {
+            // The cap is ours, so reaching it is truncation and not content no parser can read. Read off
+            // the cause chain, as Tika's own parseToString does: a parser catching a SAXException rewraps it.
+            if (!WriteLimitReachedException.isWriteLimitReached(failure)) {
+                throw failure;
+            }
+            LOGGER.warn("rendering of \"{}\" stopped at the {}-character output cap: the text up to it is kept",
+                    metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY), maxOutputChars);
+        }
         return xhtmlHandler.toString();
     }
 

--- a/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/structure/StructureMarkdownExtractor.java
@@ -252,9 +252,11 @@ public class StructureMarkdownExtractor {
             new AutoDetectParser(RESILIENT_PARSER).parse(source,
                     new WriteOutContentHandler(xhtmlHandler, maxOutputChars),
                     metadata, buildParseContext(ocr));
-        } catch (SAXException failure) {
+        } catch (SAXException | TikaException failure) {
             // The cap is ours, so reaching it is truncation and not content no parser can read. Read off
-            // the cause chain, as Tika's own parseToString does: a parser catching a SAXException rewraps it.
+            // the cause chain, as Tika's own parseToString does, and off both types: CompositeParser
+            // rethrows the SAXException the cap raises, but a leaf parser catching it rewraps it as a
+            // TikaException (Word2006MLParser, and extract-lib's resilient PST parser).
             if (!WriteLimitReachedException.isWriteLimitReached(failure)) {
                 throw failure;
             }

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -13,7 +13,6 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocume
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
-import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.DocumentSelector;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
@@ -25,7 +24,6 @@ import org.icij.datashare.text.structure.StructureMarkdownExtractor.Page;
 import org.jsoup.Jsoup;
 import org.jsoup.parser.Parser;
 import org.junit.Test;
-import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -443,17 +441,17 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
-    public void test_output_over_the_limit_stops_the_parse_instead_of_filling_the_heap() throws Exception {
-        // The rendering is buffered whole and held several times over (buffer, string, DOM, every page's
-        // XHTML and Markdown), times --parallelism, and no catch on the produce path handles an OOM.
+    public void test_output_over_the_limit_keeps_the_text_rendered_up_to_the_cap() throws Exception {
+        // The parse still stops at the cap (see DEFAULT_MAX_OUTPUT_CHARS), but reaching our own cap is
+        // truncation and not content no parser can read, so what was rendered first is kept.
         StructureMarkdownExtractor bounded = new StructureMarkdownExtractor(100);
 
-        try {
-            extract(bounded, stream("<html><body><p>" + "x".repeat(10_000) + "</p></body></html>"), "text/html");
-            org.junit.Assert.fail("expected the parse to stop at the output limit");
-        } catch (SAXException | TikaException expected) {
-            // told apart from a readable document one level up, not silently truncated
-        }
+        List<Page> pages = extract(bounded,
+                stream("<html><body><p>" + "x".repeat(10_000) + "</p></body></html>"), "text/html");
+
+        // 90 of the 100, not all of them: the cap counts every character event, and the newlines
+        // XHTMLContentHandler writes around the elements it opens are character events too.
+        assertThat(markdown(pages)).isEqualTo(List.of("x".repeat(90)));
     }
 
     @Test

--- a/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/structure/StructureMarkdownExtractorTest.java
@@ -455,6 +455,32 @@ public class StructureMarkdownExtractorTest {
     }
 
     @Test
+    public void test_output_over_the_limit_is_kept_when_a_parser_rewraps_the_cap() throws Exception {
+        // CompositeParser rethrows the SAXException the cap raises, but a leaf parser that catches it
+        // hands it back as a TikaException (Word2006MLParser here, extract-lib's resilient PST parser
+        // for a mail archive), which would otherwise land in the unreadable-content bucket again.
+        StructureMarkdownExtractor bounded = new StructureMarkdownExtractor(100);
+
+        List<Page> pages = extract(bounded, stream(wordFlatOpcPackage("x".repeat(10_000))),
+                "application/vnd.ms-word2006ml");
+
+        // 93 of the 100, the remainder being the newlines written around the elements holding the text.
+        assertThat(markdown(pages)).isEqualTo(List.of("x".repeat(93)));
+    }
+
+    // The pre-OOXML flat package Word2006MLParser reads, with a single document part: its text is written
+    // out during the parser's own SAX parse, which is where the cap is reached.
+    private String wordFlatOpcPackage(String text) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<pkg:package xmlns:pkg=\"http://schemas.microsoft.com/office/2006/xmlPackage\">"
+                + "<pkg:part pkg:name=\"/word/document.xml\" pkg:contentType=\"application/vnd."
+                + "openxmlformats-officedocument.wordprocessingml.document.main+xml\"><pkg:xmlData>"
+                + "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">"
+                + "<w:body><w:p><w:r><w:t>" + text + "</w:t></w:r></w:p></w:body></w:document>"
+                + "</pkg:xmlData></pkg:part></pkg:package>";
+    }
+
+    @Test
     public void test_body_content_entirely_inside_page_divs_is_unchanged() throws Exception {
         // Pinned byte-for-byte: a change here invalidates every already-produced page set.
         List<Page> pages = extract(stream(


### PR DESCRIPTION
Reaching the structure extractor's own output cap is truncation, not content no parser can read, so the text rendered up to the cap is kept instead of being discarded and cached as an empty entry.

- fix: return the text rendered up to the output cap instead of failing the parse
- fix: recognise the cap when a leaf parser rewraps it as a TikaException
- fix: log the cap hit as truncation rather than reporting it as unreadable content
- test: cover the cap being reached on both the rethrown and the rewrapped path

Closes #2367