### PR TITLE
fix(artifacts): classify unreadable raw content instead of failing it

### DIFF
--- a/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
+++ b/datashare-app/src/test/java/org/icij/datashare/tasks/ArtifactTaskTest.java
@@ -312,9 +312,11 @@ public class ArtifactTaskTest {
             protected SourceExtractor createSourceExtractor() {
                 return new SourceExtractor(propertiesProvider) {
                     @Override
-                    public TikaDocument extractEmbeddedSources(Project project, Document document) throws org.apache.tika.exception.TikaException {
+                    public TikaDocument extractEmbeddedSources(Project project, Document document) throws java.io.IOException {
                         if (document.getId().equals(failingId)) {
-                            throw new org.apache.tika.exception.TikaException("boom");
+                            // A read failure, not a parse failure: a parse failure is recorded as an empty
+                            // entry rather than counted as a failed document.
+                            throw new java.io.IOException("boom");
                         }
                         return null;
                     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/PageArtifact.java
@@ -2,7 +2,6 @@ package org.icij.datashare.text.artifact;
 
 import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaConfigException;
-import org.apache.tika.exception.TikaException;
 import org.apache.tika.extractor.DocumentSelector;
 import org.apache.tika.metadata.TikaCoreProperties;
 import org.icij.datashare.PropertiesProvider;
@@ -16,7 +15,6 @@ import org.icij.extract.document.DocumentFactory;
 import org.icij.extract.extractor.EmbedSpawner;
 import org.icij.extract.extractor.Extractor;
 import org.icij.task.Options;
-import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -205,18 +203,9 @@ public class PageArtifact implements Artifact {
         if (failure.getCause() instanceof TikaConfigException) {
             throw new ArtifactConfigurationException(failure.getCause());
         }
-        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
-            // Deeper down: this side going wrong for one document, and a run with the configuration
-            // fixed can still read it, so retryable rather than terminal.
-            if (cause instanceof TikaConfigException) {
-                return retryable(document, failure);
-            }
-            if (cause instanceof TikaException || cause instanceof SAXException) {
-                return StructureArtifact.isRetryable(cause) ? retryable(document, failure)
-                        : new UnreadableContentException(document.getId(), cause);
-            }
-        }
-        return retryable(document, failure);
+        Throwable unreadable = StructureArtifact.unreadableCause(failure);
+        return unreadable == null ? retryable(document, failure)
+                : new UnreadableContentException(document.getId(), unreadable);
     }
 
     private static ArtifactException retryable(Document document, IOException failure) {

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
@@ -40,6 +40,10 @@ public class RawArtifact implements Artifact {
         } catch (ArtifactException noRawBytes) {
             throw noRawBytes;
         } catch (Exception extractionFailure) {
+            Throwable unreadable = StructureArtifact.unreadableCause(extractionFailure);
+            if (unreadable != null) {
+                throw new UnreadableContentException(document.getId(), unreadable);
+            }
             throw new ArtifactException("raw extraction failed for " + document.getId(), extractionFailure);
         }
     }

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/RawArtifact.java
@@ -27,9 +27,21 @@ public class RawArtifact implements Artifact {
     public ManifestEntry produce(ArtifactContext context) throws ArtifactException {
         Document document = context.document();
         try {
-            // extract-lib writes the raw/raw.json bytes for the embedded subtree as a side effect.
-            context.sources().extractEmbeddedSources(context.project(), document);
             ManifestEntry entry = entryFor(document);
+            try {
+                // extract-lib writes the raw/raw.json bytes for the embedded subtree as a side effect.
+                context.sources().extractEmbeddedSources(context.project(), document);
+            } catch (Exception extractionFailure) {
+                // The walk writes as it goes, so it can fail further along the root's tree with this
+                // document's own bytes already written: those bytes are the artifact, and classifying
+                // another node's failure onto this one records "no payload" over a payload that is there,
+                // permanently. A root advertises no payload of its own, so nothing on disk answers for it.
+                if (document.isRootDocument()
+                        || ArtifactPayload.isMissing(context.docArtifactDir(), TYPE, entry)) {
+                    throw extractionFailure;
+                }
+                return entry;
+            }
             // extractAll can return normally without ever writing THIS polled document's bytes: a parse
             // failure the resilient parser swallows, a mid-walk abort, an OCR-off image... A silent miss
             // must fail loudly (nbFailed, re-runnable) instead of being recorded as produced.

--- a/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
+++ b/datashare-index/src/main/java/org/icij/datashare/text/artifact/StructureArtifact.java
@@ -169,6 +169,24 @@ public class StructureArtifact implements Artifact {
         return failure instanceof TikaMemoryLimitException || isZipBombGuard(failure);
     }
 
+    /**
+     * The cause that makes {@code failure} content no parser can read, or null when the failure is worth
+     * another run. Read off the cause chain rather than by catch type, since each producer wraps its parse
+     * failure differently. A TikaConfigException down the chain is this side going wrong for one document
+     * rather than unreadable content, so a run with the configuration fixed still gets to try it.
+     */
+    static Throwable unreadableCause(Throwable failure) {
+        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+            if (cause instanceof TikaConfigException) {
+                return null;
+            }
+            if (cause instanceof TikaException || cause instanceof SAXException) {
+                return isRetryable(cause) ? null : cause;
+            }
+        }
+        return null;
+    }
+
     // The document's own name, from the Tika metadata rather than from the path: an embedded document
     // carries its container's path, so the path would hand a mail attachment's bytes the name of the
     // archive they came out of.

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
@@ -1,5 +1,7 @@
 package org.icij.datashare.text.artifact;
 
+import org.apache.tika.exception.EncryptedDocumentException;
+import org.apache.tika.exception.TikaException;
 import org.icij.datashare.text.Document;
 import org.icij.datashare.text.Project;
 import org.icij.datashare.text.indexing.elasticsearch.SourceExtractor;
@@ -7,13 +9,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.zip.ZipException;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.text.DocumentBuilder.createDoc;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,16 +110,66 @@ public class RawArtifactTest {
         assertThat(entry.isComplete()).isFalse();
     }
 
-    @Test(expected = ArtifactException.class)
-    public void test_produce_throws_when_polled_doc_raw_bytes_were_not_written() throws Exception {
-        // extractEmbeddedSources runs (e.g. a swallowed per-message parse failure mid-walk) but never
-        // writes THIS polled document's raw bytes: produce() must fail loudly, not stamp a terminal entry.
-        SourceExtractor sources = mock(SourceExtractor.class); // no-op: writes nothing to disk
+    @Test
+    public void test_produce_reports_encrypted_content_as_unreadable() throws Exception {
+        // An encryption method no parser can undo surfaces as a TikaException, not as a type of its own.
+        try {
+            produceFailingWith(new EncryptedDocumentException("Unsupported feature encryption used in entry"));
+            fail("expected an UnreadableContentException");
+        } catch (UnreadableContentException expected) {
+            assertThat(expected.documentId).isEqualTo("doc-id");
+        }
+    }
+
+    @Test
+    public void test_produce_reports_a_structurally_corrupt_archive_as_unreadable() throws Exception {
+        try {
+            produceFailingWith(new TikaException("TIKA-198: Illegal IOException from PackageParser",
+                    new ZipException("Unexpected record signature")));
+            fail("expected an UnreadableContentException");
+        } catch (UnreadableContentException expected) {
+            assertThat(expected.documentId).isEqualTo("doc-id");
+        }
+    }
+
+    @Test
+    public void test_produce_keeps_a_read_failure_retryable() throws Exception {
+        try {
+            produceFailingWith(new IOException("stalled mount"));
+            fail("expected an ArtifactException");
+        } catch (UnreadableContentException unexpected) {
+            fail("a read failure is retryable, not unreadable content");
+        } catch (ArtifactException expected) {
+            assertThat(expected.getMessage()).contains("raw extraction failed");
+        }
+    }
+
+    @Test
+    public void test_produce_keeps_missing_raw_bytes_retryable() throws Exception {
+        // extractEmbeddedSources returns without writing THIS polled document's bytes (a swallowed
+        // per-message parse failure mid-walk): a genuine failure a re-run can get past, so it fails loudly.
+        SourceExtractor sources = mock(SourceExtractor.class);
         Project project = Project.project("prj");
         Document doc = createDoc("doc-id").with(Path.of("/path/to/report.pdf")).ofContentType("application/pdf").withExtractionLevel((short) 1).build();
-        ArtifactContext ctx = new ArtifactContext(project, doc, dir.getRoot().toPath(), sources);
 
-        new RawArtifact().produce(ctx);
+        try {
+            new RawArtifact().produce(new ArtifactContext(project, doc, dir.getRoot().toPath(), sources));
+            fail("expected an ArtifactException");
+        } catch (UnreadableContentException unexpected) {
+            fail("missing raw bytes are retryable, not unreadable content");
+        } catch (ArtifactException expected) {
+            assertThat(expected.getMessage()).contains("raw extraction produced no bytes");
+        }
+    }
+
+    private void produceFailingWith(Exception failure) throws Exception {
+        SourceExtractor sources = mock(SourceExtractor.class);
+        Project project = Project.project("prj");
+        Document doc = createDoc("doc-id").with(Path.of("/path/to/archive.zip"))
+                .ofContentType("application/zip").withExtractionLevel((short) 0).build();
+        doThrow(failure).when(sources).extractEmbeddedSources(project, doc);
+
+        new RawArtifact().produce(new ArtifactContext(project, doc, dir.getRoot().toPath(), sources));
     }
 
     @Test(expected = ArtifactException.class)
@@ -127,15 +183,5 @@ public class RawArtifactTest {
         ArtifactContext ctx = new ArtifactContext(project, doc, dir.getRoot().toPath(), sources);
 
         new RawArtifact().produce(ctx);
-    }
-
-    @Test(expected = ArtifactException.class)
-    public void test_produce_wraps_extraction_failure() throws Exception {
-        SourceExtractor sources = mock(SourceExtractor.class);
-        Project project = Project.project("prj");
-        Document doc = createDoc("doc-id").with(Path.of("/path/to/x.pdf")).ofContentType("application/pdf").build();
-        org.mockito.Mockito.doThrow(new java.io.IOException("nope")).when(sources).extractEmbeddedSources(project, doc);
-
-        new RawArtifact().produce(new ArtifactContext(project, doc, dir.getRoot().toPath(), sources));
     }
 }

--- a/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
+++ b/datashare-index/src/test/java/org/icij/datashare/text/artifact/RawArtifactTest.java
@@ -162,6 +162,29 @@ public class RawArtifactTest {
         }
     }
 
+    @Test
+    public void test_produce_records_the_bytes_a_failed_walk_had_already_written() throws Exception {
+        // The walk writes as it goes: a failure further along the root's tree leaves this document's own
+        // bytes on disk, and an empty entry there would disclaim a payload skip-if-current never revisits.
+        SourceExtractor sources = mock(SourceExtractor.class);
+        Project project = Project.project("prj");
+        Document doc = createDoc("doc-id").with(Path.of("/path/to/image2.jpg"))
+                .ofContentType("image/jpeg").withExtractionLevel((short) 1).build();
+        Path docDir = dir.getRoot().toPath();
+        doAnswer(invocation -> {
+            Files.createFile(docDir.resolve("raw"));
+            Files.createFile(docDir.resolve("raw.json"));
+            throw new TikaException("TIKA-198: Illegal IOException from PackageParser",
+                    new ZipException("Unexpected record signature"));
+        }).when(sources).extractEmbeddedSources(project, doc);
+
+        ManifestEntry entry = new RawArtifact().produce(new ArtifactContext(project, doc, docDir, sources));
+
+        assertThat(entry.status()).isNull();
+        assertThat(entry.contentType()).isEqualTo("image/jpeg");
+        assertThat(entry.filename()).isEqualTo("image2.jpg");
+    }
+
     private void produceFailingWith(Exception failure) throws Exception {
         SourceExtractor sources = mock(SourceExtractor.class);
         Project project = Project.project("prj");


### PR DESCRIPTION
Raw artifact production now sorts a failure into the same unreadable/retryable buckets structure and page already use, instead of failing every document that no parser can read.

- fix: record content no parser can read (an encrypted or structurally corrupt archive) as an empty `raw` entry instead of a re-runnable failure
- fix: keep the raw bytes a walk that failed further along a root's tree had already written, instead of recording an empty entry over them
- refactor: share one unreadable-cause classifier between `StructureArtifact`, `PageArtifact` and `RawArtifact`
- test: cover the encrypted, corrupt, read-failure, missing-bytes and partially-written-walk outcomes for `raw`
- behaviour: such documents no longer bump the ARTIFACT failure count, so the closing "re-run the ARTIFACT stage for them" no longer names them

Closes #2366
